### PR TITLE
[Backport release-25.05] nixos/mautrix-whatsapp: adapt to new config file format (#420722)

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1148,6 +1148,15 @@
   "module-services-mautrix-signal-migrate-configuration": [
     "index.html#module-services-mautrix-signal-migrate-configuration"
   ],
+  "module-services-mautrix-whatsapp": [
+    "index.html#module-services-mautrix-whatsapp"
+  ],
+  "module-services-mautrix-whatsapp-configuration": [
+    "index.html#module-services-mautrix-whatsapp-configuration"
+  ],
+  "module-services-mautrix-whatsapp-migrate-configuration": [
+    "index.html#module-services-mautrix-whatsapp-migrate-configuration"
+  ],
   "module-services-maubot": [
     "index.html#module-services-maubot"
   ],

--- a/nixos/modules/services/matrix/mautrix-whatsapp.md
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.md
@@ -1,0 +1,32 @@
+# Mautrix-Whatsapp {#module-services-mautrix-whatsapp}
+
+[Mautrix-Whatsapp](https://github.com/mautrix/whatsapp) is a Matrix-Whatsapp puppeting bridge.
+
+## Configuration {#module-services-mautrix-whatsapp-configuration}
+
+1. Set [](#opt-services.mautrix-whatsapp.enable) to `true`. The service will use
+   SQLite by default.
+2. To create your configuration check the default configuration for
+   [](#opt-services.mautrix-whatsapp.settings). To obtain the complete default
+   configuration, run
+   `nix-shell -p mautrix-whatsapp --run "mautrix-whatsapp -c default.yaml -e"`.
+
+::: {.warning}
+Mautrix-Whatsapp allows for some options like `encryption.pickle_key`,
+`provisioning.shared_secret`, allow the value `generate` to be set.
+Since the configuration file is regenerated on every start of the
+service, the generated values would be discarded and might break your
+installation. Instead, set those values via
+[](#opt-services.mautrix-whatsapp.environmentFile).
+:::
+
+## Migrating from an older configuration {#module-services-mautrix-whatsapp-migrate-configuration}
+
+With Mautrix-Whatsapp v0.11.0 the configuration has been rearranged. Mautrix-Whatsapp
+performs an automatic configuration migration so your pre-0.7.0 configuration
+should just continue to work.
+
+In case you want to update your NixOS configuration, compare the migrated configuration
+at `/var/lib/mautrix-whatsapp/config.yaml` with the default configuration
+(`nix-shell -p mautrix-whatsapp --run "mautrix-whatsapp -c example.yaml -e"`) and
+update your module configuration accordingly.

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -8,34 +8,55 @@ let
   cfg = config.services.mautrix-whatsapp;
   dataDir = "/var/lib/mautrix-whatsapp";
   registrationFile = "${dataDir}/whatsapp-registration.yaml";
-  settingsFile = "${dataDir}/config.json";
+  settingsFile = "${dataDir}/config.yaml";
   settingsFileUnsubstituted = settingsFormat.generate "mautrix-whatsapp-config-unsubstituted.json" cfg.settings;
   settingsFormat = pkgs.formats.json { };
   appservicePort = 29318;
 
+  # to be used with a list of lib.mkIf values
+  optOneOf = lib.lists.findFirst (value: value.condition) (lib.mkIf false null);
   mkDefaults = lib.mapAttrsRecursive (n: v: lib.mkDefault v);
   defaultConfig = {
+    network = {
+      displayname_template = "{{or .BusinessName .PushName .Phone}} (WA)";
+      identity_change_notices = true;
+      history_sync = {
+        request_full_sync = true;
+      };
+    };
+    bridge = {
+      command_prefix = "!wa";
+      relay.enabled = true;
+      permissions."*" = "relay";
+    };
+    database = {
+      type = "sqlite3-fk-wal";
+      uri = "file:${dataDir}/mautrix-whatsapp.db?_txlock=immediate";
+    };
     homeserver.address = "http://localhost:8448";
     appservice = {
       hostname = "[::]";
       port = appservicePort;
-      database.type = "sqlite3";
-      database.uri = "${dataDir}/mautrix-whatsapp.db";
       id = "whatsapp";
-      bot.username = "whatsappbot";
-      bot.displayname = "WhatsApp Bridge Bot";
+      bot = {
+        username = "whatsappbot";
+        displayname = "WhatsApp Bridge Bot";
+      };
       as_token = "";
       hs_token = "";
-    };
-    bridge = {
       username_template = "whatsapp_{{.}}";
-      displayname_template = "{{if .BusinessName}}{{.BusinessName}}{{else if .PushName}}{{.PushName}}{{else}}{{.JID}}{{end}} (WA)";
-      double_puppet_server_map = { };
-      login_shared_secret_map = { };
-      command_prefix = "!wa";
-      permissions."*" = "relay";
-      relay.enabled = true;
     };
+    double_puppet = {
+      servers = { };
+      secrets = { };
+    };
+    # By default, the following keys/secrets are set to `generate`. This would break when the service
+    # is restarted, since the previously generated configuration will be overwritten everytime.
+    # If encryption is enabled, it's recommended to set those keys via `environmentFile`.
+    encryption.pickle_key = "";
+    provisioning.shared_secret = "";
+    public_media.signing_key = "";
+    direct_media.server_key = "";
     logging = {
       min_level = "info";
       writers = lib.singleton {
@@ -49,67 +70,78 @@ let
 in
 {
   options.services.mautrix-whatsapp = {
-    enable = lib.mkEnableOption "mautrix-whatsapp, a puppeting/relaybot bridge between Matrix and WhatsApp";
+    enable = lib.mkEnableOption "mautrix-whatsapp, a Matrix-WhatsApp puppeting bridge";
 
     package = lib.mkPackageOption pkgs "mautrix-whatsapp" { };
 
     settings = lib.mkOption {
+      apply = lib.recursiveUpdate defaultConfig;
       type = settingsFormat.type;
       default = defaultConfig;
       description = ''
         {file}`config.yaml` configuration as a Nix attribute set.
-        Configuration options should match those described in
-        [example-config.yaml](https://github.com/mautrix/whatsapp/blob/master/example-config.yaml).
+        Configuration options should match those described in the example configuration.
+        Get an example configuration by executing `mautrix-whatsapp -c example.yaml --generate-example-config`
         Secret tokens should be specified using {option}`environmentFile`
         instead of this world-readable attribute set.
       '';
       example = {
-        appservice = {
-          database = {
-            type = "postgres";
-            uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
-          };
-          id = "whatsapp";
-          ephemeral_events = false;
-        };
         bridge = {
-          history_sync = {
-            request_full_sync = true;
-          };
           private_chat_portal_meta = true;
-          mute_bridging = true;
-          encryption = {
-            allow = true;
-            default = true;
-            require = true;
-          };
-          provisioning = {
-            shared_secret = "disable";
-          };
+          mute_only_on_create = false;
           permissions = {
             "example.com" = "user";
           };
         };
+        database = {
+          type = "postgres";
+          uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
+        };
+        homeserver = {
+          address = "http://[::1]:8008";
+          domain = "my-domain.tld";
+        };
+        appservice = {
+          id = "whatsapp";
+          ephemeral_events = false;
+        };
+        matrix.message_status_events = true;
+        provisioning = {
+          shared_secret = "disable";
+        };
+        backfill.enabled = true;
+        encryption = {
+          allow = true;
+          default = true;
+          require = true;
+          pickle_key = "$ENCRYPTION_PICKLE_KEY";
+        };
       };
     };
+
     environmentFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        File containing environment variables to be passed to the mautrix-whatsapp service,
-        in which secret tokens can be specified securely by optionally defining a value for
-        `MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET`.
+        File containing environment variables to be passed to the mautrix-whatsapp service.
+        If an environment variable `MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET` is set,
+        then its value will be used in the configuration file for the option
+        `double_puppet.secrets` without leaking it to the store, using the configured
+        `homeserver.domain` as key.
       '';
     };
 
     serviceDependencies = lib.mkOption {
       type = with lib.types; listOf str;
-      default = lib.optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit;
+      default =
+        lib.optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit
+        ++ lib.optional config.services.matrix-conduit.enable "conduit.service";
       defaultText = lib.literalExpression ''
-        optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnits
+        optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit
+        ++ optional config.services.matrix-conduit.enable "conduit.service"
       '';
       description = ''
-        List of Systemd services to require and wait for when starting the application service.
+        List of systemd units to require and wait for when starting the application service.
       '';
     };
 
@@ -142,20 +174,28 @@ in
       serviceConfig.SupplementaryGroups = [ "mautrix-whatsapp" ];
     };
 
-    services.mautrix-whatsapp.settings = lib.mkMerge (
-      map mkDefaults [
-        defaultConfig
-        # Note: this is defined here to avoid the docs depending on `config`
-        { homeserver.domain = config.services.matrix-synapse.settings.server_name; }
+    # Note: this is defined here to avoid the docs depending on `config`
+    services.mautrix-whatsapp.settings.homeserver = optOneOf (
+      with config.services;
+      [
+        (lib.mkIf matrix-synapse.enable (mkDefaults {
+          domain = matrix-synapse.settings.server_name;
+        }))
+        (lib.mkIf matrix-conduit.enable (mkDefaults {
+          domain = matrix-conduit.settings.global.server_name;
+          address = "http://localhost:${toString matrix-conduit.settings.global.port}";
+        }))
       ]
     );
 
     systemd.services.mautrix-whatsapp = {
-      description = "Mautrix-WhatsApp Service - A WhatsApp bridge for Matrix";
+      description = "Mautrix-WhatsApp, a Matrix-WhatsApp puppeting bridge";
 
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ] ++ cfg.serviceDependencies;
       after = [ "network-online.target" ] ++ cfg.serviceDependencies;
+      # ffmpeg is required for conversion of voice messages
+      path = [ pkgs.ffmpeg-headless ];
 
       preStart = ''
         # substitute the settings file by environment variables
@@ -185,7 +225,7 @@ in
         ${pkgs.yq}/bin/yq -s '.[0].appservice.as_token = .[1].as_token
           | .[0].appservice.hs_token = .[1].hs_token
           | .[0]
-          | if env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET then .bridge.login_shared_secret_map.[.homeserver.domain] = env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET else . end' \
+          | if env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET then .double_puppet.secrets.[.homeserver.domain] = env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET else . end' \
           '${settingsFile}' '${registrationFile}' > '${settingsFile}.tmp'
         mv '${settingsFile}.tmp' '${settingsFile}'
         umask $old_umask
@@ -203,7 +243,6 @@ in
           --registration='${registrationFile}'
         '';
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateTmp = true;
@@ -229,5 +268,12 @@ in
       restartTriggers = [ settingsFileUnsubstituted ];
     };
   };
-  meta.maintainers = with lib.maintainers; [ frederictobiasc ];
+  meta = {
+    buildDocsInSandbox = false;
+    doc = ./mautrix-whatsapp.md;
+    maintainers = with lib.maintainers; [
+      pentane
+      frederictobiasc
+    ];
+  };
 }


### PR DESCRIPTION
Manually resolved [conflicts](https://github.com/NixOS/nixpkgs/pull/420722#issuecomment-3332545501) for backport #420722 to 25.05 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
