### PR TITLE
lib: init strings.join

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -331,6 +331,7 @@ let
         hasInfix
         hasPrefix
         hasSuffix
+        join
         stringToCharacters
         stringAsChars
         escape

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -42,6 +42,36 @@ rec {
     ;
 
   /**
+    Concatenates a list of strings with a separator between each element.
+
+    # Inputs
+
+    `sep`
+    : Separator to add between elements
+
+    `list`
+    : List of strings that will be joined
+
+    # Type
+
+    ```
+    join :: string -> [ string ] -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.join` usage example
+
+    ```nix
+    join ", " ["foo" "bar"]
+    => "foo, bar"
+    ```
+
+    :::
+  */
+  join = builtins.concatStringsSep;
+
+  /**
     Concatenate a list of strings.
 
     # Type

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -69,6 +69,7 @@ let
     id
     ifilter0
     isStorePath
+    join
     lazyDerivation
     length
     lists
@@ -434,6 +435,15 @@ runTests {
   };
 
   # STRINGS
+
+  testJoin = {
+    expr = join "," [
+      "a"
+      "b"
+      "c"
+    ];
+    expected = "a,b,c";
+  };
 
   testConcatMapStrings = {
     expr = concatMapStrings (x: x + ";") [


### PR DESCRIPTION
## Context

The current naming scheme for the family of `listOf string -> ... -> string` manipulating functions in `lib`
(e.g. `concatStringsSep`, `concatMapStrings`) is fairly idiosyncratic.

This not only feels unfamiliar to people coming from more mainstream programming languages,
it also raises the [Fairbairn threshold](https://wiki.haskell.org/Fairbairn_threshold):  
there are many small, oddly-named helpers to memorize before one can effectively use what should have been a simple `join`.

## Functions potentially affected

- concatStrings
- concatStringsSep
- concatMapStrings
- concatMapStringsSep
- concatImapStrings
- concatImapStringsSep
- concatMapAttrsStringSep
- concatLines

...List goes on, how many of them do most people remember - be honest - when writing code?

## Proposal

I don’t think it’s necessary to rename or replace this entire family.  
Instead, introducing a single, memorable primitive  `join` already adds significant value:

- aligns with Python, JavaScript, Rust, and Haskell (`intercalate` )
- reduces the conceptual surface area of `lib`
- keeps existing functions available (can be trivially implemented in terms of `join`)

Of course this may also have potential counter-arguments:

- Code written with longer names reads more like prose `concatMapStringsSep "," toString [1 2 3]` vs `join "," (map toString [1 2 3])` 

## Example

```nix
# explicit, composable, and familiar
join "," (map toString [1 2 3])

# harder to recall, also reads technical.
concatMapStringsSep "," toString [1 2 3]
```

## Considering Readability

### Code is read more often than written

Which is eaxctly my point, why familiarity trumps verbosity.

If every developer already knows join from Python, JS, Rust, etc., they don’t need to learn a new, idiosyncratic phrase.

When you’re scanning code quickly, join + map is self-explanatory.
By contrast, concatMapStringsSep requires remembering Nixpkgs-specific vocabulary.

And even if you know it, it reads like a noisy technical term.

Simple and basic every day functions should have short names.  

## Verbose "prose-style" names don’t scale

concatMapStringsSep is already unwieldy,

But lets apply it to other compositions:

- concatImapStringsSep
- concatMapAttrsStringSep

If readability were really the guiding principle, we’d need dozens of even longer names. That doesn’t help readability either.

## Considering: Cargo-culting

Since the names are long and similar, people tend to copy-paste instead of thinking.

Developers might choose concatMapStringsSep not because it’s the right primitive, but because “I’ve seen it used before.”

## Considering: Maintenance burden

Every new helper adds more surface area to maintain and document.
If the philosophy is “wrap every composition into a dedicated function,” the list above keeps growing.

We should provide smaller, more memorizable building blocks.

## Summary

 introducing a single, memorable primitive  `join` already adds significant value
 
 Other bikes can be shed, but i can't think why this shouldn't be added. 

It seems some people already use [join](https://github.com/search?q=join+lang%3Anix&type=code) 

----

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
