### PR TITLE
vimPlugins.LanguageClient-neovim: fix Rust build

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/default.nix
@@ -17,7 +17,11 @@ let
     pname = "LanguageClient-neovim-bin";
     inherit version src;
 
-    cargoHash = "sha256-1tfeowqvjEjMXIfrhr388YhlZrk3ns+Y/2odQnkLw7k=";
+    cargoPatches = [
+      ./traitobject.patch
+    ];
+
+    cargoHash = "sha256-43alR84MktYTmsKeUMm4gK8AjUIkGqcsuFeQPusBKD0=";
   };
 in
 vimUtils.buildVimPlugin {
@@ -47,7 +51,5 @@ vimUtils.buildVimPlugin {
     homepage = "https://github.com/autozimu/LanguageClient-neovim/";
     changelog = "https://github.com/autozimu/LanguageClient-neovim/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    # Rust build error
-    broken = true;
   };
 }

--- a/pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/traitobject.patch
+++ b/pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/traitobject.patch
@@ -1,0 +1,15 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1026,9 +1028,9 @@ dependencies = [
+
+ [[package]]
+ name = "traitobject"
+-version = "0.1.0"
++version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
++checksum = "04a79e25382e2e852e8da874249358d382ebaf259d0d34e75d8db16a7efabbc7"
+
+ [[package]]
+ name = "treediff"
+


### PR DESCRIPTION
The build issue was caused by issue in traitobject crate https://github.com/reem/rust-traitobject/issues/8 and was fixed in 0.1.1 version. Since LanguageClient-neovim doesn't get much attention, patch Cargo.lock here to use the newer version of traitobject crate.

Fixes https://github.com/NixOS/nixpkgs/issues/424400


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
