### PR TITLE
rsync: Remove `fakeroot` from `checkInputs`

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -19,7 +19,6 @@
   enableZstd ? true,
   zstd,
   nixosTests,
-  fakeroot,
 }:
 
 stdenv.mkDerivation rec {
@@ -57,9 +56,6 @@ stdenv.mkDerivation rec {
   ++ lib.optional enableLZ4 lz4
   ++ lib.optional enableOpenSSL openssl
   ++ lib.optional enableXXHash xxHash;
-
-  # fakeroot doesn't work well on darwin anymore, apparently
-  checkInputs = lib.optionals (!stdenv.isDarwin) [ fakeroot ];
 
   configureFlags = [
     (lib.enableFeature enableLZ4 "lz4")


### PR DESCRIPTION
Having `fakeroot` in `checkInputs` has the unfortunate side effect of making rsync depend on systemd, and by extension making the linux kernel depend on systemd.

```
$ nix why-depends --derivation --all -f . linux systemd.src
/nix/store/ahnjzvyxn3jqaaqmhkrdxfimzd8m6yya-linux-6.12.48.drv
└───/nix/store/07v98114pg0v4vb8xahdj6v488piy23r-rsync-3.4.1.drv
    └───/nix/store/70yyn9xwg3gkmdw7azal22wb8hp2lyxz-fakeroot-1.37.1.2.drv
        └───/nix/store/sac9bwghprnv77v8c65ljrwpr09c2wbi-libcap-2.76.drv
            └───/nix/store/9v3wirxpv9dzjkpr2swkgfwi78q0d72d-linux-pam-1.7.1.drv
                └───/nix/store/gfkzz6c2lhr73habq4x9ci7bj6jfgjgz-systemd-minimal-libs-257.9.drv
                    └───/nix/store/kxpjbfihhzkm2dilaj4xxndxfwmbm98z-source.drv
```

My main goal is keep systemd updates from rebuilding the kernel, and admittedly the use of rsync in the kernel derivation is completely unnecessary. But I think, in its own right, removing the dependency of rsync on systemd is worthwhile.

The consequence of this is that we have to skip two additional tests (out of the total of 46), namely the `chown` and `devices` tests.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
