### PR TITLE
exploitdb: fix nix/store path warning

### DIFF
--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitLab,
   makeWrapper,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "exploitdb";
   version = "2025-09-18";
@@ -22,6 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     mkdir -p $out/bin $out/share
     cp --recursive . $out/share/exploitdb
+
+    substituteInPlace $out/share/exploitdb/.searchsploit_rc \
+      --replace-fail 'path_array+=("/opt/exploitdb")' 'path_array+=("'$out'/share/exploitdb")' \
+      --replace-fail 'path_array+=("/opt/exploitdb-papers")' 'path_array+=("'$out'/share/exploitdb")'
+
     makeWrapper $out/share/exploitdb/searchsploit $out/bin/searchsploit
     runHook postInstall
   '';


### PR DESCRIPTION
This pull request aims to fix a warning that appears when using the program. As shown in the screenshot, the warning appears constantly, which can be annoying when using it frequently for pen testing.







|  exploitdb without the change  |  exploitdb with the change   |
|-----|----|
| <img alt="exploit db before the change" src="https://github.com/user-attachments/assets/002503ee-d274-46f0-96d5-6c48d7113aaa" /> |<img alt="exploit db after the change" src="https://github.com/user-attachments/assets/789dec32-1bf4-41a2-ba65-b707f3eb33de" /> |

Packaging improvements:

* Updated the `substituteInPlace` command in the install phase to replace hardcoded `/opt/exploitdb` and `/opt/exploitdb-papers` paths in `.searchsploit_rc` with the correct Nix store path, ensuring `searchsploit` works out of the box.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.