### PR TITLE
python3Packages.tree-sitter-language-pack: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter-language-pack";
-  version = "0.9.0";
+  version = "0.9.1";
   pyproject = true;
 
   # Using the GitHub sources necessitates fetching the treesitter grammar parsers by using a vendored script.
@@ -28,17 +28,21 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "tree_sitter_language_pack";
     inherit version;
-    hash = "sha256-kA6zvYLBvPXPIO2FKxtv3H6uieQKhg+l4iGnlmh8NZo=";
+    hash = "sha256-LaU5dR7MULnmu/yji1dQGjxV5nGGqTnVvxSdnLciCXQ=";
   };
 
-  # Upstream bumped the setuptools and typing-extensions dependencies, but we can still use older versions
-  # since the newer ones aren’t packaged in nixpkgs. We can't use pythonRelaxDepsHook here because it runs
-  # in postBuild, while the dependency check occurs during the build phase.
+  # Upstream bumped dependencies aggressively, but we can still use older
+  # versions since the newer ones aren’t packaged in nixpkgs. We can't use
+  # pythonRelaxDepsHook here because it runs in postBuild, while the dependency
+  # check occurs during the build phase.
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=80.9.0" "setuptools>=78.1.0" \
-      --replace-fail "typing-extensions>=4.14.0" "typing-extensions>=4.13.2"
+      --replace-fail "typing-extensions>=4.15.0" "typing-extensions>=4.14.1"
   '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   build-system = [
     cython
@@ -53,8 +57,10 @@ buildPythonPackage rec {
     tree-sitter-yaml
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
+  pythonRelaxDeps = [
+    "tree-sitter"
+    "tree-sitter-embedded-template"
+    "tree-sitter-yaml"
   ];
 
   pythonImportsCheck = [
@@ -62,8 +68,8 @@ buildPythonPackage rec {
     "tree_sitter_language_pack.bindings"
   ];
 
+  # make sure import the built version, not the source one
   preCheck = ''
-    # make sure import the built version, not the source one
     rm -r tree_sitter_language_pack
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
