### PR TITLE
llvmPackages_{18,19}: fix build with gcc15

### DIFF
--- a/pkgs/development/compilers/llvm/18/mlir/mlir-add-include-cstdint.patch
+++ b/pkgs/development/compilers/llvm/18/mlir/mlir-add-include-cstdint.patch
@@ -1,0 +1,28 @@
+Rebase of 2 upstream commits:
+https://github.com/llvm/llvm-project/commit/41eb186fbb024898bacc2577fa3b88db0510ba1f
+https://github.com/llvm/llvm-project/commit/101109fc5460d5bb9bb597c6ec77f998093a6687
+
+diff --git a/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h b/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
+index 451c466fa0c95..642e99d963ef6 100644
+--- a/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
++++ b/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
+@@ -10,6 +10,7 @@
+ #define MLIR_DIALECT_AFFINE_IR_VALUEBOUNDSOPINTERFACEIMPL_H
+ 
+ #include "mlir/Support/LogicalResult.h"
++#include <cstdint>
+ 
+ namespace mlir {
+ class DialectRegistry;
+diff --git a/include/mlir/Target/SPIRV/Deserialization.h b/include/mlir/Target/SPIRV/Deserialization.h
+index e39258beeaac8..a346a7fd1e5f7 100644
+--- a/include/mlir/Target/SPIRV/Deserialization.h
++++ b/include/mlir/Target/SPIRV/Deserialization.h
+@@ -15,6 +15,7 @@
+ 
+ #include "mlir/IR/OwningOpRef.h"
+ #include "mlir/Support/LLVM.h"
++#include <cstdint>
+ 
+ namespace mlir {
+ class MLIRContext;

--- a/pkgs/development/compilers/llvm/19/mlir/mlir-add-include-cstdint.patch
+++ b/pkgs/development/compilers/llvm/19/mlir/mlir-add-include-cstdint.patch
@@ -1,0 +1,29 @@
+Rebase of 2 upstream commits:
+https://github.com/llvm/llvm-project/commit/41eb186fbb024898bacc2577fa3b88db0510ba1f
+https://github.com/llvm/llvm-project/commit/101109fc5460d5bb9bb597c6ec77f998093a6687
+
+diff --git a/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h b/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
+index 451c466fa0c95..642e99d963ef6 100644
+--- a/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
++++ b/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h
+@@ -10,6 +10,7 @@
+ #define MLIR_DIALECT_AFFINE_IR_VALUEBOUNDSOPINTERFACEIMPL_H
+ 
+ #include "mlir/Support/LLVM.h"
++#include <cstdint>
+ 
+ namespace mlir {
+ class DialectRegistry;
+diff --git a/include/mlir/Target/SPIRV/Deserialization.h b/include/mlir/Target/SPIRV/Deserialization.h
+index e39258beeaac8..a346a7fd1e5f7 100644
+--- a/include/mlir/Target/SPIRV/Deserialization.h
++++ b/include/mlir/Target/SPIRV/Deserialization.h
+@@ -15,6 +15,7 @@
+ 
+ #include "mlir/IR/OwningOpRef.h"
+ #include "mlir/Support/LLVM.h"
++#include <cstdint>
+ 
+ namespace mlir {
+ class MLIRContext;
+

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -70,7 +70,14 @@ stdenv.mkDerivation (
 
     sourceRoot = "${finalAttrs.src.name}/lldb";
 
-    patches = [ ./gnu-install-dirs.patch ];
+    patches = [
+      ./gnu-install-dirs.patch
+    ]
+    ++ lib.optional (lib.versions.major release_version == "18") [
+      # Fix build with gcc15
+      # https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
+      ./lldb-add-include-cstdint.patch
+    ];
 
     nativeBuildInputs = [
       cmake

--- a/pkgs/development/compilers/llvm/common/lldb/lldb-add-include-cstdint.patch
+++ b/pkgs/development/compilers/llvm/common/lldb/lldb-add-include-cstdint.patch
@@ -1,0 +1,16 @@
+Rebase of upstream commit:
+https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
+
+diff --git a/include/lldb/Utility/AddressableBits.h b/include/lldb/Utility/AddressableBits.h
+index 0d27c3561ec27..8c7a1ec5f52c0 100644
+--- a/include/lldb/Utility/AddressableBits.h
++++ b/include/lldb/Utility/AddressableBits.h
+@@ -12,6 +12,8 @@
+ #include "lldb/lldb-forward.h"
+ 
++#include <cstdint>
++
+ namespace lldb_private {
+ 
+ /// \class AddressableBits AddressableBits.h "lldb/Core/AddressableBits.h"
+

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -193,6 +193,10 @@ stdenv.mkDerivation (
           stripLen = 1;
           hash = "sha256-fqw5gTSEOGs3kAguR4tINFG7Xja1RAje+q67HJt2nGg=";
         })
+        # Fix build with gcc15
+        # https://github.com/llvm/llvm-project/commit/8f39502b85d34998752193e85f36c408d3c99248
+        # https://github.com/llvm/llvm-project/commit/7abf44069aec61eee147ca67a6333fc34583b524
+        ./llvm-add-include-cstdint.patch
       ]
       ++ lib.optionals (lib.versionOlder release_version "19") [
         # Fixes test-suite on glibc 2.40 (https://github.com/llvm/llvm-project/pull/100804)

--- a/pkgs/development/compilers/llvm/common/llvm/llvm-add-include-cstdint.patch
+++ b/pkgs/development/compilers/llvm/common/llvm/llvm-add-include-cstdint.patch
@@ -1,0 +1,27 @@
+Rebase of 2 upstream commits:
+https://github.com/llvm/llvm-project/commit/8f39502b85d34998752193e85f36c408d3c99248
+https://github.com/llvm/llvm-project/commit/7abf44069aec61eee147ca67a6333fc34583b524
+
+diff --git a/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h b/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+index 3ef00f75735b0..879dbe1b279b1 100644
+--- a/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
++++ b/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+@@ -15,6 +15,7 @@
+ #ifndef LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ 
+ namespace llvm {
+diff --git a/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h b/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+index e166b68668d9b..0e0e13e896aea 100644
+--- a/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ b/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -14,6 +14,7 @@
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -12,6 +12,7 @@
   libllvm,
   version,
   devExtraCmakeFlags ? [ ],
+  getVersionFile,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,6 +39,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./gnu-install-dirs.patch
+  ]
+  ++ lib.optional (lib.versionOlder release_version "20") [
+    # Fix build with gcc15
+    # https://github.com/llvm/llvm-project/commit/41eb186fbb024898bacc2577fa3b88db0510ba1f
+    # https://github.com/llvm/llvm-project/commit/101109fc5460d5bb9bb597c6ec77f998093a6687
+    (getVersionFile "mlir/mlir-add-include-cstdint.patch")
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -116,4 +116,16 @@
       path = ../21;
     }
   ];
+  "mlir/mlir-add-include-cstdint.patch" = [
+    {
+      after = "18";
+      before = "19";
+      path = ../18;
+    }
+    {
+      after = "19";
+      before = "20";
+      path = ../19;
+    }
+  ];
 }


### PR DESCRIPTION
llvmPackages_18.llvm: fix build with gcc15

- add combined patch from 2 upstream commits that were not backported
to llvm_18:

https://github.com/llvm/llvm-project/commit/8f39502b85d34998752193e85f36c408d3c99248
Fixes build failure with gcc15:
```
In file included from /build/llvm-src-18.1.8/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp:14:
/build/llvm-src-18.1.8/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h:44:43:
error: 'uint8_t' has not been declared
   44 | createAMDGPUELFObjectWriter(bool Is64Bit, uint8_t OSABI,
      |                                           ^~~~~~~
/build/llvm-src-18.1.8/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h:19:1:
note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   18 | #include <memory>
  +++ |+#include <cstdint>
   19 |
```

https://github.com/llvm/llvm-project/commit/7abf44069aec61eee147ca67a6333fc34583b524
Fixes build failure with gcc15:
```
In file included from /build/llvm-src-18.1.8/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h:19,
                 from /build/llvm-src-18.1.8/llvm/lib/Target/X86/MCTargetDesc/X86EncodingOptimization.cpp:14:
/build/llvm-src-18.1.8/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:86:50:
error: 'uint64_t' has not been declared
   86 |                               int MemoryOperand, uint64_t TSFlags);
      |                                                  ^~~~~~~~
/build/llvm-src-18.1.8/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h:18:1:
note: 'uint64_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cstdint>'
   17 | #include <string>
  +++ |+#include <cstdint>
   18 |
```

Cannot use `fetchpatch` because second patch does not apply on llvm_18,
no `#include "llvm/ADT/SmallVector.h"` line present on llvm_18.
So vendor combined patch from 2 commits.

---

llvmPackages_18.lldb: fix build with gcc15

- add patch from upstream commit that was not backported to llvm_18:

https://github.com/llvm/llvm-project/commit/bb59f04e7e75dcbe39f1bf952304a157f0035314
Fixes build failure with gcc15:
```
In file included from /build/lldb-src-18.1.8/lldb/source/Utility/AddressableBits.cpp:9:
/build/lldb-src-18.1.8/lldb/include/lldb/Utility/AddressableBits.h:25:27:
error: 'uint32_t' has not been declared
   25 |   void SetAddressableBits(uint32_t addressing_bits);
      |                           ^~~~~~~~
/build/lldb-src-18.1.8/lldb/include/lldb/Utility/AddressableBits.h:13:1:
note: 'uint32_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cstdint>'
   12 | #include "lldb/lldb-forward.h"
  +++ |+#include <cstdint>
   13 |
```

Cannot use `fetchpatch` because patch does not apply on llvm_18
(no `#include "lldb/lldb-public.h"` line on llvm_18).

---

llvmPackages_{18,19}.mlir: fix build with gcc15

- add patch from 2 upstream commits that were not backported to llvm_18
and llvm_19:

https://github.com/llvm/llvm-project/commit/41eb186fbb024898bacc2577fa3b88db0510ba1f
Fixes build failure with gcc15:
```
In file included from /build/mlir-src-18.1.8/mlir/lib/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.cpp:9:
/build/mlir-src-18.1.8/mlir/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h:31:11:
error: 'int64_t' was not declared in this scope
   31 | FailureOr<int64_t> fullyComposeAndComputeConstantDelta(Value value1,
      |           ^~~~~~~
/build/mlir-src-18.1.8/mlir/include/mlir/Dialect/Affine/IR/ValueBoundsOpInterfaceImpl.h:13:1:
note: 'int64_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cstdint>'
   12 | #include "mlir/Support/LogicalResult.h"
  +++ |+#include <cstdint>
   13 |
```

https://github.com/llvm/llvm-project/commit/101109fc5460d5bb9bb597c6ec77f998093a6687
Fixes failure with gcc15:
```
In file included from /build/mlir-src-19.1.7/mlir/lib/Target/SPIRV/Deserialization/Deserialization.cpp:9:
/build/mlir-src-19.1.7/mlir/include/mlir/Target/SPIRV/Deserialization.h:29:51:
error: 'uint32_t' was not declared in this scope
   29 | OwningOpRef<spirv::ModuleOp> deserialize(ArrayRef<uint32_t> binary,
      |                                                   ^~~~~~~~
/build/mlir-src-19.1.7/mlir/include/mlir/Target/SPIRV/Deserialization.h:18:1:
note: 'uint32_t' is defined in header '<cstdint>'; this is probably
fixable by adding '#include <cstdint>'
   17 | #include "mlir/Support/LLVM.h"
  +++ |+#include <cstdint>
   18 |
```

First patch can be applied with `fetchpatch`, but only on llvm_19, because
of changed include line right above.
So use 2 versions of combined patches with 2 commits.

---

Tested builds on top of https://github.com/NixOS/nixpkgs/pull/440456

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

I tried to reduce amount of patches and make them as sensible as possible.
If there are any suggestions on how to do it better, I am open to them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
