### PR TITLE
nixos/grub: add support for loading deviceTree

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -106,7 +106,7 @@ in
     let
       builderArgs =
         "-g ${toString cfg.configurationLimit} -t ${timeoutStr}"
-        + lib.optionalString (dtCfg.name != null) " -n ${dtCfg.name}"
+        + lib.optionalString config.boot.loader.loadDeviceTree " -n ${dtCfg.name}"
         + lib.optionalString (!cfg.useGenerationDeviceTree) " -r";
       installBootLoader = pkgs.writeScript "install-extlinux-conf.sh" (
         ''

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -845,6 +845,10 @@ in
 
       environment.systemPackages = mkIf (grub != null) [ grub ];
 
+      boot.bootspec.extensions."org.nixos.grub" = {
+        devicetree = lib.mkIf config.boot.loader.loadDeviceTree "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+      };
+
       boot.loader.grub.extraPrepareConfig = concatStrings (
         mapAttrsToList (
           fileName: sourcePath:

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -337,7 +337,9 @@ $conf .= "
     # Setup the graphics stack for bios and efi systems
     if [ \"\${grub_platform}\" = \"efi\" ]; then
       insmod efi_gop
-      insmod efi_uga
+      if [ \"\${grub_cpu}\" = \"i386\" -o \"\${grub_cpu}\" = \"x86_64\"]; then
+        insmod efi_uga
+      fi
     else
       insmod vbe
     fi

--- a/nixos/modules/system/boot/loader/loader.nix
+++ b/nixos/modules/system/boot/loader/loader.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 with lib;
 
@@ -9,12 +9,34 @@ with lib;
   ];
 
   options = {
-    boot.loader.timeout = mkOption {
-      default = 5;
-      type = types.nullOr types.int;
-      description = ''
-        Timeout (in seconds) until loader boots the default menu item. Use null if the loader menu should be displayed indefinitely.
-      '';
+    boot.loader = {
+      timeout = mkOption {
+        default = 5;
+        type = types.nullOr types.int;
+        description = ''
+          Timeout (in seconds) until loader boots the default menu item. Use null if the loader menu should be displayed indefinitely.
+        '';
+      };
+      loadDeviceTree = mkOption {
+        default = with config.hardware.deviceTree; enable && name != null;
+        defaultText = ''with config.hardware.deviceTree; enable && name != null'';
+        description = ''
+          Load the devicetree blob specified by `config.hardware.deviceTree.name`
+          and instruct bootloader to pass this DTB to linux.
+        '';
+      };
     };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion =
+          config.boot.loader.loadDeviceTree
+          -> config.hardware.deviceTree.enable
+          -> config.hardware.deviceTree.name != null;
+        message = "Cannot load devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
+      }
+    ];
   };
 }

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -161,6 +161,19 @@ in
       ]
       (config: lib.strings.removeSuffix ".conf" config.boot.loader.systemd-boot.netbootxyz.entryFilename)
     )
+    (mkRenamedOptionModule
+      [
+        "boot"
+        "loader"
+        "systemd-boot"
+        "installDeviceTree"
+      ]
+      [
+        "boot"
+        "loader"
+        "loadDeviceTree"
+      ]
+    )
   ];
 
   options.boot.loader.systemd-boot = {
@@ -241,15 +254,6 @@ in
 
         `null` means no limit i.e. all generations
         that have not been garbage collected yet.
-      '';
-    };
-
-    installDeviceTree = mkOption {
-      default = with config.hardware.deviceTree; enable && name != null;
-      defaultText = ''with config.hardware.deviceTree; enable && name != null'';
-      description = ''
-        Install the devicetree blob specified by `config.hardware.deviceTree.name`
-        to the ESP and instruct systemd-boot to pass this DTB to linux.
       '';
     };
 
@@ -535,13 +539,6 @@ in
         assertion = (config.boot.kernelPackages.kernel.features or { efiBootStub = true; }) ? efiBootStub;
         message = "This kernel does not support the EFI boot stub";
       }
