### PR TITLE
WIP: manim-slides: Add basic test

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11651,6 +11651,48 @@ with pkgs;
     (python3Packages.toPythonApplication python3Packages.manim-slides).overridePythonAttrs
       (oldAttrs: {
         dependencies = oldAttrs.dependencies ++ oldAttrs.optional-dependencies.pyqt6-full;
+
+        passthru = {
+          tests = {
+            hello-world = testers.runCommand {
+              name = "hello-manim-slides";
+
+              nativeBuildInputs = [
+                pkgs.manim-slides
+              ];
+
+              script = ''
+                set -euo pipefail
+
+                cat > example.py <<- EOF
+                from manim import *  # or: from manimlib import *
+
+                from manim_slides import Slide
+
+
+                class BasicExample(Slide):
+                    def construct(self):
+                        circle = Circle(radius=3, color=BLUE)
+                        dot = Dot()
+
+                        self.play(GrowFromCenter(circle))
+                        self.next_slide()  # Waits user to press continue to go to the next slide
+
+                        self.next_slide(loop=True)  # Start loop
+                        self.play(MoveAlongPath(dot, circle), run_time=2, rate_func=linear)
+                        self.next_slide()  # This will start a new non-looping slide
+
+                        self.play(dot.animate.move_to(ORIGIN))
+                EOF
+
+                manim-slides render example.py
+                manim-slides present BasicExample
+
+                touch $out
+              '';
+            };
+          };
+        };
       });
 
   manuskript = libsForQt5.callPackage ../applications/editors/manuskript { };


### PR DESCRIPTION
This should prevent further regressions in the future.

This tests the basic usage, as reported breaking in #440756. It does however not yet fix the issue with the missing qt platform plugins. 

The test can be executed by running:
```
nix-build -A manim-slides.passthru.tests.hello-world --impure
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
