### PR TITLE
pkgs/development/compilers/llvm: use makeScopeWithSplicing

### DIFF
--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -12,7 +12,7 @@
   libclang,
   version,
   python3,
-  buildLlvmTools,
+  buildLlvmPackages,
   patches ? [ ],
   devExtraCmakeFlags ? [ ],
   fetchpatch,
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
+    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")
   ]
   ++ devExtraCmakeFlags;
 

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -12,7 +12,7 @@
   release_version,
   version,
   python3,
-  buildLlvmTools,
+  buildLlvmPackages,
   fixDarwinDylibNames,
   enableManpages ? false,
   enableClangToolsExtra ? true,
@@ -96,9 +96,9 @@ stdenv.mkDerivation (
       (lib.cmakeBool "CLANGD_BUILD_XPC" false)
       (lib.cmakeBool "LLVM_ENABLE_RTTI" true)
       (lib.cmakeBool "LLVM_INCLUDE_TESTS" false)
-      (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
-      (lib.cmakeFeature "CLANG_TABLEGEN" "${buildLlvmTools.tblgen}/bin/clang-tblgen")
-      (lib.cmakeFeature "CLANG_TIDY_CONFUSABLE_CHARS_GEN" "${buildLlvmTools.tblgen}/bin/clang-tidy-confusable-chars-gen")
+      (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")
+      (lib.cmakeFeature "CLANG_TABLEGEN" "${buildLlvmPackages.tblgen}/bin/clang-tblgen")
+      (lib.cmakeFeature "CLANG_TIDY_CONFUSABLE_CHARS_GEN" "${buildLlvmPackages.tblgen}/bin/clang-tidy-confusable-chars-gen")
     ]
     ++ lib.optional (lib.versionAtLeast release_version "20") (
       lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm"
@@ -115,7 +115,7 @@ stdenv.mkDerivation (
     ]
     ++ lib.optionals (lib.versionOlder release_version "20") [
       # clang-pseudo removed in LLVM20: https://github.com/llvm/llvm-project/commit/ed8f78827895050442f544edef2933a60d4a7935
-      (lib.cmakeFeature "CLANG_PSEUDO_GEN" "${buildLlvmTools.tblgen}/bin/clang-pseudo-gen")
+      (lib.cmakeFeature "CLANG_PSEUDO_GEN" "${buildLlvmPackages.tblgen}/bin/clang-pseudo-gen")
     ]
     ++ devExtraCmakeFlags;
 

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -108,14 +108,7 @@ let
 in
 makeScopeWithSplicing' {
   inherit otherSplices;
-  extra =
-    spliced0:
-    args
-    // metadata
-    // {
-      inherit buildLlvmPackages;
-      targetLlvm = spliced0.llvm.__spliced._targetTarget or llvm;
-    };
+  extra = _spliced0: args // metadata // { inherit buildLlvmPackages; };
   f =
     self:
     let

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -8,7 +8,6 @@
   overrideCC,
   wrapCCWith,
   wrapBintoolsWith,
-  buildPackages,
   makeScopeWithSplicing',
   otherSplices,
   splicePackages,
@@ -23,6 +22,10 @@
   monorepoSrc ? null,
   version ? null,
   patchesFn ? lib.id,
+  cmake,
+  cmakeMinimal,
+  python3,
+  python3Minimal,
   # Allows passthrough to packages via newScope. This makes it possible to
   # do `(llvmPackages.override { <someLlvmDependency> = bar; }).clang` and get
   # an llvmPackages whose packages are overridden in an internally consistent way.
@@ -485,13 +488,8 @@ makeScopeWithSplicing' {
         # Use clang due to "gnu::naked" not working on aarch64.
         # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
         stdenv = overrideCC stdenv buildLlvmPackages.clangNoLibcNoRt;
-        cmake =
-          if stdenv.targetPlatform.libc == "llvm" then buildPackages.cmakeMinimal else buildPackages.cmake;
-        python3 =
-          if stdenv.targetPlatform.libc == "llvm" then
-            buildPackages.python3Minimal
-          else
-            buildPackages.python3;
+        cmake = if stdenv.targetPlatform.libc == "llvm" then cmakeMinimal else cmake;
+        python3 = if stdenv.targetPlatform.libc == "llvm" then python3Minimal else python3;
       };
 
       libc = if stdenv.targetPlatform.libc == "llvm" then self.libc-full else self.libc-overlay;

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -212,7 +212,7 @@ makeScopeWithSplicing' {
           self.systemLibcxxClang
         else if stdenv.targetPlatform.useLLVM or false then
           self.clangUseLLVM
-        else if (pkgs.targetPackages.stdenv or args.stdenv).cc.isGNU then
+        else if (targetPackages.stdenv or stdenv).cc.isGNU then
           self.libstdcxxClang
         else
           self.libcxxClang;

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -319,6 +319,9 @@ makeScopeWithSplicing' {
       clangWithLibcAndBasicRtAndLibcxx = wrapCCWith rec {
         cc = self.clang-unwrapped;
         # This is used to build compiler-rt. Make sure to use the system libc++ on Darwin.
+        #
+        # FIXME: This should almost certainly use
+        # `stdenv.targetPlatform` and `targetPackages.darwin.libcxx`.
         libcxx = if stdenv.hostPlatform.isDarwin then darwin.libcxx else targetLlvmPackages.libcxx;
         bintools = bintools';
         extraPackages = [
@@ -488,10 +491,13 @@ makeScopeWithSplicing' {
         # Use clang due to "gnu::naked" not working on aarch64.
         # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
         stdenv = overrideCC stdenv buildLlvmPackages.clangNoLibcNoRt;
+        # FIXME: This should almost certainly be `stdenv.hostPlatform`.
         cmake = if stdenv.targetPlatform.libc == "llvm" then cmakeMinimal else cmake;
         python3 = if stdenv.targetPlatform.libc == "llvm" then python3Minimal else python3;
       };
 
-      libc = if stdenv.targetPlatform.libc == "llvm" then self.libc-full else self.libc-overlay;
+      libc =
+        # FIXME: This should almost certainly be `stdenv.hostPlatform`.
+        if stdenv.targetPlatform.libc == "llvm" then self.libc-full else self.libc-overlay;
     };
 }

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -1,28 +1,22 @@
 {
   lowPrio,
-  newScope,
   pkgs,
   targetPackages,
   lib,
   stdenv,
-  libxcrypt,
-  substitute,
-  replaceVars,
   fetchFromGitHub,
-  fetchpatch,
-  fetchpatch2,
   overrideCC,
   wrapCCWith,
   wrapBintoolsWith,
   buildPackages,
-  buildLlvmTools, # tools, but from the previous stage, for cross
-  targetLlvmLibraries, # libraries, but from the next stage, for cross
-  targetLlvm,
+  makeScopeWithSplicing',
+  otherSplices,
+  splicePackages,
   # This is the default binutils, but with *this* version of LLD rather
   # than the default LLVM version's, if LLD is the choice. We use these for
   # the `useLLVM` bootstrapping below.
-  bootBintoolsNoLibc ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintoolsNoLibc,
-  bootBintools ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintools,
+  bootBintoolsNoLibc,
+  bootBintools,
   darwin,
   gitRelease ? null,
   officialRelease ? null,
@@ -110,11 +104,31 @@ let
       };
   };
 
-  tools = lib.makeExtensible (
-    tools:
+  buildLlvmPackages = otherSplices.selfBuildHost;
+in
+makeScopeWithSplicing' {
+  inherit otherSplices;
+  extra =
+    spliced0:
+    args
+    // metadata
+    // {
+      inherit buildLlvmPackages;
+      targetLlvm = spliced0.llvm.__spliced._targetTarget or llvm;
+    };
+  f =
+    self:
     let
