### PR TITLE
python3Packages.pynacl: 1.5.0 -> 1.6.0; adopt

### DIFF
--- a/pkgs/development/python-modules/pynacl/default.nix
+++ b/pkgs/development/python-modules/pynacl/default.nix
@@ -1,40 +1,43 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  fetchpatch2,
-  pytestCheckHook,
-  sphinxHook,
-  pythonOlder,
-  libsodium,
   cffi,
+  fetchFromGitHub,
   hypothesis,
+  libsodium,
+  pytestCheckHook,
+  pytest-xdist,
+  pythonOlder,
+  setuptools,
+  sphinxHook,
 }:
 
 buildPythonPackage rec {
   pname = "pynacl";
-  version = "1.5.0";
+  version = "1.6.0";
   outputs = [
     "out"
     "doc"
   ];
-  format = "setuptools";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "PyNaCl";
-    sha256 = "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba";
+  src = fetchFromGitHub {
+    owner = "pyca";
+    repo = "pynacl";
+    tag = version;
+    hash = "sha256-7SDJB2bXn0IGJQi597yehs9epdfmS7slbQ97vFVUkEA=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      # sphinx 8 compat
-      url = "https://github.com/pyca/pynacl/commit/81943b3c61b9cc731ae0f2e87b7a91e42fbc8fa1.patch";
-      hash = "sha256-iO3pBqGW2zZE8lG8khpPjqJso9/rmFbdnwCcBs8iFeI=";
-    })
+  build-system = [
+    cffi
+    setuptools
   ];
+
+  # cffi is listed in both build-system.requires and project.dependencies,
+  # and is indeed needed in both when cross-compiling
+  dependencies = [ cffi ];
 
   nativeBuildInputs = [ sphinxHook ];
 
@@ -42,21 +45,20 @@ buildPythonPackage rec {
 
   propagatedNativeBuildInputs = [ cffi ];
 
-  propagatedBuildInputs = [ cffi ];
-
   nativeCheckInputs = [
     hypothesis
     pytestCheckHook
+    pytest-xdist
   ];
 
-  SODIUM_INSTALL = "system";
+  env.SODIUM_INSTALL = "system";
 
   pythonImportsCheck = [ "nacl" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python binding to the Networking and Cryptography (NaCl) library";
     homepage = "https://github.com/pyca/pynacl/";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mdaniels5757 ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/pyca/pynacl/compare/1.5.0...1.6.0

Changelog: https://github.com/pyca/pynacl/blob/1.6.0/CHANGELOG.rst#160-2025-09-11

I had to switch the fetcher to GitHub because the pypi fetcher requires that the url path be like `/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}`, but the correct pypi URL for this version is this (case sensitive): `https://files.pythonhosted.org/packages/source/P/PyNaCl/pynacl-1.6.0.tar.gz`.

Fixes: #446500

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
