### PR TITLE
[Backport release-25.05] openseachest: 24.08.1 -> 25.05.2

### DIFF
--- a/pkgs/by-name/op/openseachest/package.nix
+++ b/pkgs/by-name/op/openseachest/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openseachest";
-  version = "24.08.1";
+  version = "25.05";
 
   src = fetchFromGitHub {
     owner = "Seagate";
     repo = "openSeaChest";
     rev = "v${version}";
-    hash = "sha256-1vfWX6uTQcM6K6wu9Ygu2xZV4nXm6VnwNHmQ2ceh62s=";
+    hash = "sha256-rxy+A2HV20RbCF6rnl04RwAP7LHm1jM9Y78N08pBr6E=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/op/openseachest/package.nix
+++ b/pkgs/by-name/op/openseachest/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openseachest";
-  version = "25.05.1";
+  version = "25.05.2";
 
   src = fetchFromGitHub {
     owner = "Seagate";
     repo = "openSeaChest";
-    rev = "v${version}";
-    hash = "sha256-kd2JRtqnxfYRJcr1yKSB0LZAR96j2WW4tR1iRTvVANs=";
+    tag = "v${version}";
+    hash = "sha256-sZ668I38TClzTmzmRM0yQ/WG7o5AEIXFouWxmqVWyMs=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/op/openseachest/package.nix
+++ b/pkgs/by-name/op/openseachest/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openseachest";
-  version = "25.05";
+  version = "25.05.1";
 
   src = fetchFromGitHub {
     owner = "Seagate";
     repo = "openSeaChest";
     rev = "v${version}";
-    hash = "sha256-rxy+A2HV20RbCF6rnl04RwAP7LHm1jM9Y78N08pBr6E=";
+    hash = "sha256-kd2JRtqnxfYRJcr1yKSB0LZAR96j2WW4tR1iRTvVANs=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Manual backport of #412552 #415502 #429691 to `release-25.05`.

Closes: #445148 (backport request)

Release notes: [v25.05](https://github.com/Seagate/openSeaChest/releases/tag/v25.05), [v25.05.1](https://github.com/Seagate/openSeaChest/releases/tag/v25.05.1), and [v25.05.2](https://github.com/Seagate/openSeaChest/releases/tag/v25.05.2)

I don't see any breaking changes in any of those releases.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
