### PR TITLE
python3Packages.{gradio: 5.49.1 -> 6.1.0,gradio-client: 1.12.1 -> 2.0.1,gradio-pdf: 0.0.22 -> 0.0.23}

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -20,6 +20,8 @@
 
 - `iroh` has been removed and split up into `iroh-dns-server` and `iroh-relay`.
 
+- `python3Packages.gradio` has been updated to version 6. See upstream's migration guide at https://www.gradio.app/main/guides/gradio-6-migration-guide.
+
 - All Log4Shell vulnerability scanners were removed, as they were all unmaintained upstream and are no longer relevant given that the vulnerability has been fixed upstream for several years.
 
 - `asio` (standalone version of `boost::asio`) has been updated from 1.24.0 to 1.36.0. Some breaking changes were introduced between these

--- a/pkgs/development/python-modules/gradio-pdf/default.nix
+++ b/pkgs/development/python-modules/gradio-pdf/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage {
   pname = "gradio-pdf";
-  version = "0.0.22";
+  version = "0.0.23";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -19,8 +19,8 @@ buildPythonPackage {
     repo = "gradio-pdf";
     # No source release on Pypi
     # No tags on GitHub
-    rev = "8833e9cd419d2a5eeff98e3ae8cbe690913bcfce";
-    hash = "sha256-z9rfVnH2qANDp2ukUGSogADbwqQQzCkB7Cp/04UtEpM=";
+    rev = "57deb0bd2823a9a75c5da498cc39a85f8fd4ff02";
+    hash = "sha256-FzO8jKZw4EBqmsQ0xXqj0lqSHXxKk+rZjuluyNJVPYk=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "gradio-client";
-  version = "1.12.1";
+  version = "2.0.1";
   pyproject = true;
 
   # no tests on pypi
@@ -39,12 +39,24 @@ buildPythonPackage rec {
     owner = "gradio-app";
     repo = "gradio";
     # not to be confused with @gradio/client@${version}
-    tag = "gradio_client@${version}";
-    sparseCheckout = [ "client/python" ];
-    hash = "sha256-Q0sEn7trWVVWh2XNZam10axuQBiPZvq//qTIR5WJn+4=";
+    # tag = "gradio_client@${version}";
+    # TODO: switch back to a tag next release, if they tag it.
+    rev = "7a8894d7249ee20c2f7a896237e290e99661fd43"; # 2.0.1
+    sparseCheckout = [
+      "client/python"
+      "gradio/media_assets"
+    ];
+    hash = "sha256-p3okK48DJjjyvUzedNR60r5P8aKUxjE+ocb3EplZ6Uk=";
   };
 
   sourceRoot = "${src.name}/client/python";
+
+  postPatch = ''
+    # Because we set sourceRoot above, the folders "client/python"
+    # don't exist, as far as this is concerned.
+    substituteInPlace test/conftest.py \
+      --replace-fail 'from client.python.test import media_data' 'import media_data'
+  '';
 
   # upstream adds upper constraints because they can, not because the need to
   # https://github.com/gradio-app/gradio/pull/4885
@@ -80,6 +92,11 @@ buildPythonPackage rec {
   ];
   # ensuring we don't propagate this intermediate build
   disallowedReferences = [ gradio.sans-reverse-dependencies ];
+
+  postInstall = ''
+    mkdir -p $out/lib/gradio
+    cp -r ../../gradio/media_assets $out/lib/gradio
+  '';
 
   # Add a pytest hook skipping tests that access network, marking them as "Expected fail" (xfail).
   preCheck = ''

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  nix-update-script,
+  gitUpdater,
 
   # build-system
   hatchling,
@@ -110,11 +110,9 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "gradio_client@(.*)"
-    ];
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "gradio_client@";
+    ignoredVersions = ".*-(beta|dev).*";
   };
 
   meta = {

--- a/pkgs/development/python-modules/gradio/conftest-skip-network-errors.py
+++ b/pkgs/development/python-modules/gradio/conftest-skip-network-errors.py
@@ -43,6 +43,7 @@ def deny_network_access(*a, **kw):
 
 import httpx
 import requests
+import safehttpx
 import socket
 import urllib
 import urllib3
@@ -54,6 +55,7 @@ httpx.Request = deny_network_access
 requests.get = deny_network_access
 requests.head = deny_network_access
 requests.post = deny_network_access
+safehttpx.get = deny_network_access
 socket.socket.connect = deny_network_access
 urllib.request.Request = deny_network_access
 urllib.request.urlopen = deny_network_access

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -14,8 +14,8 @@
 
   # web assets
   zip,
-  nodejs,
-  pnpm_9,
+  nodejs_24,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 
@@ -75,34 +75,38 @@
   vega-datasets,
   writableTmpDirAsHomeHook,
 }:
