### PR TITLE
benhsm-minesweeper: init at 0.3.1

### DIFF
--- a/pkgs/by-name/be/benhsm-minesweeper/package.nix
+++ b/pkgs/by-name/be/benhsm-minesweeper/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "benhsm-minesweeper";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "benhsm";
+    repo = "minesweeper";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4ahevo/dogjcJ6GRqVZKYapy1x16F+U6vEsgpt2RdiE=";
+  };
+
+  vendorHash = "sha256-UvvoL7Us201B13M4vwOZEhSB0slAzXCs+9wzJIDictQ=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple terminal-based implementation of Minesweeper";
+    homepage = "https://github.com/benhsm/minesweeper";
+    changelog = "https://github.com/benhsm/minesweeper/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "minesweeper";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/benhsm/minesweeper

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
