### PR TITLE
doomrunner: fix postInstall on darwin

### DIFF
--- a/pkgs/by-name/do/doomrunner/package.nix
+++ b/pkgs/by-name/do/doomrunner/package.nix
@@ -27,13 +27,20 @@ stdenv.mkDerivation (finalAttrs: {
     "INSTALL_ROOT=${placeholder "out"}"
   ];
 
-  postInstall = ''
-    mkdir -p $out/{bin,share/applications,share/icons/hicolor/128x128/apps}
-    install -Dm444 $src/Install/XDG/DoomRunner.128x128.png $out/share/icons/hicolor/128x128/apps/DoomRunner.png
-    install -Dm444 $src/Install/XDG/DoomRunner.desktop $out/share/applications/DoomRunner.desktop
-    install -Dm755 $out/usr/bin/DoomRunner $out/bin/DoomRunner
-    rm -rf $out/usr
-  '';
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      mv $out/usr/bin/DoomRunner.app $out/Applications/
+    ''
+    + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+      mkdir -p $out/{bin,share/applications,share/icons/hicolor/128x128/apps}
+      install -Dm444 $src/Install/XDG/DoomRunner.128x128.png $out/share/icons/hicolor/128x128/apps/DoomRunner.png
+      install -Dm444 $src/Install/XDG/DoomRunner.desktop $out/share/applications/DoomRunner.desktop
+      install -Dm755 $out/usr/bin/DoomRunner $out/bin/DoomRunner
+    ''
+    + ''
+      rm -rf $out/usr
+    '';
 
   meta = {
     description = "Preset-oriented graphical launcher of various ported Doom engines";


### PR DESCRIPTION
Fixed the build on darwin systems by moving `Doom Runner.app` to `$out/Applications/` instead of trying to move `DoomRunner` which is not built on darwin.

I am unsure whether this style of checking `hostPlatform` is optimal so feedback is appreciated.

I also wonder whether `lib.platforms.all` is appropriate here

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
