### PR TITLE
zellij: add service

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -12,6 +12,10 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [Zellij](https://zellij.dev), a terminal workspace with batteries included.
+
+  Available as [services.zellij](#opt-services.zellij.enable).
+
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -40,6 +40,8 @@
 
 - [RomM](https://romm.app/), a self-hosted ROM manager and player. Available as [services.romm](#opt-services.romm.enable).
 
+- [Zellij](https://zellij.dev), a terminal workspace with batteries included. Available as [services.zellij](#opt-services.zellij.enable).
+
 - [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
 
 - [tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap), an ATProtocol firehose synchronisation utility. Available as [services.tap](#opt-services.tap.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1005,6 +1005,7 @@
   ./services/misc/xmrig.nix
   ./services/misc/yarr.nix
   ./services/misc/ytdl-sub.nix
+  ./services/misc/zellij.nix
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/alerta.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1029,6 +1029,7 @@
   ./services/misc/xmrig.nix
   ./services/misc/yarr.nix
   ./services/misc/ytdl-sub.nix
+  ./services/misc/zellij.nix
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/alerta.nix

--- a/nixos/modules/services/misc/zellij.nix
+++ b/nixos/modules/services/misc/zellij.nix
@@ -82,6 +82,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.web.ip != "127.0.0.1" -> (cfg.web.certificate != null && cfg.web.key != null);
+        message = "Cannot bind to non-loopback IP: 0.0.0.0 without an SSL certificate, please set `services.zellij.web.certificate` and `services.zellij.web.key`. See https://github.com/zellij-org/zellij/issues/4347#issuecomment-3160010870";
+      }
+    ];
+
     programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
       eval "$(${lib.getExe cfg.package} setup --generate-auto-start bash)"
     '';

--- a/nixos/modules/services/misc/zellij.nix
+++ b/nixos/modules/services/misc/zellij.nix
@@ -87,6 +87,12 @@ in
         assertion = cfg.web.ip != "127.0.0.1" -> (cfg.web.certificate != null && cfg.web.key != null);
         message = "Cannot bind to non-loopback IP: 0.0.0.0 without an SSL certificate, please set `services.zellij.web.certificate` and `services.zellij.web.key`. See https://github.com/zellij-org/zellij/issues/4347#issuecomment-3160010870";
       }
+      {
+        assertion =
+          (cfg.web.certificate == null && cfg.web.key == null)
+          || (cfg.web.certificate != null && cfg.web.key != null);
+        message = "`services.zellij.web.certificate` and `services.zellij.web.key` must be both null or both filled.";
+      }
     ];
 
     programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''

--- a/nixos/modules/services/misc/zellij.nix
+++ b/nixos/modules/services/misc/zellij.nix
@@ -1,0 +1,121 @@
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.services.zellij;
+
+in
+{
+  options = {
+    services.zellij = {
+      enable = lib.mkEnableOption "Enable Zellij";
+
+      package = lib.mkPackageOption pkgs "zellij" { };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          User that will run Zellij
+        '';
+      };
+
+      enableBashIntegration = lib.mkEnableOption "Bash integration";
+      enableFishIntegration = lib.mkEnableOption "Fish integration";
+
+      web = {
+        enable = lib.mkEnableOption "Enable Zellij web";
+
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Open port in the firewall.";
+        };
+
+        ip = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            The ip address to listen on locally for connections
+          '';
+          default = "127.0.0.1";
+          example = "0.0.0.0";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          description = ''
+            The port to listen on locally for connections
+          '';
+          default = 8082;
+        };
+
+        certificate = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          description = ''
+            The path to the SSL certificate (required if not listening on 127.0.0.1)
+
+            Can be generated using this command
+            mkcert -cert-file zellij-cert.pem -key-file zellij-key.pem zellij
+          '';
+          default = null;
+          example = "config.age.secrets.zellij-cert.path";
+        };
+
+        key = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          description = ''
+            The path to the SSL key (required if not listening on 127.0.0.1)
+
+            Can be generated using this command
+            mkcert -cert-file zellij-cert.pem -key-file zellij-key.pem zellij
+          '';
+          default = null;
+          example = "config.age.secrets.zellij-key.path";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(${lib.getExe cfg.package} setup --generate-auto-start bash)"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      eval (${lib.getExe cfg.package} setup --generate-auto-start fish | string collect)
+    '';
+
+    systemd.user.services.zellij-web = lib.mkIf cfg.web.enable {
+      after = lib.lists.optional (options ? age && options.age.secrets != { }) "agenix.service";
+      wantedBy = [ "default.target" ];
+      script = ''
+        zellij web --start \
+          ${lib.strings.optionalString (null != cfg.web.ip) "--ip ${cfg.web.ip}"} \
+          ${lib.strings.optionalString (null != cfg.web.port) "--port ${builtins.toString cfg.web.port}"} \
+          ${lib.strings.optionalString (null != cfg.web.certificate) "--cert ${cfg.web.certificate}"} \
+          ${lib.strings.optionalString (null != cfg.web.key) "--key ${cfg.web.key}"}
+      '';
+      path = [
+        cfg.package
+      ];
+      environment = {
+        TERM = config.users.users."${cfg.user}".shell;
+      };
+    };
+
+    users.users."${cfg.user}" = {
+      packages = [
+        cfg.package
+      ];
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.web.enable && cfg.web.openFirewall) [
+      cfg.web.port
+    ];
+  };
+}

