### PR TITLE
sjasmplus: 1.18.3 -> 1.21.0

### DIFF
--- a/pkgs/by-name/sj/sjasmplus/package.nix
+++ b/pkgs/by-name/sj/sjasmplus/package.nix
@@ -2,18 +2,21 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  luabridge,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sjasmplus";
-  version = "1.18.3";
+  version = "1.21.0";
 
   src = fetchFromGitHub {
     owner = "z00m128";
     repo = "sjasmplus";
-    rev = "v${version}";
-    sha256 = "sha256-+FvNYfJ5I91RfuJTiOPhj5KW8HoOq8OgnnpFEgefSGc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iPtH/Uviw9m3tcbG44aZO+I6vR95/waXUejpwPPCpqo=";
   };
+
+  buildInputs = [ luabridge ];
 
   buildFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
@@ -22,16 +25,18 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    install -D sjasmplus $out/bin/sjasmplus
+
+    install -D --mode=0755 sjasmplus $out/bin/sjasmplus
+
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://z00m128.github.io/sjasmplus/";
-    description = "Z80 assembly language cross compiler. It is based on the SjASM source code by Sjoerd Mastijn";
+    description = "Z80 assembly language cross compiler based on the SjASM source code by Sjoerd Mastijn";
     mainProgram = "sjasmplus";
-    license = licenses.bsd3;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ electrified ];
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ electrified ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/z00m128/sjasmplus/compare/v1.18.3...v1.21.0
https://github.com/z00m128/sjasmplus/releases/tag/v1.21.0
https://github.com/z00m128/sjasmplus/blob/v1.21.0/CHANGELOG.md#1210---1532025


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
