### PR TITLE
assimp: fix build with gcc15

### DIFF
--- a/pkgs/by-name/as/assimp/package.nix
+++ b/pkgs/by-name/as/assimp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   zlib,
   nix-update-script,
@@ -22,6 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-ixtqK+3iiL17GEbEVHz5S6+gJDDQP7bVuSfRMJMGEOY=";
   };
+
+  patches = [
+    # Fix build with gcc15
+    # https://github.com/assimp/assimp/pull/6283
+    (fetchpatch {
+      name = "assimp-fix-invalid-vector-gcc15.patch";
+      url = "https://github.com/assimp/assimp/commit/59bc03d931270b6354690512d0c881eec8b97678.patch";
+      hash = "sha256-O+JPwcOdyFtmFE7eZojHo1DUavF5EhLYlUyxtYo/KF4=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/assimp/assimp/pull/6283

Fixes build failure with gcc15:
```
/build/source/code/AssetLib/X3D/X3DGeoHelper.cpp: In static member
function 'static void Assimp::X3DGeoHelper::coordIdx_str2lines_arr(const std::vector<int>&, std::vector<aiFace>&)':
/build/source/code/AssetLib/X3D/X3DGeoHelper.cpp:194:20: error: array
subscript -1 is outside array bounds of 'int [2305843009213693951]' [-Werror=array-bounds=]
  194 |     if (f_data.back() != (-1)) {
      |         ~~~~~~~~~~~^~
In file included from /nix/store/9jzssiinw6a2dib6k3hzd48j6ywck4iw-gcc-15.2.0/include/c++/15.2.0/x86_64-unknown-linux-gnu/bits/c++allocator.h:33,
                 from /nix/store/9jzssiinw6a2dib6k3hzd48j6ywck4iw-gcc-15.2.0/include/c++/15.2.0/bits/allocator.h:46,
                 from /nix/store/9jzssiinw6a2dib6k3hzd48j6ywck4iw-gcc-15.2.0/include/c++/15.2.0/string:45,
                 from /build/source/include/assimp/types.h:78,
                 from /build/source/code/AssetLib/X3D/X3DGeoHelper.h:6,
                 from /build/source/code/AssetLib/X3D/X3DGeoHelper.cpp:1:
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; assimp.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
