### PR TITLE
python3Packages.baize: 0.22.2 -> 0.23.1

### DIFF
--- a/pkgs/development/python-modules/baize/default.nix
+++ b/pkgs/development/python-modules/baize/default.nix
@@ -3,38 +3,27 @@
   fetchFromGitHub,
   httpx,
   lib,
-  pdm-pep517,
+  pdm-backend,
   pytest-asyncio,
   pytestCheckHook,
   setuptools,
   starlette,
-  fetchpatch,
 }:
 
 buildPythonPackage rec {
   pname = "baize";
-  version = "0.22.2";
+  version = "0.23.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "abersheeran";
     repo = "baize";
     tag = "v${version}";
-    hash = "sha256-vsYt1q8QEDmEXjd8dlzHr85Fz3YAjPowS+oBWYGbG1o=";
+    hash = "sha256-TclyTLqJ+r9Spg6VgmsqhhVj/Mp/HqFrkXjZy5f2BR0=";
   };
 
-  patches = [
-    # Fix tests failing with httpx>=0.28
-    # https://github.com/abersheeran/baize/pull/74
-    # FIXME: Remove in next release
-    (fetchpatch {
-      url = "https://github.com/abersheeran/baize/commit/40dc83bc03b4e5acd5155917be3a481e6494530e.patch";
-      hash = "sha256-z4jb4iwo51WIPAAECiM4kPThpHcrzy3349gm/orgoq8=";
-    })
-  ];
-
   build-system = [
-    pdm-pep517
+    pdm-backend
     setuptools
   ];
 
@@ -45,13 +34,6 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
     starlette
-  ];
-
-  disabledTests = [
-    # test relies on last modified date, which is set to 1970-01-01 in the sandbox
-    "test_files"
-    # starlette.testclient.WebSocketDenialResponse
-    "test_request_response"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/abersheeran/baize/compare/v0.22.2...v0.23.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
