### PR TITLE
atd: respect system timezone

### DIFF
--- a/nixos/modules/services/scheduling/atd.nix
+++ b/nixos/modules/services/scheduling/atd.nix
@@ -79,7 +79,6 @@ in
     };
 
     users.groups.atd.gid = config.ids.gids.atd;
-
     systemd.services.atd = {
       description = "Job Execution Daemon (atd)";
       documentation = [ "man:atd(8)" ];
@@ -91,8 +90,6 @@ in
         # Snippets taken and adapted from the original `install' rule of
         # the makefile.
 
-        # We assume these values are those actually used in Nixpkgs for
-        # `at'.
         spooldir=/var/spool/atspool
         jobdir=/var/spool/atjobs
         etcdir=/etc/at
@@ -115,6 +112,14 @@ in
       script = "atd";
 
       serviceConfig.Type = "forking";
+
+      # --- TZ fix for system timezone ---
+      environment = lib.mkIf (config.time.timeZone != null) {
+        TZ = config.time.timeZone;
+      };
+
+      # Restart atd if timezone changes
+      restartTriggers = [ config.time.timeZone ];
     };
   };
 }


### PR DESCRIPTION
Previously, the atd service ignored the system timezone and always used UTC. This caused scheduled jobs to run at the wrong local time.

This commit sets the TZ environment variable from `time.timeZone` and adds a restart trigger so that atd automatically restarts when the timezone changes.

Tested manually: after setting `time.timeZone = America/New_York`, scheduled at jobs run at the expected local times.

Closes: https://github.com/NixOS/nixpkgs/issues/445872


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
