### PR TITLE
move-mount-beneath: unstable-2023-11-26 -> 0-unstable-2025-09-24

### DIFF
--- a/pkgs/by-name/mo/move-mount-beneath/package.nix
+++ b/pkgs/by-name/mo/move-mount-beneath/package.nix
@@ -2,18 +2,17 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation {
   pname = "move-mount-beneath";
-  version = "unstable-2023-11-26";
+  version = "0-unstable-2025-09-24";
 
   src = fetchFromGitHub {
     owner = "brauner";
     repo = "move-mount-beneath";
-    rev = "d3d16c0d7766eb1892fcc24a75f8d35df4b0fe45";
-    hash = "sha256-hUboFthw9ABwK6MRSNg7+iu9YbiJALNdsw9Ub3v43n4=";
+    rev = "f8773d1f99f9cfa2f5bf173e1b1d1b21eb1ee446";
+    hash = "sha256-C7QiClwFTKBcdmGilwZSCAsaVoEDXTO9384Y/47JrPk=";
   };
 
   installPhase = ''
@@ -21,15 +20,6 @@ stdenv.mkDerivation {
     install -D move-mount $out/bin/move-mount
     runHook postInstall
   '';
-
-  patches = [
-    # Fix uninitialized variable in flags_attr, https://github.com/brauner/move-mount-beneath/pull/2
-    (fetchpatch {
-      name = "aarch64";
-      url = "https://github.com/brauner/move-mount-beneath/commit/0bd0b863f7b98608514d90d4f2a80a21ce2e6cd3.patch";
-      hash = "sha256-D3TttAT0aFqpYC8LuVnrkLwDcfVFOSeYzUDx6VqPu1Q=";
-    })
-  ];
 
   meta = {
     description = "Toy binary to illustrate adding a mount beneath an existing mount";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Incidentally this also fixes musl builds https://github.com/brauner/move-mount-beneath/pull/3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
