### PR TITLE
hyperion-ng: 2.0.16 -> 2.1.1

### DIFF
--- a/pkgs/applications/video/hyperion-ng/default.nix
+++ b/pkgs/applications/video/hyperion-ng/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   cmake,
+  gitMinimal,
   wrapQtAppsHook,
   perl,
   flatbuffers,
@@ -11,6 +12,7 @@
   alsa-lib,
   hidapi,
   libcec,
+  libftdi1,
   libusb1,
   libX11,
   libxcb,
@@ -20,19 +22,20 @@
   qtserialport,
   qtsvg,
   qtx11extras,
+  qtwebsockets,
   withRPiDispmanx ? false,
   libraspberrypi,
 }:
 
 stdenv.mkDerivation rec {
   pname = "hyperion.ng";
-  version = "2.0.16";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "hyperion-project";
     repo = "hyperion.ng";
     rev = version;
-    hash = "sha256-nQPtJw9DOKMPGI5trxZxpP+z2PYsbRKqOQEyaGzvmmA=";
+    hash = "sha256-lKLXgOrXp8DLmlpQe/33A30l4K9VX8P0q2LUA+lLYws=";
     # needed for `dependencies/external/`:
     # * rpi_ws281x` - not possible to use as a "system" lib
     # * qmdnsengine - not in nixpkgs yet
@@ -42,6 +45,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsa-lib
     hidapi
+    libftdi1
     libusb1
     libX11
     libxcb
@@ -53,6 +57,7 @@ stdenv.mkDerivation rec {
     qtbase
     qtserialport
     qtsvg
+    qtwebsockets
     qtx11extras
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libcec
@@ -60,6 +65,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    gitMinimal
     wrapQtAppsHook
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin perl; # for macos bundle
@@ -72,12 +78,16 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DENABLE_DEPLOY_DEPENDENCIES=OFF"
     "-DUSE_SYSTEM_FLATBUFFERS_LIBS=ON"
-    "-DUSE_SYSTEM_PROTO_LIBS=ON"
+    "-DUSE_SYSTEM_LIBFTDI_LIBS=ON"
     "-DUSE_SYSTEM_MBEDTLS_LIBS=ON"
+    "-DUSE_SYSTEM_PROTO_LIBS=ON"
     # "-DUSE_SYSTEM_QMDNS_LIBS=ON"  # qmdnsengine not in nixpkgs yet
     "-DENABLE_TESTS=ON"
   ]
-  ++ lib.optional (withRPiDispmanx == false) "-DENABLE_DISPMANX=OFF";
+  ++ lib.optional (withRPiDispmanx == false) "-DENABLE_DISPMANX=OFF"
+  ++ lib.optional (
+    stdenv.hostPlatform.system == "aarch64-linux"
+  ) "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"; # required to build dependencies/external/rpi_ws281x
 
   doCheck = true;
   checkPhase = ''


### PR DESCRIPTION
hyperion-ng: 2.0.16 -> 2.1.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
