### PR TITLE
python313Packages.asyncprawcore: set to pytest-asyncio_0

### DIFF
--- a/pkgs/development/python-modules/asyncpraw/default.nix
+++ b/pkgs/development/python-modules/asyncpraw/default.nix
@@ -9,7 +9,7 @@
   flit-core,
   mock,
   pytestCheckHook,
-  pytest-asyncio,
+  pytest-asyncio_0,
   pytest-vcr,
   pythonOlder,
   requests-toolbelt,
@@ -49,7 +49,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-asyncio
+    pytest-asyncio_0
     pytest-vcr
     vcrpy
     requests-toolbelt

--- a/pkgs/development/python-modules/asyncprawcore/default.nix
+++ b/pkgs/development/python-modules/asyncprawcore/default.nix
@@ -8,7 +8,6 @@
   pytestCheckHook,
   pytest-asyncio_0,
   pytest-vcr,
-  pythonOlder,
   requests,
   requests-toolbelt,
   testfixtures,
@@ -21,8 +20,6 @@ buildPythonPackage rec {
   version = "2.4.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
   src = fetchFromGitHub {
     owner = "praw-dev";
     repo = "asyncprawcore";
@@ -30,9 +27,9 @@ buildPythonPackage rec {
     hash = "sha256-FDQdtnNjsbiEp9BUYdQFMC/hkyJDhCh2WHhQWSQwrFY=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     requests
     aiohttp
     yarl

--- a/pkgs/development/python-modules/asyncprawcore/default.nix
+++ b/pkgs/development/python-modules/asyncprawcore/default.nix
@@ -6,7 +6,7 @@
   flit-core,
   mock,
   pytestCheckHook,
-  pytest-asyncio,
+  pytest-asyncio_0,
   pytest-vcr,
   pythonOlder,
   requests,
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     mock
     requests-toolbelt
     pytestCheckHook
-    pytest-asyncio
+    pytest-asyncio_0
     pytest-vcr
     vcrpy
   ];


### PR DESCRIPTION
https://hydra.nixos.org/build/307240272
https://hydra.nixos.org/build/307240284

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
