### PR TITLE
rumdl: init at 0.0.156

### DIFF
--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rumdl";
+  version = "0.0.156";
+
+  src = fetchFromGitHub {
+    owner = "rvben";
+    repo = "rumdl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yHOfrX3iOq1oGwHtHchMyQblqLXreoUKLBTpxxh2FEE=";
+  };
+
+  cargoHash = "sha256-U8kb3fQjA3Prrpn1KmhsQl4S0hvhcY+5qlqT5ovbUZE=";
+
+  cargoBuildFlags = [
+    "--bin=rumdl"
+  ];
+
+  __darwinAllowLocalNetworking = true; # required for LSP tests
+
+  useNextest = true;
+
+  cargoTestFlags = [
+    "--profile ci"
+  ];
+
+  checkFlags = [
+    # Skip Windows tests
+    "--skip comprehensive_windows_tests"
+    "--skip windows_vscode_tests"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Markdown linter and formatter";
+    longDescription = ''
+      rumdl is a high-performance Markdown linter and formatter
+      that helps ensure consistency and best practices in your Markdown files.
+    '';
+    homepage = "https://github.com/rvben/rumdl";
+    changelog = "https://github.com/rvben/rumdl/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kachick
+      hasnep
+    ];
+    mainProgram = "rumdl";
+    platforms = with lib.platforms; unix ++ windows;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces [rumdl](https://github.com/rvben/rumdl).
While a similar tool, [mado](https://github.com/akiomik/mado), was merged [three weeks ago](https://github.com/NixOS/nixpkgs/commit/81bf1565dffc19d1ed88cd4c0cdb5f7bc55a0d5a), rumdl offers a similar purpose but with additional features like LSP support.
Its linting rules appear to be based on [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint/) rather than the original [markdownlint/markdownlint](https://github.com/markdownlint/markdownlint) project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
