### PR TITLE
prometheus-storagebox-exporter: Init at 0-unstable-2025-07-28

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -116,6 +116,8 @@
 
 - [SuiteNumérique Meet](https://github.com/suitenumerique/meet) is an open source alternative to Google Meet and Zoom powered by LiveKit: HD video calls, screen sharing, and chat features. Built with Django and React. Available as [services.lasuite-meet](#opt-services.lasuite-meet.enable).
 
+- [Prometheus Storagebox Exporter](https://github.com/fleaz/prometheus-storagebox-exporter), a Prometheus exporter for Hetzner storage boxes.
+
 - [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available at [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
 
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -124,6 +124,7 @@ let
         "snmp"
         "sql"
         "statsd"
+        "storagebox"
         "surfboard"
         "systemd"
         "tibber"

--- a/nixos/modules/services/monitoring/prometheus/exporters/storagebox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/storagebox.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.storagebox;
+  inherit (lib) mkPackageOption;
+in
+{
+  port = 9509;
+  extraOpts = {
+    package = mkPackageOption pkgs "prometheus-storagebox-exporter" { };
+    tokenFile = lib.mkOption {
+      type = lib.types.pathWith {
+        inStore = false;
+        absolute = true;
+      };
+      description = "File that contains the Hetzner API token to use.";
+    };
+
+  };
+  serviceOpts = {
+    after = [ "network.target" ];
+    wantedBy = [ "multi-user.target" ];
+    script = ''
+      export HETZNER_TOKEN=$(< "''${CREDENTIALS_DIRECTORY}/token")
+      exec ${lib.getExe cfg.package}
+    '';
+
+    environment = {
+      LISTEN_ADDR = "${toString cfg.listenAddress}:${toString cfg.port}";
+    };
+
+    serviceConfig = {
+      DynamicUser = true;
+      Restart = "always";
+      RestartSec = "10s";
+      LoadCredential = [
+        "token:${cfg.tokenFile}"
+      ];
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1615,6 +1615,21 @@ let
       '';
     };
 
+    storagebox = {
+      exporterConfig = {
+        enable = true;
+        tokenFile = "/tmp/faketoken";
+      };
+      exporterTest = ''
+        succeed(
+          'echo faketoken > /tmp/faketoken'
+        )
+        wait_for_unit("prometheus-storagebox-exporter.service")
+        wait_for_open_port(9509)
+        succeed("curl -sSf localhost:9509/metrics | grep 'process_open_fds'")
+      '';
+    };
+
     snmp = {
       exporterConfig = {
         enable = true;

--- a/pkgs/by-name/pr/prometheus-storagebox-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-storagebox-exporter/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  pname = "prometheus-storagebox-exporter";
+  version = "0-unstable-2025-07-28";
+
+  src = fetchFromGitHub {
+    owner = "fleaz";
+    repo = "prometheus-storagebox-exporter";
+    hash = "sha256-HGUAvoLIVXwZT/CJ1yj9H6ClNRwiJ8rjjluAQ6GdBME=";
+    rev = "e03cfd5f60f7847b74de2f6f47690bc03b7c157a";
+  };
+
+  vendorHash = "sha256-w2S8LWQyDLnUba7+YnTk7GhRXR/agbF5GFIeOPk8w64=";
+
+  meta = {
+    description = "Prometheus exporter for Hetzner storage boxes";
+    homepage = "https://github.com/fleaz/prometheus-storage-exporter";
+    license = lib.licenses.mit;
+    mainProgram = "prometheus-storagebox-exporter";
+    maintainers = with lib.maintainers; [
+      erethon
+    ];
+  };
+}


### PR DESCRIPTION
Adds a new [prometheus exporter](https://github.com/fleaz/prometheus-storagebox-exporter) and a service with tests for it.

Done as part of https://github.com/NixOS/infra/issues/853. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc