### PR TITLE
hotdoc: fix build with gcc15

### DIFF
--- a/pkgs/development/tools/hotdoc/default.nix
+++ b/pkgs/development/tools/hotdoc/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPythonApplication,
+  fetchpatch,
   fetchPypi,
   replaceVars,
   clang,
@@ -44,6 +45,13 @@ buildPythonApplication rec {
     (replaceVars ./clang.patch {
       clang = lib.getExe clang;
       libclang = "${lib.getLib libclang}/lib/libclang${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+
+    # Fix build with gcc15
+    (fetchpatch {
+      name = "hotdoc-fix-c_comment_scanner-function-prototypes-gcc15.patch";
+      url = "https://github.com/hotdoc/hotdoc/commit/adf8518431fafb78c9b47862a0a9a58824b6a421.patch";
+      hash = "sha256-5y50Yk+AjV3aSk8H3k9od/Yvy09FyQQOcVOAcstQnw8=";
     })
   ];
 


### PR DESCRIPTION
- add patch from merged upstream commit:
https://github.com/hotdoc/hotdoc/commit/adf8518431fafb78c9b47862a0a9a58824b6a421

Fixes build failure with gcc15:
```
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l: In function ‘yylex’:
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:49:10:
error: too many arguments to function ‘parse_comment’; expected 0, have 1
   49 | "/*"                            { return parse_comment (comments);}
      |          ^~~~~~~~~~~~~  ~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:37:12: note: declared here
   37 | static int parse_comment ();
      |            ^~~~~~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:50:10:
error: too many arguments to function ‘parse_define’; expected 0, have 1
   50 | {HASH}{SPACE}*"define"{SPACE}*  { return parse_define (comments); }
      |          ^~~~~~~~~~~~  ~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:38:12: note: declared here
   38 | static int parse_define ();
      |            ^~~~~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l: At top level:
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:80:1:
error: conflicting types for ‘parse_define’; have ‘int(PyObject *)’ {aka ‘int(struct _object *)’}
   80 | parse_define (PyObject *comments)
      | ^~~~~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:38:12:
note: previous declaration of ‘parse_define’ with type ‘int(void)’
   38 | static int parse_define ();
      |            ^~~~~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:126:1:
error: conflicting types for ‘parse_comment’; have ‘int(PyObject *)’ {aka ‘int(struct _object *)’}
  126 | parse_comment (PyObject *comments)
      | ^~~~~~~~~~~~~
/build/hotdoc-0.17.4/hotdoc/parsers/c_comment_scanner/scanner.l:37:12:
note: previous declaration of ‘parse_comment’ with type ‘int(void)’
   37 | static int parse_comment ();
      |            ^~~~~~~~~~~~~
```

---

Could not figure out how to test it with gcc15 as is.
But it builds on top of https://github.com/NixOS/nixpkgs/pull/440456 with this fix and fails otherwise.

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
