### PR TITLE
radarr: 5.26.2.10099 -> 5.28.0.10274

### DIFF
--- a/pkgs/by-name/ra/radarr/deps.json
+++ b/pkgs/by-name/ra/radarr/deps.json
@@ -98,13 +98,13 @@
   },
   {
     "pname": "Microsoft.AspNetCore.Cryptography.Internal",
-    "version": "8.0.16",
-    "hash": "sha256-uw/5GAPpefPeMrfG69EBOVciSHxBKs0E8Txkf+rttzs="
+    "version": "8.0.17",
+    "hash": "sha256-CS/I8fajxwimZC2WNpN5ai/hEVU6Pk4El8hKNr/QgfU="
   },
   {
     "pname": "Microsoft.AspNetCore.Cryptography.KeyDerivation",
-    "version": "8.0.16",
-    "hash": "sha256-Zpt7vlY0xdrk/6XDRtXb0t9MK6SiPP6sr3fC6gQ1/YQ="
+    "version": "8.0.17",
+    "hash": "sha256-fXjTm7dua1WoGVSkGX6swTFvsNwdhAJvI3Y6onrR3p4="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
@@ -599,8 +599,8 @@
   },
   {
     "pname": "Polly",
-    "version": "8.5.2",
-    "hash": "sha256-IrN06ddOIJ0VYuVefe3LvfW0kX20ATRQkEBg9CBomRA="
+    "version": "8.6.0",
+    "hash": "sha256-wlvYcfcOExa3LopwRFO4axW682jkUZvioHe+kznspHk="
   },
   {
     "pname": "Polly.Contrib.WaitAndRetry",
@@ -609,8 +609,8 @@
   },
   {
     "pname": "Polly.Core",
-    "version": "8.5.2",
-    "hash": "sha256-PAwsWqrCieCf/7Y87fV7XMKoaY2abCQNtI+4oyyMifk="
+    "version": "8.6.0",
+    "hash": "sha256-NEGMMQ+3+i4ytsGekKfP1trUe0mRZP7MV0eBiSFXHW8="
   },
   {
     "pname": "RestSharp",
@@ -970,8 +970,8 @@
   },
   {
     "pname": "SixLabors.ImageSharp",
-    "version": "3.1.9",
-    "hash": "sha256-sB1wGc419iqT+Stm+RFMFhBy3LM0YnHhrgmhYiGlf4Q="
+    "version": "3.1.11",
+    "hash": "sha256-MlRF+3SGfahbsB1pZGKMOrsfUCx//hCo7ECrXr03DpA="
   },
   {
     "pname": "Swashbuckle.AspNetCore.Annotations",

--- a/pkgs/by-name/ra/radarr/package.nix
+++ b/pkgs/by-name/ra/radarr/package.nix
@@ -21,7 +21,7 @@
   applyPatches,
 }:
 let
-  version = "5.26.2.10099";
+  version = "5.28.0.10274";
   # The dotnet8 compatibility patches also change `yarn.lock`, so we must pass
   # the already patched lockfile to `fetchYarnDeps`.
   src = applyPatches {
@@ -29,7 +29,7 @@ let
       owner = "Radarr";
       repo = "Radarr";
       tag = "v${version}";
-      hash = "sha256-7tU9oxE1F/dcR5bwb/qHyux3WA6lEwdozLloDgOMVbU=";
+      hash = "sha256-iETtSByI9VjZdVjFHdfDcfSHUGz5Es8K8/HiB99KUqc=";
     };
     postPatch = ''
       mv src/NuGet.config NuGet.Config
@@ -41,12 +41,12 @@ let
       # However, the patches cleanly apply to v5 as well.
       (fetchpatch {
         name = "dotnet8-compatibility";
-        url = "https://github.com/Radarr/Radarr/commit/490891c63de589604bdc3373cfc85068c3826648.patch";
-        hash = "sha256-SCP7MPUkEZLSrls8ouekSXpXdgAJTwNFPirHjaMkQ6s=";
+        url = "https://github.com/Radarr/Radarr/commit/2235823af313ea1f39fd1189b69a75fc5d380c41.patch";
+        hash = "sha256-3YgQV4xc2i5DNWp2KxVz6M5S8n//a/Js7pckGZ06fWc=";
       })
       (fetchpatch {
         name = "dotnet8-darwin-compatibility";
-        url = "https://github.com/Radarr/Radarr/commit/f38a129289c49a242d8901dc2f041f9dc8bfc303.patch";
+        url = "https://github.com/Radarr/Radarr/commit/2a886fb26a70b4d48a4ad08d7ee23e5e4d81f522.patch";
         hash = "sha256-SAMUHqlSj8FPq20wY8NWbRytVZXTPtMXMfM3CoM8kSA=";
       })
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #443036

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
