### PR TITLE
soci: 4.0.2 -> 4.1.2

### DIFF
--- a/pkgs/development/libraries/soci/default.nix
+++ b/pkgs/development/libraries/soci/default.nix
@@ -1,37 +1,29 @@
 {
-  cmake,
-  fetchFromGitHub,
-  fetchpatch,
-  sqlite,
-  libpq,
-  boost,
   lib,
   stdenv,
+  fetchFromGitHub,
+  cmake,
+  boost,
+  libpq,
+  sqlite,
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "soci";
-  version = "4.0.2";
+  version = "4.1.2";
 
   src = fetchFromGitHub {
     owner = "SOCI";
     repo = "soci";
-    rev = "v${version}";
-    sha256 = "sha256-NE0ApbX8HG2VAQ9cg9+kX3kJQ4PR1XvWL9BlT8NphmE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vdvvqPTODC0AMDLZa2pOy5/qkZ1IuJ0PEDTN6oMJAqg=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-backend-search-path.patch";
-      url = "https://github.com/SOCI/soci/commit/56c93afc467bdba8ffbe68739eea76059ea62f7a.patch";
-      sha256 = "sha256-nC/39pn3Cv5e65GgIfF3l64/AbCsfZHPUPIWETZFZAY=";
-    })
-  ];
 
   # Do not build static libraries
   cmakeFlags = [
-    "-DSOCI_STATIC=OFF"
-    "-DCMAKE_CXX_STANDARD=11"
-    "-DSOCI_TESTS=off"
+    (lib.cmakeFeature "CMAKE_CXX_STANDARD" "11")
+    (lib.cmakeBool "SOCI_STATIC" false)
+    (lib.cmakeBool "SOCI_TESTS" false)
   ];
 
   nativeBuildInputs = [ cmake ];
@@ -41,11 +33,11 @@ stdenv.mkDerivation rec {
     boost
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Database access library for C++";
     homepage = "https://soci.sourceforge.net/";
-    license = licenses.boost;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ jluttine ];
+    license = lib.licenses.boost;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jluttine ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/SOCI/soci/compare/v4.0.2...v4.1.2
https://github.com/SOCI/soci/blob/4c1578d09ebbe324fbe1f00661146b483de88be2/CHANGES#L16
https://github.com/SOCI/soci/releases/tag/v4.1.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
