### PR TITLE
python3Packages.yapsy: 1.12.2-unstable-2023-03-29 -> 1.12.2-unstable-2023-03-28 (not a downgrade)

### DIFF
--- a/pkgs/development/python-modules/yapsy/default.nix
+++ b/pkgs/development/python-modules/yapsy/default.nix
@@ -4,11 +4,12 @@
   fetchFromGitHub,
   setuptools,
   pytestCheckHook,
+  unstableGitUpdater,
 }:
 
 buildPythonPackage rec {
   pname = "yapsy";
-  version = "1.12.2-unstable-2023-03-29";
+  version = "1.12.2-unstable-2023-03-28";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -25,6 +26,10 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "yapsy" ];
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "release_Yapsy-";
+  };
 
   meta = with lib; {
     homepage = "https://yapsy.sourceforge.net/";


### PR DESCRIPTION
Actually the same version as before, it just uses the committer's time zone for consistency with the scripts.

Speaking of scripts, I set passthru.updateScript. This should stop spurious r-ryantm PRs.

Closes: #436561


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
