### PR TITLE
aws-c-common: remove setup-hook

### DIFF
--- a/doc/hooks/aws-c-common.section.md
+++ b/doc/hooks/aws-c-common.section.md
@@ -1,4 +1,0 @@
-# `aws-c-common` {#aws-c-common}
-
-This hook exposes its own [CMake](#cmake) modules by setting [`CMAKE_MODULE_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_PATH.html) through [the `cmakeFlags` variable](#cmake-flags)
-to the nonstandard `$out/lib/cmake` directory, as a workaround for [an upstream bug](https://github.com/awslabs/aws-c-common/issues/844).

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -9,7 +9,6 @@ autoconf.section.md
 automake.section.md
 autopatchcil.section.md
 autopatchelf.section.md
-aws-c-common.section.md
 bmake.section.md
 breakpoint.section.md
 cernlib.section.md

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -274,7 +274,8 @@
     "index.html#sec-bower",
     "index.html#ssec-bower2nix-troubleshooting",
     "index.html#ssec-bower2nix-usage",
-    "index.html#ssec-build-bower-components"
+    "index.html#ssec-build-bower-components",
+    "index.html#aws-c-common"
   ],
   "sec-nixpkgs-release-25.11-lib": [
     "release-notes.html#sec-nixpkgs-release-25.11-lib"
@@ -2338,9 +2339,6 @@
   ],
   "setup-hook-autopatchelfhook": [
     "index.html#setup-hook-autopatchelfhook"
-  ],
-  "aws-c-common": [
-    "index.html#aws-c-common"
   ],
   "bmake-hook": [
     "index.html#bmake-hook"

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -123,6 +123,9 @@
 
 - `ansible-later` has been removed because it was discontinued by the author.
 
+- `aws-c-common` now provides a CMake config file instead of a find module. The setup-hook that appended extra `CMAKE_MODULE_PATH`
+to `cmakeFlagsArray` has been removed.
+
 - `k3s` airgap images passthru attributes have changed:
   - `imagesList` was removed
   - `airgapImages` was renamed to `airgap-images`

--- a/pkgs/by-name/aw/aws-c-common/package.nix
+++ b/pkgs/by-name/aw/aws-c-common/package.nix
@@ -27,10 +27,6 @@ stdenv.mkDerivation rec {
     "-DCMAKE_C_FLAGS=-fasynchronous-unwind-tables"
   ];
 
-  # aws-c-common misuses cmake modules, so we need
-  # to manually add a MODULE_PATH to its consumers
-  setupHook = ./setup-hook.sh;
-
   # Prevent the execution of tests known to be flaky.
   preCheck =
     let

--- a/pkgs/by-name/aw/aws-c-common/setup-hook.sh
+++ b/pkgs/by-name/aw/aws-c-common/setup-hook.sh
@@ -1,5 +1,0 @@
-addAwsCCommonModuleDir() {
-    prependToVar cmakeFlags "-DCMAKE_MODULE_PATH=@out@/lib/cmake"
-}
-
-postHooks+=(addAwsCCommonModuleDir)


### PR DESCRIPTION
aws-c-common provide cmake config file rather than find module now, we can remove the setup hook that setup CMAKE_MODULE_PATH.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
