### PR TITLE
mrs-update-script: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ap/apparency/package.nix
+++ b/pkgs/by-name/ap/apparency/package.nix
@@ -3,19 +3,16 @@
   fetchurl,
   stdenv,
   undmg,
+  versionCheckHook,
+  mrs-update-script,
 }:
 
-let
-  snapshot = "20250820092243";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apparency";
   version = "2.3";
 
   src = fetchurl {
-    # Use externally archived download URL because
-    # upstream does not provide stable URLs for versioned releases
-    url = "https://web.archive.org/web/${snapshot}/https://www.mothersruin.com/software/downloads/Apparency.dmg";
+    url = "https://www.mothersruin.com/software/archives/Apparency-${finalAttrs.version}.dmg";
     hash = "sha256-QaP7Ll5ZK0QVHPFzDPmV8rd0XmY3Ie0VPBDXJEDMECU=";
   };
 
@@ -26,12 +23,25 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/Applications/Apparency.app $out/bin
-    cp -R . $out/Applications/Apparency.app
-    ln -s ../Applications/Apparency.app/Contents/MacOS/appy $out/bin
+    mkdir -p "$out/Applications/Apparency.app" "$out/bin"
+    cp -R "." "$out/Applications/Apparency.app"
+    ln -s "../Applications/Apparency.app/Contents/MacOS/appy" "$out/bin"
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript.command = [
+    (lib.getExe mrs-update-script)
+    "Apparency"
+    ./package.nix
+  ];
 
   meta = {
     description = "Toolkit for analysing macOS applications";
@@ -42,4 +52,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/mr/mrs-update-script/package.nix
+++ b/pkgs/by-name/mr/mrs-update-script/package.nix
@@ -1,0 +1,24 @@
+{
+  python3Packages,
+  lib,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "mrs-update-script";
+  version = "1.0.0";
+
+  src = ./.;
+
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [ python3Packages.beautifulsoup4 ];
+
+  meta = {
+    description = "Updater for Mothers Ruin Software packages";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+    mainProgram = "mrs-update-script";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/mr/mrs-update-script/pyproject.toml
+++ b/pkgs/by-name/mr/mrs-update-script/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "mrs-update-script"
+version = "1.0.0"
+
+[project.scripts]
+mrs-update-script = "updater:main"

--- a/pkgs/by-name/mr/mrs-update-script/updater/__init__.py
+++ b/pkgs/by-name/mr/mrs-update-script/updater/__init__.py
@@ -1,0 +1,65 @@
+import plistlib
+import re
+from base64 import b64encode
+from bs4 import BeautifulSoup
+from sys import argv
+from urllib import request
+
+REGEX_VERSION = re.compile("version = \\\"(.*?)\\\"")
+REGEX_HASH = re.compile("hash = \\\"(.*?)\\\"")
+
+def to_sri_hash(algorithm: str, data: str) -> str:
+    """Converts a hash from an algorithm and hex string to an SRI hash."""
+    data = bytes.fromhex(data)
+    data = b64encode(data)
+    data = data.decode("ascii")
+    return f"{algorithm}-{data}".strip()
+
+
+def get_version(name: str) -> str:
+    """Gets the latest version from the plist file used by the app update checker."""
+    url = f"https://www.mothersruin.com/software/{name}/data/{name}VersionInfo.plist"
+    with request.urlopen(url) as resp:
+        info = plistlib.loads(resp.read())
+    return info["CFBundleShortVersionString"]
+
+
+def get_hash(name: str) -> str:
+    """Gets the latest file hash from the app's download page."""
+    url = f"https://mothersruin.com/software/{name}/update.html"
+    with request.urlopen(url) as resp:
+        html = BeautifulSoup(resp.read(), "html.parser")
+    sha256 = html.find("td", class_="container-sha256")
+    return to_sri_hash("sha256", sha256.string)
+
+
+def update_file(path: str, new_version: str, new_hash: str):
+    """Updates a file with the new version and hash."""
+    with open(path, "r") as fp:
+        contents = fp.read()
+
+    contents = REGEX_VERSION.sub(f"version = \"{new_version}\"", contents)
+    contents = REGEX_HASH.sub(f"hash = \"{new_hash}\"", contents)
+
+    with open(path, "w") as fp:
+        fp.write(contents)
+
+
+def main():
+    name = argv[1]
+    path = argv[2]
+
+    print(f"Updating {name} ({path})")
+
+    new_version = get_version(name)
+    print(f"New version: {new_version}")
+
+    new_hash = get_hash(name)
+    print(f"New hash: {new_hash}")
+
+    update_file(path, new_version, new_hash)
+    print(f"Successfully updated {name}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/su/suspicious-package/package.nix
+++ b/pkgs/by-name/su/suspicious-package/package.nix
@@ -4,19 +4,15 @@
   stdenv,
   undmg,
   versionCheckHook,
+  mrs-update-script,
 }:
 
-let
-  snapshot = "20250820185748";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "suspicious-package";
   version = "4.6";
 
   src = fetchurl {
-    # Use externally archived download URL because
-    # upstream does not provide stable URLs for versioned releases
-    url = "https://web.archive.org/web/${snapshot}/https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg";
+    url = "https://www.mothersruin.com/software/archives/SuspiciousPackage-${finalAttrs.version}.dmg";
     hash = "sha256-SJcXqQR/di3T8K3uNKv00QkLsmDGJNU9NQEIpDSqYJM=";
   };
 
@@ -27,9 +23,9 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/Applications/Suspicious Package.app" $out/bin
-    cp -R . "$out/Applications/Suspicious Package.app"
-    ln -s "../Applications/Suspicious Package.app/Contents/SharedSupport/spkg" $out/bin
+    mkdir -p "$out/Applications/Suspicious Package.app" "$out/bin"
+    cp -R "." "$out/Applications/Suspicious Package.app"
+    ln -s "../Applications/Suspicious Package.app/Contents/SharedSupport/spkg" "$out/bin"
 
     runHook postInstall
   '';
@@ -41,6 +37,12 @@ stdenv.mkDerivation {
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
+  passthru.updateScript.command = [
+    (lib.getExe mrs-update-script)
+    "SuspiciousPackage"
+    ./package.nix
+  ];
+
   meta = {
     description = "Toolkit for analysing macOS packages";
     homepage = "https://www.mothersruin.com/software/SuspiciousPackage/";
@@ -50,4 +52,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})


### PR DESCRIPTION
Adds an update script for [MRS](https://mothersruin.com/software/) apps, and switches them to use the official [archives](https://mothersruin.com/software/archives/) instead of Wayback Machine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
