### PR TITLE
sipp: 3.7.3-unstable-2025-01-22 -> 3.7.5

### DIFF
--- a/pkgs/by-name/si/sipp/package.nix
+++ b/pkgs/by-name/si/sipp/package.nix
@@ -11,15 +11,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sipp";
-  version = "3.7.3-unstable-2025-01-22";
+  version = "3.7.5";
 
   src = fetchFromGitHub {
     owner = "SIPp";
     repo = "sipp";
-    rev = "464cf74c7321069b51c10f0c37f19ba16c2e7138";
-    hash = "sha256-mloeBKgDXmsa/WAUhlDsgNdhK8dpisGf3ti5UQQchJ8=";
-    leaveDotGit = true;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W5KOvBBaUmyYJshYEg39QpkS8rrpGSEj4g3NZD29YrY=";
   };
+
+  postPatch = ''
+    echo '#define SIPP_VERSION VERSION' > include/version.h
+    echo '#define VERSION "v${finalAttrs.version}"' >> include/version.h
+  '';
 
   cmakeFlags = [
     "-DUSE_PCAP=1"


### PR DESCRIPTION
https://github.com/SIPp/sipp/blob/v3.7.5/CHANGES.md
Diff: https://github.com/SIPp/sipp/compare/464cf74c7321069b51c10f0c37f19ba16c2e7138...v3.7.5
https://github.com/SIPp/sipp/releases/tag/v3.7.5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