-      callPackage = newScope (tools // args // metadata);
+      targetLlvmPackages =
+        if otherSplices.selfTargetTarget == { } then self else otherSplices.selfTargetTarget;
+
+      # FIXME: This is a tragic and unprincipled hack, but I don’t
+      # know what would actually be good instead.
+      newScope = scope: self.newScope ({ inherit (args) stdenv; } // scope);
+      callPackage = newScope { };
+
       clangVersion = lib.versions.major metadata.release_version;
+
       mkExtraBuildCommands0 =
         cc:
         ''
@@ -134,37 +148,40 @@ let
               ln -s "${lib.getLib cc}/lib/clang/${clangVersion}/include" "$rsrc"
             ''
         );
+
       mkExtraBuildCommandsBasicRt =
         cc:
         mkExtraBuildCommands0 cc
         + ''
-          ln -s "${targetLlvmLibraries.compiler-rt-no-libc.out}/lib" "$rsrc/lib"
+          ln -s "${targetLlvmPackages.compiler-rt-no-libc.out}/lib" "$rsrc/lib"
         '';
+
       mkExtraBuildCommands =
         cc:
         mkExtraBuildCommands0 cc
         + ''
-          ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
-          ln -s "${targetLlvmLibraries.compiler-rt.out}/share" "$rsrc/share"
+          ln -s "${targetLlvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
+          ln -s "${targetLlvmPackages.compiler-rt.out}/share" "$rsrc/share"
         '';
 
-      bintoolsNoLibc' = if bootBintoolsNoLibc == null then tools.bintoolsNoLibc else bootBintoolsNoLibc;
-      bintools' = if bootBintools == null then tools.bintools else bootBintools;
+      bintoolsNoLibc' = if bootBintoolsNoLibc == null then self.bintoolsNoLibc else bootBintoolsNoLibc;
+      bintools' = if bootBintools == null then self.bintools else bootBintools;
     in
     {
-      libllvm = callPackage ./llvm {
-      };
+      inherit (metadata) release_version;
+
+      libllvm = callPackage ./llvm { };
 
       # `llvm` historically had the binaries.  When choosing an output explicitly,
       # we need to reintroduce `outputSpecified` to get the expected behavior e.g. of lib.get*
-      llvm = tools.libllvm;
+      llvm = self.libllvm;
 
       tblgen = callPackage ./tblgen.nix {
         patches =
           builtins.filter
             # Crude method to drop polly patches if present, they're not needed for tblgen.
             (p: (!lib.hasInfix "-polly" p))
-            tools.libllvm.patches;
+            self.libllvm.patches;
         clangPatches = [
           # Would take tools.libclang.patches, but this introduces a cycle due
           # to replacements depending on the llvm outpath (e.g. the LLVMgold patch).
@@ -173,20 +190,19 @@ let
         ];
       };
 
-      libclang = callPackage ./clang {
-      };
+      libclang = callPackage ./clang { };
 
-      clang-unwrapped = tools.libclang;
+      clang-unwrapped = self.libclang;
 
       llvm-manpages = lowPrio (
-        tools.libllvm.override {
+        self.libllvm.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
       );
 
       clang-manpages = lowPrio (
-        tools.libclang.override {
+        self.libclang.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
@@ -198,55 +214,59 @@ let
       # pick clang appropriate for package set we are targeting
       clang =
         if stdenv.targetPlatform.libc == null then
-          tools.clangNoLibc
+          self.clangNoLibc
         else if stdenv.targetPlatform.isDarwin then
-          tools.systemLibcxxClang
+          self.systemLibcxxClang
         else if stdenv.targetPlatform.useLLVM or false then
-          tools.clangUseLLVM
+          self.clangUseLLVM
         else if (pkgs.targetPackages.stdenv or args.stdenv).cc.isGNU then
-          tools.libstdcxxClang
+          self.libstdcxxClang
         else
-          tools.libcxxClang;
+          self.libcxxClang;
 
       libstdcxxClang = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         # libstdcxx is taken from gcc in an ad-hoc way in cc-wrapper.
         libcxx = null;
-        extraPackages = [ targetLlvmLibraries.compiler-rt ];
+        extraPackages = [ targetLlvmPackages.compiler-rt ];
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
       libcxxClang = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
-        libcxx = targetLlvmLibraries.libcxx;
-        extraPackages = [ targetLlvmLibraries.compiler-rt ];
+        cc = self.clang-unwrapped;
+        libcxx = targetLlvmPackages.libcxx;
+        extraPackages = [ targetLlvmPackages.compiler-rt ];
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
       # Darwin uses the system libc++ by default. It is set up as its own clang definition so that `libcxxClang`
       # continues to use the libc++ from LLVM.
       systemLibcxxClang = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         libcxx = darwin.libcxx;
-        extraPackages = [ targetLlvmLibraries.compiler-rt ];
+        extraPackages = [ targetLlvmPackages.compiler-rt ];
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
-      lld = callPackage ./lld {
-      };
+      lld = callPackage ./lld { };
 
-      lldbPlugins = lib.makeExtensible (
-        lldbPlugins:
-        let
-          callPackage = newScope (lldbPlugins // tools // args // metadata);
-        in
-        lib.recurseIntoAttrs { llef = callPackage ./lldb-plugins/llef.nix { }; }
+      lldbPlugins = lib.recurseIntoAttrs (
+        lib.makeScopeWithSplicing'
+          {
+            inherit splicePackages newScope;
+          }
+          {
+            otherSplices = lib.mapAttrs (_: selfSplice: selfSplice.lldbPlugins or { }) otherSplices;
+            f = selfLldbPlugins: {
+              llef = selfLldbPlugins.callPackage ./lldb-plugins/llef.nix { };
+            };
+          }
       );
 
       lldb = callPackage ./lldb { };
 
       lldb-manpages = lowPrio (
-        tools.lldb.override {
+        self.lldb.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
@@ -262,27 +282,29 @@ let
       bintools-unwrapped = callPackage ./bintools.nix { };
 
       bintoolsNoLibc = wrapBintoolsWith {
-        bintools = tools.bintools-unwrapped;
+        bintools = self.bintools-unwrapped;
         libc = targetPackages.preLibcHeaders;
       };
 
-      bintools = wrapBintoolsWith { bintools = tools.bintools-unwrapped; };
+      bintools = wrapBintoolsWith {
+        bintools = self.bintools-unwrapped;
+      };
 
       clangUseLLVM = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
-        libcxx = targetLlvmLibraries.libcxx;
+        cc = self.clang-unwrapped;
+        libcxx = targetLlvmPackages.libcxx;
         bintools = bintools';
         extraPackages = [
-          targetLlvmLibraries.compiler-rt
+          targetLlvmPackages.compiler-rt
         ]
         ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD) [
-          targetLlvmLibraries.libunwind
+          targetLlvmPackages.libunwind
         ];
         extraBuildCommands = mkExtraBuildCommands cc;
         nixSupport.cc-cflags = [
           "-rtlib=compiler-rt"
           "-Wno-unused-command-line-argument"
-          "-B${targetLlvmLibraries.compiler-rt}/lib"
+          "-B${targetLlvmPackages.compiler-rt}/lib"
         ]
         ++ lib.optional (
           !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
@@ -295,16 +317,16 @@ let
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
         nixSupport.cc-ldflags = lib.optionals (
           !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
-        ) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
+        ) [ "-L${targetLlvmPackages.libunwind}/lib" ];
       };
 
       clangWithLibcAndBasicRtAndLibcxx = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         # This is used to build compiler-rt. Make sure to use the system libc++ on Darwin.
-        libcxx = if stdenv.hostPlatform.isDarwin then darwin.libcxx else targetLlvmLibraries.libcxx;
+        libcxx = if stdenv.hostPlatform.isDarwin then darwin.libcxx else targetLlvmPackages.libcxx;
         bintools = bintools';
         extraPackages = [
-          targetLlvmLibraries.compiler-rt-no-libc
+          targetLlvmPackages.compiler-rt-no-libc
         ]
         ++
           lib.optionals
@@ -312,13 +334,13 @@ let
               !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
             )
             [
-              targetLlvmLibraries.libunwind
+              targetLlvmPackages.libunwind
             ];
         extraBuildCommands = mkExtraBuildCommandsBasicRt cc;
         nixSupport.cc-cflags = [
           "-rtlib=compiler-rt"
           "-Wno-unused-command-line-argument"
-          "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
+          "-B${targetLlvmPackages.compiler-rt-no-libc}/lib"
         ]
         ++ lib.optional (
           !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
@@ -331,50 +353,50 @@ let
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
         nixSupport.cc-ldflags = lib.optionals (
           !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD && !stdenv.targetPlatform.isDarwin
-        ) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
+        ) [ "-L${targetLlvmPackages.libunwind}/lib" ];
       };
 
       clangWithLibcAndBasicRt = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         libcxx = null;
         bintools = bintools';
-        extraPackages = [ targetLlvmLibraries.compiler-rt-no-libc ];
+        extraPackages = [ targetLlvmPackages.compiler-rt-no-libc ];
         extraBuildCommands = mkExtraBuildCommandsBasicRt cc;
         nixSupport.cc-cflags = [
           "-rtlib=compiler-rt"
-          "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
+          "-B${targetLlvmPackages.compiler-rt-no-libc}/lib"
           "-nostdlib++"
         ]
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
       };
 
       clangNoLibcWithBasicRt = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         libcxx = null;
         bintools = bintoolsNoLibc';
-        extraPackages = [ targetLlvmLibraries.compiler-rt-no-libc ];
+        extraPackages = [ targetLlvmPackages.compiler-rt-no-libc ];
         extraBuildCommands = mkExtraBuildCommandsBasicRt cc;
         nixSupport.cc-cflags = [
           "-rtlib=compiler-rt"
-          "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
+          "-B${targetLlvmPackages.compiler-rt-no-libc}/lib"
         ]
         ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
       };
 
       clangNoLibcNoRt = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         libcxx = null;
         bintools = bintoolsNoLibc';
         extraPackages = [ ];
-        # "-nostartfiles" used to be needed for pkgsLLVM, causes problems so don't include it.
         extraBuildCommands = mkExtraBuildCommands0 cc;
+        # "-nostartfiles" used to be needed for pkgsLLVM, causes problems so don't include it.
         nixSupport.cc-cflags = lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
       };
 
       # This is an "oddly ordered" bootstrap just for Darwin. Probably
       # don't want it otherwise.
       clangNoCompilerRtWithLibc = wrapCCWith rec {
-        cc = tools.clang-unwrapped;
+        cc = self.clang-unwrapped;
         libcxx = null;
         bintools = bintools';
         extraPackages = [ ];
@@ -383,126 +405,102 @@ let
       };
 
       # Aliases
-      clangNoCompilerRt = tools.clangNoLibcNoRt;
-      clangNoLibc = tools.clangNoLibcWithBasicRt;
-      clangNoLibcxx = tools.clangWithLibcAndBasicRt;
+      clangNoCompilerRt = self.clangNoLibcNoRt;
+      clangNoLibc = self.clangNoLibcWithBasicRt;
+      clangNoLibcxx = self.clangWithLibcAndBasicRt;
+
+      compiler-rt-libc = callPackage ./compiler-rt (
+        let
+          # temp rename to avoid infinite recursion
+          stdenv =
+            # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
+            if args.stdenv.hostPlatform.isDarwin then
+              overrideCC darwin.bootstrapStdenv buildLlvmPackages.clangWithLibcAndBasicRtAndLibcxx
+            else if args.stdenv.hostPlatform.useLLVM or false then
+              overrideCC args.stdenv buildLlvmPackages.clangWithLibcAndBasicRtAndLibcxx
+            else
+              args.stdenv;
+        in
+        {
+          inherit stdenv;
+        }
+      );
+
+      compiler-rt-no-libc = callPackage ./compiler-rt {
+        doFakeLibgcc = stdenv.hostPlatform.useLLVM or false;
+        stdenv =
+          # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
+          if stdenv.hostPlatform.isDarwin then
+            overrideCC darwin.bootstrapStdenv buildLlvmPackages.clangNoLibcNoRt
+          else
+            overrideCC stdenv buildLlvmPackages.clangNoLibcNoRt;
+      };
+
+      compiler-rt =
+        if
+          stdenv.hostPlatform.libc == null
+          # Building the with-libc compiler-rt and WASM doesn't yet work,
+          # because wasilibc doesn't provide some expected things. See
+          # compiler-rt's file for further details.
+          || stdenv.hostPlatform.isWasm
+          # Failing `#include <term.h>` in
+          # `lib/sanitizer_common/sanitizer_platform_limits_freebsd.cpp`
+          # sanitizers, not sure where to get it.
+          || stdenv.hostPlatform.isFreeBSD
+        then
+          self.compiler-rt-no-libc
+        else
+          self.compiler-rt-libc;
+
+      stdenv = overrideCC stdenv buildLlvmPackages.clang;
+
+      libcxxStdenv = overrideCC stdenv buildLlvmPackages.libcxxClang;
+
+      libcxx = callPackage ./libcxx {
+        stdenv =
+          if stdenv.hostPlatform.isDarwin then
+            overrideCC darwin.bootstrapStdenv buildLlvmPackages.clangWithLibcAndBasicRt
+          else
+            overrideCC stdenv buildLlvmPackages.clangWithLibcAndBasicRt;
+      };
+
+      libunwind = callPackage ./libunwind {
+        stdenv = overrideCC stdenv buildLlvmPackages.clangWithLibcAndBasicRt;
+      };
+
+      openmp = callPackage ./openmp { };
 
       mlir = callPackage ./mlir { };
 
       libclc = callPackage ./libclc { };
     }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "19") {
-      bolt = callPackage ./bolt {
-      };
+      bolt = callPackage ./bolt { };
     }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "20") {
-      flang = callPackage ./flang {
-        mlir = tools.mlir;
+      flang = callPackage ./flang { };
+
+      libc-overlay = callPackage ./libc {
+        isFullBuild = false;
+        # Use clang due to "gnu::naked" not working on aarch64.
+        # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
+        stdenv = overrideCC stdenv buildLlvmPackages.clang;
       };
-    }
-  );
 
