### PR TITLE
muon: setup hook

### DIFF
--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -201,7 +201,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://muon.build";
     description = "Implementation of the meson build system in C99";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.nekowinston ];
     platforms = lib.platforms.unix;
     mainProgram = "muon";
   };

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -9,6 +9,7 @@
   libarchive,
   libpkgconf,
   pkgconf,
+  replaceVars,
   samurai,
   zlib,
   embedSamurai ? false,
@@ -155,6 +156,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  setupHook = replaceVars ./setup-hook.sh {
+    embedSamurai = lib.boolToString embedSamurai;
+    isFreeBSD = lib.boolToString stdenv.hostPlatform.isFreeBSD;
+  };
+
   passthru.srcsAttrs = {
     muon-src = fetchFromSourcehut {
       name = "muon-src";
@@ -200,5 +206,3 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "muon";
   };
 })
-# TODO LIST:
-# 1. setup hook

--- a/pkgs/by-name/mu/muon/setup-hook.sh
+++ b/pkgs/by-name/mu/muon/setup-hook.sh
@@ -1,0 +1,136 @@
+# shellcheck shell=bash disable=2193
+
+# Gets rid of `build.`-prefixed options in `default_options`.
+# See https://docs.muon.build/differences.html#native-true
+muonMesonPatchHook() {
+  find . \
+    -name "meson.build" \
+    -exec sed -i -E "/default_options:\s*\[/,/],/ s/('build\.[^']+'),/# \1 # patched by muonMesonPatchHook/" {} \;
+}
+
+muonConfigurePhase() {
+  runHook preConfigure
+
+  : "${muonBuildDir:=build}"
+
+  local flagsArray=()
+
+  if [ -z "${dontAddPrefix-}" ]; then
+    flagsArray+=("-Dprefix=$prefix")
+  fi
+
+  if [ -z "${dontDisableStatic-}" ]; then
+    flagsArray+=("-Ddefault_library=both")
+  fi
+
+  # This most closely reflects meson's configurePhase.
+  # See muon’s `muon option -a`.
+  flagsArray+=(
+    "-Dlibdir=${!outputLib}/lib"
+    "-Dlibexecdir=${!outputLib}/libexec"
+    "-Dbindir=${!outputBin}/bin"
+    "-Dsbindir=${!outputBin}/sbin"
+    "-Dincludedir=${!outputInclude}/include"
+    "-Dmandir=${!outputMan}/share/man"
+    "-Dinfodir=${!outputInfo}/share/info"
+    "-Dlocaledir=${!outputLib}/share/locale"
+    "-Dauto_features=${muonAutoFeatures:-enabled}"
+    "-Dwrap_mode=${muonWrapMode:-nodownload}"
+    "-Dbuildtype=${muonBuildType:-plain}"
+  )
+
+  # --no-undefined is universally a bad idea on FreeBSD because environ is in the csu
+  if "@isFreeBSD@"; then
+    flagsArray+=("-Db_lundef=false")
+  fi
+
+  concatTo flagsArray muonFlags muonFlagsArray
+
+  echoCmd "muonConfigurePhase flags" "${flagsArray[@]}"
+
+  TERM=dumb muon setup "${flagsArray[@]}" "$muonBuildDir"
+  cd "$muonBuildDir" || {
+    echoCmd "muonConfigurePhase" "could not cd to $muonBuildDir"
+    exit 1
+  }
+
+  runHook postConfigure
+}
+
+muonBuildPhase() {
+  runHook preBuild
+
+  local buildCores=1
+
+  # Parallel building is enabled by default.
+  if [ "${enableParallelBuilding-1}" ]; then
+    buildCores="$NIX_BUILD_CORES"
+  fi
+
+  local flagsArray=(
+    "-j$buildCores"
+  )
+  concatTo flagsArray muonBuildFlags muonBuildFlagsArray
+
+  echoCmd "build flags" "${flagsArray[@]}"
+  TERM=dumb muon samu "${flagsArray[@]}"
+
+  runHook postBuild
+}
+
+muonCheckPhase() {
+  runHook preCheck
+
+  # Parallel checking is enabled by default.
+  local buildCores=1
+  if [ "${enableParallelChecking-1}" ]; then
+    buildCores="$NIX_BUILD_CORES"
+  fi
+
+  local flagsArray=(
+    "-j$buildCores"
+    # disable automatic rebuild
+    "-R"
+    # don't try to display a progress bar, resulting in tons of duplicate lines
+    "-ddots"
+  )
+  concatTo flagsArray muonCheckFlags muonCheckFlagsArray
+
+  echoCmd "muonCheckPhase flags" "${flagsArray[@]}"
+  TERM=dumb muon test "${flagsArray[@]}"
+
+  runHook postCheck
+}
+
+muonInstallPhase() {
+  runHook preInstall
+
+  local flagsArray=()
+
+  concatTo flagsArray muonInstallFlags muonInstallFlagsArray
+
+  echoCmd "muonInstallPhase flags" "${flagsArray[@]}"
+  TERM=dumb muon install "${flagsArray[@]}"
+
+  runHook postInstall
+}
+
+if [ -z "${dontMuonPatchMesonFiles-}" ]; then
+  postPatchHooks+=(muonMesonPatchHook)
+fi
+
+if [ -z "${dontUseMuonConfigure-}" ] && [ -z "${configurePhase-}" ]; then
+  configurePhase=muonConfigurePhase
+fi
+
+if "@embedSamurai@" && [ -z "${dontUseMuonBuild-}" ] && [ -z "${buildPhase-}" ]; then
+  buildPhase=muonBuildPhase
+fi
+
+if [ -z "${dontUseMuonCheck-}" ] && [ -z "${checkPhase-}" ]; then
+  checkPhase=muonCheckPhase
+fi
+
+if [ -z "${dontUseMuonInstall-}" ] && [ -z "${installPhase-}" ]; then
+  installPhase=muonInstallPhase
+fi


