### PR TITLE
hushboard: unstable-2021-03-17 -> 0-unstable-2024-04-28, move to by-name

### DIFF
--- a/pkgs/applications/audio/hushboard/default.nix
+++ b/pkgs/applications/audio/hushboard/default.nix
@@ -12,12 +12,14 @@
   six,
   wrapGAppsHook3,
   xlib,
+  nix-update-script,
+  setuptools,
 }:
 
 buildPythonApplication {
   pname = "hushboard";
   version = "unstable-2021-03-17";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stuartlangridge";
@@ -25,6 +27,8 @@ buildPythonApplication {
     rev = "c16611c539be111891116a737b02c5fb359ad1fc";
     sha256 = "06jav6j0bsxhawrq31cnls8zpf80fpwk0cak5s82js6wl4vw2582";
   };
+
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [
     wrapGAppsHook3
@@ -62,15 +66,21 @@ buildPythonApplication {
     cp hushboard-512.png $out/share/icons/hicolor/512x512/apps/hushboard.png
   '';
 
-  # There are no tests
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  # no tests
   doCheck = false;
 
-  meta = with lib; {
+  pythonImportsCheck = [
+    "hushboard"
+  ];
+
+  meta = {
     homepage = "https://kryogenix.org/code/hushboard/";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     description = "Mute your microphone while typing";
     mainProgram = "hushboard";
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ keysmashes ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ keysmashes ];
   };
 }

--- a/pkgs/by-name/hu/hushboard/package.nix
+++ b/pkgs/by-name/hu/hushboard/package.nix
@@ -9,6 +9,7 @@
   librsvg,
   wrapGAppsHook3,
   nix-update-script,
+  fetchpatch,
 }:
 
 python3Packages.buildPythonApplication {
@@ -22,6 +23,14 @@ python3Packages.buildPythonApplication {
     rev = "13f5e62add99355f90798006742f62397be8be0c";
     hash = "sha256-z5ZSqcdKUHWt7kgW7ISZJei2YzVZHJGOqJ2IXv3qiWQ=";
   };
+
+  patches = [
+    # https://github.com/stuartlangridge/hushboard/pull/30
+    (fetchpatch {
+      url = "https://github.com/stuartlangridge/hushboard/commit/b17b58cd00eb9af8184f8dcb010bbae7f9bc470c.patch";
+      hash = "sha256-C03hq2ttXY8DJzrarQvFIzo29d+owZVIHZRA28fq7Z8=";
+    })
+  ];
 
   build-system = with python3Packages; [ setuptools ];
 

--- a/pkgs/by-name/hu/hushboard/package.nix
+++ b/pkgs/by-name/hu/hushboard/package.nix
@@ -1,22 +1,17 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
   gobject-introspection,
   gtk3,
   libappindicator,
   libpulseaudio,
   librsvg,
-  pycairo,
-  pygobject3,
-  six,
   wrapGAppsHook3,
-  xlib,
   nix-update-script,
-  setuptools,
 }:
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "hushboard";
   version = "unstable-2021-03-17";
   pyproject = true;
@@ -28,7 +23,7 @@ buildPythonApplication {
     sha256 = "06jav6j0bsxhawrq31cnls8zpf80fpwk0cak5s82js6wl4vw2582";
   };
 
-  build-system = [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
   nativeBuildInputs = [
     wrapGAppsHook3
@@ -41,7 +36,7 @@ buildPythonApplication {
     libpulseaudio
   ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     pycairo
     pygobject3
     six

--- a/pkgs/by-name/hu/hushboard/package.nix
+++ b/pkgs/by-name/hu/hushboard/package.nix
@@ -13,14 +13,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "hushboard";
-  version = "unstable-2021-03-17";
+  version = "0-unstable-2024-04-28";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stuartlangridge";
     repo = "hushboard";
-    rev = "c16611c539be111891116a737b02c5fb359ad1fc";
-    sha256 = "06jav6j0bsxhawrq31cnls8zpf80fpwk0cak5s82js6wl4vw2582";
+    rev = "13f5e62add99355f90798006742f62397be8be0c";
+    hash = "sha256-z5ZSqcdKUHWt7kgW7ISZJei2YzVZHJGOqJ2IXv3qiWQ=";
   };
 
   build-system = with python3Packages; [ setuptools ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11879,8 +11879,6 @@ with pkgs;
 
   huggle = libsForQt5.callPackage ../applications/misc/huggle { };
 
-  hushboard = python3.pkgs.callPackage ../applications/audio/hushboard { };
-
   hyperion-ng = libsForQt5.callPackage ../applications/video/hyperion-ng { };
 
   jackline = callPackage ../applications/networking/instant-messengers/jackline {


### PR DESCRIPTION
Supercedes #444395

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
