### PR TITLE
python3Packages.islpy: use isl_0_27; remove unused imath

### DIFF
--- a/pkgs/development/python-modules/islpy/default.nix
+++ b/pkgs/development/python-modules/islpy/default.nix
@@ -46,10 +46,10 @@ buildPythonPackage rec {
   dontUseCmakeConfigure = true;
 
   cmakeFlags = [
-    "-DUSE_SHIPPED_ISL=OFF"
-    "-DUSE_BARVINOK=OFF"
-    "-DISL_INC_DIRS:LIST='${lib.getDev isl}/include'"
-    "-DISL_LIB_DIRS:LIST='${lib.getLib isl}/lib'"
+    (lib.cmakeBool "USE_SHIPPED_ISL" false)
+    (lib.cmakeBool "USE_BARVINOK" false)
+    (lib.cmakeFeature "ISL_INC_DIRS" "${lib.getDev isl}/include")
+    (lib.cmakeFeature "ISL_LIB_DIRS" "${lib.getLib isl}/lib")
   ];
 
   # Force resolving the package from $out to make generated ext files usable by tests

--- a/pkgs/development/python-modules/islpy/default.nix
+++ b/pkgs/development/python-modules/islpy/default.nix
@@ -12,7 +12,6 @@
   typing-extensions,
 
   # buildInputs
-  imath,
   isl,
 
   # tests
@@ -41,7 +40,6 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    imath
     isl
   ];
 
@@ -49,7 +47,6 @@ buildPythonPackage rec {
 
   cmakeFlags = [
     "-DUSE_SHIPPED_ISL=OFF"
-    "-DUSE_SHIPPED_IMATH=OFF"
     "-DUSE_BARVINOK=OFF"
     "-DISL_INC_DIRS:LIST='${lib.getDev isl}/include'"
     "-DISL_LIB_DIRS:LIST='${lib.getLib isl}/lib'"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7257,7 +7257,7 @@ self: super: with self; {
 
   isbnlib = callPackage ../development/python-modules/isbnlib { };
 
-  islpy = callPackage ../development/python-modules/islpy { isl = pkgs.isl_0_24; };
+  islpy = callPackage ../development/python-modules/islpy { isl = pkgs.isl_0_27; };
 
   ismartgate = callPackage ../development/python-modules/ismartgate { };
 


### PR DESCRIPTION
Fix build dep of python3Packages.islpy. regression introduced in https://github.com/NixOS/nixpkgs/pull/431701.
fixed in https://github.com/NixOS/nixpkgs/pull/442242.
~~Now SKBUILD_CMAKE_ARGS is seperated by local IFS ;~~
~~Now we use the space-seperated env CMAKE_ARGS.~~

cc @doronbehar  can we targeting master branch.


unstream python3Packages.islpy use vendored isl 0.27, we keep align with the system isl_0_27.
also drop the misleading buildInputs imath , imath should be the submodule of isl, now provided by system isl_0_27.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
