### PR TITLE
vpp: add config option to enable SKB-only AF-XDP interfaces

### DIFF
--- a/pkgs/by-name/vp/vpp/package.nix
+++ b/pkgs/by-name/vp/vpp/package.nix
@@ -24,6 +24,7 @@
   enableDpdk ? true,
   enableRdma ? true,
   enableAfXdp ? true,
+  enableAfXdpSkbMode ? false,
 }:
 
 let
@@ -115,9 +116,14 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  patches = lib.optionals enableAfXdp [
-    ./use-dynamic-libxdp-libbpf.patch
-  ];
+  patches = lib.optionals enableAfXdp (
+    [
+      ./use-dynamic-libxdp-libbpf.patch
+    ]
+    ++ lib.optionals enableAfXdpSkbMode [
+      ./use-skb-mode.patch
+    ]
+  );
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/vp/vpp/use-skb-mode.patch
+++ b/pkgs/by-name/vp/vpp/use-skb-mode.patch
@@ -1,0 +1,10 @@
+--- a/plugins/af_xdp/device.c    2025-09-13 07:41:51.520416000 -0500
++++ b/plugins/af_xdp/device.c   2025-09-13 07:57:19.620421900 -0500
+@@ -330,6 +330,7 @@
+   sock_config.rx_size = args->rxq_size;
+   sock_config.tx_size = args->txq_size;
+   sock_config.bind_flags = XDP_USE_NEED_WAKEUP;
++  sock_config.xdp_flags = XDP_FLAGS_SKB_MODE;
+   switch (args->mode)
+     {
+     case AF_XDP_MODE_AUTO:


### PR DESCRIPTION
This adds universal support for all network cards, but is slower than the native/auto XDP mode. So, gating this behind a conditional which is default false.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
