### PR TITLE
{pg-dump-anon,postgresql.pkgs.anonymizer}: 1.3.2 -> 2.4.1

### DIFF
--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -39,7 +39,7 @@ let
                   create table player(id serial, name text, points int);
                   insert into player(id,name,points) values (1,'Foo', 23);
                   insert into player(id,name,points) values (2,'Bar',42);
-                  security label for anon on column player.name is 'MASKED WITH FUNCTION anon.fake_last_name();';
+                  security label for anon on column player.name is 'MASKED WITH FUNCTION anon.fake_last_name()';
                   security label for anon on column player.points is 'MASKED WITH VALUE NULL';
                 ''}"
             )

--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -61,7 +61,7 @@ let
                 COPY public.player ...
                 1,Shields,
                 2,Salazar,
-                \.
+                \\.
 
             in the given dump (the commas are tabs in case of pg_dump).
                   Extract the CSV lines and split by `sep`.

--- a/pkgs/by-name/pg/pg-dump-anon/package.nix
+++ b/pkgs/by-name/pg/pg-dump-anon/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitLab {
     owner = "dalibo";
     repo = "postgresql_anonymizer";
-    rev = version;
+    tag = version;
     hash = "sha256-MGdGvd4P1fFKdd6wnS2V5Tdly6hJlAmSA4TspnO/6Tk=";
   };
 
@@ -29,11 +29,11 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ postgresql ]}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Export databases with data being anonymized with the anonymizer extension";
     homepage = "https://postgresql-anonymizer.readthedocs.io/en/stable/";
-    teams = [ teams.flyingcircus ];
-    license = licenses.postgresql;
+    teams = [ lib.teams.flyingcircus ];
+    license = lib.licenses.postgresql;
     mainProgram = "pg_dump_anon";
   };
 }

--- a/pkgs/by-name/pg/pg-dump-anon/package.nix
+++ b/pkgs/by-name/pg/pg-dump-anon/package.nix
@@ -9,12 +9,13 @@
 
 buildGoModule rec {
   pname = "pg-dump-anon";
-  version = "1.3.2";
+  version = "2.4.1";
+
   src = fetchFromGitLab {
     owner = "dalibo";
     repo = "postgresql_anonymizer";
     tag = version;
-    hash = "sha256-MGdGvd4P1fFKdd6wnS2V5Tdly6hJlAmSA4TspnO/6Tk=";
+    hash = "sha256-vAsKTkFx8HLKDdXIQt6fEF3l7EzzvcilGfqNtBa0AMM=";
   };
 
   sourceRoot = "${src.name}/pg_dump_anon";

--- a/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
@@ -17,4 +17,10 @@
     hash = "sha256-oMToAhKkRiCyC8JYS0gmo/XX3QVcVtF5mUV0aQjd+p8=";
     cargoHash = "sha256-RawGAQGtG2QVDCMbwjmUEaH6rDeRiBvvJsGCY8wySw0=";
   };
+
+  cargo-pgrx_0_16_0 = {
+    version = "0.16.0";
+    hash = "sha256-emNR7fXNVD9sY/Mdno7mwpH6l/7AD28cBUsFRn9je50=";
+    cargoHash = "sha256-3eyBDWDoCzSU0tbab8qbjSnBkkN0oOgd7YbuyHLEHYw=";
+  };
 }

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -1,30 +1,25 @@
 {
+  cargo-pgrx_0_16_0,
   jitSupport,
   lib,
-  llvm,
   nixosTests,
   pg-dump-anon,
   postgresql,
-  postgresqlBuildExtension,
+  buildPgrxExtension,
   runtimeShell,
 }:
 
-postgresqlBuildExtension {
+buildPgrxExtension {
   pname = "postgresql_anonymizer";
 
   inherit (pg-dump-anon) version src;
 
-  nativeBuildInputs = lib.optional jitSupport llvm;
+  inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_16_0;
+  cargoHash = "sha256-Z1uH6Z2qLV1Axr8dXqPznuEZcacAZnv11tb3lWBh1yw=";
 
-  # Needs to be after postInstall, where removeNestedNixStore runs
-  preFixup = ''
-    cat >$out/bin/pg_dump_anon.sh <<'EOF'
-    #!${runtimeShell}
-    echo "This script is deprecated by upstream. To use the new script,"
-    echo "please install pkgs.pg-dump-anon."
-    exit 1
-    EOF
-  '';
+  # Tries to copy extension into postgresql's store path.
+  doCheck = false;
 
   passthru.tests = nixosTests.postgresql.anonymizer.passthru.override postgresql;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5585,6 +5585,7 @@ with pkgs;
     cargo-pgrx_0_12_0_alpha_1
     cargo-pgrx_0_12_6
     cargo-pgrx_0_14_1
+    cargo-pgrx_0_16_0
     cargo-pgrx
     ;
 


### PR DESCRIPTION
Upstream switched to a PGRX based extension in 2.0.0, so rewriting the expression a bit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
