### PR TITLE
bash2048: init at 1.0

### DIFF
--- a/pkgs/by-name/ba/bash2048/package.nix
+++ b/pkgs/by-name/ba/bash2048/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  bash,
+  bc,
+  coreutils,
+  fetchFromGitHub,
+  gnugrep,
+  makeWrapper,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bash2048";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "JosefZIla";
+    repo = "bash2048";
+    tag = finalAttrs.version;
+    hash = "sha256-iSNW+S6e3HZc1b3xiyVNfBwwjrTI1riD5MYQLrok4q0=";
+  };
+
+  strictDeps = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bash2048.sh $out/bin/bash2048
+
+    wrapProgram $out/bin/bash2048 \
+      --set PATH ${
+        lib.makeBinPath [
+          bc
+          coreutils
+          gnugrep
+          ncurses
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Bash implementation of 2048 game";
+    homepage = "https://github.com/JosefZIla/bash2048";
+    license = lib.licenses.unlicense;
+    mainProgram = "bash2048";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/JosefZIla/bash2048

<img height="200" src="https://github.com/user-attachments/assets/ff84f6be-2daa-45d4-ab6a-d152cd773ed1" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
