### PR TITLE
clickhouse: 25.8.2.29-lts → 25.9.2.1-stable, clickhouse-lts: 25.8.2.29-lts → 25.8.7.3-lts

### DIFF
--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -32,7 +32,7 @@ let
   llvmStdenv = llvmPackages_19.stdenv;
 in
 llvmStdenv.mkDerivation (finalAttrs: {
-  pname = "clickhouse" + lib.optionalString lts "-lts";
+  pname = "clickhouse";
   inherit version;
 
   src = fetchFromGitHub rec {

--- a/pkgs/by-name/cl/clickhouse/lts.nix
+++ b/pkgs/by-name/cl/clickhouse/lts.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.8.2.29-lts";
-  hash = "sha256-S+1fZuYlZUMkiBlMtufMT5aAi9uwbFMjYW7Dmkt/Now=";
+  version = "25.8.7.3-lts";
+  hash = "sha256-wH/UxMgnsK6OIGxEv9CYA67f8PWC0u6IAiW2iY/KThk=";
   lts = true;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.8.2.29-lts";
-  hash = "sha256-S+1fZuYlZUMkiBlMtufMT5aAi9uwbFMjYW7Dmkt/Now=";
+  version = "25.9.2.1-stable";
+  hash = "sha256-BygRxiDhhs91/UPWY7f3jAGyTtyAj98RdDXLwjs8Abo=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"


### PR DESCRIPTION
* https://github.com/ClickHouse/ClickHouse/compare/v25.8.2.29-lts...v25.8.7.3-lts

# Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
