### PR TITLE
nixosTests.terminal-emulators: remove eterm

### DIFF
--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -36,10 +36,6 @@ let
 
     darktile.pkg = p: p.darktile;
 
-    eterm.pkg = p: p.eterm;
-    eterm.executable = "Eterm";
-    eterm.pinkValue = "#D40055";
-
     germinal.pkg = p: p.germinal;
 
     ghostty.pkg = p: p.ghostty;


### PR DESCRIPTION
- remove references to `eterm` from nixosTests.
`eterm` package was dropped back in 2023:
https://github.com/NixOS/nixpkgs/commit/2ab03da4fdfebfb5c408a9ca90968e1c06184bd6

---

Fixes eval errors while trying to build `nixosTests.terminal-emulators`:
```text
NIXPKGS_ALLOW_BROKEN=1 nix-build -A nixosTests.terminal-emulators
...
   error: attribute 'eterm' missing
       at /tmp/nixpkgs/nixos/tests/terminal-emulators.nix:39:22:
           38|
           39|     eterm.pkg = p: p.eterm;
             |                      ^
           40|     eterm.executable = "Eterm";
       Did you mean one of dterm, hterm, oterm, pterm or xterm?
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
