### PR TITLE
snakemake: 9.5.1 -> 9.11.8

### DIFF
--- a/pkgs/by-name/sn/snakemake/package.nix
+++ b/pkgs/by-name/sn/snakemake/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "snakemake";
-  version = "9.5.1";
+  version = "9.11.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snakemake";
     repo = "snakemake";
     tag = "v${version}";
-    hash = "sha256-cSFqPSLeM7hw1bxQZ2FhlHUP+O3iyrwBz4+Jz90Zck8=";
+    hash = "sha256-bbwpLSWCYKezFJj7EVn6wOLSzO/vShP98MMicKzdGSQ=";
   };
 
   postPatch = ''
@@ -58,6 +58,7 @@ python3Packages.buildPythonApplication rec {
     snakemake-interface-logger-plugins
     snakemake-interface-storage-plugins
     snakemake-interface-report-plugins
+    snakemake-interface-scheduler-plugins
     stopit
     tabulate
     throttler
@@ -140,6 +141,11 @@ python3Packages.buildPythonApplication rec {
     # Requires snakemake-storage-plugin-http
     "test_keep_local"
     "test_retrieve"
+
+    # Requires conda
+    "test_jupyter_notebook"
+    "test_jupyter_notebook_nbconvert"
+    "test_jupyter_notebook_draft"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Unclear failure:

--- a/pkgs/by-name/sn/snakemake/package.nix
+++ b/pkgs/by-name/sn/snakemake/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "snakemake";
-  version = "9.11.6";
+  version = "9.11.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snakemake";
     repo = "snakemake";
     tag = "v${version}";
-    hash = "sha256-bbwpLSWCYKezFJj7EVn6wOLSzO/vShP98MMicKzdGSQ=";
+    hash = "sha256-fQCpQ3LB0Q1USZ9YTEniR5iKq68Zri9+14zqa/jzO2o=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/snakemake-interface-common/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-common/default.nix
@@ -4,43 +4,40 @@
   buildPythonPackage,
   configargparse,
   fetchFromGitHub,
-  poetry-core,
-  pythonOlder,
-  pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "snakemake-interface-common";
-  version = "1.17.4";
+  version = "1.21.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "snakemake";
     repo = "snakemake-interface-common";
     tag = "v${version}";
-    hash = "sha256-PMEs7yeVfSnZKbabLrbXfIKCIPteNV1wzbt9RIDG3qU=";
+    hash = "sha256-8QISVZZ/kwWBNFtndzysnxFuuemkDXcWqEtCdVVsANo=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ setuptools ];
 
   dependencies = [
     argparse-dataclass
     configargparse
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
   pythonImportsCheck = [ "snakemake_interface_common" ];
 
-  enabledTestPaths = [ "tests/tests.py" ];
+  # test_snakemake_version: No module named 'snakemake'
+  # nativeCheckInputs = [ pytestCheckHook ];
 
-  meta = with lib; {
+  # enabledTestPaths = [ "tests/tests.py" ];
+
+  meta = {
     description = "Common functions and classes for Snakemake and its plugins";
     homepage = "https://github.com/snakemake/snakemake-interface-common";
     changelog = "https://github.com/snakemake/snakemake-interface-common/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ veprbl ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ veprbl ];
   };
 }

--- a/pkgs/development/python-modules/snakemake-interface-common/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-common/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "snakemake-interface-common";
-  version = "1.21.0";
+  version = "1.22.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snakemake";
     repo = "snakemake-interface-common";
     tag = "v${version}";
-    hash = "sha256-8QISVZZ/kwWBNFtndzysnxFuuemkDXcWqEtCdVVsANo=";
+    hash = "sha256-DxbB/UaBkLbG18CGHyDMo7dmRlVY2tD3BhO0MShbnq4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/snakemake-interface-scheduler-plugins/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-scheduler-plugins/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  snakemake-interface-common,
+}:
+
+let
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = "snakemake-interface-scheduler-plugins";
+    tag = "v${version}";
+    hash = "sha256-Z/rJGkby9AcYB+Gil00xhbrySChqEIEOtzLyzQPhObk=";
+  };
+in
+buildPythonPackage {
+  pname = "snakemake-interface-scheduler-plugins";
+  inherit version src;
+  pyproject = true;
+
+  build-system = [ hatchling ];
+
+  dependencies = [ snakemake-interface-common ];
+
+  pythonImportsCheck = [ "snakemake_interface_scheduler_plugins" ];
+
+  # test_scheduler: No module named 'snakemake'
+  # nativeCheckInputs = [ pytestCheckHook ];
+
+  # enabledTestPaths = [ "tests/tests.py" ];
+
+  meta = {
+    description = "Provides a stable interface for interactions between Snakemake and its scheduler plugins";
+    homepage = "https://github.com/snakemake/snakemake-interface-scheduler-plugins";
+    changelog = "https://github.com/snakemake/snakemake-interface-scheduler-plugins/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kyehn ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17013,6 +17013,10 @@ self: super: with self; {
     callPackage ../development/python-modules/snakemake-interface-report-plugins
       { };
 
+  snakemake-interface-scheduler-plugins =
+    callPackage ../development/python-modules/snakemake-interface-scheduler-plugins
+      { };
+
   snakemake-interface-storage-plugins =
     callPackage ../development/python-modules/snakemake-interface-storage-plugins
       { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/snakemake/snakemake/releases/tag/v9.11.8
https://github.com/snakemake/snakemake/blob/v9.11.8/CHANGELOG.md
https://github.com/snakemake/snakemake/compare/v9.5.1...v9.11.8

https://github.com/snakemake/snakemake-interface-common/releases/tag/v1.22.0
https://github.com/snakemake/snakemake-interface-common/compare/v1.17.4...v1.22.0

Snakemake Scheduler Plugin Interface: This package provides a stable interface for interactions between Snakemake and its scheduler plugins. https://github.com/snakemake/snakemake-interface-scheduler-plugins


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
