### PR TITLE
ironbar: fix keyboard module compilation

### DIFF
--- a/pkgs/by-name/ir/ironbar/package.nix
+++ b/pkgs/by-name/ir/ironbar/package.nix
@@ -22,6 +22,8 @@
   luajit,
   luajitPackages,
   libpulseaudio,
+  libinput,
+  libevdev,
   features ? [ ],
   systemd,
 }:
@@ -58,7 +60,11 @@ rustPlatform.buildRustPackage rec {
   ++ lib.optionals (hasFeature "http") [ openssl ]
   ++ lib.optionals (hasFeature "volume") [ libpulseaudio ]
   ++ lib.optionals (hasFeature "cairo") [ luajit ]
-  ++ lib.optionals (hasFeature "tray") [ libdbusmenu-gtk3 ];
+  ++ lib.optionals (hasFeature "tray") [ libdbusmenu-gtk3 ]
+  ++ lib.optionals (hasFeature "keyboard") [
+       libinput
+       libevdev
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ir/ironbar/package.nix
+++ b/pkgs/by-name/ir/ironbar/package.nix
@@ -62,8 +62,8 @@ rustPlatform.buildRustPackage rec {
   ++ lib.optionals (hasFeature "cairo") [ luajit ]
   ++ lib.optionals (hasFeature "tray") [ libdbusmenu-gtk3 ]
   ++ lib.optionals (hasFeature "keyboard") [
-       libinput
-       libevdev
+    libinput
+    libevdev
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Adds missing `libinput` and `libevdev` dependencies required by the `keyboard` module. Brings the changes in line with the repo's [own derivation](https://github.com/JakeStanger/ironbar/blob/master/nix/package.nix).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