-  libraries = lib.makeExtensible (
-    libraries:
-    let
-      callPackage = newScope (libraries // buildLlvmTools // args // metadata);
-    in
-    (
-      {
-        compiler-rt-libc = callPackage ./compiler-rt (
-          let
-            # temp rename to avoid infinite recursion
-            stdenv =
-              # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
-              if args.stdenv.hostPlatform.isDarwin then
-                overrideCC darwin.bootstrapStdenv buildLlvmTools.clangWithLibcAndBasicRtAndLibcxx
-              else if args.stdenv.hostPlatform.useLLVM or false then
-                overrideCC args.stdenv buildLlvmTools.clangWithLibcAndBasicRtAndLibcxx
-              else
-                args.stdenv;
-          in
-          {
-            inherit stdenv;
-          }
-        );
-
-        compiler-rt-no-libc = callPackage ./compiler-rt {
-          doFakeLibgcc = stdenv.hostPlatform.useLLVM or false;
-          stdenv =
-            # Darwin needs to use a bootstrap stdenv to avoid an infinite recursion when cross-compiling.
-            if stdenv.hostPlatform.isDarwin then
-              overrideCC darwin.bootstrapStdenv buildLlvmTools.clangNoLibcNoRt
-            else
-              overrideCC stdenv buildLlvmTools.clangNoLibcNoRt;
-        };
-
-        compiler-rt =
-          if
-            stdenv.hostPlatform.libc == null
-            # Building the with-libc compiler-rt and WASM doesn't yet work,
-            # because wasilibc doesn't provide some expected things. See
-            # compiler-rt's file for further details.
-            || stdenv.hostPlatform.isWasm
-            # Failing `#include <term.h>` in
-            # `lib/sanitizer_common/sanitizer_platform_limits_freebsd.cpp`
-            # sanitizers, not sure where to get it.
-            || stdenv.hostPlatform.isFreeBSD
-          then
-            libraries.compiler-rt-no-libc
+      libc-full = callPackage ./libc {
+        isFullBuild = true;
+        # Use clang due to "gnu::naked" not working on aarch64.
+        # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
+        stdenv = overrideCC stdenv buildLlvmPackages.clangNoLibcNoRt;
+        cmake =
+          if stdenv.targetPlatform.libc == "llvm" then buildPackages.cmakeMinimal else buildPackages.cmake;
+        python3 =
+          if stdenv.targetPlatform.libc == "llvm" then
+            buildPackages.python3Minimal
           else
-            libraries.compiler-rt-libc;
+            buildPackages.python3;
+      };
 
-        stdenv = overrideCC stdenv buildLlvmTools.clang;
-
-        libcxxStdenv = overrideCC stdenv buildLlvmTools.libcxxClang;
-
-        libcxx = callPackage ./libcxx {
-          stdenv =
-            if stdenv.hostPlatform.isDarwin then
-              overrideCC darwin.bootstrapStdenv buildLlvmTools.clangWithLibcAndBasicRt
-            else
-              overrideCC stdenv buildLlvmTools.clangWithLibcAndBasicRt;
-        };
-
-        libunwind = callPackage ./libunwind {
-          stdenv = overrideCC stdenv buildLlvmTools.clangWithLibcAndBasicRt;
-        };
-
-        openmp = callPackage ./openmp {
-        };
-      }
-      // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "20") {
-        libc-overlay = callPackage ./libc {
-          isFullBuild = false;
-          # Use clang due to "gnu::naked" not working on aarch64.
-          # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
-          stdenv = overrideCC stdenv buildLlvmTools.clang;
-        };
-
-        libc-full = callPackage ./libc {
-          isFullBuild = true;
-          # Use clang due to "gnu::naked" not working on aarch64.
-          # Issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
-          stdenv = overrideCC stdenv buildLlvmTools.clangNoLibcNoRt;
-          cmake =
-            if stdenv.targetPlatform.libc == "llvm" then buildPackages.cmakeMinimal else buildPackages.cmake;
-          python3 =
-            if stdenv.targetPlatform.libc == "llvm" then
-              buildPackages.python3Minimal
-            else
-              buildPackages.python3;
-        };
-
-        libc = if stdenv.targetPlatform.libc == "llvm" then libraries.libc-full else libraries.libc-overlay;
-      }
-    )
-  );
-
-  noExtend = extensible: lib.attrsets.removeAttrs extensible [ "extend" ];
-in
-{
-  inherit tools libraries;
-  inherit (metadata) release_version;
+      libc = if stdenv.targetPlatform.libc == "llvm" then self.libc-full else self.libc-overlay;
+    };
 }
