### PR TITLE
python313Packages.libbs: add binaries for tests

### DIFF
--- a/pkgs/development/python-modules/binsync/default.nix
+++ b/pkgs/development/python-modules/binsync/default.nix
@@ -14,6 +14,7 @@
   sortedcontainers,
   toml,
   tqdm,
+  wordfreq,
 }:
 
 buildPythonPackage rec {
@@ -39,6 +40,7 @@ buildPythonPackage rec {
     sortedcontainers
     toml
     tqdm
+    wordfreq
   ];
 
   optional-dependencies = {
@@ -52,7 +54,7 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
-    # Test tries to import angrmanagement
+    # Test tries to import angr-management
     "tests/test_angr_gui.py"
   ];
 

--- a/pkgs/development/python-modules/libbs/default.nix
+++ b/pkgs/development/python-modules/libbs/default.nix
@@ -7,6 +7,7 @@
   jfx-bridge,
   networkx,
   platformdirs,
+  ply,
   prompt-toolkit,
   psutil,
   pycparser,
@@ -18,6 +19,15 @@
   writableTmpDirAsHomeHook,
 }:
 
+let
+  # Binary files from https://github.com/binsync/bs-artifacts (only used for testing and only here)
+  binaries = fetchFromGitHub {
+    owner = "binsync";
+    repo = "bs-artifacts";
+    rev = "514c2d6ef1875435c9d137bb5d99b6fc74063817";
+    hash = "sha256-P7+BTJgdC9W8cC/7xQduFYllF+0ds1dSlm59/BFvZ2g=";
+  };
+in
 buildPythonPackage rec {
   pname = "libbs";
   version = "2.15.4";
@@ -38,6 +48,7 @@ buildPythonPackage rec {
     jfx-bridge
     networkx
     platformdirs
+    ply
     prompt-toolkit
     psutil
     pycparser
@@ -50,6 +61,14 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];
+
+  # Place test binaries in place
+  preCheck = ''
+    export HOME=$TMPDIR
+    mkdir -p $HOME/bs-artifacts/binaries
+    cp -r ${binaries} $HOME/bs-artifacts/binaries
+    export TEST_BINARIES_DIR=$HOME/bs-artifacts/binaries
+  '';
 
   pythonImportsCheck = [ "libbs" ];
 


### PR DESCRIPTION
https://hydra.nixos.org/build/307672450

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
