### PR TITLE
ppp: fix build with gcc15

### DIFF
--- a/pkgs/by-name/pp/ppp/package.nix
+++ b/pkgs/by-name/pp/ppp/package.nix
@@ -2,6 +2,7 @@
   autoreconfHook,
   bash,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   libpcap,
   libxcrypt,
@@ -24,6 +25,15 @@ stdenv.mkDerivation rec {
     tag = "v${version}";
     hash = "sha256-NV8U0F8IhHXn0YuVbfFr992ATQZaXA16bb5hBIwm9Gs=";
   };
+
+  patches = [
+    # Fix build with gcc15
+    # https://github.com/ppp-project/ppp/pull/548
+    (fetchpatch {
+      url = "https://github.com/ppp-project/ppp/commit/05361692ee7d6260ce5c04c9fa0e5a1aa7565323.patch";
+      hash = "sha256-ybuWyA1t9IJ1Sg06a0b0tin4qssr0qzmenfGoA1X0BE=";
+    })
+  ];
 
   configureFlags = [
     "--localstatedir=/var"


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/ppp-project/ppp/pull/548

Fixes build failure with gcc15:
```
pppdump.c:81:9: error: too many arguments to function 'dumplog'; expected 0, have 1
   81 |         dumplog(stdin);
      |         ^~~~~~~ ~~~~~
pppdump.c:45:6: note: declared here
   45 | void dumplog();
      |      ^~~~~~~
pppdump.c:90:17: error: too many arguments to function 'dumpppp'; expected 0, have 1
   90 |                 dumpppp(f);
      |                 ^~~~~~~ ~
pppdump.c:46:6: note: declared here
   46 | void dumpppp();
      |      ^~~~~~~
pppdump.c:92:17: error: too many arguments to function 'dumplog'; expected 0, have 1
   92 |                 dumplog(f);
      |                 ^~~~~~~ ~
pppdump.c:45:6: note: declared here
   45 | void dumplog();
      |      ^~~~~~~
pppdump.c: In function 'dumplog':
pppdump.c:102:1: error: number of arguments doesn't match prototype
  102 | {
      | ^
pppdump.c:45:6: error: prototype declaration
   45 | void dumplog();
      |      ^~~~~~~
pppdump.c:175:13: error: too many arguments to function 'show_time'; expected 0, have 2
  175 |             show_time(f, c);
      |             ^~~~~~~~~ ~
pppdump.c:47:6: note: declared here
   47 | void show_time();
      |      ^~~~~~~~~
pppdump.c: In function 'dumpppp':
pppdump.c:246:1: error: number of arguments doesn't match prototype
  246 | {
      | ^
pppdump.c:46:6: error: prototype declaration
   46 | void dumpppp();
      |      ^~~~~~~
pppdump.c:369:13: error: too many arguments to function 'show_time'; expected 0, have 2
  369 |             show_time(f, c);
      |             ^~~~~~~~~ ~
pppdump.c:47:6: note: declared here
   47 | void show_time();
      |      ^~~~~~~~~
pppdump.c: In function 'show_time':
pppdump.c:381:1: error: number of arguments doesn't match prototype
  381 | {
      | ^
pppdump.c:47:6: error: prototype declaration
   47 | void show_time();
      |      ^~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; ppp.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
