### PR TITLE
netbsd.compat: fix LLVM builds

### DIFF
--- a/pkgs/by-name/li/libcap/package.nix
+++ b/pkgs/by-name/li/libcap/package.nix
@@ -9,7 +9,10 @@
   pam ? null,
   isStatic ? stdenv.hostPlatform.isStatic,
   go,
-  withGo ? lib.meta.availableOn stdenv.buildPlatform go && stdenv.hostPlatform.go.GOARCH != null,
+  withGo ?
+    lib.meta.availableOn stdenv.buildPlatform go
+    && stdenv.hostPlatform.go.GOARCH != null
+    && !stdenv.hostPlatform.useLLVM,
 
   # passthru.tests
   bind,

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -90,6 +90,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  # Remove when >1.7.1
+  NIX_LDFLAGS = lib.optionalString (
+    stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"
+  ) "--undefined-version";
+
   mesonAutoFeatures = "auto";
   mesonFlags = [
     (lib.mesonEnable "logind" withLogind)

--- a/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
@@ -11,6 +11,7 @@
   netbsdSetupHook,
   makeMinimal,
   version,
+  buildPackages,
 }:
 
 mkDerivation (
@@ -78,6 +79,10 @@ mkDerivation (
         # GNU objcopy produces broken .a libs which won't link into dependers.
         # Makefiles only invoke `$OBJCOPY -x/-X`, so cctools strip works here.
         "OBJCOPY=${cctools}/bin/strip"
+      ]
+      # LLVM Strip fails on md2.o test
+      ++ lib.optionals stdenv.hostPlatform.useLLVM [
+        "OBJCOPY=${buildPackages.binutils}/bin/${stdenv.cc.bintools.targetPrefix}strip"
       ];
     env.RENAME = "-D";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This also fixes LLVM builds for dependencies of netbsd.compat

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
