### PR TITLE
keycloak: move build step to make derivation reproducible

### DIFF
--- a/pkgs/by-name/ke/keycloak/config_vars.patch
+++ b/pkgs/by-name/ke/keycloak/config_vars.patch
@@ -1,8 +1,8 @@
 diff --git a/quarkus/dist/src/main/content/bin/kc.sh b/quarkus/dist/src/main/content/bin/kc.sh
-index d7be862cde..16f9aa78e0 100644
+index 9a6e62e2dd..8faa4bd1f8 100644
 --- a/bin/kc.sh
 +++ b/bin/kc.sh
-@@ -32,8 +32,8 @@ abs_path () {
+@@ -34,12 +34,12 @@ abs_path () {
    fi
  }
  
@@ -11,5 +11,10 @@ index d7be862cde..16f9aa78e0 100644
 +SERVER_OPTS="-Dkc.home.dir=$KC_HOME_DIR"
 +SERVER_OPTS="$SERVER_OPTS -Djboss.server.config.dir=$KC_CONF_DIR"
  SERVER_OPTS="$SERVER_OPTS -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ SERVER_OPTS="$SERVER_OPTS -Dpicocli.disable.closures=true"
  SERVER_OPTS="$SERVER_OPTS -Dquarkus-log-max-startup-records=10000"
- CLASSPATH_OPTS="'$(abs_path "../lib/quarkus-run.jar"):$(abs_path "../lib/bootstrap/*")'"
+-CLASSPATH_OPTS="'$(abs_path "../lib/quarkus-run.jar")'"
++CLASSPATH_OPTS="'$KC_HOME_DIR/lib/quarkus-run.jar'"
+ 
+ DEBUG_MODE="${DEBUG:-false}"
+ DEBUG_PORT="${DEBUG_PORT:-8787}"


### PR DESCRIPTION
The build phase was used to do a Quarkus optimisation by caching the configuration and plugins. Sadly, this re-runs the Hibernate ORM bytecode generation which uses random strings. It also generates a properties file with a date in it.

So I've moved the build to the service. It now uses a systemd StateDirectory to put the generated JAR files and everything else is linked together into the existing KC_HOME_DIR.

I have tested that Keycloak now starts from scratch, and only rebuilds when configuration changes.

This fixes both #445665 and #445902


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
