### PR TITLE
tailscale: 1.88.1 -> 1.88.3

### DIFF
--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -1,16 +1,15 @@
 {
   lib,
   tailscale,
-  buildGo124Module,
+  buildGoModule,
 }:
 
-buildGo124Module {
-  inherit (tailscale)
-    version
-    src
-    vendorHash
-    ;
+buildGoModule {
   pname = "tailscale-gitops-pusher";
+  inherit (tailscale) version;
+
+  # It's hosted in the `tailscale` monorepo.
+  inherit (tailscale) src vendorHash;
 
   env = {
     inherit (tailscale) CGO_ENABLED;
@@ -27,11 +26,11 @@ buildGo124Module {
     "-X tailscale.com/version.shortStamp=${tailscale.version}"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://tailscale.com";
     description = "Allows users to use a GitOps flow for managing Tailscale ACLs";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     mainProgram = "gitops-pusher";
-    teams = [ teams.cyberus ];
+    teams = [ lib.teams.cyberus ];
   };
 }

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -24,7 +24,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "tailscale";
-  version = "1.88.1";
+  version = "1.88.3";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
     owner = "tailscale";
     repo = "tailscale";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hpj5yS02rQEGAu4VwHDTVx6SIOw7DQFv9SKkJtal6kk=";
+    hash = "sha256-gw4oexTyJGeBkCd07RQQdfY14xArgVIMDHKrWu9K+9Q=";
   };
 
   vendorHash = "sha256-8aE6dWMkTLdWRD9WnLVSzpOQQh61voEnjZAJHtbGCSs=";


### PR DESCRIPTION
Changelog: https://tailscale.com/changelog#client
Diff: https://github.com/tailscale/tailscale/compare/v1.88.1...v1.88.3

Minor update to Tailscale; targets `staging-next` because [the previous PR](https://github.com/NixOS/nixpkgs/pull/442245) had to target `staging`.

Resolves #446099

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test