### PR TITLE
nixos/prowlarr: fix dataDir option not being used

### DIFF
--- a/nixos/modules/services/misc/servarr/prowlarr.nix
+++ b/nixos/modules/services/misc/servarr/prowlarr.nix
@@ -13,32 +13,25 @@ in
   options = {
     services.prowlarr = {
       enable = lib.mkEnableOption "Prowlarr, an indexer manager/proxy for Torrent trackers and Usenet indexers";
-
       dataDir = lib.mkOption {
         type = lib.types.str;
         default = "/var/lib/prowlarr";
         description = ''
           The directory where Prowlarr stores its data files.
-
           Note: A bind mount will be used to mount the directory at the expected location
           if a different value than `/var/lib/prowlarr` is used.
         '';
       };
-
       package = lib.mkPackageOption pkgs "prowlarr" { };
-
       openFirewall = lib.mkOption {
         type = lib.types.bool;
         default = false;
         description = "Open ports in the firewall for the Prowlarr web interface.";
       };
-
       settings = servarr.mkServarrSettingsOptions "prowlarr" 9696;
-
       environmentFiles = servarr.mkServarrEnvironmentFiles "prowlarr";
     };
   };
-
   config = lib.mkIf cfg.enable {
     systemd = {
       services.prowlarr = {
@@ -48,31 +41,28 @@ in
         environment = servarr.mkServarrSettingsEnvVars "PROWLARR" cfg.settings // {
           HOME = "/var/empty";
         };
-
         serviceConfig = {
           Type = "simple";
           DynamicUser = true;
           StateDirectory = "prowlarr";
           EnvironmentFile = cfg.environmentFiles;
-          ExecStart = "${lib.getExe cfg.package} -nobrowser -data=/var/lib/prowlarr";
+          ExecStart = "${lib.getExe cfg.package} -nobrowser -data=${cfg.dataDir}";
           Restart = "on-failure";
         };
       };
-
       tmpfiles.settings."10-prowlarr".${cfg.dataDir}.d = lib.mkIf isCustomDataDir {
         user = "root";
         group = "root";
         mode = "0700";
       };
-
       mounts = lib.optional isCustomDataDir {
         what = cfg.dataDir;
         where = "/var/lib/private/prowlarr";
         options = "bind";
         wantedBy = [ "local-fs.target" ];
+        before = [ "prowlarr.service" ];
       };
     };
-
     networking.firewall = lib.mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.settings.server.port ];
     };


### PR DESCRIPTION
The dataDir option was defined but not actually used by the service. The ExecStart command was hardcoded to use /var/lib/prowlarr instead of the configured dataDir value. Also ensure bind mounts happen before the service starts.

Fixes #445983


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
