### PR TITLE
gyazo: init at 1.3.2

### DIFF
--- a/pkgs/by-name/gy/gyazo/package.nix
+++ b/pkgs/by-name/gy/gyazo/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  coreutils,
+  fetchFromGitHub,
+  gnugrep,
+  gnused,
+  imagemagick,
+  makeWrapper,
+  nix-update-script,
+  procps,
+  ruby,
+  which,
+  xclip,
+  xdg-utils,
+  xdotool,
+  xorg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gyazo";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "gyazo";
+    repo = "Gyazo-for-Linux";
+    tag = finalAttrs.version;
+    hash = "sha256-MW1w/XYleG29vm51F2ObiuoJUL0RhQ/kVSgtFdKP8IM=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ ruby ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/gyazo.rb $out/bin/gyazo
+    install -Dm644 src/gyazo.desktop -t $out/share/applications
+    install -Dm644 icons/gyazo.png -t $out/share/pixmaps
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/gyazo \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+          imagemagick
+          procps
+          which
+          xclip
+          xdg-utils
+          xdotool
+          xorg.xprop
+          xorg.xwininfo
+        ]
+      }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Gyazo screenshot uploader for Linux";
+    homepage = "https://github.com/gyazo/Gyazo-for-Linux";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "gyazo";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/gyazo/Gyazo-for-Linux/

Screenshot made with the tool:

![](https://i.gyazo.com/add610c82a2b4ff98e8bc6ab494bd61d.png)

Works only on X11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
