### PR TITLE
botan2: fix build with gcc15

### DIFF
--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   pkgsStatic,
   python3,
@@ -172,5 +173,13 @@ in
   botan2 = common {
     version = "2.19.5";
     hash = "sha256-3+6g4KbybWckxK8B2pp7iEh62y2Bunxy/K9S21IsmtQ=";
+    patches = [
+      # Fix build with gcc15
+      (fetchpatch {
+        name = "botan2-add-include-cstdint-gcc15.patch";
+        url = "https://src.fedoraproject.org/rpms/botan2/raw/c3fb7a3800df117e7ef8a7617ac8eacb31a4464a/f/f765f0b312f2998498f629d93369babfb2c975b4.patch";
+        hash = "sha256-8Yhxd5TCgxUMtRiv3iq5sQaVjDF+b9slppm38/6l6lw=";
+      })
+    ];
   };
 }


### PR DESCRIPTION
- add patch from fedora that adds `#include <cstdint.h>` to cli.h

Fixes build failure with gcc15:
```
In file included from src/cli/argon2.cpp:7:
src/cli/cli.h:125:71: error: 'uint8_t' does not name a type
  125 |       static std::string format_blob(const std::string& format, const uint8_t bits[], size_t len);
      |                                                                       ^~~~~~~
src/cli/cli.h:18:1: note: 'uint8_t' is defined in header '<cstdint>';
this is probably fixable by adding '#include <cstdint>'
   17 | #include "cli_exceptions.h"
  +++ |+#include <cstdint>
   18 |
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; botan2.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

Temporary solution in case:
https://github.com/NixOS/nixpkgs/issues/445861
is not solved before gcc15 update.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
