### PR TITLE
biboumi: use botan3 and cleanup

### DIFF
--- a/pkgs/by-name/bi/biboumi/package.nix
+++ b/pkgs/by-name/bi/biboumi/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchgit,
+  fetchFromGitea,
+  fetchpatch,
   cmake,
   libuuid,
   expat,
   libiconv,
-  botan2,
+  botan3,
   systemd,
   pkg-config,
   python3Packages,
@@ -26,22 +26,36 @@ assert lib.assertMsg (
 ) "At least one Biboumi database provider required";
 
 let
-  louiz_catch = fetchgit {
-    url = "https://lab.louiz.org/louiz/Catch.git";
-    rev = "0a34cc201ef28bf25c88b0062f331369596cb7b7"; # v2.2.1
-    sha256 = "0ad0sjhmzx61a763d2ali4vkj8aa1sbknnldks7xlf4gy83jfrbl";
+  catch = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "poezio";
+    repo = "catch";
+    tag = "v2.2.1";
+    hash = "sha256-dGUnB/KPONqPno1aO5cOSiE5N4lUiTbMUcH0X6HUoCk=";
   };
-in
-stdenv.mkDerivation rec {
+
   pname = "biboumi";
   version = "9.0";
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
-  src = fetchurl {
-    url = "https://git.louiz.org/biboumi/snapshot/biboumi-${version}.tar.xz";
-    sha256 = "1jvygri165aknmvlinx3jb8cclny6cxdykjf8dp0a3l3228rmzqy";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "poezio";
+    repo = "biboumi";
+    tag = version;
+    hash = "sha256-yjh9WFuFjaoZLfXTfZajmdRO+3KZqJYBEd0HgqcC28A=";
   };
 
-  patches = [ ./catch.patch ];
+  patches = [
+    ./catch.patch
+    (fetchpatch {
+      name = "update_botan_to_version_3.patch";
+      url = "https://codeberg.org/poezio/biboumi/commit/e4d32f939240ed726e9981e42c0dc251cd9879da.patch";
+      hash = "sha256-QUt2ZQtoouLHAeEUlJh+yfCYEmLboL/tk6O2TbHR67Q=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -53,7 +67,7 @@ stdenv.mkDerivation rec {
     expat
     libiconv
     systemd
-    botan2
+    botan3
   ]
   ++ lib.optional withIDN libidn
   ++ lib.optional withPostgreSQL libpq
@@ -67,17 +81,17 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace CMakeLists.txt --replace /etc/biboumi $out/etc/biboumi
-    cp ${louiz_catch}/single_include/catch.hpp tests/
+    cp ${catch}/single_include/catch.hpp tests/
   '';
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Modern XMPP IRC gateway";
     mainProgram = "biboumi";
-    platforms = platforms.unix;
-    homepage = "https://lab.louiz.org/louiz/biboumi";
-    license = licenses.zlib;
-    maintainers = [ maintainers.woffs ];
+    platforms = lib.platforms.unix;
+    homepage = "https://codeberg.org/poezio/biboumi";
+    license = lib.licenses.zlib;
+    maintainers = [ lib.maintainers.woffs ];
   };
 }


### PR DESCRIPTION
Switch to codeberg repos for biboumi sources as old source is broken. Apply patch from main branch to use botan3 instead of EOL botan2.

This is part of deprecating and removing botan2. [#445861](https://github.com/NixOS/nixpkgs/issues/445861)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
