### PR TITLE
mesa: fix build with gcc15

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -29,7 +29,6 @@
   runCommand,
   rust-bindgen,
   rust-cbindgen,
-  rustPlatform,
   rustc,
   spirv-llvm-translator,
   stdenv,
@@ -314,7 +313,6 @@ stdenv.mkDerivation {
     rustc
     rust-bindgen
     rust-cbindgen
-    rustPlatform.bindgenHook
     wayland-scanner
   ]
   ++ lib.optionals needNativeCLC [


### PR DESCRIPTION
- remove `rustPlatform.bindgenHook` from `buildInputs`, `rustPlatform.bindgenHook` adds gcc headers to `BINDGEN_EXTRA_CLANG_ARGS` which somehow conflict more with gcc15 than gcc14.
Removing hook should let meson use bindgen from cli with clang libraries.

Fixes bindgen error building `mesa` with gcc15:
```
FAILED: [code=1] src/nouveau/compiler/nak_bindings.rs
/nix/store/rm899xgm82kanr814dk8siwyghyxwphg-rust-bindgen-0.72.0/bin/bindgen
../src/nouveau/compiler/nak_bindings.h ...
/build/source/src/nouveau/winsys/./nouveau_bo.h:41:4: error: unknown
type name 'atomic_uint_fast32_t'
Unable to generate bindings: clang diagnosed error:
/build/source/src/nouveau/winsys/./nouveau_bo.h:41:4: error: unknown
type name 'atomic_uint_fast32_t'
```
---

Tested builds on both gcc14 and gcc15.
Also built and run my nixos config on stack of gcc15 related patches on top of `master` that include this.
At least `glxgears`, `firefox` and random game from steam seem to work.

Part of https://github.com/NixOS/nixpkgs/pull/440456
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
