### PR TITLE
postgresql_18: 18rc1 -> 18.0

### DIFF
--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -16,7 +16,7 @@ let
       nodes.machine =
         { pkgs, ... }:
         {
-          environment.systemPackages = [ pkgs.pg-dump-anon ];
+          environment.systemPackages = [ (pkgs.pg-dump-anon.override { postgresql = package; }) ];
           services.postgresql = {
             inherit package;
             enable = true;

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "18rc1";
-  rev = "refs/tags/REL_18_RC1";
-  hash = "sha256-PDycGuKrEa00N1h/BsWUiwG7naE0f2wFFXpQSOhs/hY=";
+  version = "18.0";
+  rev = "refs/tags/REL_18_0";
+  hash = "sha256-xA6gbJe4tIV9bYRFrdI4Rfy20ZwTkvyyjt7ZxvCFEec=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
PostgreSQL 18 will be released tomorrow. Release Notes are not published, yet, but the tag is already there.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
