### PR TITLE
picoscope: 7.1.46-1r4685 -> 7.2.6.7136

### DIFF
--- a/pkgs/by-name/pi/picoscope/package.nix
+++ b/pkgs/by-name/pi/picoscope/package.nix
@@ -1,153 +1,102 @@
 {
-  stdenv,
-  lib,
-  fetchurl,
+  cacert,
   dpkg,
-  makeWrapper,
-  mono,
-  gtk-sharp-3_0,
+  fetchurl,
+  gdk-pixbuf,
   glib,
+  glibc,
+  gtk3,
+  icu,
+  lib,
+  libcap,
+  librsvg,
   libusb1,
-  zlib,
-  gtk3-x11,
-  callPackage,
+  makeWrapper,
+  openssl,
+  patchelf,
+  stdenv,
+  systemdMinimal,
+  tbb,
   writeTextDir,
-  scopes ? [
-    "picocv"
-    "ps2000"
-    "ps2000a"
-    "ps3000"
-    "ps3000a"
-    "ps4000"
-    "ps4000a"
-    "ps5000"
-    "ps5000a"
-    "ps6000"
-    "ps6000a"
-  ],
 }:
 
 let
-  shared_meta = lib: {
-    homepage = "https://www.picotech.com/downloads/linux";
-    maintainers = with lib.maintainers; [ wirew0rm ];
-    teams = [ lib.teams.lumiguide ];
-    platforms = [ "x86_64-linux" ];
-    license = lib.licenses.unfree;
-  };
-
-  libpicoipp = callPackage (
-    {
-      stdenv,
-      lib,
-      fetchurl,
-      autoPatchelfHook,
-      dpkg,
-    }:
-    stdenv.mkDerivation {
-      pname = "libpicoipp";
-      inherit (sources.libpicoipp) version;
-      src = fetchurl { inherit (sources.libpicoipp) url sha256; };
-      nativeBuildInputs = [
-        dpkg
-        autoPatchelfHook
-      ];
-      buildInputs = [ (lib.getLib stdenv.cc.cc) ];
-
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out/lib
-        cp -d opt/picoscope/lib/* $out/lib
-        install -Dt $out/usr/share/doc/libpicoipp usr/share/doc/libpicoipp/copyright
-        runHook postInstall
-      '';
-      meta = shared_meta lib // {
-        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-        description = "Library for picotech oscilloscope software";
-      };
-    }
-  ) { };
-
-  # If we don't have a platform available, put a dummy version here, so at
-  # least evaluation succeeds.
   sources =
     (lib.importJSON ./sources.json).${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 
-  scopePkg =
-    name:
-    {
-      url,
-      version,
-      sha256,
-    }:
-    stdenv.mkDerivation {
-      pname = "lib${name}";
-      inherit version;
-      src = fetchurl { inherit url sha256; };
-      # picoscope does a signature check, so we can't patchelf these
-      nativeBuildInputs = [ dpkg ];
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out/lib
-        cp -d opt/picoscope/lib/* $out/lib
-         runHook postInstall
-      '';
-      meta =
-        with lib;
-        shared_meta lib
-        // {
-          description = "Library for picotech oscilloscope ${name} series";
-        };
-    };
+  libraryPath = lib.makeLibraryPath libraries;
+  libraries = [
+    gdk-pixbuf
+    glibc
+    gtk3
+    icu
+    libcap
+    librsvg
+    libusb1
+    openssl
+    stdenv.cc.cc.lib
+    systemdMinimal
+    tbb
+  ];
 
-  scopePkgs = lib.mapAttrs scopePkg sources;
+  gdkLoadersCache = "${gdk-pixbuf.out}/${gdk-pixbuf.moduleDir}.cache";
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "picoscope";
   inherit (sources.picoscope) version;
 
-  src = fetchurl { inherit (sources.picoscope) url sha256; };
+  srcs = lib.mapAttrsToList (_: src: fetchurl { inherit (src) url sha256; }) sources;
+
+  unpackPhase = ''
+    for src in $srcs; do
+      dpkg-deb -x "$src" .
+    done
+  '';
 
   nativeBuildInputs = [
     dpkg
     makeWrapper
   ];
-  buildInputs = [
-    gtk-sharp-3_0
-    mono
-    glib
-    libusb1
-    zlib
-  ];
 
-  scopeLibs = lib.attrVals (map (x: "lib${x}") scopes) scopePkgs;
-  MONO_PATH =
-    "${gtk-sharp-3_0}/lib/mono/gtk-sharp-3.0:"
-    + (lib.makeLibraryPath (
-      [
-        glib
-        gtk3-x11
-        gtk-sharp-3_0
-        libusb1
-        zlib
-        libpicoipp
-      ]
-      ++ scopeLibs
-    ));
+  buildInputs = libraries;
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/
-    cp -dr usr/share $out/share
     cp -dr opt/picoscope/* $out/
-    makeWrapper "$(command -v mono)" $out/bin/picoscope \
-      --add-flags $out/lib/PicoScope.GTK.exe \
-      --prefix MONO_PATH : "$MONO_PATH" \
-      --prefix LD_LIBRARY_PATH : "$MONO_PATH" \
-      --set LANG C
+    chmod +x $out/lib/PicoScope.GTK
+
+    # Patch all ELF files to prefer Pico libs then our curated runtime
+    # Set dynamic loader to Nix's glibc ld.so
+    for f in $out/lib/{PicoScope.GTK,CrashReporter} $(find $out/lib -type f -name 'lib*.so*'); do
+      ${patchelf}/bin/patchelf \
+        --set-interpreter ${glibc.out}/lib/ld-linux-x86-64.so.2 \
+        --set-rpath "$out/lib:${libraryPath}" \
+        "$f" || true
+    done
+
+    # LD_LIBRARY_PATH: not strictly needed for the main exe (rpath already covers it), but required
+    # for dlopened plugins that ignore rpath or use absolute sonames.
+    # GDK_PIXBUF_MODULE_FILE: points gdk-pixbuf to Nix’s loader cache so image loaders (gif/svg/png)
+    # come from our matched version, not the host. This fixes the “g_module_*” symbol errors.
+    # GIO_MODULE_DIR: restricts GIO to GLib’s core modules only (no dconf/gvfs host bleed-through).
+    # SSL_CERT_DIR/SSL_CERT_FILE: Gives OpenSSL a known CA bundle so any HTTPS inside the app works
+    # without querying host paths.
+    makeWrapper $out/lib/PicoScope.GTK $out/bin/picoscope \
+      --set LD_LIBRARY_PATH "$out/lib:${libraryPath}" \
+      --set GDK_PIXBUF_MODULE_FILE "${gdkLoadersCache}" \
+      --set GIO_MODULE_DIR "${glib.out}/lib/gio/modules" \
+      --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
     runHook postInstall
   '';
+
+  # Stripping causes the following error:
+  #   Failure processing application bundle; possible file corruption.
+  #   Arithmetic overflow while reading bundle.
+  #   A fatal error occurred while processing application bundle
+  dontStrip = true;
 
   # usage:
   # services.udev.packages = [ pkgs.picoscope.rules ];
@@ -157,22 +106,23 @@ stdenv.mkDerivation rec {
     SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ce9", MODE="664",GROUP="pico"
   '';
 
-  meta =
-    with lib;
-    shared_meta lib
-    // {
-      description = "Oscilloscope application that works with all PicoScope models";
-      longDescription = ''
-        PicoScope for Linux is a powerful oscilloscope application that works
-        with all PicoScope models. The most important features from PicoScope
-        for Windows are included—scope, spectrum analyzer, advanced triggers,
-        automated measurements, interactive zoom, persistence modes and signal
-        generator control. More features are being added all the time.
+  meta = {
+    homepage = "https://www.picotech.com/downloads/linux";
+    maintainers = with lib.maintainers; [ wirew0rm ] ++ lib.teams.lumiguide.members;
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    description = "Oscilloscope application that works with all PicoScope models";
+    longDescription = ''
+      PicoScope for Linux is a powerful oscilloscope application that works
+      with all PicoScope models. The most important features from PicoScope
+      for Windows are included—scope, spectrum analyzer, advanced triggers,
+      automated measurements, interactive zoom, persistence modes and signal
+      generator control. More features are being added all the time.
 
-        Waveform captures can be saved for off-line analysis, and shared with
-        PicoScope for Linux, PicoScope for macOS and PicoScope for Windows
-        users, or exported in text, CSV and MathWorks MATLAB 4 formats.
-      '';
-      sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    };
+      Waveform captures can be saved for off-line analysis, and shared with
+      PicoScope for Linux, PicoScope for macOS and PicoScope for Windows
+      users, or exported in text, CSV and MathWorks MATLAB 4 formats.
+    '';
+  };
 }

--- a/pkgs/by-name/pi/picoscope/sources.json
+++ b/pkgs/by-name/pi/picoscope/sources.json
@@ -1,69 +1,104 @@
 {
   "x86_64-linux": {
     "libpicocv": {
-      "sha256": "c0c5bec33c2c7fdd0f26b035ed942175f87012e33d6764c3abf1da31b5626037",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicocv/libpicocv_1.1.34-beta2r172_amd64.deb",
-      "version": "1.1.34-beta2r172"
+      "sha256": "cff2f4b4460ce58d97a8e4dfde55386cd1836b463b551c17928757493089e475",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicocv/libpicocv_1.1.43-1r443_amd64.deb",
+      "version": "1.1.43-1r443"
+    },
+    "libpicohrdl": {
+      "sha256": "920c529b8f49cfff3d1050f45753fa8bfca3f2d8e87c9712447c8f4fc766d60a",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicohrdl/libpicohrdl_2.0.150-1r6187_amd64.deb",
+      "version": "2.0.150-1r6187"
     },
     "libpicoipp": {
       "sha256": "4a84f0af7f4e8cba91fad620eac0cd23c36b2fdda4637904be564286b10ffe1d",
       "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicoipp/libpicoipp_1.4.0-4r161_amd64.deb",
       "version": "1.4.0-4r161"
     },
+    "libpl1000": {
+      "sha256": "5f81971fb54dc12ddb3654c95b085cc6d750e932b759cdfaae47d8ad1a1bcaaf",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpl1000/libpl1000_2.0.150-1r6187_amd64.deb",
+      "version": "2.0.150-1r6187"
+    },
+    "libplcm3": {
+      "sha256": "82a962c4a1a3049b4c258cf419e8468326f7931bdd3d5288af697271ed39a261",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libplcm3/libplcm3_2.0.150-1r6187_amd64.deb",
+      "version": "2.0.150-1r6187"
+    },
     "libps2000": {
-      "sha256": "473b065e79a7414c1e2b8c8468c8d2654333ac28f3a8c33b535626b33c60d2ca",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.127-3r5552_amd64.deb",
-      "version": "3.0.127-3r5552"
+      "sha256": "e51a2870450b9921c9b4a2a26d579b9d44047cf015ef0c51d8a19c9f26309983",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.150-3r6187_amd64.deb",
+      "version": "3.0.150-3r6187"
     },
     "libps2000a": {
-      "sha256": "8eba0052f9c7ef327710f2fba5aa11bec0c20225b39d77bb7b69cf80055c039c",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.1.127-5r5552_amd64.deb",
-      "version": "2.1.127-5r5552"
+      "sha256": "19be0c046dbd2725e236f3508af45141a6723ec51b0fcf9a2d7bcd818d53a0b1",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.2.154-5r6530_amd64.deb",
+      "version": "2.2.154-5r6530"
     },
     "libps3000": {
-      "sha256": "4e786036b8de0dd0f922aed947f30a53d31bed46b2df5132e8c9480c8a5d93e9",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.127-3r5552_amd64.deb",
-      "version": "4.0.127-3r5552"
+      "sha256": "41bbabe8abc39245612996cbc10053dfe06275b819ab57f9fbf48ef798c18a1a",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.149-3r6187_amd64.deb",
+      "version": "4.0.149-3r6187"
     },
     "libps3000a": {
-      "sha256": "d2bb1e5bb151b0953ed30ca5421bb93d05dab898c33cdc89927e943ea991867a",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.1.127-6r5552_amd64.deb",
-      "version": "2.1.127-6r5552"
+      "sha256": "7a01aedb064c366405e9b5d9af5b1adfc27b6b782bda1d0bd3b3bee3e595a41a",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.2.157-6r7555_amd64.deb",
+      "version": "2.2.157-6r7555"
     },
     "libps4000": {
-      "sha256": "4c127e67949835b5ab5c5c8caa55f73c69df354d761aa53d6df99c8f8ac39009",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.127-2r5552_amd64.deb",
-      "version": "2.1.127-2r5552"
+      "sha256": "0d1dff842e806e8f193ee319f88203b8fbb0391d53188e77fa9601bbbf8d2ef6",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.151-2r6187_amd64.deb",
+      "version": "2.1.151-2r6187"
     },
     "libps4000a": {
-      "sha256": "26df82bc946e5bb30d599c4c365247bdbaa01e830d4d00630b46a6abcc1eef04",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.1.127-2r5552_amd64.deb",
-      "version": "2.1.127-2r5552"
+      "sha256": "1d2ab448ed2b92f305410dbea452268071cb096edb88855e60dd627be7faed45",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.2.206-2r7757_amd64.deb",
+      "version": "2.2.206-2r7757"
     },
     "libps5000": {
-      "sha256": "106ef17862e98c3621f95c377f271c843664f481f84ef918d9eadd013561cd1b",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.127-3r5552_amd64.deb",
-      "version": "2.1.127-3r5552"
+      "sha256": "e3dbd0534d1acf5c81b5170d276dcb8d0b612c3fd55f5cc212581d51734079cd",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.151-3r6187_amd64.deb",
+      "version": "2.1.151-3r6187"
     },
     "libps5000a": {
-      "sha256": "fe9def134ef9df6654485911f14ece7b2ee3d79113aeee7826dd6e36bb5de3b4",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.1.127-5r5552_amd64.deb",
-      "version": "2.1.127-5r5552"
+      "sha256": "f17ab24eb77df24d4957b848f64815a47227d5eb246c31a111d7eadb43d04cf4",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.2.11-5r5086_amd64.deb",
+      "version": "2.2.11-5r5086"
     },
     "libps6000": {
-      "sha256": "9b08c5b7fb2d34b0e2e98f2e0452a59105f612cd445a9e45d3cac14d931d18f2",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.127-6r5552_amd64.deb",
-      "version": "2.1.127-6r5552"
+      "sha256": "01716b5d24f670ca709ca6e0947f3ca1cebb225d3b1037eee692ef049dc1946c",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.151-6r6187_amd64.deb",
+      "version": "2.1.151-6r6187"
     },
     "libps6000a": {
-      "sha256": "2a23ccad72b9be83b87d449b6bb8ded23fd29c85ec9f78a45b6d45b38ccf335b",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_1.0.127-0r5552_amd64.deb",
-      "version": "1.0.127-0r5552"
+      "sha256": "4ecf9543d388c6b972e78d3b2caa09f9a314e9cb6fd54b24c1e227fcaa3f8f12",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_2.0.156-0r167_amd64.deb",
+      "version": "2.0.156-0r167"
+    },
+    "libpsospa": {
+      "sha256": "adaf1f555b8b6f0950731cd642488bd8707a09291e0f1fb7a79ed22867203eb4",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpsospa/libpsospa_1.0.149-0r5787_amd64.deb",
+      "version": "1.0.149-0r5787"
+    },
+    "libusbdrdaq": {
+      "sha256": "0906429cd32b34aaaaa41ae9f60f6b47ecbdc0b53e49275a3349141f2e79d806",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libu/libusbdrdaq/libusbdrdaq_2.0.150-1r6187_amd64.deb",
+      "version": "2.0.150-1r6187"
+    },
+    "libusbpt104": {
+      "sha256": "a73a175dcced17e59ade58edb760c8e11551300841e5c30c16cbd7c1bfe6c540",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libu/libusbpt104/libusbpt104_2.0.150-1r6187_amd64.deb",
+      "version": "2.0.150-1r6187"
+    },
+    "libusbtc08": {
+      "sha256": "551f3f290d7ee672a4e0533ffebeab746ba552c3a4d0c857edaf7c2494a96659",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libu/libusbtc08/libusbtc08_2.0.150-1r6187_amd64.deb",
+      "version": "2.0.150-1r6187"
     },
     "picoscope": {
-      "sha256": "d95f269171da7273b596dae95452789e889f12ef0f15c3baea26dd1b3a8117fc",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.1.17-1r17318_amd64.deb",
-      "version": "7.1.17-1r17318"
+      "sha256": "ab4a0db634b93bd5dcf7cb7fca52591c03130d57451d3ddb3942a0e663c4ffd7",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.2.6.7136_amd64.deb",
+      "version": "7.2.6.7136"
     }
   }
 }


### PR DESCRIPTION
I updated picoscope based on work done by @proteansec in #423343. The app launches. ~You do need to allow insecure openssl in order to build it.~ I don't have the hardware to test this here. Please report if it works with hardware.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
