### PR TITLE
emacsPackages.emacs-application-framework: remove unused dependency

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -25,10 +25,6 @@ lib.packagesFromDirectoryRecursive {
 
   elpaca = callPackage ./manual-packages/elpaca { inherit (pkgs) git; };
 
-  emacs-application-framework = callPackage ./manual-packages/emacs-application-framework {
-    inherit (pkgs) git;
-  };
-
   lsp-bridge = callPackage ./manual-packages/lsp-bridge {
     inherit (pkgs)
       basedpyright

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
@@ -10,7 +10,6 @@
   # Emacs dependencies
   all-the-icons,
   # Other dependencies
-  git,
   nodejs,
   wmctrl,
   xdotool,
@@ -45,7 +44,6 @@ let
   otherPackageLists = [
     (
       [
-        git
         nodejs
         wmctrl
       ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I found that the `git` command is only used in "install-eaf.py" and "sync-eaf-resources.py", which are not used in nix. Remove "git" dependency may let the derivation clearer and more concise.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
