### PR TITLE
tetrix: init at 2.5

### DIFF
--- a/pkgs/by-name/te/tetrix/package.nix
+++ b/pkgs/by-name/te/tetrix/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  asciidoctor,
+  fetchFromGitLab,
+  makeWrapper,
+  ncurses,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "tetrix";
+  version = "2.5-unstable-2025-11-23";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "tetrix";
+    rev = "01f3d8634ad59bc32eb18e21f778ac9b111a8590";
+    hash = "sha256-IGXqi3AqUHPI6xLaD4CpYOqp4r6Uk0aE/UyZ0/yEw0Q=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "/usr/bin" "${placeholder "out"}/libexec" \
+      --replace-fail "/usr/share" "${placeholder "out"}/share"
+  '';
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    asciidoctor
+    makeWrapper
+  ];
+  buildInputs = [ ncurses ];
+
+  buildFlags = [
+    "tetrix"
+    "tetrix.6"
+  ];
+
+  preInstall = ''
+    mkdir -p $out/bin $out/libexec $out/share/man/man6
+  '';
+
+  # Store scores in the XDG state dir
+  makeFlags = [ "SCORE_FILE=.TetScores" ];
+  postInstall = ''
+    makeWrapper $out/libexec/tetrix $out/bin/tetrix --run \
+      'set -e; state="''${XDG_STATE_HOME:-$HOME/.local/state}/tetrix"; mkdir -p "$state"; cd "$state"'
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Curses-based Tetris clone";
+    homepage = "https://gitlab.com/esr/tetrix";
+    changelog = "https://gitlab.com/esr/tetrix/-/blob/master/NEWS.adoc";
+    license = lib.licenses.bsd2;
+    mainProgram = "tetrix";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+}


### PR DESCRIPTION
Packaging for https://gitlab.com/esr/tetrix

With an added improvement of storing scores in XDG_STATE_HOME/tetrix, originally /usr/tmp/ is used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
