### PR TITLE
gdm: fix build with gcc15

### DIFF
--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -106,6 +106,14 @@ stdenv.mkDerivation (finalAttrs: {
       revert = true;
     })
 
+    # Fix build with gcc15
+    # https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/273
+    (fetchpatch {
+      name = "gdm-rename-bool-variable-fix-gcc15-build.patch";
+      url = "https://gitlab.gnome.org/GNOME/gdm/-/commit/a3e0aca75e16aeafc171751028406b54f5ed8397.patch";
+      hash = "sha256-gOURo0WzBqSrVl0hnpdtd60QFKc0CT2A9YjNoPUPtyE=";
+    })
+
     # Change hardcoded paths to nix store paths.
     (replaceVars ./fix-paths.patch {
       inherit


### PR DESCRIPTION
- add patch from merged upstream MR:
https://gitlab.gnome.org/GNOME/gdm/-/merge_requests/273

Fixes build failure with gcc15:
```
FAILED: [code=1] common/libgdmcommon.a.p/gdm-settings-utils.c.o
In file included from ../common/gdm-settings-utils.c:38:
../common/gdm-settings-utils.h:47:77: error: expected ';', ',' or ')' before 'bool'
   47 |                                                                 gboolean   *bool);
      |                                                                             ^~~~
../common/gdm-settings-utils.c:290:50: error: expected ';', ',' or ')' before 'bool'
  290 |                                      gboolean   *bool)
      |                                                  ^~~~
...
FAILED: [code=1] common/libgdmcommon.a.p/gdm-settings-direct.c.o
In file included from ../common/gdm-settings-direct.c:38:
../common/gdm-settings-utils.h:47:77: error: expected ';', ',' or ')' before 'bool'
   47 |                                                                 gboolean   *bool);
      |                                                                             ^~~~
../common/gdm-settings-direct.c: In function 'gdm_settings_direct_get_boolean':
../common/gdm-settings-direct.c:159:15: error: implicit declaration of function
'gdm_settings_parse_value_as_boolean'; did you mean
'gdm_settings_parse_value_as_double'? [-Wimplicit-function-declaration]
  159 |         ret = gdm_settings_parse_value_as_boolean  (str, value);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |               gdm_settings_parse_value_as_double
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; gdm.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
