### PR TITLE
graphite2: fix build with gcc15

### DIFF
--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   llvmPackages,
+  fetchpatch,
   fetchurl,
   pkg-config,
   freetype,
@@ -39,7 +40,14 @@ stdenv.mkDerivation (finalAttrs: {
     }
   );
 
-  patches = lib.optionals stdenv.hostPlatform.isDarwin [ ./macosx.patch ];
+  patches = [
+    # Fix build with gcc15
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/graphite2/raw/deba28323b0a3b7a3dcfd06df1efc2195b102ed7/f/graphite2-1.3.14-gcc15.patch";
+      hash = "sha256-vkkGkHkcsj1mD3OHCHLWWgpcmFDv8leC4YQm+TsbIUw=";
+    })
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ ./macosx.patch ];
   postPatch = ''
     # disable broken 'nametabletest' test, fails on gcc-13:
     #   https://github.com/silnrsi/graphite/pull/74


### PR DESCRIPTION
- add patch from fedora, that adds missing `#include <stdint.h>`

Fixes build failure with gcc15:
```
/build/graphite2-1.3.14/tests/featuremap/featuremaptest.cpp: In function 'void testFeatTable(const T&, const std::string&)':
/build/graphite2-1.3.14/tests/featuremap/featuremaptest.cpp:310:14: error: 'uint16_t' was not declared in this scope [-Wtemplate-body]
  310 |         for (uint16_t j = 0; j < table.m_defs[i].m_numFeatSettings; j++)
      |              ^~~~~~~~
/build/graphite2-1.3.14/tests/featuremap/featuremaptest.cpp:310:14: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
/build/graphite2-1.3.14/tests/featuremap/featuremaptest.cpp:310:30: error: 'j' was not declared in this scope [-Wtemplate-body]
  310 |         for (uint16_t j = 0; j < table.m_defs[i].m_numFeatSettings; j++)
      |                              ^
```

---

Tested build with:
```bash
nom-build --expr 'with import ./. {}; graphite2.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

There are 2 unmerged PRs upstream with similar fixes, but patch from either would need to be vendored:
https://www.github.com/silnrsi/graphite/pull/97
https://www.github.com/silnrsi/graphite/pull/91

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
