### PR TITLE
sssd: fix tests issues

### DIFF
--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -21,7 +21,6 @@ in
         description = "Contents of {file}`sssd.conf`.";
         default = ''
           [sssd]
-          config_file_version = 2
           services = nss, pam
           domains = shadowutils
 

--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  replaceVars,
   autoreconfHook,
   makeWrapper,
   glibc,
@@ -72,8 +73,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-JN4GVx5rBfNBLaMpLcKgyd+CyNDafz85BXUcfg5kDXQ=";
   };
 
+  patches = [
+    (replaceVars ./fix-ldb-modules-path.patch {
+      inherit ldb;
+      out = null; # will be replaced in postPatch https://github.com/NixOS/nixpkgs/pull/446589#discussion_r2384899857
+    })
+  ];
+
   postPatch = ''
     patchShebangs ./sbus_generate.sh.in
+
+    substituteInPlace src/confdb/confdb.c \
+      --replace-fail "@out@" "${placeholder "out"}"
   '';
 
   # Something is looking for <libxml/foo.h> instead of <libxml2/libxml/foo.h>
@@ -101,6 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
       --with-xml-catalog-path=''${SGML_CATALOG_FILES%%:*}
       --with-ldb-lib-dir=$out/modules/ldb
       --with-nscd=${glibc.bin}/sbin/nscd
+      --with-sssd-user=root
     )
   ''
   + lib.optionalString withSudo ''

--- a/pkgs/os-specific/linux/sssd/fix-ldb-modules-path.patch
+++ b/pkgs/os-specific/linux/sssd/fix-ldb-modules-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/confdb/confdb.c b/src/confdb/confdb.c
+index 8c19142..7865684 100644
+--- a/src/confdb/confdb.c
++++ b/src/confdb/confdb.c
+@@ -775,6 +775,8 @@ int confdb_init(TALLOC_CTX *mem_ctx,
+     int ret = EOK;
+     mode_t old_umask;
+ 
++    setenv("LDB_MODULES_PATH", "@out@/modules/ldb:@ldb@/modules/ldb", 1);
++
+     if (cdb_ctx == NULL) {
+         DEBUG(SSSDBG_FATAL_FAILURE, "Bad argument\n");
+         return EFAULT;


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/pull/443366

Fix : 
`nixosTests.sssd` OK
`nixosTests.sssd-ldap` OK

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
