### PR TITLE
boringssl: unstable-2024-09-20 -> 0.20250818.0

### DIFF
--- a/pkgs/by-name/bo/boringssl/package.nix
+++ b/pkgs/by-name/bo/boringssl/package.nix
@@ -8,16 +8,21 @@
   buildGoModule,
 }:
 
-# reference: https://boringssl.googlesource.com/boringssl/+/2661/BUILDING.md
-buildGoModule {
+# reference: https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20250818.0/BUILDING.md
+buildGoModule (finalAttrs: {
   pname = "boringssl";
-  version = "unstable-2024-09-20";
+  version = "0.20250818.0";
 
   src = fetchgit {
     url = "https://boringssl.googlesource.com/boringssl";
-    rev = "718900aeb84c601523e71abbd18fd70c9e2ad884";
-    hash = "sha256-TdSObRECiGRQcgz6N2LhKvSi9yRYOZYJdK6MyfJX2Bo=";
+    tag = finalAttrs.version;
+    hash = "sha256-lykIlC0tvjtjjS/rQTeX4vK9PgI+A8EnasEC+HYspvg=";
   };
+
+  patches = [
+    # Add SECP224R1 for backward compatibility
+    ./secp224r1-compat.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -25,7 +30,7 @@ buildGoModule {
     perl
   ];
 
-  vendorHash = "sha256-GlhLsPD+yp2LdqsIsfXNEaNKKlc76p0kBCyu4rlEmMg=";
+  vendorHash = "sha256-IXmnoCYLoiQ/XL2wjksRFv5Kwsje0VNkcupgGxG6rSY=";
   proxyVendor = true;
 
   # hack to get both go and cmake configure phase
@@ -59,13 +64,10 @@ buildGoModule {
 
     mkdir -p $bin/bin $dev $out/lib
 
-    mv tool/bssl $bin/bin
+    install -Dm755 bssl -t $bin/bin
+    install -Dm644 {libboringssl_gtest,libcrypto,libdecrepit,libpki,libssl,libtest_support_lib}.a -t $out/lib
 
-    mv ssl/libssl.a           $out/lib
-    mv crypto/libcrypto.a     $out/lib
-    mv decrepit/libdecrepit.a $out/lib
-
-    mv ../include $dev
+    cp -r ../include $dev
 
     runHook postInstall
   '';
@@ -76,16 +78,16 @@ buildGoModule {
     "dev"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Free TLS/SSL implementation";
     mainProgram = "bssl";
     homepage = "https://boringssl.googlesource.com";
-    maintainers = [ maintainers.thoughtpolice ];
-    license = with licenses; [
+    maintainers = [ lib.maintainers.thoughtpolice ];
+    license = with lib.licenses; [
       openssl
       isc
       mit
       bsd3
     ];
   };
-}
+})

--- a/pkgs/by-name/bo/boringssl/secp224r1-compat.patch
+++ b/pkgs/by-name/bo/boringssl/secp224r1-compat.patch
@@ -1,0 +1,20 @@
+diff --git a/include/openssl/ssl.h b/include/openssl/ssl.h
+index 51417d412..a961a1093 100644
+--- a/include/openssl/ssl.h
++++ b/include/openssl/ssl.h
+@@ -2522,6 +2522,7 @@ OPENSSL_EXPORT size_t SSL_CTX_get_num_tickets(const SSL_CTX *ctx);
+ // |SSL_SIGN_*|.
+ 
+ // SSL_GROUP_* define TLS group IDs.
++#define SSL_GROUP_SECP224R1 22
+ #define SSL_GROUP_SECP256R1 23
+ #define SSL_GROUP_SECP384R1 24
+ #define SSL_GROUP_SECP521R1 25
+@@ -5836,6 +5837,7 @@ OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_arg(SSL_CTX *ctx, void *arg);
+ #define SSL_R_TLSV1_CERTIFICATE_REQUIRED SSL_R_TLSV1_ALERT_CERTIFICATE_REQUIRED
+ 
+ // The following symbols are compatibility aliases for |SSL_GROUP_*|.
++#define SSL_CURVE_SECP224R1 SSL_GROUP_SECP224R1
+ #define SSL_CURVE_SECP256R1 SSL_GROUP_SECP256R1
+ #define SSL_CURVE_SECP384R1 SSL_GROUP_SECP384R1
+ #define SSL_CURVE_SECP521R1 SSL_GROUP_SECP521R1

--- a/pkgs/development/python-modules/primp/default.nix
+++ b/pkgs/development/python-modules/primp/default.nix
@@ -55,6 +55,21 @@ let
       );
 
     vendorHash = "sha256-06MkjXl0DKFzIH/H+uT9kXsQdPq7qdZh2dlLW/YhJuk=";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $bin/bin $dev $out/lib
+
+      install -Dm755 tool/bssl -t $bin/bin
+      install -Dm644 ssl/libssl.a -t $out/lib
+      install -Dm644 crypto/libcrypto.a -t $out/lib
+      install -Dm644 decrepit/libdecrepit.a -t $out/lib
+
+      cp -r ../include $dev
+
+      runHook postInstall
+    '';
   });
   # boring-sys expects the static libraries in build/ instead of lib/
   boringssl-wrapper = runCommand "boringssl-wrapper" { } ''


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/445798
Diff : https://github.com/google/boringssl/compare/0.20240930.0...0.20250818.0 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
