### PR TITLE
drgn: init at v0.0.32

### DIFF
--- a/pkgs/by-name/dr/drgn/package.nix
+++ b/pkgs/by-name/dr/drgn/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+  pkg-config,
+  elfutils,
+  xz,
+  autoconf,
+  automake,
+  gcc,
+  libtool,
+  gnumake,
+  libkdumpfile,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "drgn";
+  version = "0.0.32";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "osandov";
+    repo = "drgn";
+    tag = "v${version}";
+    hash = "sha256-ge1sDQrjoKYeGRYD6l7qCSxKdTq5uqqLKy9Ghpyq7pQ=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gcc
+    gnumake
+    libtool
+    pkg-config
+  ];
+
+  buildInputs = [
+    elfutils
+    xz
+    libkdumpfile
+  ];
+
+  meta = {
+    description = "Programmable debugger for the Linux kernel";
+    longDescription = ''
+      drgn (pronounced “dragon”) is a debugger with an emphasis on programmability.
+      drgn exposes the types and variables in a program for easy, expressive
+      scripting in Python.
+    '';
+    homepage = "https://github.com/osandov/drgn";
+    changelog = "https://github.com/osandov/drgn/releases/tag/v${version}";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ panky ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "drgn";
+  };
+}

--- a/pkgs/by-name/li/libkdumpfile/kdumpid.patch
+++ b/pkgs/by-name/li/libkdumpfile/kdumpid.patch
@@ -1,0 +1,108 @@
+commit 62fd4508dcf40b8b39f862d71d18ed83b0db2263
+Author: Sam James <sam@gentoo.org>
+Date:   Thu Dec 26 04:25:40 2024 +0000
+
+    tools: kdumpid: include config.h before <dis-asm.h>
+    
+    Before including bfd.h (or any of the headers installed by binutils),
+    one has to define PACKAGE_NAME and PACKAGE_VERSION for kind of painful
+    reasons described in binutils bug PR14243.
+    
+    This doesn't show up on some distros as they patch out the #ifdef check
+    in the headers, but it does on Gentoo where we don't, at least.
+    
+    Moreover, we want to include config.h before *any* headers anyway, so
+    that e.g. AC_SYSTEM_EXTENSIONS and various other autoconf macros work
+    correctly if used.
+    
+    Bug: https://sourceware.org/PR14243
+    Signed-off-by: Sam James <sam@gentoo.org>
+
+diff --git a/tools/kdumpid/main.c b/tools/kdumpid/main.c
+index f78d36b..53e755a 100644
+--- a/tools/kdumpid/main.c
++++ b/tools/kdumpid/main.c
+@@ -14,6 +14,8 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include "config.h"
++
+ #include <stdio.h>
+ #include <errno.h>
+ #include <stdlib.h>
+diff --git a/tools/kdumpid/ppc.c b/tools/kdumpid/ppc.c
+index 1c63b18..dd97e83 100644
+--- a/tools/kdumpid/ppc.c
++++ b/tools/kdumpid/ppc.c
+@@ -12,6 +12,8 @@
+  * GNU General Public License for more details.
+  */
+ 
++#include "config.h"
++
+ #include <stdarg.h>
+ #include <string.h>
+ 
+diff --git a/tools/kdumpid/ppc64.c b/tools/kdumpid/ppc64.c
+index 11379f8..0cce802 100644
+--- a/tools/kdumpid/ppc64.c
++++ b/tools/kdumpid/ppc64.c
+@@ -12,6 +12,8 @@
+  * GNU General Public License for more details.
+  */
+ 
++#include "config.h"
++
+ #include <stdarg.h>
+ #include <string.h>
+ 
+diff --git a/tools/kdumpid/s390.c b/tools/kdumpid/s390.c
+index 0879cb9..4be5114 100644
+--- a/tools/kdumpid/s390.c
++++ b/tools/kdumpid/s390.c
+@@ -12,6 +12,8 @@
+  * GNU General Public License for more details.
+  */
+ 
++#include "config.h"
++
+ #include <stdarg.h>
+ #include <string.h>
+ 
+diff --git a/tools/kdumpid/search.c b/tools/kdumpid/search.c
+index 83d66c7..9972184 100644
+--- a/tools/kdumpid/search.c
++++ b/tools/kdumpid/search.c
+@@ -12,6 +12,8 @@
+  * GNU General Public License for more details.
+  */
+ 
++#include "config.h"
++
+ #include <stdlib.h>
+ #include <string.h>
+ 
+diff --git a/tools/kdumpid/util.c b/tools/kdumpid/util.c
+index 0e42335..2d5a078 100644
+--- a/tools/kdumpid/util.c
++++ b/tools/kdumpid/util.c
+@@ -12,6 +12,8 @@
+  * GNU General Public License for more details.
+  */
+ 
++#include "config.h"
++
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+diff --git a/tools/kdumpid/x86.c b/tools/kdumpid/x86.c
+index 5e35778..8cabc4c 100644
+--- a/tools/kdumpid/x86.c
++++ b/tools/kdumpid/x86.c
+@@ -1,3 +1,5 @@
++#include "config.h"
++
+ #include <stdarg.h>
+ #include <stdlib.h>
+ #include <string.h>

--- a/pkgs/by-name/li/libkdumpfile/package.nix
+++ b/pkgs/by-name/li/libkdumpfile/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  autoconf,
+  automake,
+  libtool,
+  autoreconfHook,
+  pkg-config,
+  zlib,
+  libbfd,
+  lzo,
+  snappy,
+  zstd,
+  doxygen,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libkdumpfile";
+  version = "0.5.5";
+
+  src = fetchgit {
+    url = "https://codeberg.org/ptesarik/libkdumpfile.git";
+    tag = "v${version}";
+    hash = "sha256-Ilgh8WWfdwIN7fquS+az0U+eykOHgsGVX6G4hjx2L8I=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    zlib
+    lzo
+    snappy
+    zstd
+    libbfd
+  ];
+
+  configureFlags = [
+    "--without-python"
+  ];
+
+  patches = [ ./kdumpid.patch ];
+
+  meta = {
+    description = "A library for accessing kernel crash dumps";
+    homepage = "https://codeberg.org/ptesarik/libkdumpfile";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ panky ];
+  };
+}


### PR DESCRIPTION
## Summary
drgn (pronounced “dragon”) is a debugger with an emphasis on programmability. drgn exposes the types and variables in a program for easy, expressive scripting in Python.

It was created by meta to debug complicated kernel issues [1]. drgn depends on libkdumpfile for some functionalities, hence, this PR also adds libkdumpfile package before adding drgn.

[1] https://www.youtube.com/watch?v=ukxH_55BiQE
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
