### PR TITLE
fltk 1.3.8 -> 1.3.11, clean up

### DIFF
--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -25,7 +25,9 @@
   withCairo ? true,
   cairo,
 
-  withPango ? withXorg,
+  # pango depends on Xft, and implicitly enables cairo.
+  # So only enable pango if cairo is enabled too.
+  withPango ? withXorg && withCairo,
   pango,
 
   withDocs ? true,

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -41,6 +41,8 @@
   wayland-scanner,
 
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
+
+  nix-update-script,
 }:
 
 # pango support depends on Xft
@@ -196,6 +198,13 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/bin/fltk-config \
       --replace-fail "/$out/" "/"
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(1\\.4\\.[0-9.]+)"
+    ];
+  };
 
   meta = {
     description = "C++ cross-platform lightweight GUI library";

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -25,15 +25,20 @@
   withCairo ? true,
   cairo,
 
-  withPango ? stdenv.hostPlatform.isLinux,
+  withPango ? withXorg,
   pango,
 
   withDocs ? true,
   doxygen,
   graphviz,
 
+  withXorg ? stdenv.hostPlatform.isLinux,
+
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
 }:
+
+# pango support depends on Xft
+assert withPango -> withXorg;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fltk";
@@ -83,6 +88,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     freetype
+  ]
+  ++ lib.optionals withXorg [
     libX11
     libXext
     libXinerama
@@ -107,11 +114,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "FLTK_USE_SYSTEM_ZLIB" true)
 
     # X11
-    (lib.cmakeBool "FLTK_USE_XINERAMA" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "FLTK_USE_XFIXES" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "FLTK_USE_XCURSOR" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "FLTK_USE_XFT" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "FLTK_USE_XRENDER" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "FLTK_USE_XINERAMA" withXorg)
+    (lib.cmakeBool "FLTK_USE_XFIXES" withXorg)
+    (lib.cmakeBool "FLTK_USE_XCURSOR" withXorg)
+    (lib.cmakeBool "FLTK_USE_XFT" withXorg)
+    (lib.cmakeBool "FLTK_USE_XRENDER" withXorg)
 
     # GL
     (lib.cmakeBool "FLTK_BUILD_GL" withGL)

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -34,11 +34,20 @@
 
   withXorg ? stdenv.hostPlatform.isLinux,
 
+  withWayland ? stdenv.hostPlatform.isLinux && withCairo,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+  wayland-scanner,
+
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
 }:
 
 # pango support depends on Xft
 assert withPango -> withXorg;
+
+# wayland support depends on cairo
+assert withWayland -> withCairo;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fltk";
@@ -63,6 +72,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+  ]
+  ++ lib.optionals withWayland [
+    wayland-scanner
   ]
   ++ lib.optionals withDocs [
     doxygen
@@ -98,6 +110,11 @@ stdenv.mkDerivation (finalAttrs: {
     libXft
     libXrender
   ]
+  ++ lib.optionals withWayland [
+    wayland
+    wayland-protocols
+    libxkbcommon
+  ]
   ++ lib.optionals withCairo [
     cairo
   ]
@@ -119,6 +136,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "FLTK_USE_XCURSOR" withXorg)
     (lib.cmakeBool "FLTK_USE_XFT" withXorg)
     (lib.cmakeBool "FLTK_USE_XRENDER" withXorg)
+
+    # Wayland
+    (lib.cmakeBool "FLTK_BACKEND_WAYLAND" withWayland)
 
     # GL
     (lib.cmakeBool "FLTK_BUILD_GL" withGL)

--- a/pkgs/development/libraries/fltk/1.4.nix
+++ b/pkgs/development/libraries/fltk/1.4.nix
@@ -35,9 +35,6 @@
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
 }:
 
-let
-  onOff = value: if value then "ON" else "OFF";
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fltk";
   version = "1.4.4";
