### PR TITLE
storii: init at 0-unstable-2025-09-26

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2728,6 +2728,12 @@
     githubId = 2998834;
     name = "Bruno Rodrigues";
   };
+  b2dennis = {
+    email = "dennis@base2.sh";
+    github = "b2dennis";
+    githubId = 121493649;
+    name = "Dennis Winghardt";
+  };
   b4dm4n = {
     email = "fabianm88@gmail.com";
     github = "B4dM4n";

--- a/pkgs/by-name/st/storii/package.nix
+++ b/pkgs/by-name/st/storii/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  xorg,
+}:
+
+buildGoModule rec {
+  pname = "storii";
+  version = "0-unstable-2025-09-26";
+
+  src = fetchFromGitHub {
+    owner = "b2dennis";
+    repo = "storii";
+    rev = "da5d8ce2b12bd68a1b8a348202dc6f6b81f79c3c";
+    hash = "sha256-7/bvthvx1BX+krcXv6x68DMdiraYr0R8h9D/eOZD4Ew=";
+  };
+
+  vendorHash = "sha256-lsRchL36mpOAY21qqTQ4+lhIpvoQq/jksBNWgqD5xo4=";
+
+  subPackages = [ "cmd/storii-cli" ];
+
+  buildInputs = [
+    xorg.libX11
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    mv $out/bin/storii-cli $out/bin/storii
+  '';
+
+  meta = {
+    description = "Secret manager written in golang";
+    homepage = "https://github.com/b2dennis/storii";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ b2dennis ];
+    mainProgram = "storii";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.

## nixpkgs-review output

```
--------- Impacted packages on 'x86_64-linux' ---------
1 package added:
storii (init at 1.0.1)

--------- Report for 'x86_64-linux' ---------
1 package built:
storii
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test