### PR TITLE
python3Packages.django-extensions: Fix tests on darwin

### DIFF
--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -15,7 +15,6 @@
   mock,
   pip,
   postgresql,
-  postgresqlTestHook,
   pygments,
   pytestCheckHook,
   pytest-cov-stub,
@@ -51,7 +50,6 @@ buildPythonPackage rec {
     mock
     pip
     postgresql
-    postgresqlTestHook
     pygments # not explicitly declared in setup.py, but some tests require it
     pytest-cov-stub
     pytest-django
@@ -60,13 +58,6 @@ buildPythonPackage rec {
     vobject
     werkzeug
   ];
-
-  env = {
-    postgresqlEnableTCP = 1;
-    PGUSER = "postgres";
-    PGPASSWORD = "postgres";
-    PGDATABASE = "django_extensions_test";
-  };
 
   disabledTestPaths = [
     # https://github.com/django-extensions/django-extensions/issues/1871


### PR DESCRIPTION
django-extensions tests don’t need Postgresql and `postgresqlTestHook` is not supported on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