@@ -103,43 +100,42 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     # Common
-    "-DFLTK_BUILD_SHARED_LIBS=${onOff (!stdenv.hostPlatform.isStatic)}"
-    "-DFLTK_USE_SYSTEM_LIBDECOR=ON"
-    "-DFLTK_USE_SYSTEM_LIBJPEG=ON"
-    "-DFLTK_USE_SYSTEM_LIBPNG=ON"
-    "-DFLTK_USE_SYSTEM_ZLIB=ON"
+    (lib.cmakeBool "FLTK_BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "FLTK_USE_SYSTEM_LIBDECOR" true)
+    (lib.cmakeBool "FLTK_USE_SYSTEM_LIBJPEG" true)
+    (lib.cmakeBool "FLTK_USE_SYSTEM_LIBPNG" true)
+    (lib.cmakeBool "FLTK_USE_SYSTEM_ZLIB" true)
 
     # X11
-    "-DFLTK_USE_XINERAMA=${onOff stdenv.hostPlatform.isLinux}"
-    "-DFLTK_USE_XFIXES=${onOff stdenv.hostPlatform.isLinux}"
-    "-DFLTK_USE_XCURSOR=${onOff stdenv.hostPlatform.isLinux}"
-    "-DFLTK_USE_XFT=${onOff stdenv.hostPlatform.isLinux}"
-    "-DFLTK_USE_XRENDER=${onOff stdenv.hostPlatform.isLinux}"
+    (lib.cmakeBool "FLTK_USE_XINERAMA" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "FLTK_USE_XFIXES" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "FLTK_USE_XCURSOR" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "FLTK_USE_XFT" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "FLTK_USE_XRENDER" stdenv.hostPlatform.isLinux)
 
     # GL
-    "-DFLTK_BUILD_GL=${onOff withGL}"
-    "-DOpenGL_GL_PREFERENCE=GLVND"
+    (lib.cmakeBool "FLTK_BUILD_GL" withGL)
 
     # Cairo
-    "-DFLTK_OPTION_CAIRO_WINDOW=${onOff withCairo}"
-    "-DFLTK_OPTION_CAIRO_EXT=${onOff withCairo}"
+    (lib.cmakeBool "FLTK_OPTION_CAIRO_WINDOW" withCairo)
+    (lib.cmakeBool "FLTK_OPTION_CAIRO_EXT" withCairo)
 
     # Pango
-    "-DFLTK_USE_PANGO=${onOff withPango}"
+    (lib.cmakeBool "FLTK_USE_PANGO" withPango)
 
     # Examples & Tests
-    "-DFLTK_BUILD_EXAMPLES=${onOff withExamples}"
-    "-DFLTK_BUILD_TEST=${onOff withExamples}"
+    (lib.cmakeBool "FLTK_BUILD_EXAMPLES" withExamples)
+    (lib.cmakeBool "FLTK_BUILD_TEST" withExamples)
 
     # Docs
-    "-DFLTK_BUILD_HTML_DOCS=${onOff withDocs}"
-    "-DFLTK_BUILD_PDF_DOCS=OFF"
-    "-DFLTK_INSTALL_HTML_DOCS=${onOff withDocs}"
-    "-DFLTK_INSTALL_PDF_DOCS=OFF"
-    "-DFLTK_INCLUDE_DRIVER_DOCS=${onOff withDocs}"
+    (lib.cmakeBool "FLTK_BUILD_HTML_DOCS" withDocs)
+    (lib.cmakeBool "FLTK_INSTALL_HTML_DOCS" withDocs)
+    (lib.cmakeBool "FLTK_INCLUDE_DRIVER_DOCS" withDocs)
+    (lib.cmakeBool "FLTK_BUILD_PDF_DOCS" false)
+    (lib.cmakeBool "FLTK_INSTALL_PDF_DOCS" false)
 
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
   ];
 
   postBuild = lib.optionalString withDocs ''

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -33,6 +33,8 @@
 
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
   withShared ? true,