+let
+  nodejs = nodejs_24;
+  pnpm = pnpm_10.override { inherit nodejs; };
+in
 buildPythonPackage rec {
   pname = "gradio";
-  version = "5.49.1";
+  version = "6.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
     tag = "gradio@${version}";
-    hash = "sha256-tfjyu2yl+2ndPZWrsSrVf8qv2eqpU5ZJHVqM9saJVt4=";
+    hash = "sha256-CvlMZlZ0aN/oreCiSL7RCVz8hq9Q9EGPrnQMIxCTVUs=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit
       pname
+      pnpm
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-XnCx34nbX+essVfXJlxvYB9/lnolAkF81Jp6dAOqr8E=";
+    fetcherVersion = 3;
+    hash = "sha256-Lk8B2nQsKHs7JP3tjZufghXI7VL7GYfC30e/gpSSd4M=";
   };
 
   pythonRelaxDeps = [
     "aiofiles"
     "gradio-client"
     "markupsafe"
-    "pillow"
+    "pydantic" # Requests >=2.11.10,<=2.12.4. Staging has it, master doesn't.
   ];
 
   pythonRemoveDeps = [
@@ -113,8 +117,9 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     zip
     nodejs
+    pnpm
     pnpmConfigHook
-    pnpm_9
+    writableTmpDirAsHomeHook
   ];
 
   build-system = [
@@ -184,7 +189,6 @@ buildPythonPackage rec {
 
     # mock calls to `shutil.which(...)`
     (writeShellScriptBin "npm" "false")
-    writableTmpDirAsHomeHook
   ]
   ++ optional-dependencies.oauth
   ++ pydantic.optional-dependencies.email;
@@ -256,32 +260,55 @@ buildPythonPackage rec {
     # Flaky test (AssertionError when comparing to a fixed array)
     # https://github.com/gradio-app/gradio/issues/11620
     "test_auto_datatype"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
-    "test_component_example_values"
-    "test_component_functions"
-    "test_public_request_pass"
 
     # Failed: DID NOT RAISE <class 'ValueError'>
-    # test.conftest.NixNetworkAccessDeniedError
+    # (because it raises our NixNetworkAccessDeniedError)
     "test_private_request_fail"
-    "test_theme_builder_launches"
 
+    # TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
+    "test_component_example_values"
+    "test_public_request_pass"
+    "test_theme_builder_launches"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # flaky on darwin (depend on port availability)
     "test_all_status_messages"
+    "test_analytics_summary"
     "test_async_generators"
     "test_async_generators_interface"
     "test_async_iterator_update_with_new_component"
-    "test_concurrency_limits"
+    "test_blocks_close_closes_thread_properly"
+    "test_caching"
+    "test_caching_audio_with_progress"
+    "test_caching_image"
+    "test_caching_with_async_generators"
+    "test_caching_with_batch"
+    "test_caching_with_batch_multiple_outputs"
+    "test_caching_with_dict"
+    "test_caching_with_float_numbers"
+    "test_caching_with_generators"
+    "test_caching_with_generators_and_streamed_output"
+    "test_caching_with_mix_update"
+    "test_caching_with_non_io_component"
+    "test_caching_with_update"
+    "test_chat_interface_api_name"
+    "test_chat_interface_api_names_with_additional_inputs"
+    "test_component_returned"
+    "test_css_and_css_paths_parameters"
+    "test_custom_css"
     "test_default_concurrency_limits"
     "test_default_flagging_callback"
     "test_end_to_end"
     "test_end_to_end_cache_examples"
     "test_event_data"
     "test_every_does_not_block_queue"
+    "test_example_caching"
+    "test_example_caching_async"
     "test_example_caching_relaunch"
-    "test_example_caching_relaunch"
+    "test_example_caching_with_additional_inputs"
+    "test_example_caching_with_additional_inputs_already_rendered"
+    "test_example_caching_with_streaming"
+    "test_example_caching_with_streaming_async"
     "test_exit_called_at_launch"
     "test_file_component_uploads"
     "test_files_saved_as_file_paths"
@@ -290,17 +317,25 @@ buildPythonPackage rec {
     "test_info_and_warning_alerts"
     "test_info_isolation"
     "test_launch_analytics_does_not_error_with_invalid_blocks"
+    "test_mcp_streamable_http_client"
+    "test_mcp_streamable_http_client_with_progress_callback"
+    "test_multiple_file_flagging"
+    "test_multiple_messages"
     "test_no_empty_audio_files"
     "test_no_empty_image_files"
     "test_no_empty_video_files"
     "test_non_streaming_api"
     "test_non_streaming_api_async"
+    "test_no_postprocessing"
+    "test_no_preprocessing"
     "test_pil_images_hashed"
+    "test_post_process_file_blocked"
     "test_progress_bar"
     "test_progress_bar_track_tqdm"
     "test_queue_when_using_auth"
     "test_restart_after_close"
     "test_set_share_in_colab"
+    "test_setting_cache_dir_env_variable"
     "test_show_error"
     "test_simple_csv_flagging_callback"
     "test_single_request"
@@ -315,6 +350,7 @@ buildPythonPackage rec {
     "test_sync_generators"
     "test_time_to_live_and_delete_callback_for_state"
     "test_updates_stored_up_to_capacity"
+    "test_use_default_theme_as_fallback"
     "test_varying_output_forms_with_generators"
   ];
 
@@ -340,7 +376,10 @@ buildPythonPackage rec {
 
   pytestFlags = [
     "-x" # abort on first failure
-    #"-Wignore" # uncomment for debugging help
+    # "-Wignore" # uncomment for debugging help
+    # Requires writable media assets in /nix/store
+    "--deselect"
+    "test/components/test_video.py::TestVideo::test_component_functions"
   ];
 
   # check the binary works outside the build env
@@ -354,16 +393,21 @@ buildPythonPackage rec {
   # This is gradio without gradio-client and gradio-pdf
   passthru = {
     sans-reverse-dependencies =
-      (gradio.override (old: {
+      (gradio.override {
         gradio-client = null;
         gradio-pdf = null;
-      })).overridePythonAttrs
+      }).overridePythonAttrs
         (old: {
           pname = old.pname + "-sans-reverse-dependencies";
           pythonRemoveDeps = (old.pythonRemoveDeps or [ ]) ++ [ "gradio-client" ];
           doInstallCheck = false;
           doCheck = false;
+          postPatch = "";
           preCheck = "";
+          disabledTests = [ ];
+          disabledTestPaths = [ ];
+          disabledTestMarks = [ ];
+          pytestFlags = [ ];
           postInstall = ''
             shopt -s globstar
             for f in $out/**/*.py; do


### PR DESCRIPTION
Closes: #445159

* python3Packages.gradio: add updateScript
* python3Packages.gradio-client: modify updateScript
  This change is needed because nix-update only checks so many versions, so sometimes gradio's releases align such that no version for gradio_client is present in the first N releases.
* python3Packages.gradio-client: 1.12.1 -> 2.0.1
  Despite the pinned `rev`, this is exactly version 2.0.1, not unstable.
 See https://github.com/gradio-app/gradio/pull/12478.
  Upstream issue: https://github.com/gradio-app/gradio/issues/12541.
  Changelog: https://github.com/gradio-app/gradio/blob/7a8894d7249ee20c2f7a896237e290e99661fd43/client/python/CHANGELOG.md
* python3Packages.gradio-pdf: 0.0.22 -> 0.0.23
  Diff: https://github.com/freddyaboulton/gradio-pdf/compare/8833e9cd419d2a5eeff98e3ae8cbe690913bcfce...57deb0bd2823a9a75c5da498cc39a85f8fd4ff02
* python3Packages.gradio: 5.49.1 -> 6.1.0
  Changelog: https://github.com/gradio-app/gradio/blob/gradio%406.1.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
