### PR TITLE
unifdef: fix build with gcc15, cleanup

### DIFF
--- a/pkgs/by-name/un/unifdef/package.nix
+++ b/pkgs/by-name/un/unifdef/package.nix
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "00647bp3m9n01ck6ilw6r24fk4mivmimamvm4hxp5p6wxh10zkj3";
   };
 
+  patches = [
+    # Fix build with gcc15
+    # https://github.com/fanf2/unifdef/pull/19
+    ./unifdef-fix-build-with-gcc15.patch
+  ];
+
   makeFlags = [
     "prefix=$(out)"
     "DESTDIR="

--- a/pkgs/by-name/un/unifdef/package.nix
+++ b/pkgs/by-name/un/unifdef/package.nix
@@ -4,13 +4,13 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "unifdef";
   version = "2.12";
 
   src = fetchurl {
-    url = "https://dotat.at/prog/unifdef/unifdef-${version}.tar.xz";
-    sha256 = "00647bp3m9n01ck6ilw6r24fk4mivmimamvm4hxp5p6wxh10zkj3";
+    url = "https://dotat.at/prog/unifdef/unifdef-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Q84PAuzc3HI7JHVXVWPdsZLpiMiG02gmC8CmOu46xAA=";
   };
 
   patches = [
@@ -24,11 +24,11 @@ stdenv.mkDerivation rec {
     "DESTDIR="
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://dotat.at/prog/unifdef/";
     description = "Selectively remove C preprocessor conditionals";
-    license = licenses.bsd2;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ orivej ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ orivej ];
   };
-}
+})

--- a/pkgs/by-name/un/unifdef/unifdef-fix-build-with-gcc15.patch
+++ b/pkgs/by-name/un/unifdef/unifdef-fix-build-with-gcc15.patch
@@ -1,0 +1,54 @@
+From d616741e6b0d5b57b66447e85ad32b283b28adde Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sun, 17 Nov 2024 01:26:27 +0000
+Subject: [PATCH] Don't use C23 constexpr keyword
+
+This fixes building with upcoming GCC 15 which defaults to -std=gnu23.
+---
+ unifdef.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/unifdef.c b/unifdef.c
+index dc145a2..4bd3bda 100644
+--- a/unifdef.c
++++ b/unifdef.c
+@@ -202,7 +202,7 @@ static int              depth;			/* current #if nesting */
+ static int              delcount;		/* count of deleted lines */
+ static unsigned         blankcount;		/* count of blank lines */
+ static unsigned         blankmax;		/* maximum recent blankcount */
+-static bool             constexpr;		/* constant #if expression */
++static bool             is_constexpr;		/* constant #if expression */
+ static bool             zerosyms;		/* to format symdepth output */
+ static bool             firstsym;		/* ditto */
+ 
+@@ -1086,7 +1086,7 @@ eval_unary(const struct ops *ops, long *valp, const char **cpp)
+ 			*valp = (value[sym] != NULL);
+ 			lt = *valp ? LT_TRUE : LT_FALSE;
+ 		}
+-		constexpr = false;
++		is_constexpr = false;
+ 	} else if (!endsym(*cp)) {
+ 		debug("eval%d symbol", prec(ops));
+ 		sym = findsym(&cp);
+@@ -1103,7 +1103,7 @@ eval_unary(const struct ops *ops, long *valp, const char **cpp)
+ 			lt = *valp ? LT_TRUE : LT_FALSE;
+ 			cp = skipargs(cp);
+ 		}
+-		constexpr = false;
++		is_constexpr = false;
+ 	} else {
+ 		debug("eval%d bad expr", prec(ops));
+ 		return (LT_ERROR);
+@@ -1170,10 +1170,10 @@ ifeval(const char **cpp)
+ 	long val = 0;
+ 
+ 	debug("eval %s", *cpp);
+-	constexpr = killconsts ? false : true;
++	is_constexpr = killconsts ? false : true;
+ 	ret = eval_table(eval_ops, &val, cpp);
+ 	debug("eval = %d", val);
+-	return (constexpr ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
++	return (is_constexpr ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
+ }
+ 
+ /*


### PR DESCRIPTION
unifdef: fix build with gcc15

- add patch from unmerged upstream PR:
https://www.github.com/fanf2/unifdef/pull/19

Fixes build failure with gcc15:
```
unifdef.c:205:1: error: 'constexpr' in empty declaration
unifdef.c: In function 'eval_unary':
unifdef.c:1089:27: error: expected identifier or '(' before '=' token
 1089 |                 constexpr = false;
      |                           ^
unifdef.c:1106:27: error: expected identifier or '(' before '=' token
 1106 |                 constexpr = false;
      |                           ^
unifdef.c: In function 'ifeval':
unifdef.c:1173:19: error: expected identifier or '(' before '=' token
 1173 |         constexpr = killconsts ? false : true;
      |                   ^
unifdef.c:1176:27: error: expected specifier-qualifier-list before '?' token
 1176 |         return (constexpr ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
      |                           ^
```

---

unifdef: cleanup

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
- replace `sha256` with `hash`
nix hash to-sri --type sha256 "00647bp3m9n01ck6ilw6r24fk4mivmimamvm4hxp5p6wxh10zkj3"
sha256-Q84PAuzc3HI7JHVXVWPdsZLpiMiG02gmC8CmOu46xAA=

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; unifdef.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
