### PR TITLE
bluemoon: init at 2.13

### DIFF
--- a/pkgs/by-name/bl/bluemoon/package.nix
+++ b/pkgs/by-name/bl/bluemoon/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  asciidoctor,
+  fetchFromGitLab,
+  ncurses,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bluemoon";
+  version = "2.13";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "bluemoon";
+    tag = finalAttrs.version;
+    hash = "sha256-zZ9saECg5fqC+VEMHi4TtJopOo9R8dKmxlZ8mKN5khU=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-quiet '//usr' '/usr' \
+      --replace-fail '$(DESTDIR)/usr' '/usr' \
+      --replace-fail ' /usr' ' ${placeholder "out"}'
+  '';
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ asciidoctor ];
+  buildInputs = [ ncurses ];
+
+  buildFlags = [
+    "bluemoon"
+    "bluemoon.6"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Blue Moon card solitaire game with a TUI";
+    homepage = "https://gitlab.com/esr/bluemoon";
+    changelog = "https://gitlab.com/esr/bluemoon/-/blob/${finalAttrs.version}/NEWS.adoc";
+    license = lib.licenses.bsd2;
+    mainProgram = "bluemoon";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://gitlab.com/esr/bluemoon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
