### PR TITLE
2048-qt: init at 0.1.6

### DIFF
--- a/pkgs/by-name/_2/_2048-qt/package.nix
+++ b/pkgs/by-name/_2/_2048-qt/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  libsForQt5,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "2048-qt";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "xiaoyong";
+    repo = "2048-Qt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wA4MZlox3X5OKGR9JQ12+JLF1rz8AAJDcxWq7TQSx7k=";
+  };
+
+  postPatch = ''
+    substituteInPlace res/2048-qt.desktop \
+      --replace-fail "#!/usr/bin/env xdg-open" ""
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    libsForQt5.qmake
+    libsForQt5.qtdeclarative
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtquickcontrols
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+  ''
+  + (
+    if stdenv.isDarwin then
+      ''
+        mkdir -p "$out/Applications" "$out/bin"
+        cp -r 2048-qt.app "$out/Applications"
+        ln -s "$out/Applications/2048-qt.app/Contents/MacOS/2048-qt" "$out/bin"
+      ''
+    else
+      ''
+        install -Dm755 2048-qt -t "$out/bin"
+      ''
+  )
+  + ''
+    install -Dm644 res/2048-qt.desktop -t "$out/share/applications"
+
+    for p in res/icons/*/apps/2048-qt.*; do
+      install -Dm644 "$p" "$out/share/icons/hicolor/''${p#res/icons/}"
+    done
+
+    installManPage res/man/2048-qt.6
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "The 2048 number game implemented in Qt";
+    homepage = "https://github.com/xiaoyong/2048-Qt";
+    changelog = "https://github.com/xiaoyong/2048-Qt/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "2048-qt";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/xiaoyong/2048-Qt

I enjoy simple linux games and I also wanted to get better at packaging software. With Repology I figured out this package is popular among other distros but is missing in nixpkgs.

```
/nix/store/i9c8bzn2bisfzdfaz00x5ss9ahh921j7-2048-qt-0.1.6/
├── bin
│   └── 2048-qt
└── share
    ├── applications
    │   └── 2048-qt.desktop
    ├── icons
    │   └── hicolor
    │       ├── 16x16
    │       │   └── apps
    │       │       └── 2048-qt.png
    │       ├── 256x256
    │       │   └── apps
    │       │       └── 2048-qt.png
    │       ├── 32x32
    │       │   └── apps
    │       │       └── 2048-qt.png
    │       ├── 48x48
    │       │   └── apps
    │       │       └── 2048-qt.png
    │       └── scalable
    │           └── apps
    │               └── 2048-qt.svg
    └── man
        └── man6
            └── 2048-qt.6.gz
```

<img height="400" alt="image" src="https://github.com/user-attachments/assets/d80b8ac4-d049-4944-87e6-746521b1799d" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
