### PR TITLE
forgejo: rename bin/gitea -> bin/forgejo

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -71,6 +71,8 @@
 
 - `hiawata` has been removed, due to lack of active development upstream, lack of maintainership downstream and upcoming security issues.
 
+- `forgejo` main program has been renamed to `bin/forgejo` from the previous `bin/gitea`.
+
 - `cudaPackages.cudatoolkit-legacy-runfile` has been removed.
 
 - `conduwuit` was removed due to upstream ceasing development and deleting their repository. For existing data, a migration to `matrix-conduit`, `matrix-continuwuity` or `matrix-tuwunel` may be possible.

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -176,7 +176,7 @@ let
               + "Please contact your site administrator.'"
           )
           server.succeed(
-              "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo gitea admin user create "
+              "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo forgejo admin user create "
               + "--username test --password totallysafe --email test@localhost --must-change-password=false'"
           )
 
@@ -223,7 +223,7 @@ let
 
           with subtest("Testing runner registration and action workflow"):
               server.succeed(
-                  "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo gitea actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/forgejo/runner_token"
+                  "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo forgejo actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/forgejo/runner_token"
               )
               server.succeed("${serverSystem}/specialisation/runner/bin/switch-to-configuration test")
               server.wait_for_unit("gitea-runner-test.service")

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -129,7 +129,7 @@ buildGoModule rec {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   preInstall = ''
-    mv "$GOPATH/bin/forgejo.org" "$GOPATH/bin/gitea"
+    mv "$GOPATH/bin/forgejo.org" "$GOPATH/bin/forgejo"
   '';
 
   postInstall = ''
@@ -137,7 +137,7 @@ buildGoModule rec {
     cp -R ./{templates,options} ${frontend}/public $data
     mkdir -p $out
     cp -R ./options/locale $out/locale
-    wrapProgram $out/bin/gitea \
+    wrapProgram $out/bin/forgejo \
       --prefix PATH : ${
         lib.makeBinPath [
           bash
@@ -202,6 +202,6 @@ buildGoModule rec {
       tebriel
     ];
     broken = stdenv.hostPlatform.isDarwin;
-    mainProgram = "gitea";
+    mainProgram = "forgejo";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Let's make this match what help outputs, and drop another legacy gitea thing. After this, I think the last remaining piece would be if we want to finally split the runner module.

Before:
```
𑁱 nix run nixpkgs#forgejo -- --help
NAME:
   forgejo - Beyond coding. We forge.

USAGE:
   forgejo [global options] [command [command options]]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
