### PR TITLE
emacs-macport: enable librsvg for proper SVG rendering parity

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -357,6 +357,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withNS [
     librsvg
+  ]
+  ++ lib.optionals (variant == "macport") [
+    librsvg
   ];
 
   # Emacs needs to find movemail at run time, see info (emacs) Movemail


### PR DESCRIPTION
Add librsvg to the macport variant’s build inputs. Emacs’ configure logic enables RSVG automatically on mac GUI builds when the library is present (unless explicitly disabled), so no extra flag is required. Without librsvg, Emacs falls back to the built‑in Elisp SVG renderer, which caused incorrect / degraded SVG rendering (e.g. complex icons, Org exports). This aligns macport with other GUI variants that already ship robust SVG support.

Upstream context: Investigated an SVG rendering issue (jdtsmith/emacs-mac#97). Adding librsvg resolved the problem immediately; RSVG now appears in system-configuration-features and the rendering glitches disappear. Similar precedent in nixpkgs commit 0919966ec74f9e402c5ed442d938f12980c57fc2 (adding librsvg for other variants).

Impact:
- Improves fidelity and performance of SVG rendering (themes, icon sets, Org-mode, modelines, tree-sitter / LSP UI adornments).
- Slight closure size increase due to librsvg and its dependencies (already common in other Emacs builds).
- No change to behavior for users who already overrode to include librsvg; now default is sane.

Verification steps (darwin/macOS):
1. nix build .#emacsMacport
2. Run resulting Emacs: M-: (string-match "RSVG" system-configuration-features)
3. Open a representative SVG using gradients/CSS; compare before/after if desired.

No change to non-macport variants.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
