### PR TITLE
egctl: fix inconsistent vendorHash

### DIFF
--- a/pkgs/by-name/eg/egctl/package.nix
+++ b/pkgs/by-name/eg/egctl/package.nix
@@ -18,11 +18,10 @@ buildGoModule (finalAttrs: {
     hash = "sha256-glOnAnNuefdTq4BOd1NKpsadrWEqVOOc18jPx7lEwEQ=";
   };
 
-  vendorHash =
-    if stdenv.buildPlatform.isDarwin then
-      "sha256-GoaucckTuJIvaq1/3R1rPDr3Nm8q27OICisomKXYJ28="
-    else
-      "sha256-+RTnsUg2LNSQ6pB99ikAKxd3q6IRhp2LHdBznYrHm4o=";
+  vendorHash = "sha256-SNXnEutsDQwoGKiJN3uXxVrCl4gFcd62ZuX8GPyGliI=";
+  # Fix case-insensitive conflicts producing platform-dependent checksums
+  # https://github.com/microsoft/go-mssqldb/issues/234
+  proxyVendor = true;
 
   subPackages = [
     "cmd/egctl"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Properly fixes:

```
vendor/github.com/replicatedhq/troubleshoot/pkg/collect/mssql.go:12:2: cannot find module providing package github.com/microsoft/go-mssqldb: import lookup disabled by -mod=vendor
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
