### PR TITLE
[testing] duckdb: 1.3.2 -> 1.4.1; python3Packages.duckdb: 1.3.2 -> 1.4.1; python3Packages.{sqlglot,narwhals,frictionless}: fixes

### DIFF
--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -13,7 +13,6 @@
 }:
 
 let
-  enableFeature = yes: if yes then "ON" else "OFF";
   versions = lib.importJSON ./versions.json;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -47,14 +46,12 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withOdbc [ unixODBC ];
 
   cmakeFlags = [
-    "-DDUCKDB_EXTENSION_CONFIGS=${finalAttrs.src}/.github/config/in_tree_extensions.cmake"
-    "-DBUILD_ODBC_DRIVER=${enableFeature withOdbc}"
-    "-DJDBC_DRIVER=${enableFeature withJdbc}"
-    "-DOVERRIDE_GIT_DESCRIBE=v${finalAttrs.version}-0-g${finalAttrs.rev}"
-  ]
-  ++ lib.optionals finalAttrs.doInstallCheck [
+    (lib.cmakeFeature "DUCKDB_EXTENSION_CONFIGS" "${finalAttrs.src}/.github/config/in_tree_extensions.cmake")
+    (lib.cmakeBool "BUILD_ODBC_DRIVER" withOdbc)
+    (lib.cmakeBool "JDBC_DRIVER" withJdbc)
+    (lib.cmakeFeature "OVERRIDE_GIT_DESCRIBE" "v${finalAttrs.version}-0-g${finalAttrs.rev}")
     # development settings
-    "-DBUILD_UNITTESTS=ON"
+    (lib.cmakeBool "BUILD_UNITTESTS" finalAttrs.doInstallCheck)
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/du/duckdb/versions.json
+++ b/pkgs/by-name/du/duckdb/versions.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.2",
-  "rev": "0b83e5d2f68bc02dfefde74b846bd039f078affa",
-  "hash": "sha256-6NMQ893g+nOiH8dnb63oa+fZMNXs8N6tJv+Er4x547U="
+  "version": "1.4.1",
+  "rev": "b390a7c3760bd95926fe8aefde20d04b349b472e",
+  "hash": "sha256-w/mELyRs4B9hJngi1MLed0fHRq/ldkkFV+SDkSxs3O8="
 }