--- a/nixos/modules/services/misc/zellij.nix
+++ b/nixos/modules/services/misc/zellij.nix
@@ -1,0 +1,120 @@
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.services.zellij;
+
+in
+{
+  options = {
+    services.zellij = {
+      enable = lib.mkEnableOption "Enable Zellij";
+
+      package = lib.mkPackageOption pkgs "zellij" { };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          User that will run Zellij
+        '';
+      };
+
+      enableBashIntegration = lib.mkEnableOption "Bash integration";
+      enableFishIntegration = lib.mkEnableOption "Fish integration";
+
+      web = {
+        enable = lib.mkEnableOption "Enable Zellij web";
+
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Open port in the firewall.";
+        };
+
+        ip = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            The ip address to listen on locally for connections
+          '';
+          default = "127.0.0.1";
+          example = "0.0.0.0";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          description = ''
+            The port to listen on locally for connections
+          '';
+          default = 8082;
+        };
+
+        certificate = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          description = ''
+            The path to the SSL certificate (required if not listening on 127.0.0.1)
+
+            Can be generated using this command
+            mkcert -cert-file zellij-cert.pem -key-file zellij-key.pem zellij
+          '';
+          default = null;
+          example = "config.age.secrets.zellij-cert.path";
+        };
+
+        key = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          description = ''
+            The path to the SSL key (required if not listening on 127.0.0.1)
+
+            Can be generated using this command
+            mkcert -cert-file zellij-cert.pem -key-file zellij-key.pem zellij
+          '';
+          default = null;
+          example = "config.age.secrets.zellij-key.path";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(${lib.getExe cfg.package} setup --generate-auto-start bash)"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      eval (${lib.getExe cfg.package} setup --generate-auto-start fish | string collect)
+    '';
+
+    systemd.user.services.zellij-web = lib.mkIf cfg.web.enable {
+      wantedBy = [ "default.target" ];
+      script = ''
+        zellij web --start \
+          ${lib.optionalString (null != cfg.web.ip) "--ip ${cfg.web.ip}"} \
+          ${lib.optionalString (null != cfg.web.port) "--port ${builtins.toString cfg.web.port}"} \
+          ${lib.optionalString (null != cfg.web.certificate) "--cert ${cfg.web.certificate}"} \
+          ${lib.optionalString (null != cfg.web.key) "--key ${cfg.web.key}"}
+      '';
+      path = [
+        cfg.package
+      ];
+      environment = {
+        TERM = config.users.users."${cfg.user}".shell;
+      };
+    };
+
+    users.users."${cfg.user}" = {
+      packages = [
+        cfg.package
+      ];
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.web.enable && cfg.web.openFirewall) [
+      cfg.web.port
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1872,6 +1872,7 @@ in
   yggdrasil = runTest ./yggdrasil.nix;
   your_spotify = runTest ./your_spotify.nix;
   zammad = runTest ./zammad.nix;
+  zellij = runTest ./zellij/default.nix;
   zenohd = runTest ./zenohd.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;
   zfs = import ./zfs.nix { inherit system pkgs runTest; };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1936,6 +1936,7 @@ in
   your_spotify = runTest ./your_spotify.nix;
   zammad = runTest ./zammad.nix;
   zapret2 = runTest ./zapret2.nix;
+  zellij = runTest ./zellij/default.nix;
   zenohd = runTest ./zenohd.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;
   zfs = import ./zfs.nix { inherit system pkgs runTest; };

--- a/nixos/tests/zellij/default.nix
+++ b/nixos/tests/zellij/default.nix
@@ -5,6 +5,8 @@
 
 let
   port = 8085;
+  remote_hostname = "acme.test";
+  remote_ip = "192.168.1.100";
 in
 {
   name = "zellij";
@@ -25,6 +27,44 @@ in
       };
 
       environment.etc."zellij/config.kdl".text = ""; # without this, the server seems to not start in the test, but it seems to work in real world
+
+      security.pki.certificateFiles = [
+        ../common/acme/server/ca.cert.pem
+      ];
+      networking.extraHosts = ''
+        ${remote_ip} ${remote_hostname}
+      '';
+    };
+
+    remote = {
+      imports = [
+        ../common/user-account.nix
+      ];
+
+      services.zellij = {
+        enable = true;
+        user = "alice";
+        web = {
+          enable = true;
+          port = port;
+          openFirewall = true;
+          ip = "0.0.0.0";
+          certificate = ../common/acme/server/acme.test.cert.pem;
+          key = ../common/acme/server/acme.test.key.pem;
+        };
+      };
+
+      environment.etc."zellij/config.kdl".text = ""; # without this, the server seems to not start in the test, but it seems to work in real world
+
+      networking = {
+        useDHCP = false;
+        interfaces.eth1.ipv4.addresses = [
+          {
+            address = remote_ip;
+            prefixLength = 24;
+          }
+        ];
+      };
     };
   };
 
