### PR TITLE
[Backport release-25.05] various: add maintainer iedame

### DIFF
--- a/pkgs/applications/backup/vorta/default.nix
+++ b/pkgs/applications/backup/vorta/default.nix
@@ -103,7 +103,10 @@ python3Packages.buildPythonApplication rec {
     description = "Desktop Backup Client for Borg";
     homepage = "https://vorta.borgbase.com/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ma27 ];
+    maintainers = with lib.maintainers; [
+      ma27
+      iedame
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "vorta";
   };

--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -158,6 +158,7 @@ buildPythonApplication rec {
     maintainers = with maintainers; [
       Madouura
       rapiteanu
+      iedame
     ];
     platforms = platforms.linux;
     mainProgram = "lutris";

--- a/pkgs/by-name/ad/adwsteamgtk/package.nix
+++ b/pkgs/by-name/ad/adwsteamgtk/package.nix
@@ -46,7 +46,10 @@ python3Packages.buildPythonApplication rec {
     description = "Simple Gtk wrapper for Adwaita-for-Steam";
     homepage = "https://github.com/Foldex/AdwSteamGtk";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.reedrw ];
+    maintainers = with lib.maintainers; [
+      reedrw
+      iedame
+    ];
     mainProgram = "adwaita-steam-gtk";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -108,7 +108,10 @@ buildGoModule {
     homepage = "https://github.com/garethgeorge/backrest";
     changelog = "https://github.com/garethgeorge/backrest/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ interdependence ];
+    maintainers = with lib.maintainers; [
+      interdependence
+      iedame
+    ];
     mainProgram = "backrest";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/bo/borgbackup/package.nix
+++ b/pkgs/by-name/bo/borgbackup/package.nix
@@ -148,6 +148,7 @@ python.pkgs.buildPythonApplication rec {
     maintainers = with maintainers; [
       dotlambda
       globin
+      iedame
     ];
   };
 }

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -111,6 +111,7 @@ flutter324.buildFlutterApplication rec {
       schnow265
       zi3m5f
       gepbird
+      iedame
     ];
     mainProgram = "enteauth";
     platforms = [

--- a/pkgs/by-name/en/ente-cli/package.nix
+++ b/pkgs/by-name/en/ente-cli/package.nix
@@ -86,8 +86,9 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/ente-io/ente/tree/main/cli#readme";
     changelog = "https://github.com/ente-io/ente/releases/tag/cli-v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
-    maintainers = [
-      lib.maintainers.zi3m5f
+    maintainers = with lib.maintainers; [
+      zi3m5f
+      iedame
     ];
     mainProgram = "ente";
   };

--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -142,6 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       pinpox
       yuka
+      iedame
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/en/ente-web/package.nix
+++ b/pkgs/by-name/en/ente-web/package.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       pinpox
+      iedame
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/lu/ludusavi/package.nix
+++ b/pkgs/by-name/lu/ludusavi/package.nix
@@ -125,6 +125,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       pasqui23
       megheaiulian
+      iedame
     ];
     mainProgram = "ludusavi";
   };

--- a/pkgs/by-name/mu/museum/package.nix
+++ b/pkgs/by-name/mu/museum/package.nix
@@ -54,6 +54,7 @@ buildGoModule rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       pinpox
+      iedame
     ];
     mainProgram = "museum";
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pg/pgbackrest/package.nix
+++ b/pkgs/by-name/pg/pgbackrest/package.nix
@@ -58,6 +58,9 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/pgbackrest/pgbackrest/releases/tag/release%2F${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "pgbackrest";
-    maintainers = with lib.maintainers; [ zaninime ];
+    maintainers = with lib.maintainers; [
+      zaninime
+      iedame
+    ];
   };
 })


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/443599

~~for `backrest` I removed the previous maintainer because he already removed himself from maintaining the package but didn't back port.~~ I adopted the orphaned package.

Edit: Left the previous `backrest` maintainer there since CI did not fancy my change. Sorry CI!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