-// (noExtend libraries)
-// (noExtend tools)

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
     (lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm")
+    # TODO: Needs patches and the `lit` package like other LLVM builds?
     (lib.cmakeFeature "LLVM_TOOLS_BINARY_DIR" "${buildLlvmPackages.tblgen}/bin/")
     (lib.cmakeFeature "LLVM_EXTERNAL_LIT" "${buildLlvmPackages.tblgen}/bin/llvm-lit")
     (lib.cmakeFeature "CLANG_DIR" "${libclang.dev}/lib/cmake/clang")

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -15,7 +15,7 @@
   mlir,
   version,
   python3,
-  buildLlvmTools,
+  buildLlvmPackages,
   devExtraCmakeFlags ? [ ],
 }:
 
@@ -64,11 +64,11 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
     (lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm")
-    (lib.cmakeFeature "LLVM_TOOLS_BINARY_DIR" "${buildLlvmTools.tblgen}/bin/")
-    (lib.cmakeFeature "LLVM_EXTERNAL_LIT" "${buildLlvmTools.tblgen}/bin/llvm-lit")
+    (lib.cmakeFeature "LLVM_TOOLS_BINARY_DIR" "${buildLlvmPackages.tblgen}/bin/")
+    (lib.cmakeFeature "LLVM_EXTERNAL_LIT" "${buildLlvmPackages.tblgen}/bin/llvm-lit")
     (lib.cmakeFeature "CLANG_DIR" "${libclang.dev}/lib/cmake/clang")
     (lib.cmakeFeature "MLIR_DIR" "${mlir.dev}/lib/cmake/mlir")
-    (lib.cmakeFeature "MLIR_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/mlir-tblgen")
+    (lib.cmakeFeature "MLIR_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/mlir-tblgen")
     (lib.cmakeFeature "MLIR_TABLEGEN_TARGET" "MLIR-TBLGen")
     (lib.cmakeBool "LLVM_BUILD_EXAMPLES" false)
     (lib.cmakeBool "LLVM_ENABLE_PLUGINS" false)

--- a/pkgs/development/compilers/llvm/common/libclc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libclc/default.nix
@@ -6,7 +6,7 @@
   monorepoSrc,
   llvm,
   buildPackages,
-  buildLlvmTools,
+  buildLlvmPackages,
   ninja,
   cmake,
   python3,
@@ -15,7 +15,7 @@
 }:
 let
   spirv-llvm-translator = buildPackages.spirv-llvm-translator.override {
-    inherit (buildLlvmTools) llvm;
+    inherit (buildLlvmPackages) llvm;
   };
 
   # The build requires an unwrapped clang but wrapped clang++ thus we need to
@@ -23,7 +23,7 @@ let
   # unwrapped clang++
   clang-only = runCommand "clang-only" { } ''
     mkdir -p "$out"/bin
-    ln -s "${lib.getExe' buildLlvmTools.clang.cc "clang"}" "$out"/bin
+    ln -s "${lib.getExe' buildLlvmPackages.clang.cc "clang"}" "$out"/bin
   '';
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -59,13 +59,13 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionalString (lib.versionOlder release_version "19") ''
       substituteInPlace CMakeLists.txt \
         --replace-fail 'find_program( LLVM_CLANG clang PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                  'find_program( LLVM_CLANG clang PATHS "${buildLlvmTools.clang.cc}/bin" NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_CLANG clang PATHS "${buildLlvmPackages.clang.cc}/bin" NO_DEFAULT_PATH )' \
         --replace-fail 'find_program( LLVM_AS llvm-as PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                  'find_program( LLVM_AS llvm-as PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_AS llvm-as PATHS "${buildLlvmPackages.llvm}/bin" NO_DEFAULT_PATH )' \
         --replace-fail 'find_program( LLVM_LINK llvm-link PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                  'find_program( LLVM_LINK llvm-link PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_LINK llvm-link PATHS "${buildLlvmPackages.llvm}/bin" NO_DEFAULT_PATH )' \
         --replace-fail 'find_program( LLVM_OPT opt PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
-                  'find_program( LLVM_OPT opt PATHS "${buildLlvmTools.llvm}/bin" NO_DEFAULT_PATH )' \
+                  'find_program( LLVM_OPT opt PATHS "${buildLlvmPackages.llvm}/bin" NO_DEFAULT_PATH )' \
         --replace-fail 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )' \
                   'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv-llvm-translator}/bin" NO_DEFAULT_PATH )'
     ''
@@ -74,13 +74,13 @@ stdenv.mkDerivation (finalAttrs: {
         ''
           substituteInPlace CMakeLists.txt \
             --replace-fail 'COMMAND prepare_builtins' \
-                           'COMMAND ${buildLlvmTools.libclc.dev}/bin/prepare_builtins'
+                           'COMMAND ${buildLlvmPackages.libclc.dev}/bin/prepare_builtins'
         ''
       else
         ''
           substituteInPlace CMakeLists.txt \
             --replace-fail 'set( prepare_builtins_exe prepare_builtins )' \
-                           'set( prepare_builtins_exe ${buildLlvmTools.libclc.dev}/bin/prepare_builtins )'
+                           'set( prepare_builtins_exe ${buildLlvmPackages.libclc.dev}/bin/prepare_builtins )'
         ''
     );
 

--- a/pkgs/development/compilers/llvm/common/libclc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libclc/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (lib.versionAtLeast release_version "19") [
     clang-only
-    buildLlvmTools.llvm
+    llvm
     spirv-llvm-translator
   ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   llvm_meta,
   release_version,
-  buildLlvmTools,
+  buildLlvmPackages,
   monorepoSrc ? null,
   src ? null,
   runCommand,
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "LLD_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/lld")
-    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
+    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")
   ]
   ++ devExtraCmakeFlags;
 

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -22,7 +22,7 @@
   zlib,
   which,
   sysctl,
-  buildLlvmTools,
+  buildLlvmPackages,
   updateAutotoolsGnuConfigScriptsHook,
   enableManpages ? false,
   enableSharedLibraries ? !stdenv.hostPlatform.isStatic,