@@ -34,6 +74,7 @@ in
       pkgs.replaceVars ./test.py {
         user_name = "alice";
         port = port;
+        remote_hostname = remote_hostname;
       }
     );
 }

--- a/nixos/tests/zellij/default.nix
+++ b/nixos/tests/zellij/default.nix
@@ -1,0 +1,39 @@
+{
+  pkgs,
+  ...
+}:
+
+let
+  port = 8085;
+in
+{
+  name = "zellij";
+
+  nodes = {
+    local = {
+      imports = [
+        ../common/user-account.nix
+      ];
+
+      services.zellij = {
+        enable = true;
+        user = "alice";
+        web = {
+          enable = true;
+          port = port;
+        };
+      };
+
+      environment.etc."zellij/config.kdl".text = ""; # without this, the server seems to not start in the test, but it seems to work in real world
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    builtins.readFile (
+      pkgs.replaceVars ./test.py {
+        user_name = "alice";
+        port = port;
+      }
+    );
+}

--- a/nixos/tests/zellij/default.nix
+++ b/nixos/tests/zellij/default.nix
@@ -1,0 +1,50 @@
+{
+  pkgs,
+  ...
+}:
+
+let
+  port = 8085;
+in
+{
+  name = "zellij";
+
+  nodes = {
+    local = {
+      imports = [
+        ../common/user-account.nix
+      ];
+
+      services.zellij = {
+        enable = true;
+        user = "alice";
+        web = {
+          enable = true;
+          port = port;
+        };
+      };
+
+      environment.etc."zellij/config.kdl".text = ""; # without this, the server seems to not start in the test, but it seems to work in real world
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      user_name = "alice"
+
+      start_all()
+
+      local.succeed(f"loginctl enable-linger {user_name}")
+
+      with subtest("Wait all VMs to be ready"):
+          local.wait_for_unit("default.target")
+
+      with subtest("Package is installed"):
+          local.succeed(f"su - {user_name} --command 'command -v zellij'")
+
+      with subtest("Server works localy"):
+          local.wait_for_unit("zellij-web.service", user_name)
+          local.succeed("curl --silent --show-error http://localhost:${toString port}/")
+    '';
+}

--- a/nixos/tests/zellij/default.nix
+++ b/nixos/tests/zellij/default.nix
@@ -5,6 +5,8 @@
 
 let
   port = 8085;
+  remote_hostname = "acme.test";
+  remote_ip = "192.168.1.100";
 in
 {
   name = "zellij";
@@ -25,6 +27,44 @@ in
       };
 
       environment.etc."zellij/config.kdl".text = ""; # without this, the server seems to not start in the test, but it seems to work in real world
+
+      security.pki.certificateFiles = [
+        ../common/acme/server/ca.cert.pem
+      ];
+      networking.extraHosts = ''
+        ${remote_ip} ${remote_hostname}
+      '';
+    };
+
+    remote = {
+      imports = [
+        ../common/user-account.nix
+      ];
+
+      services.zellij = {
+        enable = true;
+        user = "alice";
+        web = {
+          enable = true;
+          port = port;
+          openFirewall = true;
+          ip = "0.0.0.0";
+          certificate = ../common/acme/server/acme.test.cert.pem;
+          key = ../common/acme/server/acme.test.key.pem;
+        };
+      };
+
+      environment.etc."zellij/config.kdl".text = ""; # without this, the server seems to not start in the test, but it seems to work in real world
+
+      networking = {
+        useDHCP = false;
+        interfaces.eth1.ipv4.addresses = [
+          {
+            address = remote_ip;
+            prefixLength = 24;
+          }
+        ];
+      };
     };
   };
 
@@ -36,9 +76,11 @@ in
       start_all()
 
       local.succeed(f"loginctl enable-linger {user_name}")
+      remote.succeed(f"loginctl enable-linger {user_name}")
 
       with subtest("Wait all VMs to be ready"):
           local.wait_for_unit("default.target")
+          remote.wait_for_unit("default.target")
 
       with subtest("Package is installed"):
           local.succeed(f"su - {user_name} --command 'command -v zellij'")
@@ -46,5 +88,9 @@ in
       with subtest("Server works localy"):
           local.wait_for_unit("zellij-web.service", user_name)
           local.succeed("curl --silent --show-error http://localhost:${toString port}/")
+
+      with subtest("Server works remotely"):
+          remote.wait_for_unit("zellij-web.service", user_name)
+          local.succeed("curl --silent --show-error https://${remote_hostname}:${toString port}/")
     '';
 }

--- a/nixos/tests/zellij/test.py
+++ b/nixos/tests/zellij/test.py
@@ -1,0 +1,13 @@
+start_all()
+
+local.succeed("loginctl enable-linger @user_name@")
+
+with subtest("Wait all VMs to be ready"):
+    local.wait_for_unit("default.target")
+
+with subtest("Package is installed"):
+    local.succeed("su - @user_name@ --command 'command -v zellij'")
+
+with subtest("Server works localy"):
+    local.wait_for_unit("zellij-web.service", "@user_name@")
+    local.succeed("curl --silent --show-error http://localhost:@port@/")

--- a/nixos/tests/zellij/test.py
+++ b/nixos/tests/zellij/test.py
@@ -1,9 +1,11 @@
 start_all()
 
 local.succeed("loginctl enable-linger @user_name@")
+remote.succeed("loginctl enable-linger @user_name@")
 
 with subtest("Wait all VMs to be ready"):
     local.wait_for_unit("default.target")
+    remote.wait_for_unit("default.target")
 
 with subtest("Package is installed"):
     local.succeed("su - @user_name@ --command 'command -v zellij'")
@@ -11,3 +13,7 @@ with subtest("Package is installed"):
 with subtest("Server works localy"):
     local.wait_for_unit("zellij-web.service", "@user_name@")
     local.succeed("curl --silent --show-error http://localhost:@port@/")
+
+with subtest("Server works remotely"):
+    remote.wait_for_unit("zellij-web.service", "@user_name@")
+    local.succeed("curl --silent --show-error https://@remote_hostname@:@port@/")


### PR DESCRIPTION
## Things done

this allows to run Zellij web server in a systemd service

i copied the service from my dotfiles

the service is working on 2 machines for several weeks

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. :warning: i only ran my tests
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
