### PR TITLE
scotch: sort build inputs; make ptscotch optional

### DIFF
--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -47,7 +47,7 @@ let
   );
 in
 stdenv.mkDerivation (finalAttrs: {
-  name = "mumps";
+  pname = "mumps";
   version = "5.8.1";
   # makeFlags contain space and one should use makeFlagsArray+
   # Setting this magic var is an optional solution

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -20,6 +20,7 @@
 assert withParmetis -> mpiSupport;
 assert withPtScotch -> mpiSupport;
 let
+  scotch' = scotch.override { inherit withPtScotch; };
   profile = if mpiSupport then "debian.PAR" else "debian.SEQ";
   LMETIS = toString ([ "-lmetis" ] ++ lib.optional withParmetis "-lparmetis");
   LSCOTCH = toString (
@@ -78,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
       "LIBEXT_SHARED=.dylib"
     ]
     ++ [
-      "ISCOTCH=-I${lib.getDev scotch}/include"
+      "ISCOTCH=-I${lib.getDev scotch'}/include"
       "LMETIS=${LMETIS}"
       "LSCOTCH=${LSCOTCH}"
       "ORDERINGSF=${ORDERINGSF}"
@@ -115,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
       blas
       lapack
       metis
-      scotch
+      scotch'
     ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -108,16 +108,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional mpiSupport mpi
   ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
-  # Parmetis should be placed before scotch to avoid conflict of header file "parmetis.h"
-  buildInputs =
-    lib.optional withParmetis parmetis
-    ++ lib.optional mpiSupport scalapack
-    ++ [
-      blas
-      lapack
-      metis
-      scotch'
-    ];
+  buildInputs = [
+    blas
+    lapack
+    metis
+    scotch'
+  ]
+  ++ lib.optional mpiSupport scalapack
+  ++ lib.optional withParmetis parmetis;
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -26,10 +26,10 @@
   # External libraries options
   withHdf5 ? withCommonDeps,
   withMetis ? withCommonDeps,
-  withZlib ? (withP4est || withPtscotch),
+  withZlib ? (withP4est || withPtScotch),
   withScalapack ? withCommonDeps && mpiSupport,
   withParmetis ? withFullDeps, # parmetis is unfree
-  withPtscotch ? withCommonDeps && mpiSupport,
+  withPtScotch ? withCommonDeps && mpiSupport,
   withMumps ? withCommonDeps,
   withP4est ? withFullDeps,
   withHypre ? withCommonDeps && mpiSupport,
@@ -67,7 +67,7 @@ assert withP4est -> (mpiSupport && withZlib);
 # Package parmetis depend on metis and mpi support
 assert withParmetis -> (withMetis && mpiSupport);
 
-assert withPtscotch -> (mpiSupport && withZlib);
+assert withPtScotch -> (mpiSupport && withZlib);
 assert withScalapack -> mpiSupport;
 assert (withMumps && mpiSupport) -> withScalapack;
 assert withHypre -> mpiSupport;
@@ -83,6 +83,7 @@ let
       fortranSupport
       pythonSupport
       precision
+      withPtScotch
       ;
     enableMpi = self.mpiSupport;
 
@@ -139,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withP4est petscPackages.p4est
   ++ lib.optional withMetis petscPackages.metis
   ++ lib.optional withParmetis petscPackages.parmetis
-  ++ lib.optional withPtscotch petscPackages.scotch
+  ++ lib.optional withPtScotch petscPackages.scotch
   ++ lib.optional withScalapack petscPackages.scalapack
   ++ lib.optional withMumps petscPackages.mumps
   ++ lib.optional withHypre petscPackages.hypre
@@ -184,7 +185,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional pythonSupport "--with-petsc4py=1"
   ++ lib.optional withMetis "--with-metis=1"
   ++ lib.optional withParmetis "--with-parmetis=1"
-  ++ lib.optional withPtscotch "--with-ptscotch=1"
+  ++ lib.optional withPtScotch "--with-ptscotch=1"
   ++ lib.optional withScalapack "--with-scalapack=1"
   ++ lib.optional withMumps "--with-mumps=1"
   ++ lib.optional (withMumps && !mpiSupport) "--with-mumps-serial=1"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -198,11 +198,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withFftw "--with-fftw=1"
   ++ lib.optional withSuitesparse "--with-suitesparse=1";
 
-  hardeningDisable = lib.optionals debug [
-    "fortify"
-    "fortify3"
-  ];
-
   installTargets = [ (if withExamples then "install" else "install-lib") ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -10,6 +10,7 @@
   xz,
   zlib,
   mpi,
+  withPtScotch ? false,
   testers,
 }:
 
@@ -33,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BUILD_PTSCOTCH" withPtScotch)
   ];
 
   nativeBuildInputs = [
@@ -48,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = lib.optionals withPtScotch [
     mpi
   ];
 

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "BUILD_PTSCOTCH" withPtScotch)
+    # Prefix Scotch version of MeTiS routines
+    (lib.cmakeBool "SCOTCH_METIS_PREFIX" true)
+    # building tests is broken with SCOTCH_METIS_PREFIX enabled in 7.0.9
+    (lib.cmakeBool "ENABLE_TESTS" false)
   ];
 
   nativeBuildInputs = [
@@ -62,6 +66,14 @@ stdenv.mkDerivation (finalAttrs: {
       };
     };
   };
+
+  # SCOTCH provide compatibility with Metis/Parmetis interface.
+  # We install the metis compatible headers to subdirectory to
+  # avoid conflict with metis/parmetis.
+  postFixup = ''
+    mkdir -p $dev/include/scotch
+    mv $dev/include/{*metis,metisf}.h $dev/include/scotch
+  '';
 
   meta = {
     description = "Graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering";

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -1,15 +1,16 @@
 {
-  bison,
-  bzip2,
-  cmake,
-  fetchFromGitLab,
-  flex,
-  gfortran,
   lib,
-  mpi,
   stdenv,
-  zlib,
+  fetchFromGitLab,
+  cmake,
+  gfortran,
+  bison,
+  flex,
+  bzip2,
   xz,
+  zlib,
+  mpi,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,21 +31,35 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
   ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
 
   nativeBuildInputs = [
     cmake
     gfortran
+    bison
+    flex
   ];
 
   buildInputs = [
-    bison
     bzip2
-    mpi
-    flex
     xz
     zlib
   ];
+
+  propagatedBuildInputs = [
+    mpi
+  ];
+
+  passthru = {
+    tests = {
+      cmake-config = testers.hasCmakeConfigModules {
+        moduleNames = [ "SCOTCH" ];
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
 
   meta = {
     description = "Graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering";

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -54,6 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://www.labri.fr/perso/pelegrin/scotch";
     license = lib.licenses.cecill-c;
-    maintainers = [ lib.maintainers.bzizou ];
+    maintainers = with lib.maintainers; [
+      bzizou
+      qbisi
+    ];
   };
 })


### PR DESCRIPTION
Inspired by https://github.com/NixOS/nixpkgs/pull/431612, this PR makes Scotch build PT-Scotch optionally, with the default being to not build PT-Scotch. As a consequence, MPI is removed from Scotch and its downstream package closures (typically VTK).

Things done in the last commit:
- The issue: possible conflict of the header file "metis.h" "parmetis.h" in scotch, metis, parmetis when used together in mumps/petsc. 
- The reason:  scotch provide compatibility with Metis/Parmetis interface. libscotchmetis serve as a replacement of metis library. Hence providing its own metis.h header file.
- The solution: move scotch's "metis.h" "parmetis.h" to subdirectory $dev/include/scotch. keep align with how debian package libscotchmetis-dev. See https://sources.debian.org/src/scotch/7.0.9-1exp4/debian/libscotchmetis-dev.install. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
