### PR TITLE
python3Packages.phart: init at 1.1.4

### DIFF
--- a/pkgs/by-name/ph/phart/package.nix
+++ b/pkgs/by-name/ph/phart/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.phart

--- a/pkgs/development/python-modules/phart/default.nix
+++ b/pkgs/development/python-modules/phart/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  networkx,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pydot,
+}:
+
+buildPythonPackage rec {
+  pname = "phart";
+  version = "1.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-JpHjEVKpOPSNUdUjZxWBHt6AFCpci1nSRWhDXxG6nyw=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    hatchling
+  ];
+
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+  '';
+
+  postPatch = ''
+
+    # pythonRelaxDeps = true; didn't work
+    substituteInPlace pyproject.toml \
+      --replace-fail 'hatchling==1.26.3' 'hatchling'
+
+    # This line makes the cli tool not work, removing it fixes it
+    substituteInPlace src/phart/cli.py \
+      --replace-fail "renderer.options.use_ascii = args.ascii" ""
+
+  '';
+
+  dependencies = [
+    networkx
+  ];
+
+  disabledTestPaths = [
+    # Many of the tests are stale
+    "tests/test_cli.py"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    pydot
+  ];
+
+  pythonImportsCheck = [
+    "phart"
+  ];
+
+  meta = {
+    description = "Python Hierarchical ASCII Representation Tool";
+    homepage = "https://github.com/scottvr/phart";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+  };
+}

--- a/pkgs/development/python-modules/phart/default.nix
+++ b/pkgs/development/python-modules/phart/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
   '';
 
   postPatch = ''
-
     # pythonRelaxDeps = true; didn't work
     substituteInPlace pyproject.toml \
       --replace-fail 'hatchling==1.26.3' 'hatchling'
@@ -37,7 +36,6 @@ buildPythonPackage rec {
     # This line makes the cli tool not work, removing it fixes it
     substituteInPlace src/phart/cli.py \
       --replace-fail "renderer.options.use_ascii = args.ascii" ""
-
   '';
 
   dependencies = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11706,6 +11706,8 @@ self: super: with self; {
 
   pgvector = callPackage ../development/python-modules/pgvector { };
 
+  phart = callPackage ../development/python-modules/phart { };
+
   phe = callPackage ../development/python-modules/phe { };
 
   phik = callPackage ../development/python-modules/phik { };


### PR DESCRIPTION
Adds phart. Disabled stale and non-functioning tests. The cli tool is broken, but an easy fix makes it run. We could also remove `mainProgram` and just include the python library I suppose.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
