### PR TITLE
postfix: fix build with gcc15

### DIFF
--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -38,6 +38,9 @@ let
       "-DUSE_CYRUS_SASL"
       "-I${cyrus_sasl.dev}/include/sasl"
       "-DHAS_DB_BYPASS_MAKEDEFS_CHECK"
+      # Fix build with gcc15, no upstream fix for stable releases:
+      # https://www.mail-archive.com/postfix-devel@postfix.org/msg01270.html
+      "-std=gnu17"
     ]
     ++ lib.optional withPgSQL "-DHAS_PGSQL"
     ++ lib.optionals withMySQL [


### PR DESCRIPTION
- add "-std=gnu17" to `ccargs`

Fixes build failure with gcc15:
```
In file included from flush_clnt.c:96:
./mail_params.h:17:13: error: 'bool' cannot be defined via 'typedef'
   17 | typedef int bool;
      |             ^~~~
./mail_params.h:17:13: note: 'bool' is a keyword with '-std=c23' onwards
./mail_params.h:17:1: warning: useless type name in empty declaration
   17 | typedef int bool;
      | ^~~~~~~
```

---

From fedora report (that also added `-std=gnu17`), upstream does not intend to add fixes for this to stable releases:
https://www.mail-archive.com/postfix-devel@postfix.org/msg01270.html

Tested build with:
```bash
nix-build --expr 'with import ./. {}; postfix.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
