### PR TITLE
nixos/tor.middle-box: init module for `iptables` modification

### DIFF
--- a/nixos/modules/services/networking/tor/middle-box.nix
+++ b/nixos/modules/services/networking/tor/middle-box.nix
@@ -1,0 +1,401 @@
+/**
+   Only `iptables` be supported, for now, and this module assumes following
+   NixOS chains have been defined;
+
+  - `-N nixos-fw-accept`
+  - `-A nixos-fw -m conntrack --ctstate RELATED,ESTABLISHED -j nixos-fw-accept`
+
+  ...  Additionally, due to `DOCKER` rules having a veracious appetite for local
+  addresses, this module will attempt to inject packet jumps prior to
+  problematic services.  Testing with other setups will reveal more edge-cases.
+
+   Use some of the following commands to debug issues;
+
+   ```bash
+   systemctl status firewall.service
+
+   iptables -L PREROUTING -vn
+   iptables -L tor-middle-box-pre -vn
+
+   iptables -S PREROUTING
+   iptables -S tor-middle-box-pre
+
+   journalctl -k | grep 'refused connection:.*${localAddress}.*' | less
+   ```
+
+   ## Attributions
+
+   - https://gitlab.torproject.org/legacy/trac/-/wikis/doc/TransparentProxy#anonymizing-middlebox
+   - https://archive.torproject.org/websites/lists.torproject.org/pipermail/tor-talk/2014-March/032503.html
+   - https://archive.torproject.org/websites/lists.torproject.org/pipermail/tor-talk/2014-March/032507.html
+   - https://www.dnsleaktest.com/
+*/
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    literalExpression
+    mkIf
+    mkOption
+    ;
+
+  inherit (lib.types)
+    attrs
+    nonEmptyStr
+    port
+    submodule
+    ;
+
+  inherit (pkgs.formats) keyValue;
+  keyValueFormat = keyValue { };
+
+  cfgsModule = config.networking.tor.middle-box;
+  cfgsTor = config.services.tor;
+in
+{
+  options.networking.tor.middle-box = {
+    enable = mkEnableOption "Enable modifying iptables";
+
+    settings = mkOption {
+      default = { };
+
+      description = ''
+        ## Check `iptables` rules are applied
+
+        ```bash
+        iptables -t nat -S PREROUTING | grep 'tor-middle-box-pre' &&
+          iptables -t nat -S tor-middle.box-pre
+        ```
+
+        Above commands _should_ produce output similar to
+
+        ```
+        -A PREROUTING -s 192.168.1.2/32 -j tor-middle-box-pre
+
+        -N tor-middle-box-pre
+        -A tor-middle-box-pre -p udp -m udp --dport 53 -j DNAT --to-destination 192.168.122.36:5353
+        -A tor-middle-box-pre -p udp -m udp --dport 5353 -j DNAT --to-destination 192.168.122.36:5353
+        -A tor-middle-box-pre -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j DNAT --to-destination 192.168.122.36:9040
+        ```
+
+        > `192.168.1.2/32` -> `containers.<name>.localAddress`
+        > `192.168.122.36` -> `services.tor.settings.TransPort` and/or `DNSPort`
+
+        ## Check DNS lookups work
+
+        ```bash
+        ssh tor-client.containers <<'EOF'
+          dig google.com
+        EOF
+        ```
+
+        Above _should_ show using the `torListenAddr` IP for `SERVER`
+
+        ## Check for DNS leaks
+
+        ```bash
+        ssh tor-client.containers <<'EOF'
+          curl -l https://www.dnsleaktest.com/ |
+            pup '.welcome'
+        EOF
+        ```
+
+        Above _should_ show an external IP different from clear-net host
+
+        ## Check for TCP over Tor
+
+        ```bash
+        ssh tor-client.containers <<'EOF'
+          curl -l https://check.torproject.org/ |
+            pup '.content > .not, .not + p, .security'
+        EOF
+        ```
+
+        Above _should_ show "Congradulations" for being connected and warnings about not using Tor browser
+
+      '';
+
+      example = literalExpression ''
+        { config, ... }:
+        let
+          containerName = "tor-client";
+          containerUser = "your-user";
+
+          torListenAddr = "192.168.122.36";
+
+          stateVersion = "25.05";
+
+          cfgs = config;
+          DNSAddr = cfgs.networking.tor.middle-box.settings.DNSPort.addr;
+        in
+        {
+          containers.''${containerName} = {
+            autoStart = false;
+            privateNetwork = true;
+
+            ## This will bind to host via interface like: `ve-''${containerName}@if2`
+            hostAddress = "192.168.3.1";
+            ## This will bind to guest via interface like: `eth0@if6`
+            localAddress = "192.168.1.2";
+
+            config =
+              { lib, pkgs, ... }:
+              {
+                system.stateVersion = stateVersion;
+
+                networking = {
+                  hostName = containerName;
+                  useHostResolvConf = lib.mkForce false;
+                };
+
+                ## https://github.com/NixOS/nixpkgs/issues/162686
+                services.resolved = {
+                  enable = true;
+                  extraConfig = \'\'
+                    nameserver ''${DNSAddr}
+                  \'\';
+                };
+                environment.etc."resolv.conf".text = lib.mkForce \'\'
+                  nameserver ''${DNSAddr}
+                  options edns0 trust-ad
+                  search .
+                \'\';
+
+                services.openssh = {
+                  enable = true;
+                  settings = {
+                    PasswordAuthentication = false;
+                    KbdInteractiveAuthentication = false;
+                    PermitRootLogin = "no";
+                    AllowUsers = [ "''${containerUser}" ];
+                  };
+                };
+
+                users.users.''${containerUser} = {
+                  isNormalUser = true;
+
+                  openssh.authorizedKeys.keyFiles = [
+                    ## Adjustment likely necessary
+                    ../services/openssh/id_rsa.pub
+                  ];
+
+                  packages = with pkgs; [
+                    dig
+                    pup
+                  ];
+                };
+              };
+          };
+
+          networking.tor.middle-box = {
+            enable = true;
+            settings.clients = {
+              ''${containerName} = cfgs.containers.''${containerName};
+            };
+          };
+
+          services.tor = {
+            enable = true;
+            settings =
+              let
+                ## WARN: order is important!
+                addresses = [
+                  "''${torListenAddr}"
+                  "127.0.0.1"
+                ];
+              in
+              {
+                TransPort = builtins.map (addr: {
+                  inherit addr;
+                  port = 9040;
+                  flags = [
+                    "IsolateClientAddr"
+                    "IsolateClientProtocol"
+                    "IsolateDestAddr"
+                    "IsolateDestPort"
+                  ];
+                }) addresses;
+
+                DNSPort = builtins.map (addr: {
+                  inherit addr;
+                  port = 5353;
+                }) addresses;
+
+                VirtualAddrNetworkIPv4 = "10.192.0.0/10";
+                AutomapHostsOnResolve = true;
+
+                ## Following may not be necessary but are nice to have
+                SOCKSPort = [ 9050 ];
+                HTTPTunnelPort = [ 9999 ];
+              };
+          };
+        }
+      '';
+
+      type =
+        let
+          typeTorAddrPort = submodule {
+            freeformType = keyValueFormat.type;
+            options = {
+              addr = mkOption {
+                description = "Address Tor service listens on for clients";
+                type = nonEmptyStr;
+              };
+              port = mkOption {
+                description = "Port Tor service listens on for clients";
+                type = port;
+              };
+            };
+          };
+        in
+        submodule {
+          options = {
+            clients = mkOption {
+              default = { };
+
+              description = "Attribute set of clients to forward traffic through Tor network";
+
+              example = literalExpression ''
+                {
+                  tor-client1.localAddress = "192.168.1.68";
+                  tor-client2.localAddress = "192.168.13.36";
+                }
+              '';
+
+              ## TODO: get smort about requiring `localAddress` to be `nonEmptyStr`
+              type = attrs;
+            };
+
+            SOCKSPort = mkOption {
+              default = builtins.head cfgsTor.settings.SOCKSPort;
+
+              description = "Address and port Tor service listens for SOCKS trafic on";
+
+              example = literalExpression ''
+                {
+                  addr = "192.168.122.36";
+                  port = 9050;
+                }
+              '';
+
+              type = typeTorAddrPort;
+            };
+
+            TransPort = mkOption {
+              default = builtins.head cfgsTor.settings.TransPort;
+
+              description = "Address and port Tor service listens for TCP trafic on";
+
+              example = literalExpression ''
+                {
+                  addr = "192.168.122.36";
+                  port = 9040;
+                }
+              '';
+
+              type = typeTorAddrPort;
+            };
+
+            DNSPort = mkOption {
+              default = builtins.head cfgsTor.settings.DNSPort;
+
+              description = "Address and port Tor service listens for DNS trafic on";
+
+              example = literalExpression ''
+                {
+                  addr = "192.168.122.36";
+                  port = 5353;
+                }
+              '';
+
+              type = typeTorAddrPort;
+            };
+
+            iptables = mkOption {
+              default = { };
+
+              description = "Names of custom `iptables` chain names";
+
+              example = literalExpression ''
+                {
+                  nat.prerouting = "tor-middle-box-pre";
+                }
+              '';
+
+              type = submodule {
+                options = {
+                  nat = mkOption {
+                    default = { };
+                    description = "Names of chain names for `iptables -t nat` table(s)";
+                    type = submodule {
+                      options = {
+                        prerouting = mkOption {
+                          default = "tor-middle-box-pre";
+                          description = "Custom chain name for iptables PREROUTING rules";
+                          type = nonEmptyStr;
+                        };
+                      };
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+    };
+  };
+
+  config = mkIf (cfgsModule.enable && cfgsModule.settings != { }) {
+    networking.firewall.extraCommands =
+      let
+        SOCKSPort = cfgsModule.settings.SOCKSPort;
+        TransPort = cfgsModule.settings.TransPort;
+        DNSPort = cfgsModule.settings.DNSPort;
+        chainNamePre = cfgsModule.settings.iptables.nat.prerouting;
+      in
+      ''
+        ## Delete jumps to pre/post-routing chains
+        for _table in PREROUTING POSTROUTING; do
+          while read -r _line; do
+            iptables -t nat $_line;
+          done < <(iptables -t nat -S $_table | sed -nE '/-j (${chainNamePre})$/{
+            s/^-A/-D/g;
+            p;
+          }')
+        done
+
+        ## Flush and delete chains if they exists
+        for _chain in ${chainNamePre}; do
+          iptables -t nat -F $_chain 2> /dev/null || true;
+          iptables -t nat -X $_chain 2> /dev/null || true;
+        done
+
+        iptables -t nat -N ${chainNamePre};
+      ''
+      + lib.optionalString (DNSPort ? addr && DNSPort ? port) ''
+        iptables -t nat -A ${chainNamePre} -p udp --dport 53 -j DNAT --to-destination ${DNSPort.addr}:${toString DNSPort.port};
+        iptables -t nat -A ${chainNamePre} -p udp --dport 5353 -j DNAT --to-destination ${DNSPort.addr}:${toString DNSPort.port};
+      ''
+      + lib.optionalString (SOCKSPort ? addr && SOCKSPort ? port) ''
+        iptables -t nat -A ${chainNamePre} -p tcp --dport ${toString SOCKSPort.port} -j DNAT --to-destination ${SOCKSPort.addr}:${toString SOCKSPort.port};
+      ''
+      + lib.optionalString (SOCKSPort ? port && TransPort ? addr && TransPort ? port) ''
+        iptables -t nat -A ${chainNamePre} -p tcp ! --dport ${toString SOCKSPort.port} --syn -j DNAT --to-destination ${TransPort.addr}:${toString TransPort.port};
+      ''
+      + lib.optionalString ((SOCKSPort ? port == false) && TransPort ? addr && TransPort ? port) ''
+        iptables -t nat -A ${chainNamePre} -p tcp --syn -j DNAT --to-destination ${TransPort.addr}:${toString TransPort.port};
+      ''
+      + builtins.concatStringsSep "\n" (
+        lib.mapAttrsToList (_name: value: ''
+          ${lib.getExe pkgs.iptables-insert-before} --target '-j DOCKER$' -- -t nat -A PREROUTING -s ${value.localAddress} -j ${chainNamePre};
+          ${lib.getExe pkgs.iptables-insert-before} --target '-j nixos-fw-log-refuse$' -- -A nixos-fw -s ${value.localAddress} -j nixos-fw-accept;
+        '') (lib.filterAttrs (_name: value: value ? localAddress) cfgsModule.settings.clients)
+      );
+
+  };
+}

--- a/pkgs/by-name/ip/iptables-insert-before/iptables-insert-before.sh
+++ b/pkgs/by-name/ip/iptables-insert-before/iptables-insert-before.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# set -uTEe -o pipefail;
+
+__usage__() {
+  local _message="${1}";
+
+  cat <<EOF
+Insert iptables rule before given target or append rule if target is not found
+
+-h,   --help
+  Print this message and exit
+
+-t,  --target "<REGEXP>"
+  Pattern to match against 'iptables -S' or 'iptables -t nat' output to insert rules before
+
+--
+  Must be declared as final option, all remaining words will be passed to iptables with minimal modification
+
+Example, supose Tor is listening on address '192.168.4.2' on various ports for
+client from '192.168.4.19' but Docker is gobbling all local address packets,
+this script may be used for injecting a jump to a custom chain before Docker;
+
+  iptables -t nat -N tor-middle-box
+  iptables -t nat -A tor-middle-box -p udp --dport 53 -j DNAT --to-destination 192.168.4.2:9053
+  iptables -t nat -A tor-middle-box -p udp --dport 5353 -j DNAT --to-destination 192.168.4.2:9053
+  iptables -t nat -A tor-middle-box -p tcp --dport 9050 -j DNAT --to-destination 192.168.4.2:9050
+  iptables -t nat -A tor-middle-box -p tcp ! --dport 9040 --syn -j DNAT --to-destination 192.168.4.2:9040
+
+  ./iptables-insert-before.sh --target '-j DOCKER$' -- -t nat -A PREROUTING -s 192.168.4.19 -j tor-middle-box
+EOF
+
+  if (( ${#_message} )); then
+    printf '\n';
+    printf >&2 '%s\n' "${_message}";
+  fi
+}
+
+while (( ${#@} )); do
+  case "${1}" in
+    -t|--target)
+      _target="${2}";
+      shift 2;
+    ;;
+    --)
+      shift 1;
+      _rules=( "${@}" );
+      shift "${#@}";
+    ;;
+    -h|--help)
+      __usage__ '';
+      exit 0;
+    ;;
+    *)
+      __usage__ "Error: unrecognized argument(s): ${*}";
+      exit 1;
+    ;;
+  esac
+done
+
+if ! (( ${#_target} )); then
+  __usage__ 'Error: missing required value for --target';
+  exit 1;
+elif ! (( ${#_rules[@]} )); then
+  __usage__ 'Error: missing required values after --';
+  exit 1;
+fi
+
+case "${_rules[*]}" in
+  '-t '*|'--table '*)
+    _table=( "${_rules[@]:0:2}" );
+    _chain_name="${_rules[3]}";
+  ;;
+  *)
+    _chain_name="${_rules[1]}";
+  ;;
+esac
+
+_insert_rulenum="$(
+  iptables "${_table[@]}" -S "${_chain_name:?Undefined chain name}" |
+    awk -v _target="${_target}" '{
+      if ($0 ~ _target) {
+        _line_number = NR;
+        nextfile;
+      }
+  }
+  END {
+    if (_line_number) {
+      print _line_number - 1;
+    } else {
+      print NR;
+    }
+  }'
+)";
+
+case "${_rules[*]}" in
+  '-t '*|'--table '*)
+    _args_check=( "${_rules[@]:0:2}" '-C' "${_rules[@]:3}" );
+    _args_delete=( "${_rules[@]:0:2}" '-D' "${_rules[@]:3}" );
+    _args_insert=( "${_rules[@]:0:2}" '-I' "${_chain_name}" "${_insert_rulenum}" "${_rules[@]:4}" );
+  ;;
+  *)
+    _args_check=( '-C' "${_rules[@]:1}" );
+    _args_delete=( '-D' "${_rules[@]:1}" );
+    _args_insert=( '-I' "${_chain_name}" "${_insert_rulenum}" "${_rules[@]:2}" );
+  ;;
+esac
+
+if iptables "${_args_check[@]}" 1>/dev/null 2>&1; then
+  iptables "${_args_delete[@]}";
+fi
+iptables "${_args_insert[@]}";
+

--- a/pkgs/by-name/ip/iptables-insert-before/package.nix
+++ b/pkgs/by-name/ip/iptables-insert-before/package.nix
@@ -1,0 +1,28 @@
+{
+  writeShellApplication,
+  lib,
+  gawk,
+}:
+writeShellApplication {
+  name = "iptables-insert-before";
+  text = builtins.readFile ./iptables-insert-before.sh;
+  runtimeInputs = [ gawk ];
+  bashOptions = [
+    "errexit"
+    "nounset"
+    "pipefail"
+    "errtrace"
+    "functrace"
+  ];
+  derivationArgs = {
+    version = "0.0.1";
+  };
+  meta = with lib; {
+    homepage = "https://github.com/network-utilities";
+    description = "Insert iptables rules before a target";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ S0AndS0 ];
+    platforms = platforms.linux;
+    # mainProgram = "bin/iptables-insert-before.sh";
+  };
+}


### PR DESCRIPTION
This module handles some of the edge-cases involved with setting-up a Tor middle-box, for forwarding packets from containers/clients to Tor network, and attempts to play nice on hosts that may have Docker installed.

Defaults assume Tor is configured with `addr`/`port` attributes for; `DNSPort`, `SOCKSPort`, and `TransPort`.  And defaults assume order is of first in each list is intended for external clients.  All of which may be explicitly defined.

This PR includes a script, `iptables-insert-before`, separately packaged to facilitate inserting rules before known troublesome jumps.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~~[ ] Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
    > Where do I add that file/content?... doesn't seem documented in [`nixos/README.md`](https://github.com/NixOS/nixpkgs/blob/master/nixos/README.md)
  - ~~[ ] Module update: when the change is significant.~~
- [¿?] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
