### PR TITLE
etlegacy-unwrapped: cleanup, remove obsolete things, restore `fakeGit`

### DIFF
--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -1,13 +1,10 @@
 {
   lib,
   stdenv,
-  writeShellApplication,
+  writeScriptBin,
   fetchFromGitHub,
   cjson,
   cmake,
-  git,
-  makeBinaryWrapper,
-  unzip,
   curl,
   freetype,
   glew,
@@ -25,15 +22,11 @@
 }:
 let
   version = "2.83.2";
-  fakeGit = writeShellApplication {
-    name = "git";
-
-    text = ''
-      if [ "$1" = "describe" ]; then
-        echo "${version}"
-      fi
-    '';
-  };
+  fakeGit = writeScriptBin "git" ''
+    if [ "$1" = "describe" ]; then
+      echo "${version}"
+    fi
+  '';
 in
 stdenv.mkDerivation {
   pname = "etlegacy-unwrapped";
@@ -51,9 +44,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     fakeGit
-    git
-    makeBinaryWrapper
-    unzip
   ];
 
   buildInputs = [
@@ -101,8 +91,6 @@ stdenv.mkDerivation {
     (lib.cmakeFeature "INSTALL_DEFAULT_BASEDIR" "${placeholder "out"}/lib/etlegacy")
     (lib.cmakeFeature "INSTALL_DEFAULT_BINDIR" "${placeholder "out"}/bin")
   ];
-
-  hardeningDisable = [ "fortify" ];
 
   meta = {
     description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";


### PR DESCRIPTION
This PR:

1. Started from seeing that `etlegacy32` was available in AUR (https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=etlegacy32)
2. Restore `fakeGit`
  - Prevents the `-dirty` prefix from appearing in the console log.
3. Replace `writeShellApplication` with `writeScriptBin`
  - While building a 32-bit version of `etlegacy`, I noticed that `writeShellApplication` was triggering many unnecessary local rebuilds that were not cached (I don't really know why). My assumption is that this happens because `writeShellApplication` enables `shellcheck` by default, which in turn pulls in the full Haskell toolchain.
  - By switching to `writeScriptBin`, local recompilations are avoided, and I can build it successfully with `nix-build -A pkgsi686Linux.etlegacy`

I tried to run the i686 version of `etlegacy` in order to play Jaymod (_only available on 32-bit_). Unfortunately, I couldn’t get it working on my machine. When I attempt to run it, I get the following error:

```
❯ ./result/bin/etl.i386 
       0 ^2ET Legacy 2.83.2 linux-i386 Jan  1 1980
       0 Zone megs: 64
       0 INFO: fs_game now defaults to 'legacy' mod instead of 'etmain'
       0 ----- Initializing Filesystem --
       0 Current working directory:
       0     /home/pol/Code/NixOS/nixpkgs
       0 Current search path:
       0     D /home/pol/.etlegacy/legacy
       0     D /nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy/legacy
       0     D /home/pol/.etlegacy/etmain
       0     D /nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy/etmain
       0     P /nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy/legacy/legacy_2.83.2.pk3 (1459 files)
       0     P /nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy/etmain/pak2.pk3 (22 files)
       0     P /nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy/etmain/pak1.pk3 (10 files)
       0     P /nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy/etmain/pak0.pk3 (3725 files)
       0 
       0 5216 files in pk3 files
       0 --------------------------------
       0 Creating PID file 'profiles/p1ld7a/profile.pid'
       0 ----- Database Initialization --
       0 SQLite3 libversion 3.50.2 - database URI 'etl.db' - in file
       0 ... loading existing database '/home/pol/.etlegacy/etl.db'
       0 ... database file '/home/pol/.etlegacy/etl.db' loaded
       0 SQLite3 ETL: database init #2 /home/pol/.etlegacy/etl.db in [0] ms - autocommit 1
       0 SQLite3 ETL: DB schema version #2 is up to date
       0 --------------------------------
       0 execing default.cfg
       0 execing profiles/p1ld7a/etconfig.cfg
       0 execing autoexec.cfg
       0 Hunk_Clear: reset the hunk ok
       0 Not logging server attacks to disk
       0 ----- Client Initialization ----
       0 Trying to load "librenderer_opengl1_i386.so" from "./result/bin"...
       0 Trying to load "librenderer_opengl1_i386.so" from "/nix/store/wdvb4ij1lhr825syvxa0mwl50yp3f31j-etlegacy/lib/etlegacy"...
       0 ETKEY found
       0 Available client translations: Afrikaans Bulgarian Catalan Czech Danish German Greek English Esperanto Spanish Finnish French Irish Hebrew Hungarian Italian Japanese Korean Dutch Norwegian Punjabi Polish Portuguese Romanian Russian Slovak Slovenian Albanian Serbian Swedish Turkish Ukrainian Chinese
       0 Available mod translations: Afrikaans Bulgarian Catalan Czech Danish German Greek English Esperanto Spanish Finnish French Irish Hebrew Hungarian Italian Japanese Korean Dutch Norwegian Punjabi Polish Portuguese Romanian Russian Slovak Slovenian Albanian Serbian Swedish Turkish Ukrainian Chinese
       0 Language set to English
       0 --------------------------------
       0 IP: 127.0.0.1
       0 IP: 192.168.2.129
       0 IP6: ::1
       0 IP6: fdc4:6819:9e70:48c8:fecc:34d8:4488:554d
       0 IP6: fdc4:6819:9e70:48c8:2bcd:b67b:16be:c989
       0 IP6: fe80::8c0c:7781:97e9:a199%wlp0s20f3
       0 Opening IP6 socket: [::]:27960
       0 Opening IP socket: 0.0.0.0:27960
       0 Network initialized
       0 ----- Initializing Renderer ----
       0 SDL build version 2.32.56 - link version 2.32.56
       0 SDL initialized driver "wayland"
       0 Initializing window
       0 Estimated display aspect: 1.600
       0 ...setting mode -2: 1920x1200
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 Available modes [19]: '1280x800 1440x900 1680x1050 1920x1200 720x480 864x486 1280x720 1600x900 1920x1080 1368x768 640x480 800x600 1024x768 1152x864 1280x960 1400x1050 1440x1080 1600x1200 1280x1024'
       0 Couldn't get a visual
       0 ...WARNING: could not set the given mode (-2)
       0 Initializing window
       0 Estimated display aspect: 1.600
       0 ...setting mode -2: 1920x1200
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 Available modes [19]: '1280x800 1440x900 1680x1050 1920x1200 720x480 864x486 1280x720 1600x900 1920x1080 1368x768 640x480 800x600 1024x768 1152x864 1280x960 1400x1050 1440x1080 1600x1200 1280x1024'
       0 Couldn't get a visual
       0 ...WARNING: could not set the given mode (-2)
       0 Setting r_mode -2 failed, falling back on r_mode 4
       0 Initializing window
       0 Estimated display aspect: 1.600
       0 ...setting mode 4: 800x600
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 SDL_CreateWindow failed: Invalid window
       0 Available modes [19]: '1280x800 1440x900 1680x1050 1920x1200 720x480 864x486 1280x720 1600x900 1920x1080 1368x768 640x480 800x600 1024x768 1152x864 1280x960 1400x1050 1440x1080 1600x1200 1280x1024'
       0 Couldn't get a visual
       0 ...WARNING: could not set the given mode (4)
       0 ----- Client Shutdown ----------
       0 RE_Shutdown( 1 )
       0 ----- Client Shutdown ----------
       0 WARNING: Recursive shutdown
       0 PID file removed.
       0 Network shutdown
```

Perhaps you might have an idea @ashleyghooper ? What could we do to have a 32-bit version of etlegacy working on a x86_64 ? Should we enable cross compiling (flag `CROSS_COMPILE32`) ? Any other idea ? 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
