### PR TITLE
dotnet-sdk-setup-hook: fix case where ln fails because file exists

### DIFF
--- a/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
+++ b/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
@@ -23,7 +23,9 @@ _linkPackages() {
         for x in "$src"/*/*; do
             dir=$dest/$(basename "$(dirname "$x")")
             mkdir -p "$dir"
-            ln -s "$x" "$dir"/
+            if [[ ! -f "$dir/$(basename "$x")" ]]; then
+              ln -s "$x" "$dir"/
+            fi
         done
     )
 }

--- a/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
+++ b/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
@@ -23,7 +23,7 @@ _linkPackages() {
         for x in "$src"/*/*; do
             dir=$dest/$(basename "$(dirname "$x")")
             mkdir -p "$dir"
-            if [[ ! -f "$dir/$(basename "$x")" ]]; then
+            if [[ ! -e "$dir/$(basename "$x")" ]]; then
               ln -s "$x" "$dir"/
             fi
         done


### PR DESCRIPTION
This fixes linking errors experienced when using `buildDotnetModule` in the `setupHook`, for example:

```
       > Running phase: configureNuget
       > ln: failed to create symbolic link '/nix/var/nix/builds/nix-build-coord_api-0.0.1.drv-28488-3028090113/nuget.VG6nI7/fallback/microsoft.aspnetcore.app.ref/8.0.20': File exists
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
