### PR TITLE
xvidcore: fix build with gcc15, cleanup

### DIFF
--- a/pkgs/by-name/xv/xvidcore/package.nix
+++ b/pkgs/by-name/xv/xvidcore/package.nix
@@ -9,13 +9,13 @@
   libtool,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xvidcore";
   version = "1.3.7";
 
   src = fetchurl {
-    url = "https://downloads.xvid.com/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "1xyg3amgg27zf7188kss7y248s0xhh1vv8rrk0j9bcsd5nasxsmf";
+    url = "https://downloads.xvid.com/downloads/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-ruqulS1Ns5UkmDmjvQOEHWhEhD9aT4TCcf+I96oaz/c=";
   };
 
   patches = [
@@ -69,14 +69,14 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/*.dll $out/lib
   '';
 
-  meta = with lib; {
+  meta = {
     description = "MPEG-4 video codec for PC";
     homepage = "https://www.xvid.com/";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [
       codyopel
       lovek323
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/xv/xvidcore/package.nix
+++ b/pkgs/by-name/xv/xvidcore/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   yasm,
   autoconf,
@@ -16,6 +17,14 @@ stdenv.mkDerivation rec {
     url = "https://downloads.xvid.com/downloads/${pname}-${version}.tar.bz2";
     sha256 = "1xyg3amgg27zf7188kss7y248s0xhh1vv8rrk0j9bcsd5nasxsmf";
   };
+
+  patches = [
+    # Fix build with gcc15
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/xvidcore/raw/95382dbe529e5589a727fffceb620b0a89ff55f2/f/xvidcore-c23.patch";
+      hash = "sha256-bGwWNmXIEIIw4Tc7lrMZ4jnhcQ+uKAsxL6fuAOosMVA=";
+    })
+  ];
 
   preConfigure = ''
     # Configure script is not in the root of the source directory


### PR DESCRIPTION
xvidcore: fix build with gcc15
- add patch from fedora

Fixes build failure with gcc15:
```
In file included from ../../src/bitstream/bitstream.h:31,
                 from ../../src/decoder.c:40:
../../src/bitstream/../encoder.h:45:13: error: 'bool' cannot be defined via 'typedef'
   45 | typedef int bool;
      |             ^~~~
../../src/bitstream/../encoder.h:45:13: note: 'bool' is a keyword with '-std=c23' onwards
../../src/bitstream/../encoder.h:45:1: warning: useless type name in empty declaration
   45 | typedef int bool;
      | ^~~~~~~
```

---

xvidcore: cleanup
- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
- replace `sha256` with `hash`
nix hash to-sri --type sha256 "1xyg3amgg27zf7188kss7y248s0xhh1vv8rrk0j9bcsd5nasxsmf"
sha256-ruqulS1Ns5UkmDmjvQOEHWhEhD9aT4TCcf+I96oaz/c=

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; xvidcore.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
