### PR TITLE
home-asssistant: Add extraConfig option to add arbitrary string to configuration.yaml

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -72,7 +72,14 @@ let
   filteredConfig = converge (filterAttrsRecursive (_: v: !elem v [ null ])) (
     recursiveUpdate customLovelaceModulesResources (cfg.config or { })
   );
-  configFile = renderYAMLFile "configuration.yaml" filteredConfig;
+  configFileInitial = builtins.readFile (renderYAMLFile "configurationInitial.yaml" filteredConfig);
+  configFile = pkgs.writeText "configuration.yaml" (
+    builtins.concatStringsSep "\n" [
+      configFileInitial
+      (if cfg.extraConfig != null then cfg.extraConfig else "")
+      ""
+    ]
+  );
 
   lovelaceConfigFile =
     if cfg.lovelaceConfig != null then
@@ -475,6 +482,14 @@ in
         Unless this option is explicitly set to `null`
         we assume your {file}`configuration.yaml` is
         managed through this module and thereby overwritten on startup.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Extra configuration to add to {file}`configuration.yaml`.
       '';
     };
 


### PR DESCRIPTION
Sometimes it's less clunky to just add !includes and the like as strings, so add an option to allow arbitrary strings at the bottom of the file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
