### PR TITLE
irmago: init at 0.19.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12630,6 +12630,12 @@
     githubId = 1767283;
     name = "Joris Engbers";
   };
+  jorritvanderheide = {
+    email = "jorrit.vanderheide@ru.nl";
+    github = "jorritvanderheide";
+    githubId = 35707261;
+    name = "Jorrit van der Heide";
+  };
   jorsn = {
     name = "Johannes Rosenberger";
     email = "johannes@jorsn.eu";

--- a/pkgs/by-name/ir/irmago/package.nix
+++ b/pkgs/by-name/ir/irmago/package.nix
@@ -1,0 +1,31 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule rec {
+  pname = "irmago";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "privacybydesign";
+    repo = "irmago";
+    tag = "v${version}";
+    hash = "sha256-KhTaxMCoc9e6aJcGZ0bz4438ln4qky8Xr07UVmHiv7s=";
+  };
+
+  vendorHash = "sha256-JUwzhngYf50PhknAladHrO/67z9UmLpr5f9LeLX5fI4=";
+
+  subPackages = [ "irma" ];
+
+  meta = {
+    changelog = "https://github.com/privacybydesign/irmago/releases/tag/${src.tag}";
+    description = "IRMA CLI and server implementation in Go for privacy-preserving attribute issuance and verification";
+    homepage = "https://docs.yivi.app/irma-cli";
+    license = lib.licenses.asl20;
+    mainProgram = "irmago";
+    maintainers = with lib.maintainers; [
+      jorritvanderheide
+    ];
+  };
+}


### PR DESCRIPTION
<!--
IRMA backend in GO, used as a backend for the Yivi identity wallet that is used by public organizations and municipalities in the Netherlands.

More info: https://docs.yivi.app/irma-cli/
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
