### PR TITLE
zutils: init at 1.15

### DIFF
--- a/pkgs/by-name/zu/zutils/package.nix
+++ b/pkgs/by-name/zu/zutils/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  gzip,
+  lzip,
+  nix-update-script,
+  testers,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zutils";
+  version = "1.15";
+
+  src = fetchurl {
+    url = "mirror://savannah/zutils/${finalAttrs.pname}-${finalAttrs.version}.tar.lz";
+    hash = "sha256-BeawPzM+q9eKEFUTlVforaa2NPGljoUB87jxEacFy4c=";
+  };
+
+  # Flake (tdata): mixed‑stream input triggers EPIPE during zcat’s internal teardown;
+  # depending on timing the feeder returns non‑zero (EPIPE) instead of SIGPIPE→0 handled by child_status,
+  # even though output is complete. Ignore that and let the following `cmp` assert bytes.
+  postPatch = ''
+    substituteInPlace testsuite/check.sh --replace-fail \
+      'cat in.lz in in in in | "''${ZCAT}" -N > out || test_failed $LINENO	# tdata' \
+      'cat in.lz in in in in | "''${ZCAT}" -N > out || : # tdata'
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ lzip ];
+
+  doCheck = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/zcat";
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests = {
+      zgrep = testers.runCommand {
+        name = "zutils-zgrep";
+        buildInputs = [
+          finalAttrs.finalPackage
+          gzip
+        ];
+        script = ''
+          echo hello > message.txt
+          gzip -1 message.txt
+          zgrep -q hello message.txt.gz
+          touch $out
+        '';
+      };
+    };
+  };
+
+  meta = {
+    description = "Collection of utilities that transparently operate on compressed data";
+    homepage = "https://www.nongnu.org/zutils/zutils.html";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://www.nongnu.org/zutils/zutils.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
