### PR TITLE
ubase: init at 0-unstable-2024-03-07

### DIFF
--- a/pkgs/by-name/ub/ubase/package.nix
+++ b/pkgs/by-name/ub/ubase/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  libxcrypt,
+  testers,
+  unstableGitUpdater,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ubase";
+  version = "0-unstable-2024-03-07";
+
+  src = fetchgit {
+    url = "https://git.suckless.org/ubase";
+    rev = "a570a80ed1606bed43118cb148fc83c3ac22b5c1";
+    hash = "sha256-afsTkctATIZ6ug9S2gIGoxtFM1h/esgsexyuxXpocs0=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  buildInputs = [ libxcrypt ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  buildFlags = [ "ubase-box" ];
+  installTargets = [ "ubase-box-install" ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+
+    tests = {
+      ddCopiesBytes = testers.runCommand {
+        name = "ubase-dd-copies-bytes";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          dd if=/dev/zero of=test.bin bs=1 count=4
+          set -- $(stat -t test.bin)
+          [ "$1" = "test.bin" ] && [ "$2" = "4" ]
+          touch $out
+        '';
+      };
+
+      idMatchesUid = testers.runCommand {
+        name = "ubase-id-matches-uid";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          [ "$(id -u)" = "$UID" ]
+          touch $out
+        '';
+      };
+
+      pagesizePositive = testers.runCommand {
+        name = "ubase-pagesize-positive";
+        buildInputs = [ finalAttrs.finalPackage ];
+        script = ''
+          [ "$(pagesize)" -gt 0 ]
+          touch $out
+        '';
+      };
+
+      whichIdIsBox = testers.runCommand {
+        name = "ubase-which-id-is-box";
+        buildInputs = [
+          which
+          finalAttrs.finalPackage
+        ];
+        script = ''
+          [ $(which id) -ef $(which ubase-box) ]
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    description = "Linux base utilities from suckless.org";
+    homepage = "https://core.suckless.org/ubase/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "ubase-box";
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://core.suckless.org/ubase/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