--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -47,6 +47,7 @@ pythonPackages.buildPythonApplication rec {
   };
 
   pythonRelaxDeps = [
+    "click"
     "numpy"
     "pyarrow"
     "questionary"
@@ -104,6 +105,9 @@ pythonPackages.buildPythonApplication rec {
     # Tests require network access
     "test_connect_extensions"
     "test_connect_prql"
+    # CLI error message validation tests fail with Click 8.2.1
+    # Expected error keywords don't appear in stdout with newer Click version
+    "test_bad_adapter_opt"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [
     # Test incorrectly tries to load a dylib/so compiled for x86_64

--- a/pkgs/development/python-modules/duckdb/default.nix
+++ b/pkgs/development/python-modules/duckdb/default.nix
@@ -2,14 +2,21 @@
   lib,
   stdenv,
   buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  cmake,
+  ninja,
   duckdb,
   fsspec,
   google-cloud-storage,
+  ipython,
   numpy,
   openssl,
   pandas,
   psutil,
+  pyarrow,
   pybind11,
+  scikit-build-core,
   setuptools-scm,
   pytest-reraise,
   pytestCheckHook,
@@ -17,43 +24,79 @@
 
 buildPythonPackage rec {
   inherit (duckdb)
-    patches
     pname
-    rev
-    src
     version
     ;
   pyproject = true;
 
-  postPatch = (duckdb.postPatch or "") + ''
-    # we can't use sourceRoot otherwise patches don't apply, because the patches apply to the C++ library
-    cd tools/pythonpkg
+  src = fetchFromGitHub {
+    owner = "duckdb";
+    repo = "duckdb-python";
+    tag = "v${version}";
+    hash = "sha256-cZyiTqu5iW/cqEo42b/XnOG7hJqtQs1h2RXXL392ujA=";
+  };
 
-    # 1. let nix control build cores
-    # 2. default to extension autoload & autoinstall disabled
-    substituteInPlace setup.py \
-      --replace-fail "ParallelCompile()" 'ParallelCompile("NIX_BUILD_CORES")' \
-      --replace-fail "define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])" "pass"
+  postPatch = ''
+    # patch cmake to ignore absence of git submodule copy of duckdb
+    substituteInPlace cmake/duckdb_loader.cmake \
+      --replace-fail '"''${CMAKE_CURRENT_SOURCE_DIR}/external/duckdb"' \
+                     '"${duckdb.src}"'
 
+    # replace pybind11[global] with pybind11
     substituteInPlace pyproject.toml \
-      --replace-fail 'setuptools_scm>=6.4,<8.0' 'setuptools_scm'
+      --replace-fail "pybind11[global]" "pybind11"
+
+    # replace custom build backend with standard scikit-build-core
+    substituteInPlace pyproject.toml \
+      --replace-fail 'build-backend = "duckdb_packaging.build_backend"' \
+                     'build-backend = "scikit_build_core.build"' \
+      --replace-fail 'backend-path = ["./"]' \
+                     '# backend-path removed'
   '';
 
-  env = {
-    DUCKDB_BUILD_UNITY = 1;
-    OVERRIDE_GIT_DESCRIBE = "v${version}-0-g${rev}";
-  };
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  dontUseCmakeConfigure = true;
 
   build-system = [
     pybind11
+    scikit-build-core
     setuptools-scm
   ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    duckdb
+    openssl
+  ];
 
-  dependencies = [
-    numpy
-    pandas
+  optional-dependencies = {
+    # Note: ipython and adbc_driver_manager currently excluded despite inclusion in upstream
+    # https://github.com/duckdb/duckdb-python/blob/v1.4.0/pyproject.toml#L44-L52
+    all = [
+      ipython
+      fsspec
+      numpy
+    ]
+    ++ lib.optionals (pythonOlder "3.14") [
+      # https://github.com/duckdb/duckdb-python/blob/0ee500cfa35fc07bf81ed02e8ab6984ea1f665fd/pyproject.toml#L49-L51
+      # adbc_driver_manager noted for migration to duckdb C source
+      pandas
+      pyarrow
+    ];
+  };
+
+  env = {
+    DUCKDB_BUILD_UNITY = 1;
+    # default to disabled extension autoload/autoinstall
+    CMAKE_DEFINE_DUCKDB_EXTENSION_AUTOLOAD_DEFAULT = "0";
+    CMAKE_DEFINE_DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT = "0";
+  };
+
+  cmakeFlags = [
+    (lib.cmakeFeature "OVERRIDE_GIT_DESCRIBE" "v${version}-0-g${duckdb.rev}")
   ];
 
   nativeCheckInputs = [
@@ -62,7 +105,8 @@ buildPythonPackage rec {
     psutil
     pytest-reraise
     pytestCheckHook
-  ];
+  ]
+  ++ optional-dependencies.all;
 
   pytestFlags = [ "--verbose" ];
 
@@ -71,8 +115,12 @@ buildPythonPackage rec {
   enabledTestPaths = if stdenv.hostPlatform.isDarwin then [ "tests/fast" ] else [ "tests" ];
 
   disabledTestPaths = [
-    # avoid dependency on mypy
-    "tests/stubs/test_stubs.py"
+    # avoid dependency on adbc_driver_manager
+    "tests/fast/adbc"
+    # avoid dependency on pyotp
+    "tests/fast/test_pypi_cleanup.py"
+    # avoid test data download requiring network access
+    "tests/slow/test_h2oai_arrow.py"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/frictionless/default.nix
+++ b/pkgs/development/python-modules/frictionless/default.nix
@@ -200,6 +200,11 @@ buildPythonPackage rec {
     # The tests of other unavailable formats are auto-skipped
     "frictionless/formats/excel"
     "frictionless/formats/spss"
+    # Console CLI tests fail due to typer/Click CliRunner output capture issues
+    # result.stdout is empty when error messages are expected
+    # All 1690 functional tests pass (including duckdb adapter tests)
+    "frictionless/console/__spec__/test_console.py"
+    "frictionless/console/commands/__spec__/test_summary.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/narwhals/default.nix
+++ b/pkgs/development/python-modules/narwhals/default.nix
@@ -75,6 +75,11 @@ buildPythonPackage rec {
     "test_lazy"
     # Incompatible with ibis 11
     "test_unique_3069"
+    # DuckDB 1.4.x compatibility - empty result schema handling with PyArrow
+    "test_skew_expr"
+    # ibis improvements cause strict XPASS failures (tests expected to fail now pass)
+    "test_empty_scalar_reduction_with_columns"
+    "test_collect_empty"
   ];
 
   pytestFlags = [

--- a/pkgs/development/python-modules/sqlfmt/default.nix
+++ b/pkgs/development/python-modules/sqlfmt/default.nix
@@ -54,6 +54,14 @@ buildPythonPackage rec {
     export PATH="$PATH:$out/bin";
   '';
 
+  disabledTestPaths = [
+    # Tests fail due to Click API incompatibility with CliRunner(mix_stderr=False)
+    # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
+    # The mix_stderr parameter was removed in newer Click versions
+    "tests/functional_tests/test_end_to_end.py"
+    "tests/unit_tests/test_cli.py"
+  ];
+
   pythonImportsCheck = [ "sqlfmt" ];
 
   meta = {

--- a/pkgs/development/python-modules/sqlglot/default.nix
+++ b/pkgs/development/python-modules/sqlglot/default.nix
@@ -13,6 +13,8 @@
   # tests
   pytestCheckHook,
   duckdb,
+  numpy,
+  pandas,
 }:
 
 buildPythonPackage rec {
@@ -40,6 +42,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     duckdb
+    numpy
+    pandas
   ];
 
   pythonImportsCheck = [ "sqlglot" ];


### PR DESCRIPTION
This PR is stacked on the discussion in #444225 to include
- 3666b8aee9e5f7d6343f97a494ac6c547d6f37d2
  - the original updates to the unified duckdb package hashes (impacting duckdb and python3Packages.duckdb) from https://github.com/NixOS/nixpkgs/commit/e78be6fd515e39485ec4bfbffea8d0d94b63270b
  - duckdb derivation update proposals from https://github.com/NixOS/nixpkgs/pull/444225#issuecomment-3323599695
- 35c1c7fa4c666f8836f4338752d7b9d5c958cb92
  - a slightly refactored version of [pkgs/development/python-modules/duckdb/default.nix](https://github.com/NixOS/nixpkgs/blob/55f2008c61bb08349991e052ee64bd49c5483fd1/pkgs/development/python-modules/duckdb/default.nix) to address https://github.com/NixOS/nixpkgs/pull/444225#issuecomment-3316083087, which notes the upstream migration from a monorepo that vendored the python package in `tools/pythonpkg` to a [separate repository hosting the python package source](https://github.com/duckdb/duckdb-python) with a slightly modified build system.

This is necessary since updates to the package hashes in

https://github.com/NixOS/nixpkgs/blob/af9aee2c96f85b61e0b7f34461b6fc6365e7af1d/pkgs/by-name/du/duckdb/versions.json#L1-L5

automatically propagate to both the duckdb and python3Packages.duckdb derivations and the current python3Packages.duckdb derivation depends on the presence of `tools/pythonpkg` in the upstream monorepo up to v1.3.2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
