### PR TITLE
zuban: 0.0.23 -> 0.1.1

### DIFF
--- a/pkgs/by-name/zu/zuban/package.nix
+++ b/pkgs/by-name/zu/zuban/package.nix
@@ -1,30 +1,34 @@
 {
-  fetchFromGitHub,
   lib,
+  fetchFromGitHub,
   rustPlatform,
   versionCheckHook,
   nix-update-script,
+  python3,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zuban";
 
-  version = "0.0.23";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "zubanls";
     repo = "zuban";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EPF1HW/oqUKHLTorkO3C+X+ziq6i1lCxGY5y1ioKg6A=";
+    hash = "sha256-nm6HSyoK1DC+x6ojAt9snBM7fiwrC2AW4/rsEEtp/CU=";
+    fetchSubmodules = true;
   };
 
   buildAndTestSubdir = "crates/zuban";
 
-  cargoHash = "sha256-TAFdS4NmXchmhqVRcsckz6GhZG35IE2fukDlZiRF8Ms=";
+  cargoHash = "sha256-Etjo2/2HKe0fOZKVrAaIZCWiuCp3TOmPGnbxBMfYCHA=";
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  postInstall = ''
+    mkdir -p $out/${python3.sitePackages}/zuban
+    cp -r typeshed $out/${python3.sitePackages}/zuban/typeshed
+  '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 


### PR DESCRIPTION
Update zuban, a mypy-compatible linter & LSP written in Rust.

We need to get the submodules to get the specific `typeshed` commit used for zuban, and copy it in the final package.
(Zuban will try to find it based on its own binary path)

<details>
<summary>Previous description, or failing package</summary>

WIP because when I play with zuban I almost always get a crash like:
```
thread 'main' panicked at crates/zuban_python/src/sys_path.rs:301:13:
The Python environment lib folder "/nix/store/qyk15qaybm41ngrc3xra1sik1496lcin-zuban-0.0.24/lib" should be readable (No such file or directory (os error 2)).
                    You might want to set ZUBAN_TYPESHED.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
The `/nix/store/qyk15qaybm41ngrc3xra1sik1496lcin-zuban-0.0.24/` only has `bin/`, there is no `lib/` there.

Panic's source: https://github.com/zubanls/zuban/blob/ee7cf0d4b73a9260cbe650324ce67349728e266a/crates/zuban_python/src/sys_path.rs#L302

I'm wondering if it ever worked 🤔

@mcjocobe (as maintainer)
Do you use a Nix-built `zuban` on your projects?

I don't have time to look into it at the moment, but I'll try to fix it

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
