### PR TITLE
onetbb: fix build with gcc15

### DIFF
--- a/pkgs/by-name/on/onetbb/package.nix
+++ b/pkgs/by-name/on/onetbb/package.nix
@@ -49,6 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/uxlfoundation/oneTBB/commit/e57411968661ab1205322ba1c84fc1cd90a306c6.patch";
       hash = "sha256-PFixW4lYqA5oy4LSwewvxgJbjVKJceRHnp8mgW9zBF0=";
     })
+
+    # Fix build with gcc15
+    # <https://github.com/uxlfoundation/oneTBB/pull/1831>
+    (fetchpatch {
+      name = "onetbb-fix-gcc15-build.patch";
+      url = "https://github.com/uxlfoundation/oneTBB/commit/712ad98443300aab202f5e93a76472d59b79752a.patch";
+      hash = "sha256-4qoVCy3xQZK6Vp471miE79FSrU0D0Iu6KWMJ08m0EsE=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/uxlfoundation/oneTBB/pull/1831
https://github.com/uxlfoundation/oneTBB/commit/712ad98443300aab202f5e93a76472d59b79752a

Fixes build failure with gcc15:
```
FAILED: [code=1] test/CMakeFiles/test_concurrent_unordered_map.dir/tbb/test_concurrent_unordered_map.cpp.o
...
/nix/store/rd8c9w16nwys8yz1a9j2g2nhjn07464r-gcc-15.2.0/include/c++/15.2.0/bits/new_allocator.h:198:11:
error: array subscript 2 is outside array bounds of
'StaticSharedCountingAllocator<std::allocator<tbb::detail::d2::list_node<long unsigned int> > >::value_type [1]'
{aka 'tbb::detail::d2::list_node<long unsigned int> [1]'} [-Werror=array-bounds=]
  198 |         { __p->~_Up(); }
      |           ^~~
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
...
FAILED: [code=1] test/CMakeFiles/test_concurrent_unordered_set.dir/tbb/test_concurrent_unordered_set.cpp.o
...
/build/source/src/tbb/../../include/tbb/../oneapi/tbb/detail/_concurrent_unordered_base.h:172:20:
error: array subscript 'tbb::detail::d2::value_node<AllocatorAwareData<std::scoped_allocator_adaptor<std::allocator<int> > >,
long unsigned int>[0]' is partly outside array bounds of 'unsigned char [16]' [-Werror=array-bounds=]
  172 |     ~value_node() {}
      |                    ^
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; onetbb.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
