### PR TITLE
afflib: fix build on darwin, remove libiconv

### DIFF
--- a/pkgs/by-name/af/afflib/package.nix
+++ b/pkgs/by-name/af/afflib/package.nix
@@ -5,21 +5,21 @@
   zlib,
   curl,
   expat,
+  fuse,
   fuse3,
   openssl,
   autoreconfHook,
   python3,
-  libiconv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "3.7.22";
   pname = "afflib";
 
   src = fetchFromGitHub {
     owner = "sshock";
     repo = "AFFLIBv3";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-pGInhJQBhFJhft/KfB3J3S9/BVp9D8TZ+uw2CUNVC+Q=";
   };
 
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
     openssl
     python3
   ]
-  ++ lib.optionals (with stdenv; isLinux || isDarwin) [ fuse3 ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ fuse3 ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ fuse ];
 
   meta = {
     homepage = "http://afflib.sourceforge.net/";
@@ -42,4 +42,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.raskin ];
     downloadPage = "https://github.com/sshock/AFFLIBv3/tags";
   };
-}
+})


### PR DESCRIPTION
Fixes build on Darwin that was broken in <https://github.com/NixOS/nixpkgs/commit/be80c76f699714f3e8dd80bf197fa1a98ab24dd5>, when it was switched to `fuse3` which doesn't support Darwin. The `fuse` Darwin package redirects to the MacFUSE stubs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
