### PR TITLE
python3Packages.typedunits: 0.0.1.dev20250509200845 -> 0.0.1

### DIFF
--- a/pkgs/development/python-modules/typedunits/default.nix
+++ b/pkgs/development/python-modules/typedunits/default.nix
@@ -12,17 +12,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "typedunits";
-  version = "0.0.1.dev20250509200845";
+  version = "0.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "quantumlib";
     repo = "TypedUnits";
-    # PyPi ships platform- and python- specific wheels, so pin the matching source
-    rev = "95e698b10454dc8dffdb708d56199a748e6dab75";
-    hash = "sha256-mNo2s1sIMOa7zYfp6XyF8CBQ840+XvN0Ek59W6bRqeM=";
+    tag = "v${version}";
+    hash = "sha256-g/kUPEtdyNvcWJOqcTCF27pW22WTg0EiHoEXgSs2xMs=";
   };
 
   build-system = [
@@ -63,6 +62,6 @@ buildPythonPackage {
     description = "Units and dimensions library with support for static dimensionality checking and protobuffer serialization";
     homepage = "https://github.com/quantumlib/TypedUnits";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.sarahec ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 }


### PR DESCRIPTION
https://github.com/quantumlib/TypedUnits/releases/tag/v0.0.1

Per https://github.com/quantumlib/TypedUnits/issues/67

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