@@ -468,7 +468,7 @@ stdenv.mkDerivation (
           (lib.cmakeFeature "LLVM_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/llvm")
           (lib.cmakeBool "LLVM_ENABLE_RTTI" true)
           (lib.cmakeBool "LLVM_LINK_LLVM_DYLIB" enableSharedLibraries)
-          (lib.cmakeFeature "LLVM_TABLEGEN" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
+          (lib.cmakeFeature "LLVM_TABLEGEN" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")
         ];
       in
       flagsForLlvmConfig

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   llvm_meta,
   release_version,
-  buildLlvmTools,
+  buildLlvmPackages,
   monorepoSrc,
   runCommand,
   cmake,
@@ -63,8 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "LLVM_HOST_TRIPLE" stdenv.hostPlatform.config)
     (lib.cmakeFeature "LLVM_DEFAULT_TARGET_TRIPLE" stdenv.hostPlatform.config)
     (lib.cmakeBool "LLVM_ENABLE_DUMP" true)
-    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
-    (lib.cmakeFeature "MLIR_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/mlir-tblgen")
+    (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/llvm-tblgen")
+    (lib.cmakeFeature "MLIR_TABLEGEN_EXE" "${buildLlvmPackages.tblgen}/bin/mlir-tblgen")
     (lib.cmakeBool "LLVM_BUILD_LLVM_DYLIB" (!stdenv.hostPlatform.isStatic))
   ]
   ++ lib.optionals stdenv.hostPlatform.isStatic [

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    python3.pythonOnBuildForHost
+    python3
     perl
     ninja
     pkg-config

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -9,7 +9,6 @@
   cmake,
   ninja,
   llvm,
-  targetLlvm,
   lit,
   clang-unwrapped,
   perl,
@@ -62,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    (if stdenv.buildPlatform == stdenv.hostPlatform then llvm else targetLlvm)
+    llvm
   ]
   ++ lib.optionals (ompdSupport && ompdGdbSupport) [
     python3

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -13,6 +13,7 @@
   bootBintoolsNoLibc ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintoolsNoLibc,
   bootBintools ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintools,
   llvmVersions ? { },
+  generateSplicesForMkScope,
   patchesFn ? lib.id,
   # Allows passthrough to packages via newScope in ./common/default.nix.
   # This makes it possible to do
@@ -59,19 +60,17 @@ let
         callPackage ./common (
           {
             inherit (stdenvAdapters) overrideCC;
-            buildLlvmTools = buildPackages."llvmPackages_${attrName}".tools;
-            targetLlvmLibraries =
-              # Allow overriding targetLlvmLibraries; this enables custom runtime builds.
-              packageSetArgs.targetLlvmLibraries or targetPackages."llvmPackages_${attrName}".libraries
-                or llvmPackages."${attrName}".libraries;
-            targetLlvm = targetPackages."llvmPackages_${attrName}".llvm or llvmPackages."${attrName}".llvm;
             inherit
               officialRelease
               gitRelease
               monorepoSrc
               version
               patchesFn
+              bootBintools
+              bootBintoolsNoLibc
               ;
+
+            otherSplices = generateSplicesForMkScope "llvmPackages_${attrName}";
           }
           // packageSetArgs # Allow overrides.
         )

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -501,7 +501,6 @@ overrideLlvmPackagesRocm (s: {
     with s.final;
     (llvmPackagesRocm.openmp.override {
       llvm = llvm;
-      targetLlvm = llvm;
       clang-unwrapped = clang-unwrapped;
     }).overrideAttrs
       (old: {

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -10,7 +10,6 @@
   runCommand,
   symlinkJoin,
   rdfind,
-  wrapBintoolsWith,
   zstd,
   zlib,
   gcc-unwrapped,
@@ -32,7 +31,7 @@
   withLto ? true,
   # whether rocm stdenv uses libcxx (clang c++ stdlib) instead of gcc stdlibc++
   withLibcxx ? false,
-}@args:
+}:
 
 let
   version = "6.4.3";
@@ -142,6 +141,28 @@ let
     stdenv.cc.cc
     stdenv.cc.bintools
   ];
+  # Hacky way to avoid nixfmt indenting the entire scope body suggested by @emilazy
+  overrideLlvmPackagesRocm =
+    f:
+    let
+      overridenScope = llvmPackagesRocm.overrideScope (final: prev: f { inherit final prev; });
+    in
+    {
+      inherit (overridenScope)
+        # Expose only a limited set of packages that we care about for ROCm
+        bintools
+        compiler-rt
+        compiler-rt-libc
+        clang
+        clang-unwrapped
+        libcxx
+        lld
+        llvm
+        rocm-toolchain
+        rocmClangStdenv
+        openmp
+        ;
+    };
   sysrootCompiler =
     {
       cc,
@@ -258,13 +279,8 @@ let
     ]
   );
 in
-rec {
-  inherit (llvmPackagesRocm) libcxx;
-  inherit args;
-  # Pass through original attrs for debugging where non-overridden llvm/clang is getting used
-  # llvm-orig = llvmPackagesRocm.llvm; # nix why-depends --derivation .#rocmPackages.clr .#rocmPackages.llvm.llvm-orig
-  # clang-orig = llvmPackagesRocm.clang; # nix why-depends --derivation .#rocmPackages.clr .#rocmPackages.llvm.clang-orig
-  llvm = llvmPackagesRocm.llvm.overrideAttrs (old: {
+overrideLlvmPackagesRocm (s: {
+  libllvm = (s.prev.libllvm.override { }).overrideAttrs (old: {
     patches = old.patches ++ [
       (fetchpatch {
         # fix compile error in tools/gold/gold-plugin.cpp
@@ -310,8 +326,7 @@ rec {
     meta = old.meta // llvmMeta;
   });
   lld =
-    (llvmPackagesRocm.lld.override {
-      libllvm = llvm;
+    (s.prev.lld.override {
     }).overrideAttrs
       (old: {
         dontStrip = profilableStdenv;
@@ -336,8 +351,7 @@ rec {
         meta = old.meta // llvmMeta;
       });
   clang-unwrapped = (
-    (llvmPackagesRocm.clang-unwrapped.override {
-      libllvm = llvm;
+    (s.prev.clang-unwrapped.override {
       enableClangToolsExtra = false;
     }).overrideAttrs
       (
@@ -373,10 +387,10 @@ rec {
               url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/6d296f879b0fed830c54b2a9d26240da86c8bb3a.patch";
               relative = "clang";
             })
-            # FIXME: Needed due to https://github.com/NixOS/nixpkgs/issues/375431
-            # Once we can switch to overrideScope this can be removed
+            # FIXME: Temporarily kept for rebuild avoidance
+            # Should be dropped in followup and we no longer need to filter out the original application
             (replaceVars ./../../../compilers/llvm/common/clang/clang-at-least-16-LLVMgold-path.patch {
-              libllvmLibdir = "${llvm.lib}/lib";
+              libllvmLibdir = "${s.final.libllvm.lib}/lib";
             })
           ];
           hardeningDisable = [ "all" ];
@@ -397,6 +411,7 @@ rec {
           __structuredAttrs = true;
           # https://github.com/llvm/llvm-project/blob/6976deebafa8e7de993ce159aa6b82c0e7089313/clang/cmake/caches/DistributionExample-stage2.cmake#L9-L11
           cmakeFlags =
+            # TODO: Remove in followup, tblgen now works correctly but would rebuild
             (builtins.filter tablegenUsage old.cmakeFlags)
             ++ commonCmakeFlags
             ++ lib.optionals (!withLibcxx) [
@@ -426,6 +441,7 @@ rec {
   # in the right order
   # and expects its libc to be in the sysroot
   rocm-toolchain =
+    with s.final;
     (sysrootCompiler {
       cc = clang-unwrapped;
       name = "rocm-toolchain";
@@ -458,42 +474,31 @@ rec {
       isClang = true;
       isGNU = false;
     };
-  compiler-rt-libc =
-    (llvmPackagesRocm.compiler-rt-libc.override {
-      libllvm = llvm;
-    }).overrideAttrs
-      (old: {
-        patches = old.patches ++ [
-          (fetchpatch {
-            name = "Fix-missing-main-function-in-float16-bfloat16-support-checks.patch";
-            url = "https://github.com/ROCm/llvm-project/commit/68d8b3846ab1e6550910f2a9a685690eee558af2.patch";
-            hash = "sha256-Db+L1HFMWVj4CrofsGbn5lnMoCzEcU+7q12KKFb17/g=";
-            relative = "compiler-rt";
-          })
-          (fetchpatch {
-            # Fixes fortify hardening compile error related to openat usage
-            hash = "sha256-pgpN1q1vIQrPXHPxNSZ6zfgV2EflHO5Amzl+2BDjXbs=";
-            url = "https://github.com/llvm/llvm-project/commit/155b7a12820ec45095988b6aa6e057afaf2bc892.patch";
-            relative = "compiler-rt";
-          })
-        ];
-        meta = old.meta // llvmMeta;
-      });
-  compiler-rt = compiler-rt-libc;
-  bintools = wrapBintoolsWith {
-    bintools = llvmPackagesRocm.bintools-unwrapped.override {
-      inherit lld llvm;
-    };
-  };
+  compiler-rt-libc = s.prev.compiler-rt-libc.overrideAttrs (old: {
+    patches = old.patches ++ [
+      (fetchpatch {
+        name = "Fix-missing-main-function-in-float16-bfloat16-support-checks.patch";
+        url = "https://github.com/ROCm/llvm-project/commit/68d8b3846ab1e6550910f2a9a685690eee558af2.patch";
+        hash = "sha256-Db+L1HFMWVj4CrofsGbn5lnMoCzEcU+7q12KKFb17/g=";
+        relative = "compiler-rt";
+      })
+      (fetchpatch {
+        # Fixes fortify hardening compile error related to openat usage
+        hash = "sha256-pgpN1q1vIQrPXHPxNSZ6zfgV2EflHO5Amzl+2BDjXbs=";
+        url = "https://github.com/llvm/llvm-project/commit/155b7a12820ec45095988b6aa6e057afaf2bc892.patch";
+        relative = "compiler-rt";
+      })
+    ];
+    meta = old.meta // llvmMeta;
+  });
+  compiler-rt = s.final.compiler-rt-libc;
+  clang = s.final.rocm-toolchain;
 
-  clang = rocm-toolchain;
-
-  rocmClangStdenv = overrideCC (
-    if withLibcxx then llvmPackagesRocm.libcxxStdenv else llvmPackagesRocm.stdenv
-  ) clang;
+  rocmClangStdenv = with s.final; overrideCC (if withLibcxx then libcxxStdenv else stdenv) clang;
 
   # Projects
   openmp =
+    with s.final;
     (llvmPackagesRocm.openmp.override {
       llvm = llvm;
       targetLlvm = llvm;
@@ -521,4 +526,7 @@ rec {
           libffi
         ];
       });
-}
+  # AMD has a separate MLIR impl which we package under rocmPackages.rocmlir
+  # It would be an error to rely on the original mlir package from this scope
+  mlir = null;
+})

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -466,87 +466,91 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           }
         );
 
-        llvmPackages = super.llvmPackages.overrideScope (
-          selfLlvmPackages: _: {
-            libclang = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-clang";
-              version = "boot";
-              outputs = [
-                "out"
-                "lib"
-              ];
-              buildCommand = ''
-                mkdir -p $out/lib
-                ln -s $out $lib
-                ln -s ${bootstrapTools}/bin       $out/bin
-                ln -s ${bootstrapTools}/lib/clang $out/lib
-                ln -s ${bootstrapTools}/include   $out
-              '';
-              passthru = {
-                isFromBootstrapFiles = true;
-                hardeningUnsupportedFlags = [
-                  "fortify3"
-                  "pacret"
-                  "shadowstack"
-                  "stackclashprotection"
-                  "zerocallusedregs"
+        llvmPackages =
+          (super.llvmPackages.overrideScope (
+            selfLlvmPackages: _: {
+              libclang = self.stdenv.mkDerivation {
+                name = "bootstrap-stage0-clang";
+                version = "boot";
+                outputs = [
+                  "out"
+                  "lib"
                 ];
+                buildCommand = ''
+                  mkdir -p $out/lib
+                  ln -s $out $lib
+                  ln -s ${bootstrapTools}/bin       $out/bin
+                  ln -s ${bootstrapTools}/lib/clang $out/lib
+                  ln -s ${bootstrapTools}/include   $out
+                '';
+                passthru = {
+                  isFromBootstrapFiles = true;
+                  hardeningUnsupportedFlags = [
+                    "fortify3"
+                    "pacret"
+                    "shadowstack"
+                    "stackclashprotection"
+                    "zerocallusedregs"
+                  ];
+                };
               };
-            };
-            libllvm = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-llvm";
-              outputs = [
-                "out"
-                "lib"
-              ];
-              buildCommand = ''
-                mkdir -p $out/bin $out/lib
-                ln -s $out $lib
-                for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
-                  cctoolsTool=''${tool//-/_}
-                  toolsrc="${bootstrapTools}/bin/$cctoolsTool"
-                  if [ -e "$toolsrc" ]; then
-                    ln -s "$toolsrc" $out/bin/llvm-$tool
-                  fi
-                done
-                ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
-                ln -s ${bootstrapTools}/bin/llvm-readtapi $out/bin/llvm-readtapi
-                ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
-              '';
-              passthru.isFromBootstrapFiles = true;
-            };
-            llvm-manpages = self.llvmPackages.libllvm;
-            lld = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-lld";
-              buildCommand = "";
-              passthru = {
-                isLLVM = true;
-                isFromBootstrapFiles = true;
+              libllvm = self.stdenv.mkDerivation {
+                name = "bootstrap-stage0-llvm";
+                outputs = [
+                  "out"
+                  "lib"
+                ];
+                buildCommand = ''
+                  mkdir -p $out/bin $out/lib
+                  ln -s $out $lib
+                  for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
+                    cctoolsTool=''${tool//-/_}
+                    toolsrc="${bootstrapTools}/bin/$cctoolsTool"
+                    if [ -e "$toolsrc" ]; then
+                      ln -s "$toolsrc" $out/bin/llvm-$tool
+                    fi
+                  done
+                  ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
+                  ln -s ${bootstrapTools}/bin/llvm-readtapi $out/bin/llvm-readtapi
+                  ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
+                '';
+                passthru.isFromBootstrapFiles = true;
               };
-            };
-            compiler-rt = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-compiler-rt";
-              buildCommand = ''
-                mkdir -p $out/lib $out/share
-                ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
-                ln -s ${bootstrapTools}/lib/darwin       $out/lib
-              '';
-              passthru.isFromBootstrapFiles = true;
-            };
-            libcxx = self.stdenv.mkDerivation {
-              name = "bootstrap-stage0-libcxx";
-              buildCommand = ''
-                mkdir -p $out/lib $out/include
-                ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
-                ln -s ${bootstrapTools}/include/c++      $out/include
-              '';
-              passthru = {
-                isLLVM = true;
-                isFromBootstrapFiles = true;
+              llvm-manpages = self.llvmPackages.libllvm;
+              lld = self.stdenv.mkDerivation {
+                name = "bootstrap-stage0-lld";
+                buildCommand = "";
+                passthru = {
+                  isLLVM = true;
+                  isFromBootstrapFiles = true;
+                };
               };
-            };
-          }
-        );
+              compiler-rt = self.stdenv.mkDerivation {
+                name = "bootstrap-stage0-compiler-rt";
+                buildCommand = ''
+                  mkdir -p $out/lib $out/share
+                  ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
+                  ln -s ${bootstrapTools}/lib/darwin       $out/lib
+                '';
+                passthru.isFromBootstrapFiles = true;
+              };
+              libcxx = self.stdenv.mkDerivation {
+                name = "bootstrap-stage0-libcxx";
+                buildCommand = ''
+                  mkdir -p $out/lib $out/include
+                  ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
+                  ln -s ${bootstrapTools}/include/c++      $out/include
+                '';
+                passthru = {
+                  isLLVM = true;
+                  isFromBootstrapFiles = true;
+                };
+              };
+            }
+          ))
+          // {
+            inherit (super.llvmPackages) override;
+          };
       };
 
       extraPreHook = ''
@@ -671,9 +675,13 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           }
         );
 
-        llvmPackages = super.llvmPackages.overrideScope (
-          _: _: llvmToolsPackages prevStage // llvmLibrariesPackages prevStage
-        );
+        llvmPackages =
+          (super.llvmPackages.overrideScope (
+            _: _: llvmToolsPackages prevStage // llvmLibrariesPackages prevStage
+          ))
+          // {
+            inherit (super.llvmPackages) override;
+          };
       };
 
       extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
@@ -819,14 +827,18 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               }
             );
 
-            llvmPackages = super.llvmPackages.overrideScope (
-              _: _:
-              llvmToolsPackages prevStage
-              // llvmLibrariesPackages prevStage
+            llvmPackages =
+              (super.llvmPackages.overrideScope (
+                _: _:
+                llvmToolsPackages prevStage
+                // llvmLibrariesPackages prevStage
+                // {
+                  inherit (prevStage.llvmPackages) clangNoCompilerRtWithLibc;
+                }
+              ))
               // {
-                inherit (prevStage.llvmPackages) clangNoCompilerRtWithLibc;
-              }
-            );
+                inherit (super.llvmPackages) override;
+              };
           }
         ];
 
@@ -901,7 +913,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               }
             );
 
-            llvmPackages = super.llvmPackages.overrideScope (_: _: llvmLibrariesPackages prevStage);
+            llvmPackages = (super.llvmPackages.overrideScope (_: _: llvmLibrariesPackages prevStage)) // {
+              inherit (super.llvmPackages) override;
+            };
           }
         ];
 
