### PR TITLE
nixos/nginx: remove deprecated vhost option enableSSL

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -324,7 +324,7 @@ let
     mapAttrsToList (
       vhostName: vhost:
       let
-        onlySSL = vhost.onlySSL || vhost.enableSSL;
+        onlySSL = vhost.onlySSL;
         hasSSL = onlySSL || vhost.addSSL || vhost.forceSSL;
 
         # First evaluation of defaultListen based on a set of listen lines.
@@ -1324,18 +1324,6 @@ in
   ];
 
   config = mkIf cfg.enable {
-    warnings =
-      let
-        deprecatedSSL =
-          name: config:
-          optional config.enableSSL ''
-            config.services.nginx.virtualHosts.<name>.enableSSL is deprecated,
-            use config.services.nginx.virtualHosts.<name>.onlySSL instead.
-          '';
-
-      in
-      flatten (mapAttrsToList deprecatedSSL virtualHosts);
-
     assertions =
       let
         hostOrAliasIsNull = l: l.root == null || l.alias == null;
@@ -1352,7 +1340,7 @@ in
             with host;
             count id [
               addSSL
-              (onlySSL || enableSSL)
+              onlySSL
               forceSSL
               rejectSSL
             ] <= 1

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -170,12 +170,6 @@ with lib;
       '';
     };
 
-    enableSSL = mkOption {
-      type = types.bool;
-      visible = false;
-      default = false;
-    };
-
     forceSSL = mkOption {
       type = types.bool;
       default = false;

--- a/nixos/tests/matrix/conduit.nix
+++ b/nixos/tests/matrix/conduit.nix
@@ -18,7 +18,7 @@ in
         virtualHosts.${name} = {
           enableACME = false;
           forceSSL = false;
-          enableSSL = false;
+          onlySSL = false;
 
           locations."/_matrix" = {
             proxyPass = "http://[::1]:6167";


### PR DESCRIPTION
The option `services.nginx.virtualHost.<...>.enableSSL` is deprecated for 8 years [^1]. It causes confusion for people who guess the option and think it's the right one.
I think it's time to remove it for good.

^1: https://github.com/NixOS/nixpkgs/commit/a912a6a291eaa5f6a2ad9143c9e276779c357a41


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
