### PR TITLE
pacman4console: init at 1.3

### DIFF
--- a/pkgs/by-name/pa/pacman4console/package.nix
+++ b/pkgs/by-name/pa/pacman4console/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pacman4console";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "YoctoForBeaglebone";
+    repo = "pacman4console";
+    rev = "ddc229c3478b43b572cef4fc09bb1580f00a1e74";
+    hash = "sha256-kdf9zzlz6jv6ZvRVVwFNQ7F4TjBCsy+G+aZfWMOwkQ8=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'gcc ' '$(CC) '
+  '';
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  buildInputs = [ ncurses ];
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-std=gnu89"
+  ];
+
+  meta = {
+    description = "Console version of Pac-Man";
+    homepage = "https://github.com/YoctoForBeaglebone/pacman4console";
+    changelog = "https://github.com/YoctoForBeaglebone/pacman4console/blob/master/ChangeLog";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "pacman";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging of https://github.com/YoctoForBeaglebone/pacman4console

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