### PR DESCRIPTION
Adds a setup hook to muon, and adds myself as a maintainer for muon. Still a WIP because of the problems described below.

I'm currently still seeing an issue when trying to build e.g. `mpd` with this:
The build works fine: after the `buildPhase`, running `ldd` on the binary in `./build/mpd` looks good, and tests pass.
In the `installPhase` however, running `ldd` on the binary in `$out/bin/mpd` shows two instances of `libstdc++`:

```console
$ ldd $out/bin/mpd | grep libstdc++
    libstdc++.so.6 => not found
    libstdc++.so.6 => /nix/store/41ym1jm1b7j3rhglk82gwg9jml26z1km-gcc-14.3.0-lib/lib/libstdc++.so.6 (0x00007ffff3200000)
```

and trying to run the resulting binary after the `nix-build` results in this, as one would expect with missing shared libraries:
```console
$ ./result/bin/mpd -V
./result/bin/mpd: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
```

If we build both `mpd` (meson) and `muon.tests.mpd`, and look at a diff like
```console
diff -u <(nix-store --query --references ./result-meson) <(nix-store --query --references ./result-muon)
```
I can see:
```patch
--- /proc/self/fd/11    2025-09-27 15:02:04.246556164 +0200
+++ /proc/self/fd/12    2025-09-27 15:02:04.246556164 +0200
@@ -1,5 +1,4 @@
 /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66
-/nix/store/41ym1jm1b7j3rhglk82gwg9jml26z1km-gcc-14.3.0-lib
 /nix/store/nixnvas033myv1iafb4r15h3547c3q0l-libogg-1.3.6
 /nix/store/20idlzn0vam7ql7c7dj5fzb3c74glsar-flac-1.5.0
 /nix/store/kvpy3lbc1xs8n1rkv3gdj2r04yrxahyz-libsamplerate-0.2.2
@@ -41,4 +40,4 @@
 /nix/store/w2891rmnag0qladsazg04rsa5lh8nrmk-libnfs-5.0.2
 /nix/store/wxjs6sb18xkfx3dgwrlmg2z77jn98iqa-ffmpeg-7.1.1-lib
 /nix/store/ynhsdwxzv5i9q92zcak1l54xywp9i850-faad2-2.11.2
-/nix/store/allg7wswfja95ghb9rgmzlxlhai8iz53-mpd-0.24.5
+/nix/store/7yswyvnv39f2d7r4xb4mzg4cpqsxs1zj-mpd-0.24.5
```

So unlike the meson build, the muon build is missing a reference to `gcc-*-lib`.
I read how `ninja` etc work, and tried adding `depsBuildBuild = [ buildPackages.stdenv.cc ];`, but this didn't help.

Note that adding `autoPatchelfHook` fixes this issue, but I'm pretty sure that is to be avoided.

I'd appreciate any input for how I could fix this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
