### PR TITLE
nixos/gerrit: Drop global lib expansion

### DIFF
--- a/nixos/modules/services/web-apps/gerrit.nix
+++ b/nixos/modules/services/web-apps/gerrit.nix
@@ -5,20 +5,18 @@
   ...
 }:
 
-with lib;
 let
   cfg = config.services.gerrit;
 
   # NixOS option type for git-like configs
   gitIniType =
-    with types;
     let
-      primitiveType = either str (either bool int);
-      multipleType = either primitiveType (listOf primitiveType);
-      sectionType = lazyAttrsOf multipleType;
-      supersectionType = lazyAttrsOf (either multipleType sectionType);
+      primitiveType = lib.types.either lib.types.str (lib.types.either lib.types.bool lib.types.int);
+      multipleType = lib.types.either primitiveType (lib.types.listOf primitiveType);
+      sectionType = lib.types.lazyAttrsOf multipleType;
+      supersectionType = lib.types.lazyAttrsOf (lib.types.either multipleType sectionType);
     in
-    lazyAttrsOf supersectionType;
+    lib.types.lazyAttrsOf supersectionType;
 
   gerritConfig = pkgs.writeText "gerrit.conf" (lib.generators.toGitINI cfg.settings);
 
@@ -64,14 +62,14 @@ in
 {
   options = {
     services.gerrit = {
-      enable = mkEnableOption "Gerrit service";
+      enable = lib.mkEnableOption "Gerrit service";
 
-      package = mkPackageOption pkgs "gerrit" { };
+      package = lib.mkPackageOption pkgs "gerrit" { };
 
-      jvmPackage = mkPackageOption pkgs "jdk21_headless" { };
+      jvmPackage = lib.mkPackageOption pkgs "jdk21_headless" { };
 
-      jvmOpts = mkOption {
-        type = types.listOf types.str;
+      jvmOpts = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [
           "-Dflogger.backend_factory=com.google.common.flogger.backend.log4j.Log4jBackendFactory#getInstance"
           "-Dflogger.logging_context=com.google.gerrit.server.logging.LoggingContext#getInstance"
@@ -79,16 +77,16 @@ in
         description = "A list of JVM options to start gerrit with.";
       };
 
-      jvmHeapLimit = mkOption {
-        type = types.str;
+      jvmHeapLimit = lib.mkOption {
+        type = lib.types.str;
         default = "1024m";
         description = ''
           How much memory to allocate to the JVM heap
         '';
       };
 
-      listenAddress = mkOption {
-        type = types.str;
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "[::]:8080";
         description = ''
           `hostname:port` to listen for HTTP traffic.
@@ -97,7 +95,7 @@ in
         '';
       };
 
-      settings = mkOption {
+      settings = lib.mkOption {
         type = gitIniType;
         default = { };
         description = ''
@@ -106,7 +104,7 @@ in
         '';
       };
 
-      replicationSettings = mkOption {
+      replicationSettings = lib.mkOption {
         type = gitIniType;
         default = { };
         description = ''
@@ -115,8 +113,8 @@ in
         '';
       };
 
-      plugins = mkOption {
-        type = types.listOf types.package;
+      plugins = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
           List of plugins to add to Gerrit. Each derivation is a jar file
@@ -124,8 +122,8 @@ in
         '';
       };
 
-      builtinPlugins = mkOption {
-        type = types.listOf (types.enum cfg.package.passthru.plugins);
+      builtinPlugins = lib.mkOption {
+        type = lib.types.listOf (lib.types.enum cfg.package.passthru.plugins);
         default = [ ];
         description = ''
           List of builtins plugins to install. Those are shipped in the
@@ -133,8 +131,8 @@ in
         '';
       };
 
-      serverId = mkOption {
-        type = types.str;
+      serverId = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Set a UUID that uniquely identifies the server.
 
@@ -145,11 +143,11 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions = [
       {
-        assertion = cfg.replicationSettings != { } -> elem "replication" cfg.builtinPlugins;
+        assertion = cfg.replicationSettings != { } -> lib.elem "replication" cfg.builtinPlugins;
         message = "Gerrit replicationSettings require enabling the replication plugin";
       }
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
