### PR TITLE
liblqr1: fix build with gcc15, cleanup

### DIFF
--- a/pkgs/by-name/li/liblqr1/package.nix
+++ b/pkgs/by-name/li/liblqr1/package.nix
@@ -6,7 +6,7 @@
   glib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "liblqr-1";
   version = "0.4.2";
 
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "carlobaldassi";
     repo = "liblqr";
-    rev = "v${version}";
-    sha256 = "10mrl5k3l2hxjhz4w93n50xwywp6y890rw2vsjcgai8627x5f1df";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-rgVX+hEGRfWY1FvwDBLy5nLPOyh2JE4+lB0KOmahuYI=";
   };
 
   # Fix build with gcc15
@@ -28,13 +28,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [ glib ];
 
-  meta = with lib; {
+  meta = {
     homepage = "http://liblqr.wikidot.com";
     description = "Seam-carving C/C++ library called Liquid Rescaling";
-    platforms = platforms.all;
-    license = with licenses; [
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [
       gpl3
       lgpl3
     ];
   };
-}
+})

--- a/pkgs/by-name/li/liblqr1/package.nix
+++ b/pkgs/by-name/li/liblqr1/package.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
     sha256 = "10mrl5k3l2hxjhz4w93n50xwywp6y890rw2vsjcgai8627x5f1df";
   };
 
+  # Fix build with gcc15
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [ glib ];
 


### PR DESCRIPTION
liblqr1: fix build with gcc15

- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE`, most updates upstream
were in 2017 or before.

Fixes build failure with gcc15:
```
lqr_energy.c:452:1: error: conflicting types for
'lqr_carver_generate_rcache_bright'; have 'gdouble *(LqrCarver *)'
{aka 'double *(struct _LqrCarver *)'}
  452 | lqr_carver_generate_rcache_bright(LqrCarver *r)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../lqr/lqr_energy.h:27,
                 from lqr_energy.c:32:
../lqr/lqr_energy_priv.h:59:10: note: previous declaration of
'lqr_carver_generate_rcache_bright' with type 'gdouble *(void)'
{aka 'double *(void)'}
   59 | gdouble *lqr_carver_generate_rcache_bright();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lqr_energy.c:471:1: error: conflicting types for
'lqr_carver_generate_rcache_luma'; have 'gdouble *(LqrCarver *)'
{aka 'double *(struct _LqrCarver *)'}
  471 | lqr_carver_generate_rcache_luma(LqrCarver *r)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
```
---

liblqr1: cleanup

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
- replace `sha256` with `hash`
nix hash to-sri --type sha256 "10mrl5k3l2hxjhz4w93n50xwywp6y890rw2vsjcgai8627x5f1df"
sha256-rgVX+hEGRfWY1FvwDBLy5nLPOyh2JE4+lB0KOmahuYI=

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; liblqr1.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Upstream is not very active, most updates were before 2017 and
other distros also fixed gcc15 issues by adding `-std=gnu17` or `-std=gnu11`:
https://gitlab.archlinux.org/archlinux/packaging/packages/liblqr/-/commit/5c2eb2a39389c874f2c019cad255b25db29a52c7
https://src.fedoraproject.org/rpms/liblqr-1/c/6f74801f26aee9c7030aca920813fcfeb4d856a4
https://build.opensuse.org/requests/1267258/changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
