### PR TITLE
vsftpd: fix build with gcc15, cleanup

### DIFF
--- a/pkgs/by-name/vs/vsftpd/package.nix
+++ b/pkgs/by-name/vs/vsftpd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   libcap,
   libseccomp,
   openssl,
@@ -27,7 +28,16 @@ stdenv.mkDerivation rec {
     libxcrypt
   ];
 
-  patches = [ ./CVE-2015-1419.patch ];
+  patches = [
+    ./CVE-2015-1419.patch
+
+    # Fix build with gcc15
+    (fetchpatch {
+      name = "vsftpd-correct-the-definition-of-setup_bio_callbacks-in-ssl.patch";
+      url = "https://src.fedoraproject.org/rpms/vsftpd/raw/c31087744900967ff4d572706a296bf6c8c4a68e/f/0076-Correct-the-definition-of-setup_bio_callbacks-in-ssl.patch";
+      hash = "sha256-eYiY2eKQ+qS3CiRZYGuRHcnAe32zLDdb/GwF6NyHch4=";
+    })
+  ];
 
   postPatch = ''
     sed -i "/VSF_BUILD_SSL/s/^#undef/#define/" builddefs.h

--- a/pkgs/by-name/vs/vsftpd/package.nix
+++ b/pkgs/by-name/vs/vsftpd/package.nix
@@ -11,13 +11,13 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vsftpd";
   version = "3.0.5";
 
   src = fetchurl {
-    url = "https://security.appspot.com/downloads/vsftpd-${version}.tar.gz";
-    sha256 = "sha256-JrYCrkVLC6bZnvRKCba54N+n9nIoEGc23x8njHC8kdM=";
+    url = "https://security.appspot.com/downloads/vsftpd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-JrYCrkVLC6bZnvRKCba54N+n9nIoEGc23x8njHC8kdM=";
   };
 
   buildInputs = [
@@ -64,11 +64,11 @@ stdenv.mkDerivation rec {
     tests = { inherit (nixosTests) vsftpd; };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Very secure FTP daemon";
     mainProgram = "vsftpd";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ peterhoeg ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
vsftpd: fix build with gcc15

- add patch from fedora, fixing `setup_bio_callbacks` definition

Fixes build failure with gcc15:
```
ssl.c: In function 'ssl_accept':
ssl.c:493:3: error: too many arguments to function 'setup_bio_callbacks';
expected 0, have 1
  493 |   setup_bio_callbacks(p_ssl);
      |   ^~~~~~~~~~~~~~~~~~~ ~~~~~
ssl.c:37:13: note: declared here
   37 | static void setup_bio_callbacks();
      |             ^~~~~~~~~~~~~~~~~~~
ssl.c: In function 'ssl_session_init':
ssl.c:647:3: error: too many arguments to function 'setup_bio_callbacks';
expected 0, have 1
  647 |   setup_bio_callbacks(p_ssl);
      |   ^~~~~~~~~~~~~~~~~~~ ~~~~~
ssl.c:37:13: note: declared here
   37 | static void setup_bio_callbacks();
      |             ^~~~~~~~~~~~~~~~~~~
ssl.c: At top level:
ssl.c:692:13: error: conflicting types for 'setup_bio_callbacks'; have
'void(SSL *)' {aka 'void(struct ssl_st *)'}
  692 | static void setup_bio_callbacks(SSL* p_ssl)
      |             ^~~~~~~~~~~~~~~~~~~
ssl.c:37:13: note: previous declaration of 'setup_bio_callbacks' with
type 'void(void)'
   37 | static void setup_bio_callbacks();
      |             ^~~~~~~~~~~~~~~~~~~
```

---

vsftpd: cleanup

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
- replace `sha256` with `hash`

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; vsftpd.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

FYI nixos test for package (`nixosTests.vsftpd`) is flaky.
Failed once, then succeeded 3 times in a row, same on `master`.
Did not investigate further.

---

Tried to see if upstream has either issue or fix, but could not figure out how to do it.
The only "public repo" linked on homepage is ftp hosting of tarball that does not open (with separate ftp app as modern browsers no longer support ftp).
There is no mailing list, forge or anything other than email address of the author.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
