### PR TITLE
sniproxy: 0.6.1 -> 0.7.0

### DIFF
--- a/pkgs/by-name/sn/sniproxy/package.nix
+++ b/pkgs/by-name/sn/sniproxy/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchurl,
   autoreconfHook,
   gettext,
   libev,
@@ -11,28 +10,18 @@
   udns,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sniproxy";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "dlundquist";
     repo = "sniproxy";
-    rev = version;
-    sha256 = "sha256-htM9CrzaGnn1dnsWQ+0V6N65Og7rsFob3BlSc4UGfFU=";
+    tag = finalAttrs.version;
+    hash = "sha256-TUXwixnBFdegYRzeXlLVno2M3gVXyCw5Jdfb9ulOROs=";
   };
 
-  patches = [
-    ./gettext-0.25.patch
-    (fetchurl {
-      name = "compat-pcre2.patch";
-      # Using Arch Linux patch because the following upstream patches do not apply cleanly:
-      # https://github.com/dlundquist/sniproxy/commit/62e621f050f79eb78598b1296a089ef88a19ea91
-      # https://github.com/dlundquist/sniproxy/commit/7fdd86c054a21f7ac62343010de20f28645b14d2
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/sniproxy/-/raw/3272f9f0d406c51122f90708bfcc7b4ba0eb38c9/sniproxy-0.6.1-pcre2.patch?inline=false";
-      hash = "sha256-v6qdBAWXit0Zg43OsgzCTb4cSPm7gsEXVd7W8LvBgMk=";
-    })
-  ];
+  patches = [ ./gettext-0.25.patch ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -45,16 +34,15 @@ stdenv.mkDerivation rec {
     udns
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/dlundquist/sniproxy";
     description = "Transparent TLS and HTTP layer 4 proxy with SNI support";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
       womfoo
       raitobezarius
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "sniproxy";
   };
-
-}
+})


### PR DESCRIPTION
Diff: https://github.com/dlundquist/sniproxy/compare/0.6.1...0.7.0
https://github.com/dlundquist/sniproxy/releases/tag/0.7.0
https://github.com/dlundquist/sniproxy/blob/1cc625ea41796695a54593d1bd779366b82b8b4e/ChangeLog#L2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
