### PR TITLE
airdrop-cli: 0-unstable-2024-04-13 -> 0-unstable-2025-07-14

### DIFF
--- a/pkgs/by-name/ai/airdrop-cli/package.nix
+++ b/pkgs/by-name/ai/airdrop-cli/package.nix
@@ -9,13 +9,13 @@
 # Doesn't build without using the same stdenv (and Clang) to build swift
 swiftPackages.stdenv.mkDerivation {
   pname = "airdrop-cli";
-  version = "0-unstable-2024-04-13";
+  version = "0-unstable-2025-07-14";
 
   src = fetchFromGitHub {
     owner = "vldmrkl";
     repo = "airdrop-cli";
-    rev = "dcdd570c3af3aae509ba7ad9fb26782b427f3a1a";
-    hash = "sha256-7gKKeedRayf27XrOhntu41AMXgxc7fqJRE8Jhbihh3o=";
+    rev = "8bb7d64c9f9ce1166405aa5b9a11f00dcc466ea0";
+    hash = "sha256-aaczNVDJhkzeaSBXP+HmgHGZWVztggwv3OtTBAFCFvk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update airdrop-cli from 0-unstable-2024-04-13 -> 0-unstable-2025-07-14

Diff:
[airdrop-cli@`dcdd570..8bb7d64`](https://github.com/vldmrkl/airdrop-cli//compare/dcdd570..8bb7d64)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
