### PR TITLE
ocamlPackages.ocaml-sat-solvers: 0.4 → 0.8

### DIFF
--- a/pkgs/development/ocaml-modules/minisat/default.nix
+++ b/pkgs/development/ocaml-modules/minisat/default.nix
@@ -1,10 +1,11 @@
 {
   lib,
+  stdenv,
   buildDunePackage,
   fetchFromGitHub,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "minisat";
   version = "0.6";
 
@@ -13,8 +14,12 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-minisat";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dH0Ndlyo/DTZ6Ao1S478aBuxoZFSkRBi5HblkTWCPas=";
+  };
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_CFLAGS_COMPILE = "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
   };
 
   meta = {
@@ -23,4 +28,4 @@ buildDunePackage rec {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ mgttlinger ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ocaml-sat-solvers/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-sat-solvers/default.nix
@@ -1,21 +1,19 @@
 {
   lib,
-  fetchFromGitHub,
-  buildOasisPackage,
+  fetchurl,
+  buildDunePackage,
   minisat,
 }:
 
-buildOasisPackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ocaml-sat-solvers";
-  version = "0.4";
+  version = "0.8";
 
-  minimumOCamlVersion = "4.03.0";
+  minimalOCamlVersion = "4.05";
 
-  src = fetchFromGitHub {
-    owner = "tcsprojects";
-    repo = "ocaml-sat-solvers";
-    rev = "v${version}";
-    sha256 = "1hxr16cyl1p1k1cik848mqrysq95wxmlykpm93a99pn55mp28938";
+  src = fetchurl {
+    url = "https://github.com/tcsprojects/ocaml-sat-solvers/releases/download/v${finalAttrs.version}/ocaml-sat-solvers-${finalAttrs.version}.tbz";
+    hash = "sha256-1eXzuY6rrrjdEG/XnkJe4o9zAcUvfTVFO1+ZIzcgpOU=";
   };
 
   propagatedBuildInputs = [ minisat ];
@@ -26,4 +24,4 @@ buildOasisPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mgttlinger ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/pgsolver/default.nix
+++ b/pkgs/development/ocaml-modules/pgsolver/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   buildOasisPackage,
   ounit,
   tcslib,
@@ -16,6 +17,16 @@ buildOasisPackage rec {
     repo = "pgsolver";
     rev = "v${version}";
     sha256 = "16skrn8qql9djpray25xv66rjgfl20js5wqnxyq1763nmyizyj8a";
+  };
+
+  # Compatibility with ocaml-sat-solvers 0.8
+  patches = fetchpatch {
+    url = "https://github.com/tcsprojects/pgsolver/commit/e57a4fc5c8050b8d4ada5583a6c65ecf8cd65141.patch";
+    hash = "sha256-QFKxWByptnCl1SfleNASyXmKM2gkh1OE66L8PAZX+TU=";
+    includes = [
+      "src/solvers/*.ml"
+      "src/tools/*.ml"
+    ];
   };
 
   buildInputs = [ ounit ];


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
