### PR TITLE
haskellPackages: disable remaining dependents on libsoup_2_4

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1764,6 +1764,12 @@ with haskellLib;
     unmarkBroken
   ];
 
+  # Requires jsaddle-webkit2gtk to build outside of pkgsCross.ghcjs
+  # which requires a version of libsoup that's marked as insecure
+  reflex-dom = dontDistribute super.reflex-dom;
+  reflex-localize-dom = dontDistribute super.reflex-localize-dom;
+  trasa-reflex = dontDistribute super.trasa-reflex;
+
   # https://github.com/ghcjs/jsaddle/pull/160/
   jsaddle = appendPatch (fetchpatch {
     name = "fix-on-firefox.patch";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -141,14 +141,12 @@ package-maintainers:
     - generics-sop
     - ghcjs-base
     - ghcjs-dom
-    - ghcjs-dom-hello
     - ghcjs-dom-javascript
     - ghcjs-dom-jsaddle
     - haveibeenpwned
     - jsaddle
     - jsaddle-clib
     - jsaddle-dom
-    - jsaddle-hello
     - jsaddle-warp
     - jsaddle-wkwebview
     - json-sop
@@ -929,7 +927,9 @@ dont-distribute-packages:
   - yices-painless
 
   # These packages don’t build because they use deprecated libsoup 2.4 versions.
+  - jsaddle-hello
   - jsaddle-webkit2gtk
+  - ghcjs-dom-hello
   - gi-javascriptcore4
   - gi-soup2
   - gi-webkit2


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This should get us back the `maintained` job in `nixpkgs:haskell-updates`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
