### PR TITLE
python3Packages.pydgraph: init at 25.1.0

### DIFF
--- a/pkgs/development/python-modules/pydgraph/default.nix
+++ b/pkgs/development/python-modules/pydgraph/default.nix
@@ -1,0 +1,70 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build system
+  setuptools,
+
+  # dependencies
+  grpcio,
+  protobuf,
+
+  # test dependencies
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pydgraph";
+  version = "25.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hypermodeinc";
+    repo = "pydgraph";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KHxFRnKG5taC39vNTWIXdbdh2BWi0kVjrmR4J1/9Vdg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    grpcio
+    protobuf
+  ];
+
+  pythonImportsCheck = [ "pydgraph" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # integration tests that touch the network
+    "tests/test_acct_upsert.py"
+    "tests/test_alter.py"
+    "tests/test_async.py"
+    "tests/test_async_client.py"
+    "tests/test_client_stub.py"
+    "tests/test_essentials.py"
+    "tests/test_queries.py"
+    "tests/test_namespace.py"
+    "tests/test_txn.py"
+    "tests/test_type_system.py"
+    "tests/test_upsert_block.py"
+    "tests/test_zero.py"
+  ];
+  disabledTests = [
+    # integration tests that touch the network
+    "test_connection_with_auth"
+  ];
+
+  meta = {
+    changelog = "https://github.com/hypermodeinc/pydgraph/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Official Dgraph Python client";
+    homepage = "https://github.com/hypermodeinc/pydgraph";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13295,6 +13295,8 @@ self: super: with self; {
 
   pydexcom = callPackage ../development/python-modules/pydexcom { };
 
+  pydgraph = callPackage ../development/python-modules/pydgraph { };
+
   pydicom = callPackage ../development/python-modules/pydicom { };
 
   pydicom-seg = callPackage ../development/python-modules/pydicom-seg { };


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
