### PR TITLE
wemeet: improve packaging

### DIFF
--- a/pkgs/by-name/we/wemeet/package.nix
+++ b/pkgs/by-name/we/wemeet/package.nix
@@ -189,6 +189,7 @@ stdenv.mkDerivation {
     mkdir -p $out/app
     cp -r opt/wemeet $out/app/wemeet
     cp -r usr/share $out/share
+    # bundled libcurl depends on openssl 1.1 which is not available in nixpkgs
     rm -f $out/app/wemeet/lib/libcurl.so
     substituteInPlace $out/share/applications/wemeetapp.desktop \
       --replace-fail "/opt/wemeet/wemeetapp.sh" "wemeet" \
@@ -200,8 +201,7 @@ stdenv.mkDerivation {
     ln -s $out/app/wemeet/bin/raw/xcast.conf $out/app/wemeet/bin/xcast.conf
     ln -s $out/app/wemeet/plugins $out/app/wemeet/lib/plugins
     ln -s $out/app/wemeet/resources $out/app/wemeet/lib/resources
-    mkdir -p $out/app/wemeet/lib/translations
-    ln -s $out/app/wemeet/translations/qtwebengine_locales $out/app/wemeet/lib/translations/qtwebengine_locales
+    ln -s $out/app/wemeet/translations $out/app/wemeet/lib/translations
 
     runHook postInstall
   '';
@@ -217,9 +217,9 @@ stdenv.mkDerivation {
         "--set QT_STYLE_OVERRIDE fusion"
         "--set IBUS_USE_PORTAL 1"
         "--set XKB_CONFIG_ROOT ${xkeyboard_config}/share/X11/xkb"
-        "--prefix LD_LIBRARY_PATH : $out/lib:$out/translations:${xorg.libXext}/lib:${xorg.libXdamage}/lib:${opencv4WithoutCuda}/lib:${xorg.libXrandr}/lib"
-        "--prefix PATH : $out/bin"
-        "--prefix QT_PLUGIN_PATH : $out/plugins"
+        "--prefix LD_LIBRARY_PATH : $out/app/wemeet/lib:$out/translations:${xorg.libXext}/lib:${xorg.libXdamage}/lib:${opencv4WithoutCuda}/lib:${xorg.libXrandr}/lib"
+        "--prefix PATH : $out/app/wemeet/bin"
+        "--prefix QT_PLUGIN_PATH : $out/app/wemeet/plugins"
       ];
       commonWrapperArgs = baseWrapperArgs ++ [
         "--prefix LD_PRELOAD : ${libwemeetwrap}/lib/libwemeetwrap.so"


### PR DESCRIPTION
This commit make following changes:

1. fix wrong bwrap paths
2. add a comment about why we need to remove bundled libcurl

Sadly, I still can't avoid wemeet 3.26.10.400 crashing. This PR doesn't fix https://github.com/NixOS/nixpkgs/issues/441999.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
