### PR TITLE
libodfgen: fix build with gcc15

### DIFF
--- a/pkgs/by-name/li/libodfgen/libodfgen-add-include-cstdint-gcc15.patch
+++ b/pkgs/by-name/li/libodfgen/libodfgen-add-include-cstdint-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/src/OdfGenerator.cxx b/src/OdfGenerator.cxx
+index adf176b0a4..79de4dd2b7 100644
+--- a/src/OdfGenerator.cxx
++++ b/src/OdfGenerator.cxx
+@@ -33,6 +33,7 @@
+ #include <math.h>
+
+ #include <cctype>
++#include <cstdint>
+ #include <limits>
+ #include <string>
+ #include <stack>

--- a/pkgs/by-name/li/libodfgen/package.nix
+++ b/pkgs/by-name/li/libodfgen/package.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Mj5JH5VsjKKrsSyZjjUGcJMKMjF7+WYrBhXdSzkiuDE=";
   };
 
+  patches = [
+    # Fix build with gcc15, based on:
+    # https://sourceforge.net/p/libwpd/libodfgen/ci/4da0b148def5b40ee60d4cd79762c0f158d64cc7/
+    ./libodfgen-add-include-cstdint-gcc15.patch
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     boost


### PR DESCRIPTION
- add patch that adds `#include <cstdint>` to `OdfGenerator.cxx`,
based on upstream commit that is not included in tagged versions:
https://sourceforge.net/p/libwpd/libodfgen/ci/4da0b148def5b40ee60d4cd79762c0f158d64cc7/

Fixes build failure with gcc15:
```
OdfGenerator.cxx:53:9: error: 'uint8_t' was not declared in this scope
   53 |         uint8_t first;
      |         ^~~~~~~
OdfGenerator.cxx:45:1: note: 'uint8_t' is defined in header '<cstdint>';
this is probably fixable by adding '#include <cstdint>'
   44 | #include "GraphicFunctions.hxx"
  +++ |+#include <cstdint>
   45 | #include "InternalHandler.hxx"
OdfGenerator.cxx:57:17: error: 'first' was not declared in this scope
   57 |                 first = 0;
      |                 ^~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; libodfgen.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
