### PR TITLE
mist: add mist and mist-cli packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20204,6 +20204,12 @@
     githubId = 31112680;
     name = "oidro";
   };
+  ojsef39 = {
+    name = "Josef Hofer";
+    github = "ojsef39";
+    email = "me+github@jhofer.de";
+    githubId = 43563019;
+  };
   ok-nick = {
     email = "nick.libraries@gmail.com";
     github = "ok-nick";

--- a/pkgs/by-name/mi/mist-cli/package.nix
+++ b/pkgs/by-name/mi/mist-cli/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  installShellFiles,
+  xar,
+  cpio,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mist-cli";
+  version = "2.2";
+
+  src = fetchurl {
+    url = "https://github.com/ninxsoft/mist-cli/releases/download/v${finalAttrs.version}/mist-cli.${finalAttrs.version}.pkg";
+    hash = "sha256-d+tm37X6JC5r23D8WTsxIkL0RU4U58pJmLermwjOgCE=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    xar
+    cpio
+  ];
+
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    xar -xf "$src"
+    gunzip -dc Payload | cpio -idmv
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D usr/local/bin/mist "$out/bin/mist"
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd mist \
+      --bash <($out/bin/mist --generate-completion-script bash) \
+      --fish <($out/bin/mist --generate-completion-script fish) \
+      --zsh <($out/bin/mist --generate-completion-script zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line tool that downloads macOS firmwares and installers";
+    homepage = "https://github.com/ninxsoft/mist-cli";
+    license = lib.licenses.mit;
+    mainProgram = "mist";
+    maintainers = with lib.maintainers; [ ojsef39 ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/mi/mist/package.nix
+++ b/pkgs/by-name/mi/mist/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mist";
+  version = "0.30";
+
+  src = fetchurl {
+    url = "https://github.com/ninxsoft/Mist/releases/download/v${finalAttrs.version}/Mist.${finalAttrs.version}.dmg";
+    hash = "sha256-J3Oxtw+yFV2Mpzqc6NqPPJR76r0DwywJdAU1FSvbYKE=";
+  };
+
+  sourceRoot = ".";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -r *.app "$out/Applications"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility that automatically downloads macOS firmwares and installers";
+    homepage = "https://github.com/ninxsoft/Mist";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ojsef39 ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
A little helper to get IPSWs, firmware and InstallAssistants for macOS from apples CDNs.
For more see:
https://github.com/ninxsoft/Mist
https://github.com/ninxsoft/mist-cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