@@ -971,45 +985,49 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               }
             );
 
-            llvmPackages = super.llvmPackages.overrideScope (
-              _: _:
-              llvmToolsPackages prevStage
-              // llvmLibrariesPackages prevStage
+            llvmPackages =
+              (super.llvmPackages.overrideScope (
+                _: _:
+                llvmToolsPackages prevStage
+                // llvmLibrariesPackages prevStage
+                // {
+                  systemLibcxxClang = super.wrapCCWith rec {
+                    nativeTools = false;
+                    nativeLibc = false;
+
+                    inherit (prevStage) expand-response-params;
+
+                    extraPackages = [ self.llvmPackages.compiler-rt ];
+
+                    extraBuildCommands = ''
+                      rsrc="$out/resource-root"
+                      mkdir "$rsrc"
+                      ln -s "${lib.getLib cc}/lib/clang/${lib.versions.major (lib.getVersion cc)}/include" "$rsrc"
+                      echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+                      ln -s "${prevStage.llvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
+                      ln -s "${prevStage.llvmPackages.compiler-rt.out}/share" "$rsrc/share"
+                    '';
+
+                    cc = self.llvmPackages.clang-unwrapped;
+                    bintools = self.darwin.binutils;
+
+                    isClang = true;
+                    libc = self.darwin.libSystem;
+                    inherit (self.darwin) libcxx;
+
+                    inherit lib;
+                    inherit (self)
+                      stdenvNoCC
+                      coreutils
+                      gnugrep
+                      runtimeShell
+                      ;
+                  };
+                }
+              ))
               // {
