### PR TITLE
python27: fix build with gcc15

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -319,7 +319,8 @@ stdenv.mkDerivation (
 
     env.NIX_CFLAGS_COMPILE =
       lib.optionalString (stdenv.targetPlatform.system == "x86_64-darwin") "-msse2"
-      + lib.optionalString stdenv.hostPlatform.isMusl " -DTHREAD_STACK_SIZE=0x100000";
+      + lib.optionalString stdenv.hostPlatform.isMusl " -DTHREAD_STACK_SIZE=0x100000"
+      + " -std=gnu17";
     DETERMINISTIC_BUILD = 1;
 
     setupHook = python-setup-hook sitePackages;


### PR DESCRIPTION
- add " -std=gnu17" to `env.NIX_CFLAGS_COMPILE`

Fixes build failure with gcc15:
```
In file included from Include/Python-ast.h:3,
                 from Python/bltinmodule.c:4:
Include/asdl.h:9:15: error: cannot use keyword 'false' as enumeration constant
    9 | typedef enum {false, true} bool;
      |               ^~~~~
Include/asdl.h:9:15: note: 'false' is a keyword with '-std=c23' onwards
Include/asdl.h:9:28: error: expected ';', identifier or '(' before 'bool'
    9 | typedef enum {false, true} bool;
      |                            ^~~~
Include/asdl.h:9:28: warning: useless type name in empty declaration
In file included from Include/Python-ast.h:3,
                 from Python/compile.c:26:
Include/asdl.h:9:15: error: cannot use keyword 'false' as enumeration constant
    9 | typedef enum {false, true} bool;
      |               ^~~~~
Include/asdl.h:9:15: note: 'false' is a keyword with '-std=c23' onwards
Include/asdl.h:9:28: error: expected ';', identifier or '(' before 'bool'
    9 | typedef enum {false, true} bool;
      |                            ^~~~
```

---

Tested build with:
```bash
NIXPKGS_ALLOW_INSECURE=1 nix-build --expr 'with import ./. {}; python27.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
