### PR TITLE
nixos/i2pd: tunnel improvements

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -106,10 +106,6 @@ let
         description = "Number of ElGamal/AES tags to send.";
         default = 40;
       };
-      destination = mkOption {
-        type = types.str;
-        description = "Remote endpoint, I2P hostname or b32.i2p address.";
-      };
       keys = mkOption {
         type = types.str;
         default = name + "-keys.dat";
@@ -254,7 +250,6 @@ let
             (intOpt "port" tun.port)
             (strOpt "host" tun.address)
           ]
-          ++ (optionals (tun ? destination) (optionalNullString "destination" tun.destination))
           ++ (optionals (tun ? keys) (optionalNullString "keys" tun.keys))
           ++ (optionals (tun ? inPort) (optionalNullInt "inport" tun.inPort))
           ++ (optionals (tun ? accessList) (optionalEmptyList "accesslist" tun.accessList));
@@ -685,6 +680,10 @@ in
             { name, ... }:
             {
               options = {
+                destination = mkOption {
+                  type = types.str;
+                  description = "Remote endpoint, I2P hostname or b32.i2p address.";
+                };
                 destinationPort = mkOption {
                   type = with types; nullOr port;
                   default = null;

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -224,7 +224,7 @@ let
         let
           outTunOpts = [
             (sec tun.name)
-            "type = client"
+            (intOpt "type" tun.type)
             (intOpt "port" tun.port)
             (strOpt "destination" tun.destination)
           ]
@@ -246,7 +246,7 @@ let
         let
           inTunOpts = [
             (sec tun.name)
-            "type = server"
+            (intOpt "type" tun.type)
             (intOpt "port" tun.port)
             (strOpt "host" tun.address)
           ]
@@ -680,6 +680,14 @@ in
             { name, ... }:
             {
               options = {
+                type = mkOption {
+                  type = types.enum [
+                    "client"
+                    "udpclient"
+                  ];
+                  default = "client";
+                  description = "Tunnel type.";
+                };
                 destination = mkOption {
                   type = types.str;
                   description = "Remote endpoint, I2P hostname or b32.i2p address.";
@@ -709,6 +717,16 @@ in
             { name, ... }:
             {
               options = {
+                type = mkOption {
+                  type = types.enum [
+                    "server"
+                    "http"
+                    "irc"
+                    "udpserver"
+                  ];
+                  default = "server";
+                  description = "Tunnel type.";
+                };
                 inPort = mkOption {
                   type = types.port;
                   default = 0;

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -397,7 +397,8 @@ in
 
       floodfill = mkEnableOption "floodfill" // {
         description = ''
-          If the router is declared to be unreachable and needs introduction nodes.
+          Makes your router a floodfill, that means what other routers will
+          publish and get LeaseSets and RouterInfos on your router.
         '';
       };
 

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -252,7 +252,14 @@ let
           ]
           ++ (optionals (tun ? keys) (optionalNullString "keys" tun.keys))
           ++ (optionals (tun ? inPort) (optionalNullInt "inport" tun.inPort))
-          ++ (optionals (tun ? accessList) (optionalEmptyList "accesslist" tun.accessList));
+          ++ (optionals (tun ? accessList) (optionalEmptyList "accesslist" tun.accessList))
+          ++ (optionals (tun ? inbound.length) (optionalNullInt "inbound.length" tun.inbound.length))
+          ++ (optionals (tun ? inbound.quantity) (optionalNullInt "inbound.quantity" tun.inbound.quantity))
+          ++ (optionals (tun ? outbound.length) (optionalNullInt "outbound.length" tun.outbound.length))
+          ++ (optionals (tun ? outbound.quantity) (optionalNullInt "outbound.quantity" tun.outbound.quantity))
+          ++ (optionals (tun ? crypto.tagsToSend) (
+            optionalNullInt "crypto.tagstosend" tun.crypto.tagsToSend
+          ));
         in
         lib.concatStringsSep "\n" inTunOpts;
 


### PR DESCRIPTION
- dehardcode tunnel types
  Different types might have different behaviors, e.g irc tunnel replaces IP address to user's .b32 I2P address.
- remove destination from incoming tunnels
  It's currently mandatory for incoming tunnels because it's defined as non-optional string. But it should be needed only for outgoing tunnels.
- add missing common parameters to incoming tunnels
- correct floodfill description

https://i2pd.readthedocs.io/en/latest/user-guide/tunnels/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