+
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -179,6 +181,13 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/bin/fltk-config \
       --replace-fail "/$out/" "/"
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(1\\.3\\.[0-9.]+)"
+    ];
+  };
 
   meta = {
     description = "C++ cross-platform lightweight GUI library";

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -29,6 +29,8 @@
   doxygen,
   graphviz,
 
+  withXorg ? stdenv.hostPlatform.isLinux,
+
   withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
   withShared ? true,
 }:
@@ -85,6 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     freetype
+  ]
+  ++ lib.optionals withXorg [
     libX11
     libXext
     libXinerama
@@ -105,12 +109,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "OPTION_USE_SYSTEM_LIBPNG" true)
 
     # X11
-    (lib.cmakeBool "OPTION_USE_XINERAMA" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "OPTION_USE_XFIXES" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "OPTION_USE_XCURSOR" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "OPTION_USE_XFT" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "OPTION_USE_XRENDER" stdenv.hostPlatform.isLinux)
-    (lib.cmakeBool "OPTION_USE_XDBE" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "OPTION_USE_XINERAMA" withXorg)
+    (lib.cmakeBool "OPTION_USE_XFIXES" withXorg)
+    (lib.cmakeBool "OPTION_USE_XCURSOR" withXorg)
+    (lib.cmakeBool "OPTION_USE_XFT" withXorg)
+    (lib.cmakeBool "OPTION_USE_XRENDER" withXorg)
+    (lib.cmakeBool "OPTION_USE_XDBE" withXorg)
 
     # GL
     (lib.cmakeBool "OPTION_USE_GL" withGL)

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -25,9 +25,6 @@
   withCairo ? true,
   cairo,
 
-  withPango ? false,
-  pango,
-
   withDocs ? true,
   doxygen,
   graphviz,
@@ -36,9 +33,6 @@
   withShared ? true,
 }:
 
-let
-  onOff = value: if value then "ON" else "OFF";
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fltk";
   version = "1.3.8";
