### PR TITLE
nixosTests/bpf: enable fentry tests for aarch64

### DIFF
--- a/nixos/tests/bpf.nix
+++ b/nixos/tests/bpf.nix
@@ -34,10 +34,7 @@
         "    printf(\"tgid: %d\\n\", ((struct task_struct*) curtask)->tgid); exit() "
         "}'"))
     # module BTF (bpftrace >= 0.17)
-    # test is currently disabled on aarch64 as kfunc does not work there yet
-    # https://github.com/iovisor/bpftrace/issues/2496
-    print(machine.succeed("uname -m | grep aarch64 || "
-        "bpftrace -e 'kfunc:nft_trans_alloc_gfp { "
+    print(machine.succeed("bpftrace -e 'fentry:nft_trans_alloc_gfp { "
         "    printf(\"portid: %d\\n\", args->ctx->portid); "
         "} BEGIN { exit() }'"))
     # glibc includes

--- a/nixos/tests/bpf.nix
+++ b/nixos/tests/bpf.nix
@@ -21,12 +21,7 @@
     # simple BEGIN probe (user probe on bpftrace itself)
     print(machine.succeed("bpftrace -e 'BEGIN { print(\"ok\\n\"); exit(); }'"))
     # tracepoint
-    # workaround: this needs more than the default of 1k FD to attach ~350 probes, bump fd limit
-    # see https://github.com/bpftrace/bpftrace/issues/2110
-    print(machine.succeed("""
-        ulimit -n 2048
-        bpftrace -e 'tracepoint:syscalls:sys_enter_* { print(probe); exit() }'
-    """))
+    print(machine.succeed("bpftrace -e 'tracepoint:syscalls:sys_enter_* { print(probe); exit() }'"))
     # kprobe
     print(machine.succeed("bpftrace -e 'kprobe:schedule { print(probe); exit() }'"))
     # BTF

--- a/pkgs/by-name/bp/bpftrace/package.nix
+++ b/pkgs/by-name/bp/bpftrace/package.nix
@@ -39,6 +39,16 @@ stdenv.mkDerivation rec {
       includes = [ "src/ast/passes/clang_parser.cpp" ];
       hash = "sha256-xk+/eBNJJJSUqNTs0HFr0BAaqRB5B7CNWRSmnoBMTs0=";
     })
+    (fetchpatch {
+      name = "increase-RLIMIT_NOFILE-if-needed.patch";
+      url = "https://github.com/bpftrace/bpftrace/pull/4716.patch";
+      includes = [
+        "src/bpftrace.cpp"
+        "src/main.cpp"
+        "src/required_resources.h"
+      ];
+      hash = "sha256-kRFyfuLf2CUR5QNJljLFNwmAzAoa8I3DNIW4SWwSUd0=";
+    })
   ];
 
   buildInputs = with llvmPackages; [


### PR DESCRIPTION
I don't have hardware to test but my reading is that fentry should work for aarch64 starting ~6.14~ 6.12 or earlier

bpftrace also replaced kfunc by fentry to match the kernel feature, so update the probe name, but it's the same thing

Also remove the kludge for syscall test that's no longer needed with upstream fix


## Things done

This PR to run ofborg on aarch64.
In theory the check should probably be updated to skip if older kernel, but that'll do for now...

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
