### PR TITLE
2048-c: init at 1.0.3

### DIFF
--- a/pkgs/by-name/_2/_2048-c/package.nix
+++ b/pkgs/by-name/_2/_2048-c/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "2048-c";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "mevdschee";
+    repo = "2048.c";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ohpHkxPytxH+De/OT0wY7Y2saJeQaT9NIujiOajOz0Y=";
+  };
+
+  doCheck = true;
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Console version of the game 2048 implemented in C";
+    homepage = "https://github.com/mevdschee/2048.c";
+    changelog = "https://github.com/mevdschee/2048.c/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "2048";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/mevdschee/2048.c

I enjoy simple linux games and I also wanted to get better at packaging software. With Repology I figured out this package is popular among other distros but is missing in nixpkgs.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/b3dc3144-4acf-4d01-a42e-3cdb63a8ad74" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
