### PR TITLE
python3Packages.llm*: update

### DIFF
--- a/pkgs/development/python-modules/llm-gemini/default.nix
+++ b/pkgs/development/python-modules/llm-gemini/default.nix
@@ -15,14 +15,14 @@
 }:
 buildPythonPackage rec {
   pname = "llm-gemini";
-  version = "0.25";
+  version = "0.26";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "llm-gemini";
     tag = version;
-    hash = "sha256-jnPFlLUQ+NSTDUStocUldqT7Z+bjrtzGSOJHfMFCScU=";
+    hash = "sha256-Blkes0d7pVpltP2Vj8ngFRpNYnb9Z/m6O6UByAjrdfw=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/llm-grok/default.nix
+++ b/pkgs/development/python-modules/llm-grok/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "llm-grok";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Hiepler";
     repo = "llm-grok";
     tag = "v${version}";
-    hash = "sha256-YSpo7dsQ0/s+sS2DXeLq7zHBdktxCr0P96vr6PtEu9o=";
+    hash = "sha256-Z/q7A7lidtDPpuD+xnD7+puWxvUZi4ruO7l1AZEu1vU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/llm-openai-plugin/default.nix
+++ b/pkgs/development/python-modules/llm-openai-plugin/default.nix
@@ -15,14 +15,14 @@
 }:
 buildPythonPackage rec {
   pname = "llm-openai-plugin";
-  version = "0.5";
+  version = "0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "llm-openai-plugin";
     tag = version;
-    hash = "sha256-xlJS+xAKOo40hZH751yrvIuXZw1HQsB7K2anFoMxthU=";
+    hash = "sha256-PDjrsuZMt4XpYyRg8VRyHZmAu4gD5lLl6aQezhavOvc=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/llm-openrouter/default.nix
+++ b/pkgs/development/python-modules/llm-openrouter/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "llm-openrouter";
-  version = "0.4.1";
+  version = "0.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "llm-openrouter";
     tag = version;
-    hash = "sha256-ojBkyXqEaqTcOv7mzTWL5Ihhb50zeVzeQZNA6DySuVg=";
+    hash = "sha256-lofijdGKkQRQa2Hle4puIBOj+I28hGdKRILeQZOLkz4=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/llm-venice/default.nix
+++ b/pkgs/development/python-modules/llm-venice/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "llm-venice";
-  version = "0.7.0";
+  version = "0.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ar-jan";
     repo = "llm-venice";
     tag = version;
-    hash = "sha256-vsb3oXGr+2FDJnTwYomICfald1ptben28hAJ8ypKiBI=";
+    hash = "sha256-jvZWMEJAWlX2y2Mivi8Kib5tbMtf+CXYP6fmLvNmD9k=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
- 1ccb4a8d32f5ea2c597df15edf93bc582b127b8b `python3Packages.llm-gemini`: 0.25 -> 0.26 with new models `gemini-2.5-flash-preview-09-2025` and `gemini-2.5-flash-lite-preview-09-2025`, plus `gemini-flash-latest` and `gemini-flash-lite-latest` aliases that record resolved IDs.
- c40f9290f25a7c2c283cd66f97cd8a9cbdecf5cc `python3Packages.llm-grok`: 1.2.0 -> 1.3.0 
- ca8da5384d604019b6811f3401f56319f5af28df `python3Packages.llm-openai-plugin`: 0.5 -> 0.6 adding support for GPT-5 models including `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, and `gpt-5-codex` with tool calling.
- fa443ee07c3218a0848d4b4639b1117719ab204b `python3Packages.llm-openrouter`: 0.4.1 -> 0.5 with tool calling support and reasoning options like `-o reasoning_effort medium`.
- 764b913d3f3079101f47f80409055e238d97baba `python3Packages.llm-venice`: 0.7.0 -> 0.8.0 adding tool support (function calling), thinking-related venice_parameters, and reorganized tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