-      {
-        assertion =
-          cfg.installDeviceTree
-          -> config.hardware.deviceTree.enable
-          -> config.hardware.deviceTree.name != null;
-        message = "Cannot install devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
-      }
     ]
     ++ concatMap (filename: [
       {
@@ -626,7 +623,7 @@ in
 
     boot.bootspec.extensions."org.nixos.systemd-boot" = {
       inherit (config.boot.loader.systemd-boot) sortKey;
-      devicetree = lib.mkIf cfg.installDeviceTree "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+      devicetree = lib.mkIf config.boot.loader.loadDeviceTree "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
     };
 
     system = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -440,6 +440,7 @@ in
   dendrite = runTest ./matrix/dendrite.nix;
   dep-scan = runTest ./dep-scan.nix;
   dependency-track = runTest ./dependency-track.nix;
+  device-tree = import ./device-tree.nix { inherit pkgs runTestOn; };
   devpi-server = runTest ./devpi-server.nix;
   dex-oidc = runTest ./dex-oidc.nix;
   dhparams = runTest ./dhparams.nix;

--- a/nixos/tests/device-tree.nix
+++ b/nixos/tests/device-tree.nix
@@ -1,0 +1,80 @@
+{
+  pkgs,
+  runTestOn,
+}:
+
+let
+  supportedSystems = [
+    "aarch64-linux"
+  ];
+  common =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      inherit (pkgs.stdenv.hostPlatform) qemuArch;
+    in
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+
+      hardware.deviceTree = {
+        name = "qemu-${qemuArch}-virt.dtb";
+        package = lib.mkForce (
+          pkgs.runCommand "qemu-dtb" { } ''
+            mkdir $out
+            ${pkgs.qemu}/bin/qemu-system-${qemuArch} \
+              -cpu max -machine virt,gic-version=max,accel=kvm:tcg,dumpdtb=$out/${config.hardware.deviceTree.name}
+          ''
+        );
+      };
+    };
+  testScript =
+    { nodes, ... }:
+    ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("grep 'linux,dummy-virt' /sys/firmware/devicetree/base/model")
+    '';
+in
+
+{
+  systemd-boot = runTestOn supportedSystems {
+    name = "device-tree-systemd-boot";
+    meta.maintainers = with pkgs.lib.maintainers; [
+      qbisi
+    ];
+
+    nodes.machine = {
+      imports = [ common ];
+
+      boot.loader.systemd-boot.enable = true;
+    };
+
+    inherit testScript;
+  };
+
+  grub = runTestOn supportedSystems {
+    name = "device-tree-grub";
+    meta.maintainers = with pkgs.lib.maintainers; [
+      qbisi
+    ];
+
+    nodes.machine = {
+      imports = [ common ];
+
+      boot.loader.grub = {
+        enable = true;
+        device = "nodev";
+        efiSupport = true;
+        efiInstallAsRemovable = true;
+      };
+    };
+
+    inherit testScript;
+  };
+}

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -212,7 +212,7 @@ in
             # (we would then be able to use `dumpdtb`). Thus, the following config
             # will not boot, but it does allow us to assert that the boot entry has
             # the correct contents.
-            boot.loader.systemd-boot.installDeviceTree = pkgs.stdenv.hostPlatform.isAarch64;
+            boot.loader.loadDeviceTree = pkgs.stdenv.hostPlatform.isAarch64;
             hardware.deviceTree.name = "dummy.dtb";
             hardware.deviceTree.package = lib.mkForce (
               pkgs.runCommand "dummy-devicetree-package" { } ''


### PR DESCRIPTION
grub do have support for loading deviceTree from filesystem and pass it to linux.
See https://www.gnu.org/software/grub/manual/grub/html_node/devicetree.html.
Here we implement deviceTree support for grub module.



## Things done
1. Fix `efi_uga module not available` on aarch64-linux platform when using grub. (efi_uga is only available on x86)
2. Add support for nixos grub module to load deviceTree if hardware.deviceTree.name is specified.
3. The option boot.loader.loadDeviceTree, renamed from boot.loader.systemd-boot.installDeviceTree, now provides generic device tree loading support for bootloaders.
4. A new bootspec field, org.nixos.grub, is introduced to store generation’s device-tree information.

## Future plan
1.  implement deviceTree support for limine 
2.  [RFC] migrate the systemd-boot bootspec field "org.nixos.systemd-boot".deviceTree to "org.nixos.bootspec.v2".deviceTree. It will just work with a simple replacement, however it brokes compatibility with legacy configuration and prevent rolling back to legacy onfiguration. 
3. make generic-exlinux to use bootspec "org.nixos.bootspec.v2"

cc @jfly  @jmbaur  for your comment.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
