### PR TITLE
opencollada-blender: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/op/opencollada-blender/cmake4-compat.patch
+++ b/pkgs/by-name/op/opencollada-blender/cmake4-compat.patch
@@ -1,0 +1,26 @@
+From f036950f1ccc3ebdfe2fdc0a52d35a4620252901 Mon Sep 17 00:00:00 2001
+From: Grimmauld <Grimmauld@grimmauld.de>
+Date: Sat, 27 Sep 2025 11:43:21 +0200
+Subject: [PATCH] Build: update cmake minimum version to 3.10
+
+cmake ABI compatibility with cmake <3.5 has been removed in cmake 4.
+Compatibility with cmake <3.10 is deprecated and soon to be removed.
+Thus set 3.10 minimum version. This is available in the vast majority
+of current linux distributions, as well as other platforms.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95abbe213..2d14b2552 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,7 +18,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+ 	endif()
+ endif()
+ 
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.10)
+ 
+ 
+ #-----------------------------------------------------------------------------

--- a/pkgs/by-name/op/opencollada-blender/package.nix
+++ b/pkgs/by-name/op/opencollada-blender/package.nix
@@ -1,5 +1,6 @@
 {
   cmake,
+  dos2unix,
   fetchFromGitHub,
   lib,
   libxml2,
@@ -19,9 +20,20 @@ stdenv.mkDerivation {
     sha256 = "sha256-ctr+GjDzxOJxBfaMwjwayPkAOcF+FMsP1X72QCOwvTY=";
   };
 
+  # Fix freaky dos-style CLRF things
+  prePatch = ''
+    dos2unix CMakeLists.txt
+  '';
+
+  patches = [
+    # https://github.com/aras-p/OpenCOLLADA/pull/1
+    ./cmake4-compat.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
+    dos2unix
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/op/opencollada-blender/package.nix
+++ b/pkgs/by-name/op/opencollada-blender/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Library for handling the COLLADA file format";
-    homepage = "https://github.com/KhronosGroup/OpenCOLLADA/";
+    homepage = "https://github.com/aras-p/OpenCOLLADA";
     maintainers = [ lib.maintainers.amarshall ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;


### PR DESCRIPTION
Fixed the homepage url too, it now actually points to the fork repo.

Part of https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
