### PR TITLE
beye: init at 6.1.0

### DIFF
--- a/pkgs/by-name/be/beye/package.nix
+++ b/pkgs/by-name/be/beye/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchurl,
+  gcc13Stdenv,
+  gpm,
+  libX11,
+}:
+
+gcc13Stdenv.mkDerivation (finalAttrs: {
+  pname = "beye";
+  version = "6.1.0";
+
+  src = fetchurl {
+    url =
+      let
+        versionNoDots = lib.replaceStrings [ "." ] [ "" ] finalAttrs.version;
+      in
+      "mirror://sourceforge/beye/biew/${finalAttrs.version}/biew-${versionNoDots}-src.tar.bz2";
+    hash = "sha256-LoXwPJCN1uyDJGH7+8eRaaM/TKzPSMj+YMvSn1+wbRc=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  hardeningDisable = [ "format" ];
+
+  buildInputs = [
+    gpm
+    libX11
+  ];
+
+  configureFlags = [
+    "--with-x11incdir=${lib.getDev libX11}/include"
+    "--with-x11libdir=${lib.getLib libX11}/lib"
+  ];
+
+  meta = {
+    description = "Binary file vIEWer with built-in disassemblers and editor";
+    homepage = "https://sourceforge.net/projects/beye/";
+    changelog = "https://sourceforge.net/p/beye/news/";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "biew";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://sourceforge.net/projects/beye/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
