### PR TITLE
ascii-patrol: init at 1.7-unstable-2022-05-02

### DIFF
--- a/pkgs/by-name/as/ascii-patrol/package.nix
+++ b/pkgs/by-name/as/ascii-patrol/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libX11,
+  libXi,
+  libpulseaudio,
+  curl,
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ascii-patrol";
+  version = "1.7-unstable-2022-05-02";
+
+  src = fetchFromGitHub {
+    owner = "msokalski";
+    repo = "ascii-patrol";
+    rev = "bd3bd7c4eebddc90c3aa793b14b4a9ff11b2637c";
+    hash = "sha256-0AuZE9s8BJ6QflF0vZ9BN707sT0k/mWc8QYlUAu2lII=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "-L/usr/X11/lib " ""
+  '';
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    libX11
+    libXi
+    libpulseaudio
+  ];
+
+  makeFlags = [
+    "CXX=${stdenv.cc.targetPrefix}c++"
+    "LD=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 asciipat -t $out/bin
+    install -Dm644 asciipat.psf -t $out/share/ascii-patrol
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/asciipat \
+      --prefix PATH : ${lib.makeBinPath [ curl ]}
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Moon Patrol inspired ASCII game";
+    homepage = "https://ascii-patrol.com";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "asciipat";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/msokalski/ascii-patrol

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
