### PR TITLE
libmysqlclient: move .so to /lib folder for compatibility with nix-ld

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -82,6 +82,12 @@ stdenv.mkDerivation {
     ln -sv mariadb_version.h $dev/include/mariadb/mysql_version.h
     ln -sv libmariadb.pc $dev/lib/pkgconfig/mysqlclient.pc
     install -Dm644 include/ma_config.h $dev/include/mariadb/my_config.h
+    # The dynamically loaded library must be found directly inside /lib
+    # This is necessary for nix-ld to work properly
+    # https://github.com/nix-community/nix-ld
+    ln -sv $out/lib/mysql/*.so $out/lib
+    ln -sv $out/lib/mysql/*.so.3 $out/lib
+    ln -sv $out/lib/mysql/*.a $out/lib
   '';
 
   meta = with lib; {

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -85,8 +85,7 @@ stdenv.mkDerivation {
     # The dynamically loaded library must be found directly inside /lib
     # This is necessary for nix-ld to work properly
     # https://github.com/nix-community/nix-ld
-    ln -sv $out/lib/mysql/*.so $out/lib
-    ln -sv $out/lib/mysql/*.so.3 $out/lib
+    ln -sv $out/lib/mysql/*.so* $out/lib
     ln -sv $out/lib/mysql/*.a $out/lib
   '';
 


### PR DESCRIPTION
## libmysqlclient: move `.so` to `/lib` for nix-ld compatibility

I recently ran into an issue running an unpatched binary that required `libmariadb.so.3`.
Normally, this can be resolved by using [nix-ld](https://github.com/nix-community/nix-ld) when a patched binary isn’t available.

The problem was that `libmysqlclient` installs its shared objects under `lib/mysql` and `lib/mariadb`, while `nix-ld` expects them directly under `lib`.

This change adds symbolic links in `lib` so that `nix-ld` can locate the libraries correctly.

This is my first contribution to nixpkgs, so please let me know if anything needs adjustment. I’m happy to learn and improve.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  NOTE:  I tryed running nixpkgs-review, but my pc runs out of ram...
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
