### PR TITLE
llvmPackages.libclang: add enableClangToolsExtra flag

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -15,10 +15,13 @@
   buildLlvmTools,
   fixDarwinDylibNames,
   enableManpages ? false,
+  enableClangToolsExtra ? true,
   devExtraCmakeFlags ? [ ],
   replaceVars,
   getVersionFile,
   fetchpatch,
+  # for tests
+  libclang,
 }:
 stdenv.mkDerivation (
   finalAttrs:
@@ -32,7 +35,7 @@ stdenv.mkDerivation (
           mkdir -p "$out"
           cp -r ${monorepoSrc}/cmake "$out"
           cp -r ${monorepoSrc}/clang "$out"
-          cp -r ${monorepoSrc}/clang-tools-extra "$out"
+          ${lib.optionalString enableClangToolsExtra "cp -r ${monorepoSrc}/clang-tools-extra \"$out\""}
         '')
       else
         src;
@@ -171,7 +174,8 @@ stdenv.mkDerivation (
 
       mkdir -p $dev/bin
     ''
-    + (
+    # TODO(@LunNova): Clean up this rebuild avoidance in staging
+    + lib.optionalString enableClangToolsExtra (
       if lib.versionOlder release_version "20" then
         ''
           cp bin/{clang-tblgen,clang-tidy-confusable-chars-gen,clang-pseudo-gen} $dev/bin
@@ -180,7 +184,10 @@ stdenv.mkDerivation (
         ''
           cp bin/{clang-tblgen,clang-tidy-confusable-chars-gen} $dev/bin
         ''
-    );
+    )
+    + lib.optionalString (!enableClangToolsExtra) ''
+      cp bin/clang-tblgen $dev/bin
+    '';
 
     env =
       lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform && !stdenv.hostPlatform.useLLVM)
@@ -209,6 +216,9 @@ stdenv.mkDerivation (
         ) "stackclashprotection"
         ++ lib.optional (!(targetPlatform.isx86_64 || targetPlatform.isAarch64)) "zerocallusedregs"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or [ ]);
+      tests.withoutOptionalFeatures = libclang.override {
+        enableClangToolsExtra = false;
+      };
     };
 
     requiredSystemFeatures = [ "big-parallel" ];


### PR DESCRIPTION
`rocmPackages` needs a clang at runtime, it would be nice to avoid including clang-tools-extra/clang-tidy related files in clang to reduce the runtime closure size of packages that support ROCm.

The approach in this change avoids rebuilds and is messy, I will make a followup in staging that changes this to more idiomatic `optionalString` usage if this is merged

