### PR TITLE
haskellPackages: support template-haskell and test suites when cross compiling

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -636,7 +636,7 @@ stdenv.mkDerivation (
       "--with-ffi-includes=${targetLibs.libffi.dev}/include"
       "--with-ffi-libraries=${targetLibs.libffi.out}/lib"
     ]
-    ++ lib.optionals (targetPlatform == hostPlatform && !enableNativeBignum) [
+    ++ lib.optionals (!enableNativeBignum) [
       "--with-gmp-includes=${targetLibs.gmp.dev}/include"
       "--with-gmp-libraries=${targetLibs.gmp.out}/lib"
     ]

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -342,7 +342,7 @@ let
       "*.*.ghc.c.opts += -optc-std=gnu99"
     ]
     # Inform GHC that we can't load dynamic libraries which forces iserv-proxy to load static libraries.
-    ++ lib.optionals targetPlatform.isStatic [
+    ++ lib.optionals (targetPlatform.isAndroid || targetPlatform.isStatic) [
       "*.ghc.cabal.configure.opts += --flags=-dynamic-system-linker"
     ];
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -38,7 +38,6 @@ in
   haskeline = null;
   hpc = null;
   integer-gmp = null;
-  libiserv = null;
   mtl = null;
   parsec = null;
   pretty = null;
@@ -59,6 +58,11 @@ in
   unix = null;
   xhtml = null;
   Win32 = null;
+
+  # Was only ever released for a few exact versions of ghc
+  libiserv = unmarkBroken (doJailbreak super.libiserv);
+
+  iserv-proxy = addBuildDepends [ self.libiserv ] super.iserv-proxy;
 
   # Becomes a core package in GHC >= 9.8
   semaphore-compat = doDistribute self.semaphore-compat_1_0_0;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -2151,9 +2151,10 @@ builtins.intersectAttrs super {
           enableExternalInterpreter = false;
         };
       in
-      lib.mapAttrs (_: noExternalInterpreter) { inherit (super) iserv-proxy network; }
+      lib.mapAttrs (_: noExternalInterpreter) { inherit (super) iserv-proxy libiserv network; }
     )
     iserv-proxy
+    libiserv
     network
     ;
 }

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1279,9 +1279,6 @@ builtins.intersectAttrs super {
       '';
     }) (addBuildTool pkgs.buildPackages.makeWrapper super.cut-the-crap);
 
-  # Compiling the readme throws errors and has no purpose in nixpkgs
-  aeson-gadt-th = disableCabalFlag "build-readme" super.aeson-gadt-th;
-
   # Fix compilation of Setup.hs by removing the module declaration.
   # See: https://github.com/tippenein/guid/issues/1
   guid = overrideCabal (drv: {


### PR DESCRIPTION
Adapted from
https://github.com/input-output-hk/haskell.nix/blob/c0454391b7b026387623289d3deb4ce9b431a528/overlays/linux-cross.nix

~Also unblocks meaningful work on cross testing since TH is used in every other suite for test discovery, including QuickCheck's~ 
~EDIT: Also run test suites ( pkgsCross.ghcjs ones need #451527 )~ Moved to https://github.com/NixOS/nixpkgs/pull/451928/

Building/running `haskell.packages.ghc912.aeson-gadt-th` on x86_64-linux:
- :heavy_check_mark: pkgsStatic
- :heavy_check_mark: pkgsCross.aarch64-multiplatform
- :heavy_check_mark: pkgsCross.aarch64-multiplatform-musl
- :x: pkgsCross.aarch64-android-prebuilt
- :x: pkgsCross.ucrt64

Note `aarch64-android-prebuilt.pkgsStatic` builds for the wrong reasons as 
```
nix-repl> with pkgsCross.aarch64-android-prebuilt.pkgsStatic.stdenv.hostPlatform; { inherit isAarch isMusl isStatic isAndroid useAndroidPrebuilt; }                       
{
  isAarch = true;
  isAndroid = false;
  isMusl = true;
  isStatic = true;
  useAndroidPrebuilt = false;
}
```
which leads to problems down the line (e.g when trying to add system tools). However, trying
```
{
  isAarch = true;
  isAndroid = true;
  isMusl = false;
  isStatic = true;
  useAndroidPrebuilt = true;
}
```
fails when building TH with `iserv-proxy-interpreter: internal error: ASSERTION FAILED: file rts/linker/Elf.c, line 812`
which is https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.12.2-release/rts/linker/Elf.c#L812

Example run

```
$ uname -mo
x86_64 GNU/Linux
```
```
$ nix-build -A pkgsCross.aarch64-multiplatform.haskell.packages.ghc912.th-orphans   
...
Running phase: buildPhase
Preprocessing library for th-orphans-0.13.16...
Building library for th-orphans-0.13.16...
[1 of 2] Compiling Language.Haskell.TH.Instances.Internal ( src/Language/Haskell/TH/Instances/Internal.hs, dist/build/Language/Haskell/TH/Instances/Internal.o, dist/build/Language/Haskell/TH/Instances/Internal.dyn_o )
[2 of 2] Compiling Language.Haskell.TH.Instances ( src/Language/Haskell/TH/Instances.hs, dist/build/Language/Haskell/TH/Instances.o, dist/build/Language/Haskell/TH/Instances.dyn_o )
---> Starting interpreter on port 6151
---| interpreter should have started on 6151
Listening on port 6151
---> killing interpreter...
[1 of 2] Compiling Language.Haskell.TH.Instances.Internal ( src/Language/Haskell/TH/Instances/Internal.hs, dist/build/Language/Haskell/TH/Instances/Internal.p_o )
[2 of 2] Compiling Language.Haskell.TH.Instances ( src/Language/Haskell/TH/Instances.hs, dist/build/Language/Haskell/TH/Instances.p_o )
---> Starting interpreter on port 5830
---| interpreter should have started on 5830
Listening on port 5830
---> killing interpreter...
buildPhase completed in 3 minutes 32 seconds
...
``` 
```
> $(nix-build -A qemu-user)/bin/qemu-aarch64 $(nix-build -A pkgsCross.aarch64-multiplatform.haskell.packages.ghc912.aeson-gadt-th)/bin/readme
Encoding of A_a:
"[\"A_a\",[]]"
Decoding of encoded A_a:
Just (Some A_a)

Encoding of (A_b 1):
"[\"A_b\",1]"
Decoding of encoded (A_b 1):
Just (Some (A_b 1))

Encoding of (B_a 'a' (A_b 1)):
"[\"B_a\",[\"a\",[\"A_b\",1]]]"
Decoding of encoded (B_a 'a' (A_b 1)):
Succeeded
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