@@ -101,50 +95,44 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withCairo [
     cairo
-  ]
-  ++ lib.optionals withPango [
-    pango
   ];
 
   cmakeFlags = [
     # Common
-    "-DOPTION_BUILD_SHARED_LIBS=${onOff withShared}"
-    "-DOPTION_USE_SYSTEM_ZLIB=ON"
-    "-DOPTION_USE_SYSTEM_LIBJPEG=ON"
-    "-DOPTION_USE_SYSTEM_LIBPNG=ON"
+    (lib.cmakeBool "OPTION_BUILD_SHARED_LIBS" withShared)
+    (lib.cmakeBool "OPTION_USE_SYSTEM_ZLIB" true)
+    (lib.cmakeBool "OPTION_USE_SYSTEM_LIBJPEG" true)
+    (lib.cmakeBool "OPTION_USE_SYSTEM_LIBPNG" true)
 
     # X11
-    "-DOPTION_USE_XINERAMA=${onOff stdenv.hostPlatform.isLinux}"
-    "-DOPTION_USE_XFIXES=${onOff stdenv.hostPlatform.isLinux}"
-    "-DOPTION_USE_XCURSOR=${onOff stdenv.hostPlatform.isLinux}"
-    "-DOPTION_USE_XFT=${onOff stdenv.hostPlatform.isLinux}"
-    "-DOPTION_USE_XRENDER=${onOff stdenv.hostPlatform.isLinux}"
-    "-DOPTION_USE_XDBE=${onOff stdenv.hostPlatform.isLinux}"
+    (lib.cmakeBool "OPTION_USE_XINERAMA" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "OPTION_USE_XFIXES" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "OPTION_USE_XCURSOR" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "OPTION_USE_XFT" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "OPTION_USE_XRENDER" stdenv.hostPlatform.isLinux)
+    (lib.cmakeBool "OPTION_USE_XDBE" stdenv.hostPlatform.isLinux)
 
     # GL
-    "-DOPTION_USE_GL=${onOff withGL}"
+    (lib.cmakeBool "OPTION_USE_GL" withGL)
     "-DOpenGL_GL_PREFERENCE=GLVND"
 
     # Cairo
-    "-DOPTION_CAIRO=${onOff withCairo}"
-    "-DOPTION_CAIROEXT=${onOff withCairo}"
-
-    # Pango
-    "-DOPTION_USE_PANGO=${onOff withPango}"
+    (lib.cmakeBool "OPTION_CAIRO" withCairo)
+    (lib.cmakeBool "OPTION_CAIROEXT" withCairo)
 
     # Examples & Tests
-    "-DFLTK_BUILD_EXAMPLES=${onOff withExamples}"
-    "-DFLTK_BUILD_TEST=${onOff withExamples}"
+    (lib.cmakeBool "FLTK_BUILD_EXAMPLES" withExamples)
+    (lib.cmakeBool "FLTK_BUILD_TEST" withExamples)
 
     # Docs
-    "-DOPTION_BUILD_HTML_DOCUMENTATION=${onOff withDocs}"
-    "-DOPTION_BUILD_PDF_DOCUMENTATION=OFF"
-    "-DOPTION_INSTALL_HTML_DOCUMENTATION=${onOff withDocs}"
-    "-DOPTION_INSTALL_PDF_DOCUMENTATION=OFF"
-    "-DOPTION_INCLUDE_DRIVER_DOCUMENTATION=${onOff withDocs}"
+    (lib.cmakeBool "OPTION_BUILD_HTML_DOCUMENTATION" withDocs)
+    (lib.cmakeBool "OPTION_INSTALL_HTML_DOCUMENTATION" withDocs)
+    (lib.cmakeBool "OPTION_INCLUDE_DRIVER_DOCUMENTATION" withDocs)
+    (lib.cmakeBool "OPTION_BUILD_PDF_DOCUMENTATION" false)
+    (lib.cmakeBool "OPTION_INSTALL_PDF_DOCUMENTATION" false)
 
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
   ];
 
   preBuild = lib.optionalString (withCairo && withShared && stdenv.hostPlatform.isDarwin) ''

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -185,7 +185,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     substituteInPlace $out/bin/fltk-config \
-      --replace "/$out/" "/"
+      --replace-fail "/$out/" "/"
   '';
 
   meta = {

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -39,13 +39,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fltk";
-  version = "1.3.8";
+  version = "1.3.11";
 
   src = fetchFromGitHub {
     owner = "fltk";
     repo = "fltk";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-OQWyOV3EeyFhwFg/eOX66QtFUxaDR1x4ZyHnZHmzhN8=";
+    hash = "sha256-aN0WdHDjxb9O4OgTfBncIj12tRYfeltKev6pgSMu6/E=";
   };
 
   outputs = [ "out" ] ++ lib.optional withExamples "bin" ++ lib.optional withDocs "doc";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7455,7 +7455,6 @@ with pkgs;
   fltk13-minimal = fltk13.override {
     withGL = false;
     withCairo = false;
-    withPango = false;
     withExamples = false;
     withDocs = false;
   };


### PR DESCRIPTION
- replaced the custom on/off logic with `lib.cmakeBool`
- replaced `--replace` with `--replace-fail`
- removed cmake flags that were unused (`OpenGL_GL_PREFERENCE` in 1.4, pango support in 1.3 because 1.3 does not support pango)
- added update script
- updated fltk 1.3.8 -> 1.3.11
- added wayland support to fltk14
- put x11 support behind its own dedicated feature flag

Follow-up of #401257
Part of #445447, fixes `fltk` with cmake 4
Tested by building and running `fltk-versions` on `x86_64-linux`, both forcing x11 and seeing it default to wayland if available.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
