### PR TITLE
rustlings: 6.4.0 -> 6.5.0

### DIFF
--- a/pkgs/by-name/ru/rustlings/package.nix
+++ b/pkgs/by-name/ru/rustlings/package.nix
@@ -11,7 +11,7 @@
 }:
 let
   pname = "rustlings";
-  version = "6.4.0";
+  version = "6.5.0";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -19,15 +19,16 @@ rustPlatform.buildRustPackage {
     owner = "rust-lang";
     repo = "rustlings";
     rev = "v${version}";
-    hash = "sha256-VdIIcpyoCuid3MECVc9aKeIOUlxGlxcG7znqbqo9pjc=";
+    hash = "sha256-dUQIzNPxmKbhew9VjFIW7bY0D1IkuJ5+hRY2/CwmYhY=";
   };
 
-  cargoHash = "sha256-QWmK+chAUnMGjqLq2xN5y6NJZJBMDTszImB9bXhO4+w=";
+  cargoHash = "sha256-AvwulWEqZMywaG7lEmT8nn9s2hda+bbIV1rnVXnKH8o=";
 
   # Disabled test that does not work well in an isolated environment
   checkFlags = [
     "--skip=run_compilation_success"
     "--skip=run_test_success"
+    "--skip=init"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
changelog: https://github.com/rust-lang/rustlings/releases/tag/v6.5.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
