### PR TITLE
unixODBCDrivers.sqlite: fix build with gcc15

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  fetchpatch,
   fetchurl,
   stdenv,
   unixODBC,
@@ -110,6 +111,15 @@
       url = "http://www.ch-werner.de/sqliteodbc/sqliteodbc-${version}.tar.gz";
       sha256 = "0dgsj28sc7f7aprmdd0n5a1rmcx6pv7170c8dfjl0x1qsjxim6hs";
     };
+
+    patches = [
+      # Fix build with gcc15
+      (fetchpatch {
+        name = "sqlite-connector-odbc-fix-incompatible-pointer-compilation-error.patch";
+        url = "https://src.fedoraproject.org/rpms/sqliteodbc/raw/e3d93f5909c884fd8846b36b71ba67a3ad65da2a/f/sqliteodbc-0.99991-Fix-incompatible-pointer-compilation-error.patch";
+        hash = "sha256-IAZDujEkAyU40sKa4GC+upURNt7vplCDAx91Eeny+bU=";
+      })
+    ];
 
     buildInputs = [
       unixODBC


### PR DESCRIPTION
- add patch from fedora fixing incompatible-pointer-types errors.

Fixes build failure with gcc15:
```
sqlite3odbc.c:4521:24: error: assignment to 'void (*)(void)'
from incompatible pointer type 'void (*)(char **)' [-Wincompatible-pointer-types]
 4521 |             s->rowfree = freerows;
      |                        ^
sqlite3odbc.c:2185:1: note: 'freerows' declared here
 2185 | freerows(char **rowp)
      | ^~~~~~~~
sqlite3odbc.c: In function 'drvtableprivileges':
sqlite3odbc.c:6173:24: error: assignment to 'void (*)(void)'
from incompatible pointer type 'void (*)(char **)' [-Wincompatible-pointer-types]
 6173 |             s->rowfree = sqlite3_free_table;
      |                        ^
In file included from sqlite3odbc.h:49,
                 from sqlite3odbc.c:25:
/nix/store/w3ibvzff0yrpg8abrl8n2fxn0d9fpfpc-sqlite-3.50.2-dev/include/sqlite3.h:3144:17:
note: 'sqlite3_free_table' declared here
 3144 | SQLITE_API void sqlite3_free_table(char **result);
      |                 ^~~~~~~~~~~~~~~~~~
sqlite3odbc.c: In function 'drvprimarykeys':
sqlite3odbc.c:6593:16: error: assignment to 'void (*)(void)' from
incompatible pointer type 'void (*)(char **)' [-Wincompatible-pointer-types]
 6593 |     s->rowfree = freerows;
      |                ^
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; unixODBCDrivers.sqlite.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
