### PR TITLE
podman: openssh required for machine subcommand

### DIFF
--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -28,6 +28,7 @@
   nftables,
   iptables,
   iproute2,
+  openssh,
   catatonit,
   gvproxy,
   aardvark-dns,
@@ -43,7 +44,8 @@ let
   # do not add qemu to this wrapper, store paths get written to the podman vm config and break when GCed
 
   binPath = lib.makeBinPath (
-    lib.optionals stdenv.hostPlatform.isLinux [
+    [ openssh ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       fuse-overlayfs
       util-linuxMinimal
       iptables


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I was testing something in podman and wanted to confirm that I didnt have any outside pollution of the environment. I then noticed that `ssh-keygen` wasnt placed in the PATH for `podman` This resulted in an error while using `podman machine`:

```
$ nix shell --ignore-environment .#podman  --command $SHELL --norc
bash-5.2$ podman machine list
NAME                     VM TYPE     CREATED        LAST UP       CPUS        MEMORY      DISK SIZE
podman-machine-default*  applehv     14 months ago  2 months ago  8           8.789GiB    100GiB
bash-5.2$ podman machine reset
Warning: this command will delete all existing Podman machines
and all of the configuration and data directories for Podman machines

The following machine(s) will be deleted:

NAME                     PROVIDER
podman-machine-default   applehv

Are you sure you want to continue? [y/N] y
bash-5.2$ podman machine list
NAME        VM TYPE     CREATED     LAST UP     CPUS        MEMORY      DISK SIZE
bash-5.2$ podman machine init
Error: exec: "ssh-keygen": executable file not found in $PATH
```

Checking `podman` this is indeed required to provisioning a machine with `podman machine`: https://github.com/containers/podman/blob/main/pkg/machine/keys.go#L16

Originally I thought this would be a non-linux environment dep but from the manpage for [podman-machine](https://docs.podman.io/en/v5.6.1/markdown/podman-machine.1.html)

> Podman on MacOS and Windows requires a virtual machine. This is because containers are Linux - containers do not run on any other OS because containers’ core functionality are tied to the Linux kernel. Podman machine must be used to manage MacOS and Windows machines, but can be optionally used on Linux.

Testing the fix:

```
$ nix shell --ignore-environment .#podman  --command $SHELL --norc
bash-5.2$ export HOME=/Users/robert.hernandez
bash-5.2$ podman machine reset
Warning: this command will delete all existing Podman machines
and all of the configuration and data directories for Podman machines

The following machine(s) will be deleted:

NAME                     PROVIDER
podman-machine-default   applehv

Are you sure you want to continue? [y/N] y
bash-5.2$ podman machine init
Looking up Podman Machine image at quay.io/podman/machine-os:5.6 to create VM
Getting image source signatures
Copying blob 594da50074cf done   |
Copying config 44136fa355 done   |
Writing manifest to image destination
594da50074cf9ca13ed914364cbf3d7ccde2257a5204e2513ab3754797121d81
Extracting compressed file: podman-machine-default-arm64.raw: done
Machine init complete
To start your machine run:

        podman machine start

bash-5.2$ podman machine start
Starting machine "podman-machine-default"

This machine is currently configured in rootless mode. If your containers
require root permissions (e.g. ports < 1024), or if you run into compatibility
issues with non-podman clients, you can switch using the following command:

        podman machine set --rootful

API forwarding listening on: /tmp/podman/podman-machine-default-api.sock
You can still connect Docker API clients by setting DOCKER_HOST using the
following command in your terminal session:

        export DOCKER_HOST='unix:///tmp/podman/podman-machine-default-api.sock'

Machine "podman-machine-default" started successfully
bash-5.2$ podman machine list
NAME                     VM TYPE     CREATED        LAST UP            CPUS        MEMORY      DISK SIZE
podman-machine-default*  applehv     3 minutes ago  Currently running  8           2GiB        100GiB
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
