### PR TITLE
nixos/incus,incus{,-lts}: add multi-platform incus-agent support

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -134,6 +134,7 @@ let
       INCUS_LXC_HOOK = "${cfg.lxcPackage}/share/lxc/hooks";
       INCUS_LXC_TEMPLATE_CONFIG = "${pkgs.lxcfs}/share/lxc/config";
       INCUS_USBIDS_PATH = "${pkgs.hwdata}/share/hwdata/usb.ids";
+      INCUS_AGENT_PATH = "${cfg.package}/share/agent";
       PATH = lib.mkForce serverBinPath;
     }
     (lib.mkIf (cfg.ui.enable) { "INCUS_UI" = cfg.ui.package; })

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -10,6 +10,7 @@
 {
   callPackage,
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   acl,
@@ -114,8 +115,25 @@ buildGoModule (finalAttrs: {
     substituteInPlace Makefile --replace-fail '. $(SPHINXENV) ; ' ""
     make doc-incremental
 
+    # build multiple binaries of incus-agent
+    build_incus_agent() {
+      GOOS="$1" GOARCH="$2" CGO_ENABLED=0 \
+      go build -ldflags="-s" -tags=agent,netgo \
+        -o "$out/share/agent/incus-agent.$1.$3" ./cmd/incus-agent
+    }
+    ${lib.optionalString stdenv.hostPlatform.isx86_64 ''
+      build_incus_agent linux   amd64  x86_64
+      build_incus_agent linux   386    i686
+      build_incus_agent windows amd64  x86_64
+      build_incus_agent windows 386    i686
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isAarch64 ''
+      build_incus_agent linux   arm64 aarch64
+      build_incus_agent windows arm64 aarch64
+    ''}
+
     # build some static executables
-    make incus-agent incus-migrate
+    make incus-migrate
   '';
 
   # Disable tests requiring local operations
@@ -140,9 +158,9 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/incus completion zsh)
 
     mkdir -p $agent_loader/bin $agent_loader/etc/systemd/system $agent_loader/lib/udev/rules.d
-    cp internal/server/instance/drivers/agent-loader/incus-agent-setup $agent_loader/bin/
-    chmod +x $agent_loader/bin/incus-agent-setup
-    patchShebangs $agent_loader/bin/incus-agent-setup
+    cp internal/server/instance/drivers/agent-loader/incus-agent{,-setup} $agent_loader/bin/
+    chmod +x $agent_loader/bin/incus-agent{,-setup}
+    patchShebangs $agent_loader/bin/incus-agent{,-setup}
     cp internal/server/instance/drivers/agent-loader/systemd/incus-agent.service $agent_loader/etc/systemd/system/
     cp internal/server/instance/drivers/agent-loader/systemd/incus-agent.rules $agent_loader/lib/udev/rules.d/99-incus-agent.rules
     substituteInPlace $agent_loader/etc/systemd/system/incus-agent.service --replace-fail 'TARGET/systemd' "$agent_loader/bin"


### PR DESCRIPTION
Resolves #446091

Based on [the packaging guide for incus](https://github.com/lxc/incus/blob/main/doc/packaging.md#multiple-agent-setup).

1. Just like what is done in [this repo](https://github.com/zabbly/incus/blob/68a8b54cc7a0683930f890000978e51e691c1e7b/.github/workflows/builds.yml#L324-L332), the package now provides `i686/amd64 (Windows & Linux)` on `x86_64` hostPlatform, and `aarch64 (Windows & Linux)` on `aarch64` hostPlatform under `$out/share/agent`.
2. Add the `incus-agent` script to the `agent_loader` output so that multiple binaries are possible.
3. Added the `INCUS_AGENT_PATH` to the incus service, allowing `incusd` to provide the correct `incus-agent` based on the VM OS type.

`nixosTests.incus.virtual-machine` and my self-test for Windows VM have both passed.

Thanks to @adamcstephens for the inspiration!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
