### PR TITLE
harlequin: pin textual to 5.3.0 to fix runtime

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -10,7 +10,27 @@
   withPostgresAdapter ? true,
   withBigQueryAdapter ? true,
 }:
-python3Packages.buildPythonApplication rec {
+let
+  # Using textual 5.3.0 to avoid error at runtime
+  # https://github.com/tconbeer/harlequin/issues/841
+  python = python3Packages.python.override {
+    self = python3Packages.python;
+    packageOverrides = self: super: {
+      textual = super.textual.overridePythonAttrs (old: rec {
+        version = "5.3.0";
+
+        src = fetchFromGitHub {
+          owner = "Textualize";
+          repo = "textual";
+          tag = "v${version}";
+          hash = "sha256-J7Sb4nv9wOl1JnR6Ky4XS9HZHABKtNKPB3uYfC/UGO4=";
+        };
+      });
+    };
+  };
+  pythonPackages = python.pkgs;
+in
+pythonPackages.buildPythonApplication rec {
   pname = "harlequin";
   version = "2.1.2";
   pyproject = true;
@@ -28,14 +48,15 @@ python3Packages.buildPythonApplication rec {
     "textual"
     "tree-sitter"
     "tree-sitter-sql"
+    "rich-click"
   ];
 
-  build-system = with python3Packages; [ poetry-core ];
+  build-system = with pythonPackages; [ poetry-core ];
 
   nativeBuildInputs = [ glibcLocales ];
 
   dependencies =
-    with python3Packages;
+    with pythonPackages;
     [
       click
       duckdb
@@ -67,7 +88,7 @@ python3Packages.buildPythonApplication rec {
     updateScript = nix-update-script { };
   };
 
-  nativeCheckInputs = with python3Packages; [
+  nativeCheckInputs = with pythonPackages; [
     pytest-asyncio
     pytestCheckHook
     versionCheckHook


### PR DESCRIPTION
Current harlequin is failing at runtime with:

```
╭─────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────╮
│ /nix/store/k85brz40sqhaidwxarpcwhx58cfqx7wi-harlequin-2.1.2/lib/python3.13/site-packages/harlequin/components/data_catalog/__ini │
│ t__.py:168 in on_focus                                                                                                           │
│                                                                                                                                  │
│   165 │                                                                                                                          │
│   166 │   def on_focus(self) -> None:                                                                                            │
│   167 │   │   try:                                                                                                               │
│ ❱ 168 │   │   │   active_widget = self.query_one(f"#{self.active}").children[0]                                                  │
│   169 │   │   except NoMatches:                                                                                                  │
│   170 │   │   │   self.database_tree.focus()                                                                                     │
│   171 │   │   else:                                                                                                              │
│                                                                                                                                  │
│ ╭──────────────── locals ─────────────────╮                                                                                      │
│ │ self = DataCatalog(classes='hide-tabs') │                                                                                      │
│ ╰─────────────────────────────────────────╯                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
InvalidQueryFormat: Unable to parse '#' as a query; check for syntax errors
```

As mentioned by project maintainer, this is due to the version of textual used (6.1.0).

https://github.com/tconbeer/harlequin/issues/841

I found that it works fine with 5.3.0 so I temporarily pin it until harlequin gets updated to use more recent versions.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.