### PR TITLE
skippy-xd: 0.8.0 -> 2025.09.07

### DIFF
--- a/pkgs/by-name/sk/skippy-xd/package.nix
+++ b/pkgs/by-name/sk/skippy-xd/package.nix
@@ -13,16 +13,20 @@
   giflib,
   pkg-config,
 }:
-stdenv.mkDerivation {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "skippy-xd";
-  version = "0.8.0";
+  version = "2025.09.07";
+
   src = fetchFromGitHub {
     owner = "felixfung";
     repo = "skippy-xd";
-    rev = "30da57cb59ccf77f766718f7d533ddbe533ba241";
-    hash = "sha256-YBUDbI1SHsBI/fA3f3W1sPu3wXSodMbTGvAMqOz7RCM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PxVU0atl5OLINFTM1n3REVA/M9iozkHOW9kPgTU/+qI=";
   };
+
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
     xorgproto
     libX11
@@ -34,15 +38,18 @@ stdenv.mkDerivation {
     libjpeg
     giflib
   ];
+
   makeFlags = [ "PREFIX=$(out)" ];
+
   preInstall = ''
     sed -e "s@/etc/xdg@$out&@" -i Makefile
   '';
-  meta = with lib; {
+
+  meta = {
     description = "Expose-style compositing-based standalone window switcher";
     homepage = "https://github.com/felixfung/skippy-xd";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ raskin ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ raskin ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/felixfung/skippy-xd/blob/6c2e6ece3a2355194f408502f4694bcb05660ee6/CHANGELOG#L3
https://github.com/felixfung/skippy-xd/releases/tag/v2025.09.07
https://github.com/felixfung/skippy-xd/compare/30da57cb59ccf77f766718f7d533ddbe533ba241...v2025.09.07

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