-                systemLibcxxClang = super.wrapCCWith rec {
-                  nativeTools = false;
-                  nativeLibc = false;
-
-                  inherit (prevStage) expand-response-params;
-
-                  extraPackages = [ self.llvmPackages.compiler-rt ];
-
-                  extraBuildCommands = ''
-                    rsrc="$out/resource-root"
-                    mkdir "$rsrc"
-                    ln -s "${lib.getLib cc}/lib/clang/${lib.versions.major (lib.getVersion cc)}/include" "$rsrc"
-                    echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-                    ln -s "${prevStage.llvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
-                    ln -s "${prevStage.llvmPackages.compiler-rt.out}/share" "$rsrc/share"
-                  '';
-
-                  cc = self.llvmPackages.clang-unwrapped;
-                  bintools = self.darwin.binutils;
-
-                  isClang = true;
-                  libc = self.darwin.libSystem;
-                  inherit (self.darwin) libcxx;
-
-                  inherit lib;
-                  inherit (self)
-                    stdenvNoCC
-                    coreutils
-                    gnugrep
-                    runtimeShell
-                    ;
-                };
-              }
-            );
+                inherit (super.llvmPackages) override;
+              };
           }
         ];
 
@@ -1220,14 +1238,18 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                 let
                   llvmVersion = lib.versions.major prevStage.llvmPackages.release_version;
                 in
-                super."llvmPackages_${llvmVersion}".overrideScope (
+                (super."llvmPackages_${llvmVersion}".overrideScope (
                   _: _:
                   llvmToolsPackages prevStage
                   // llvmLibrariesPackages prevStage
                   // {
                     inherit (super."llvmPackages_${llvmVersion}") llvm-manpages;
                   }
-                );
+                ))
+                // {
+                  inherit (super."llvmPackages_${llvmVersion}") override;
+                  recurseForDerivations = true;
+                };
             }
           ];
       };
@@ -1259,7 +1281,24 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     assert prevStage.libiconv == prevStage.darwin.libiconv;
 
     {
-      inherit (prevStage) config overlays stdenv;
+      inherit (prevStage) config overlays;
+      # This should be done in the `overrideScope` above, but it causes rebuilds.
+      # TODO: Move it there once https://github.com/NixOS/nixpkgs/pull/445668 is merged.
+      stdenv = prevStage.stdenv // {
+        overrides =
+          self: super:
+          (prevStage.stdenv.overrides self super)
+          // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) (
+            let
+              llvmVersion = lib.versions.major prevStage.llvmPackages.release_version;
+            in
+            {
+              "llvmPackages_${llvmVersion}" = prevStage."llvmPackages_${llvmVersion}" // {
+                inherit (prevStage) clang;
+              };
+            }
+          );
+      };
     }
   )
 ]

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -466,98 +466,87 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           }
         );
 
-        llvmPackages =
-          super.llvmPackages
-          // (
-            let
-              tools = super.llvmPackages.tools.extend (
-                selfTools: _: {
-                  libclang = self.stdenv.mkDerivation {
-                    name = "bootstrap-stage0-clang";
-                    version = "boot";
-                    outputs = [
-                      "out"
-                      "lib"
-                    ];
-                    buildCommand = ''
-                      mkdir -p $out/lib
-                      ln -s $out $lib
-                      ln -s ${bootstrapTools}/bin       $out/bin
-                      ln -s ${bootstrapTools}/lib/clang $out/lib
-                      ln -s ${bootstrapTools}/include   $out
-                    '';
-                    passthru = {
-                      isFromBootstrapFiles = true;
-                      hardeningUnsupportedFlags = [
-                        "fortify3"
-                        "pacret"
-                        "shadowstack"
-                        "stackclashprotection"
-                        "zerocallusedregs"
-                      ];
-                    };
-                  };
-                  libllvm = self.stdenv.mkDerivation {
-                    name = "bootstrap-stage0-llvm";
-                    outputs = [
-                      "out"
-                      "lib"
-                    ];
-                    buildCommand = ''
-                      mkdir -p $out/bin $out/lib
-                      ln -s $out $lib
-                      for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
-                        cctoolsTool=''${tool//-/_}
-                        toolsrc="${bootstrapTools}/bin/$cctoolsTool"
-                        if [ -e "$toolsrc" ]; then
-                          ln -s "$toolsrc" $out/bin/llvm-$tool
-                        fi
-                      done
-                      ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
-                      ln -s ${bootstrapTools}/bin/llvm-readtapi $out/bin/llvm-readtapi
-                      ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
-                    '';
-                    passthru.isFromBootstrapFiles = true;
-                  };
-                  llvm-manpages = self.llvmPackages.libllvm;
-                  lld = self.stdenv.mkDerivation {
-                    name = "bootstrap-stage0-lld";
-                    buildCommand = "";
-                    passthru = {
-                      isLLVM = true;
-                      isFromBootstrapFiles = true;
-                    };
-                  };
-                }
-              );
-              libraries = super.llvmPackages.libraries.extend (
-                _: _: {
-                  compiler-rt = self.stdenv.mkDerivation {
-                    name = "bootstrap-stage0-compiler-rt";
-                    buildCommand = ''
-                      mkdir -p $out/lib $out/share
-                      ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
-                      ln -s ${bootstrapTools}/lib/darwin       $out/lib
-                    '';
-                    passthru.isFromBootstrapFiles = true;
-                  };
-                  libcxx = self.stdenv.mkDerivation {
-                    name = "bootstrap-stage0-libcxx";
-                    buildCommand = ''
-                      mkdir -p $out/lib $out/include
-                      ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
-                      ln -s ${bootstrapTools}/include/c++      $out/include
-                    '';
-                    passthru = {
-                      isLLVM = true;
-                      isFromBootstrapFiles = true;
-                    };
-                  };
-                }
-              );
-            in
-            { inherit tools libraries; } // tools // libraries
-          );
+        llvmPackages = super.llvmPackages.overrideScope (
+          selfLlvmPackages: _: {
+            libclang = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-clang";
+              version = "boot";
+              outputs = [
+                "out"
+                "lib"
+              ];
+              buildCommand = ''
+                mkdir -p $out/lib
+                ln -s $out $lib
+                ln -s ${bootstrapTools}/bin       $out/bin
+                ln -s ${bootstrapTools}/lib/clang $out/lib
+                ln -s ${bootstrapTools}/include   $out
+              '';
+              passthru = {
+                isFromBootstrapFiles = true;
+                hardeningUnsupportedFlags = [
+                  "fortify3"
+                  "pacret"
+                  "shadowstack"
+                  "stackclashprotection"
+                  "zerocallusedregs"
+                ];
+              };
+            };
+            libllvm = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-llvm";
+              outputs = [
+                "out"
+                "lib"
+              ];
+              buildCommand = ''
+                mkdir -p $out/bin $out/lib
+                ln -s $out $lib
+                for tool in ${toString super.darwin.binutils-unwrapped.llvm_cmds}; do
+                  cctoolsTool=''${tool//-/_}
+                  toolsrc="${bootstrapTools}/bin/$cctoolsTool"
+                  if [ -e "$toolsrc" ]; then
+                    ln -s "$toolsrc" $out/bin/llvm-$tool
+                  fi
+                done
+                ln -s ${bootstrapTools}/bin/dsymutil $out/bin/dsymutil
+                ln -s ${bootstrapTools}/bin/llvm-readtapi $out/bin/llvm-readtapi
+                ln -s ${bootstrapTools}/lib/libLLVM* $out/lib
+              '';
+              passthru.isFromBootstrapFiles = true;
+            };
+            llvm-manpages = self.llvmPackages.libllvm;
+            lld = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-lld";
+              buildCommand = "";
+              passthru = {
+                isLLVM = true;
+                isFromBootstrapFiles = true;
+              };
+            };
+            compiler-rt = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-compiler-rt";
+              buildCommand = ''
+                mkdir -p $out/lib $out/share
+                ln -s ${bootstrapTools}/lib/libclang_rt* $out/lib
+                ln -s ${bootstrapTools}/lib/darwin       $out/lib
+              '';
+              passthru.isFromBootstrapFiles = true;
+            };
+            libcxx = self.stdenv.mkDerivation {
+              name = "bootstrap-stage0-libcxx";
+              buildCommand = ''
+                mkdir -p $out/lib $out/include
+                ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib
+                ln -s ${bootstrapTools}/include/c++      $out/include
+              '';
+              passthru = {
+                isLLVM = true;
+                isFromBootstrapFiles = true;
+              };
+            };
+          }
+        );
       };
 
       extraPreHook = ''
