### PR TITLE
libpq: 17.6 -> 18.0

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   bootstrap_cmds,
   byacc, # can also use bison, but byacc has fewer dependencies
   keyutils,
@@ -41,6 +42,15 @@ stdenv.mkDerivation rec {
     url = "https://kerberos.org/dist/krb5/${lib.versions.majorMinor version}/krb5-${version}.tar.gz";
     hash = "sha256-GogyuMrZI+u/E5T2fi789B46SfRgKFpm41reyPoAU68=";
   };
+
+  patches = lib.optionals stdenv.hostPlatform.isFreeBSD [
+    (fetchpatch {
+      name = "fix-missing-ENODATA.patch";
+      url = "https://cgit.freebsd.org/ports/plain/security/krb5-122/files/patch-lib_krad_packet.c?id=0501f716c4aff7880fde56e42d641ef504593b7d";
+      extraPrefix = "";
+      hash = "sha256-l8ev+WrDKbTqwgBRYhfJGELkCCE8mJTqVHFBvvCPvgE=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
PostgreSQL 18 will be released tomorrow, so no release notes, yet.

The new `libpq` version now has OAuth support via `curl`, thus I copied the respective flags and deps from `generic.nix`.

While testing, I noticed that `libkrb5` was broken on FreeBSD, so fixed that as well.

## Things done

- Built on platform:
  - [x] x86_64-linux (pkgs + pkgsStatic)
  - [x] aarch64-linux (pkgs + pkgsStatic)
  - [x] x86_64-darwin (pkgs + pkgsStatic)
  - [x] aarch64-darwin (pkgs + pkgsStatic)
  - [x] x86_64-freebsd (pkgsCross)
- [x] Build PostgREST as an exemplary consumer on x86_64-linux (pkgs + pkgsStatic)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
