### PR TITLE
tuna-profiler: init at 0.5.11

### DIFF
--- a/pkgs/by-name/tu/tuna-profiler/package.nix
+++ b/pkgs/by-name/tu/tuna-profiler/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchurl,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "tuna-profiler";
+  version = "0.5.11";
+
+  src = fetchFromGitHub {
+    owner = "nschloe";
+    repo = "tuna";
+    tag = "v${version}";
+    hash = "sha256-ugtKa5kN1WzvCtLz/cTr0MnNBMzM7sHWQrfokwHFtCk=";
+  };
+
+  bootstrap-css = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css";
+    hash = "sha256-YvdLHPgkqJ8DVUxjjnGVlMMJtNimJ6dYkowFFvp4kKs=";
+  };
+
+  d3-js = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js";
+    hash = "sha256-8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk=";
+  };
+
+  postPatch = ''
+    mkdir -p tuna/web/static/
+    ln -s ${bootstrap-css} tuna/web/static/bootstrap.min.css
+    ln -s ${d3-js} tuna/web/static/d3.min.js
+  '';
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  pyproject = true;
+
+  # This preCheck makes tests run successfully by adding
+  # tuna to the PATH
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+  '';
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "tuna" ];
+
+  meta = {
+    description = "Visualize Python profile data";
+    homepage = "https://github.com/nschloe/tuna";
+    mainProgram = "tuna";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+  };
+}


### PR DESCRIPTION
Adds tuna

- Added preBuild step to download required static assets (Bootstrap CSS and D3.js) 
  that are not included in the upstream repository
- Package builds successfully and serves web interface correctly

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