@@ -682,12 +671,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           }
         );
 
-        llvmPackages =
-          let
-            tools = super.llvmPackages.tools.extend (_: _: llvmToolsPackages prevStage);
-            libraries = super.llvmPackages.libraries.extend (_: _: llvmLibrariesPackages prevStage);
-          in
-          super.llvmPackages // { inherit tools libraries; } // tools // libraries;
+        llvmPackages = super.llvmPackages.overrideScope (
+          _: _: llvmToolsPackages prevStage // llvmLibrariesPackages prevStage
+        );
       };
 
       extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
@@ -833,14 +819,14 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               }
             );
 
-            llvmPackages =
-              let
-                tools = super.llvmPackages.tools.extend (
-                  _: _: llvmToolsPackages prevStage // { inherit (prevStage.llvmPackages) clangNoCompilerRtWithLibc; }
-                );
-                libraries = super.llvmPackages.libraries.extend (_: _: llvmLibrariesPackages prevStage);
-              in
-              super.llvmPackages // { inherit tools libraries; } // tools // libraries;
+            llvmPackages = super.llvmPackages.overrideScope (
+              _: _:
+              llvmToolsPackages prevStage
+              // llvmLibrariesPackages prevStage
+              // {
+                inherit (prevStage.llvmPackages) clangNoCompilerRtWithLibc;
+              }
+            );
           }
         ];
 
@@ -915,11 +901,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               }
             );
 
-            llvmPackages =
-              let
-                libraries = super.llvmPackages.libraries.extend (_: _: llvmLibrariesPackages prevStage);
-              in
-              super.llvmPackages // { inherit libraries; } // libraries;
+            llvmPackages = super.llvmPackages.overrideScope (_: _: llvmLibrariesPackages prevStage);
           }
         ];
 
@@ -989,49 +971,45 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               }
             );
 
-            llvmPackages =
-              let
-                tools = super.llvmPackages.tools.extend (
-                  _: _:
-                  llvmToolsPackages prevStage
-                  // {
-                    systemLibcxxClang = super.wrapCCWith rec {
-                      nativeTools = false;
-                      nativeLibc = false;
+            llvmPackages = super.llvmPackages.overrideScope (
+              _: _:
+              llvmToolsPackages prevStage
+              // llvmLibrariesPackages prevStage
+              // {
+                systemLibcxxClang = super.wrapCCWith rec {
+                  nativeTools = false;
+                  nativeLibc = false;
 
-                      inherit (prevStage) expand-response-params;
+                  inherit (prevStage) expand-response-params;
 
-                      extraPackages = [ self.llvmPackages.compiler-rt ];
+                  extraPackages = [ self.llvmPackages.compiler-rt ];
 
-                      extraBuildCommands = ''
-                        rsrc="$out/resource-root"
-                        mkdir "$rsrc"
-                        ln -s "${lib.getLib cc}/lib/clang/${lib.versions.major (lib.getVersion cc)}/include" "$rsrc"
-                        echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-                        ln -s "${prevStage.llvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
-                        ln -s "${prevStage.llvmPackages.compiler-rt.out}/share" "$rsrc/share"
-                      '';
+                  extraBuildCommands = ''
+                    rsrc="$out/resource-root"
+                    mkdir "$rsrc"
+                    ln -s "${lib.getLib cc}/lib/clang/${lib.versions.major (lib.getVersion cc)}/include" "$rsrc"
+                    echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+                    ln -s "${prevStage.llvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
+                    ln -s "${prevStage.llvmPackages.compiler-rt.out}/share" "$rsrc/share"
+                  '';
 
-                      cc = self.llvmPackages.clang-unwrapped;
-                      bintools = self.darwin.binutils;
+                  cc = self.llvmPackages.clang-unwrapped;
+                  bintools = self.darwin.binutils;
 
-                      isClang = true;
-                      libc = self.darwin.libSystem;
-                      inherit (self.darwin) libcxx;
+                  isClang = true;
+                  libc = self.darwin.libSystem;
+                  inherit (self.darwin) libcxx;
 
-                      inherit lib;
-                      inherit (self)
-                        stdenvNoCC
-                        coreutils
-                        gnugrep
-                        runtimeShell
-                        ;
-                    };
-                  }
-                );
-                libraries = super.llvmPackages.libraries.extend (_: _: llvmLibrariesPackages prevStage);
-              in
-              super.llvmPackages // { inherit tools libraries; } // tools // libraries;
+                  inherit lib;
+                  inherit (self)
+                    stdenvNoCC
+                    coreutils
+                    gnugrep
+                    runtimeShell
+                    ;
+                };
+              }
+            );
           }
         ];
 
@@ -1241,22 +1219,15 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               "llvmPackages_${lib.versions.major prevStage.llvmPackages.release_version}" =
                 let
                   llvmVersion = lib.versions.major prevStage.llvmPackages.release_version;
-                  tools = super."llvmPackages_${llvmVersion}".tools.extend (_: _: llvmToolsPackages prevStage);
-                  libraries = super."llvmPackages_${llvmVersion}".libraries.extend (
-                    _: _:
-                    llvmLibrariesPackages prevStage
-                    # Avoid depending on llvm-manpages from the bootstrap, which brings a bunch of Python dependencies
-                    # into the bootstrap. This means that there are no man pages in darwin.binutils, but they are still
-                    # available from llvm-manpages, ld64, and cctools.
-                    // {
-                      inherit (super."llvmPackages_${llvmVersion}") llvm-manpages;
-                    }
-                    // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
-                      inherit (prevStage.llvmPackages) clang;
-                    }
-                  );
                 in
-                super."llvmPackages_${llvmVersion}" // { inherit tools libraries; } // tools // libraries;
+                super."llvmPackages_${llvmVersion}".overrideScope (
+                  _: _:
+                  llvmToolsPackages prevStage
+                  // llvmLibrariesPackages prevStage
+                  // {
+                    inherit (super."llvmPackages_${llvmVersion}") llvm-manpages;
+                  }
+                );
             }
           ];
       };


### PR DESCRIPTION
Rebase of @RossComputerGuy's PR #436350 + ROCm scope usage & rebuild avoidance + darwin rebuild avoidance.

## Things done

- [x] Ensure no rebuilds
- [x] why is `.override` trying to disappear from darwin default llvmPackages?
  - Because override and overrideScope don't compose without [changes to makeOverridable](https://github.com/NixOS/nixpkgs/pull/445668#issuecomment-3328834974)
  - We need these to compose for cases like https://github.com/NixOS/nixpkgs/blob/2458def781a8a3e34d76b3561adc2f9bcef2a3b7/pkgs/build-support/build-mozilla-mach/default.nix#L207-L214
  - To get to zero rebuilds we need to propagate an incorrect `override` function that discards all of the stdenv overrides, because that's what happened in the past
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
