### PR TITLE
sbase: init at 0.1-unstable-2025-09-19

### DIFF
--- a/pkgs/by-name/sb/sbase/package.nix
+++ b/pkgs/by-name/sb/sbase/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  testers,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sbase";
+  version = "0.1-unstable-2025-09-19";
+
+  src = fetchgit {
+    url = "https://git.suckless.org/sbase";
+    rev = "a0998d0252cff0bce7c2e41505b2505f536ae964";
+    hash = "sha256-ehGCPRPLAh+tRBoIODS+/qOkg4UTOtvjAJ3sVuKX8+g=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    cat >> compat.h <<'EOF'
+
+    #if defined(__APPLE__)
+    #define st_atim st_atimespec
+    #define st_mtim st_mtimespec
+    #define st_ctim st_ctimespec
+
+    extern int chroot(const char *);
+    #endif
+    EOF
+  '';
+
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
+    "-D_DARWIN_C_SOURCE"
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildFlags = [ "sbase-box" ];
+  installTargets = [ "sbase-box-install" ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+
+    tests = {
+      boxSha256 = testers.runCommand {
+        name = "sbase-box-sha256";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          expected=ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+          printf abc > f
+          set -- $(sha256sum f);            [ "$1" = "$expected" ]
+          set -- $(sbase-box sha256sum f);  [ "$1" = "$expected" ]
+          touch $out
+        '';
+      };
+
+      copyRoundtrip = testers.runCommand {
+        name = "sbase-copy-roundtrip";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          echo 12345 > a
+          cp a b
+          cmp -s a b
+          touch $out
+        '';
+      };
+
+      echoUpper = testers.runCommand {
+        name = "sbase-echo-upper";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          printf Hello | tr '[:lower:]' '[:upper:]' | grep -qx HELLO
+          touch $out
+        '';
+      };
+
+      whichWhichIsBox = testers.runCommand {
+        name = "sbase-which-which-is-box";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          [ $(which which) -ef $(which sbase-box) ]
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    description = "Small, portable base system utilities from suckless.org";
+    homepage = "https://core.suckless.org/sbase/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    mainProgram = "sbase-box";
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://core.suckless.org/sbase/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