I've been working on closure size reduction for `rocmPackages` in #444860 and figured it'd be nicer on reviewers to separate out this clang change.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 446207 --extra-nixpkgs-config '{ allowAliases = true; }' --package llvmPackages.libclang.tests.withoutOptionalFeatures --package llvmPackages_18.libclang.tests.withoutOptionalFeatures --package llvmPackages_21.libclang.tests.withoutOptionalFeatures --package llvmPackages_git.libclang.tests.withoutOptionalFeatures`
Commit: `1f4626619139ff66e420b8446c25e93dc8903b3f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 20 packages built:</summary>
  <ul>
    <li>llvmPackages.libclang.tests.withoutOptionalFeatures</li>
    <li>llvmPackages.libclang.tests.withoutOptionalFeatures.debug (llvmPackages.libclang.tests.withoutOptionalFeatures.debug.debug, llvmPackages.libclang.tests.withoutOptionalFeatures.debug.dev, llvmPackages.libclang.tests.withoutOptionalFeatures.debug.lib, llvmPackages.libclang.tests.withoutOptionalFeatures.debug.python)</li>
    <li>llvmPackages.libclang.tests.withoutOptionalFeatures.dev (llvmPackages.libclang.tests.withoutOptionalFeatures.dev.debug, llvmPackages.libclang.tests.withoutOptionalFeatures.dev.dev, llvmPackages.libclang.tests.withoutOptionalFeatures.dev.lib, llvmPackages.libclang.tests.withoutOptionalFeatures.dev.python)</li>
    <li>llvmPackages.libclang.tests.withoutOptionalFeatures.lib (llvmPackages.libclang.tests.withoutOptionalFeatures.lib.debug, llvmPackages.libclang.tests.withoutOptionalFeatures.lib.dev, llvmPackages.libclang.tests.withoutOptionalFeatures.lib.lib, llvmPackages.libclang.tests.withoutOptionalFeatures.lib.python)</li>
    <li>llvmPackages.libclang.tests.withoutOptionalFeatures.python (llvmPackages.libclang.tests.withoutOptionalFeatures.python.debug, llvmPackages.libclang.tests.withoutOptionalFeatures.python.dev, llvmPackages.libclang.tests.withoutOptionalFeatures.python.lib, llvmPackages.libclang.tests.withoutOptionalFeatures.python.python)</li>
    <li>llvmPackages_18.libclang.tests.withoutOptionalFeatures</li>
    <li>llvmPackages_18.libclang.tests.withoutOptionalFeatures.debug (llvmPackages_18.libclang.tests.withoutOptionalFeatures.debug.debug, llvmPackages_18.libclang.tests.withoutOptionalFeatures.debug.dev, llvmPackages_18.libclang.tests.withoutOptionalFeatures.debug.lib, llvmPackages_18.libclang.tests.withoutOptionalFeatures.debug.python)</li>
    <li>llvmPackages_18.libclang.tests.withoutOptionalFeatures.dev (llvmPackages_18.libclang.tests.withoutOptionalFeatures.dev.debug, llvmPackages_18.libclang.tests.withoutOptionalFeatures.dev.dev, llvmPackages_18.libclang.tests.withoutOptionalFeatures.dev.lib, llvmPackages_18.libclang.tests.withoutOptionalFeatures.dev.python)</li>
    <li>llvmPackages_18.libclang.tests.withoutOptionalFeatures.lib (llvmPackages_18.libclang.tests.withoutOptionalFeatures.lib.debug, llvmPackages_18.libclang.tests.withoutOptionalFeatures.lib.dev, llvmPackages_18.libclang.tests.withoutOptionalFeatures.lib.lib, llvmPackages_18.libclang.tests.withoutOptionalFeatures.lib.python)</li>
    <li>llvmPackages_18.libclang.tests.withoutOptionalFeatures.python (llvmPackages_18.libclang.tests.withoutOptionalFeatures.python.debug, llvmPackages_18.libclang.tests.withoutOptionalFeatures.python.dev, llvmPackages_18.libclang.tests.withoutOptionalFeatures.python.lib, llvmPackages_18.libclang.tests.withoutOptionalFeatures.python.python)</li>
    <li>llvmPackages_21.libclang.tests.withoutOptionalFeatures</li>
    <li>llvmPackages_21.libclang.tests.withoutOptionalFeatures.debug (llvmPackages_21.libclang.tests.withoutOptionalFeatures.debug.debug, llvmPackages_21.libclang.tests.withoutOptionalFeatures.debug.dev, llvmPackages_21.libclang.tests.withoutOptionalFeatures.debug.lib, llvmPackages_21.libclang.tests.withoutOptionalFeatures.debug.python)</li>
    <li>llvmPackages_21.libclang.tests.withoutOptionalFeatures.dev (llvmPackages_21.libclang.tests.withoutOptionalFeatures.dev.debug, llvmPackages_21.libclang.tests.withoutOptionalFeatures.dev.dev, llvmPackages_21.libclang.tests.withoutOptionalFeatures.dev.lib, llvmPackages_21.libclang.tests.withoutOptionalFeatures.dev.python)</li>
    <li>llvmPackages_21.libclang.tests.withoutOptionalFeatures.lib (llvmPackages_21.libclang.tests.withoutOptionalFeatures.lib.debug, llvmPackages_21.libclang.tests.withoutOptionalFeatures.lib.dev, llvmPackages_21.libclang.tests.withoutOptionalFeatures.lib.lib, llvmPackages_21.libclang.tests.withoutOptionalFeatures.lib.python)</li>
    <li>llvmPackages_21.libclang.tests.withoutOptionalFeatures.python (llvmPackages_21.libclang.tests.withoutOptionalFeatures.python.debug, llvmPackages_21.libclang.tests.withoutOptionalFeatures.python.dev, llvmPackages_21.libclang.tests.withoutOptionalFeatures.python.lib, llvmPackages_21.libclang.tests.withoutOptionalFeatures.python.python)</li>
    <li>llvmPackages_git.libclang.tests.withoutOptionalFeatures</li>
    <li>llvmPackages_git.libclang.tests.withoutOptionalFeatures.debug (llvmPackages_git.libclang.tests.withoutOptionalFeatures.debug.debug, llvmPackages_git.libclang.tests.withoutOptionalFeatures.debug.dev, llvmPackages_git.libclang.tests.withoutOptionalFeatures.debug.lib, llvmPackages_git.libclang.tests.withoutOptionalFeatures.debug.python)</li>
    <li>llvmPackages_git.libclang.tests.withoutOptionalFeatures.dev (llvmPackages_git.libclang.tests.withoutOptionalFeatures.dev.debug, llvmPackages_git.libclang.tests.withoutOptionalFeatures.dev.dev, llvmPackages_git.libclang.tests.withoutOptionalFeatures.dev.lib, llvmPackages_git.libclang.tests.withoutOptionalFeatures.dev.python)</li>
    <li>llvmPackages_git.libclang.tests.withoutOptionalFeatures.lib (llvmPackages_git.libclang.tests.withoutOptionalFeatures.lib.debug, llvmPackages_git.libclang.tests.withoutOptionalFeatures.lib.dev, llvmPackages_git.libclang.tests.withoutOptionalFeatures.lib.lib, llvmPackages_git.libclang.tests.withoutOptionalFeatures.lib.python)</li>
    <li>llvmPackages_git.libclang.tests.withoutOptionalFeatures.python (llvmPackages_git.libclang.tests.withoutOptionalFeatures.python.debug, llvmPackages_git.libclang.tests.withoutOptionalFeatures.python.dev, llvmPackages_git.libclang.tests.withoutOptionalFeatures.python.lib, llvmPackages_git.libclang.tests.withoutOptionalFeatures.python.python)</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
