### PR TITLE
lib.systems: rust: Make rustcTargetSpec the primary entrypoint

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -254,7 +254,7 @@ By default, it takes the `stdenv.hostPlatform.config` and replaces components
 where they are known to differ. But there are ways to customize the argument:
 
  - To choose a different target by name, define
-   `stdenv.hostPlatform.rust.rustcTarget` as that name (a string), and that
+   `stdenv.hostPlatform.rust.rustcTargetSpec` as that name (a string), and that
    name will be used instead.
 
    For example:
@@ -262,7 +262,7 @@ where they are known to differ. But there are ways to customize the argument:
    ```nix
    import <nixpkgs> {
      crossSystem = (import <nixpkgs/lib>).systems.examples.armhf-embedded // {
-       rust.rustcTarget = "thumbv7em-none-eabi";
+       rust.rustcTargetSpec = "thumbv7em-none-eabi";
      };
    }
    ```
@@ -274,22 +274,24 @@ where they are known to differ. But there are ways to customize the argument:
    ```
 
  - To pass a completely custom target, define
-   `stdenv.hostPlatform.rust.rustcTarget` with its name, and
-   `stdenv.hostPlatform.rust.platform` with the value.  The value will be
-   serialized to JSON in a file called
-   `${stdenv.hostPlatform.rust.rustcTarget}.json`, and the path of that file
-   will be used instead.
+   `stdenv.hostPlatform.rust.rustcTargetSpec` with the path to the custom
+   target specification JSON file.
+
+   Note that some tools like Cargo and some crates like `cc` make use of the
+   file name of the target JSON.  Therefore, do not use
+   `./path/to/target-spec.json` directly, because it will be renamed by Nix.
+   Instead, place it a directory and use `"${./path/to/dir}/target-spec.json"`.
+   The directory should contain only this one file, to avoid unrelated changes
+   causing unnecessary rebuilds.
 
    For example:
 
    ```nix
    import <nixpkgs> {
-     crossSystem = (import <nixpkgs/lib>).systems.examples.armhf-embedded // {
-       rust.rustcTarget = "thumb-crazy";
-       rust.platform = {
-         foo = "";
-         bar = "";
-       };
+     crossSystem = {
+       config = "mips64el-unknown-linux-gnuabi64";
+       # gcc = ...; # Config for C compiler omitted
+       rust.rustcTargetSpec = "${./rust}/mips64el_mips3-unknown-linux-gnuabi64.json";
      };
    }
    ```
@@ -297,11 +299,8 @@ where they are known to differ. But there are ways to customize the argument:
    will result in:
 
    ```shell
-   --target /nix/store/asdfasdfsadf-thumb-crazy.json # contains {"foo":"","bar":""}
+   --target /nix/store/...-rust/mips64el_mips3-unknown-linux-gnuabi64.json
    ```
-
-Note that currently custom targets aren't compiled with `std`, so `cargo test`
-will fail. This can be ignored by adding `doCheck = false;` to your derivation.
 
 ### Running package tests {#running-package-tests}
 

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -417,62 +417,65 @@ let
       // args
       // {
         rust = rust // {
-          # Once args.rustc.platform.target-family is deprecated and
-          # removed, there will no longer be any need to modify any
-          # values from args.rust.platform, so we can drop all the
-          # "args ? rust" etc. checks, and merge args.rust.platform in
-          # /after/.
-          platform = rust.platform or { } // {
-            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
-            arch =
-              if rust ? platform then
-                rust.platform.arch
-              else if final.isAarch32 then
-                "arm"
-              else if final.isMips64 then
-                "mips64" # never add "el" suffix
-              else if final.isPower64 then
-                "powerpc64" # never add "le" suffix
-              else
-                final.parsed.cpu.name;
+          platform =
+            rust.platform or { }
 
-            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_os
-            os =
-              if rust ? platform then
-                rust.platform.os or "none"
-              else if final.isDarwin then
-                "macos"
-              else if final.isWasm && !final.isWasi then
-                "unknown" # Needed for {wasm32,wasm64}-unknown-unknown.
-              else
-                final.parsed.kernel.name;
+            # Once args.rustc.platform.target-family is deprecated and
+            # removed, there will no longer be any need to modify any
+            # values from args.rust.platform, so we can drop all the
+            # "args ? rust" etc. checks, and merge args.rust.platform in
+            # /after/.
+            // {
+              # https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
+              arch =
+                if rust ? platform then
+                  rust.platform.arch
+                else if final.isAarch32 then
+                  "arm"
+                else if final.isMips64 then
+                  "mips64" # never add "el" suffix
+                else if final.isPower64 then
+                  "powerpc64" # never add "le" suffix
+                else
+                  final.parsed.cpu.name;
 
-            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
-            target-family =
-              if args ? rust.platform.target-family then
-                args.rust.platform.target-family
-              else if args ? rustc.platform.target-family then
-                (
-                  # Since https://github.com/rust-lang/rust/pull/84072
-                  # `target-family` is a list instead of single value.
-                  let
-                    f = args.rustc.platform.target-family;
-                  in
-                  if isList f then f else [ f ]
-                )
-              else
-                optional final.isUnix "unix" ++ optional final.isWindows "windows" ++ optional final.isWasm "wasm";
+              # https://doc.rust-lang.org/reference/conditional-compilation.html#target_os
+              os =
+                if rust ? platform then
+                  rust.platform.os or "none"
+                else if final.isDarwin then
+                  "macos"
+                else if final.isWasm && !final.isWasi then
+                  "unknown" # Needed for {wasm32,wasm64}-unknown-unknown.
+                else
+                  final.parsed.kernel.name;
 
-            # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
-            vendor =
-              let
-                inherit (final.parsed) vendor;
-              in
-              rust.platform.vendor or {
-                "w64" = "pc";
-              }
-              .${vendor.name} or vendor.name;
-          };
+              # https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
+              target-family =
+                if args ? rust.platform.target-family then
+                  args.rust.platform.target-family
+                else if args ? rustc.platform.target-family then
+                  (
+                    # Since https://github.com/rust-lang/rust/pull/84072
+                    # `target-family` is a list instead of single value.
+                    let
+                      f = args.rustc.platform.target-family;
+                    in
+                    if isList f then f else [ f ]
+                  )
+                else
+                  optional final.isUnix "unix" ++ optional final.isWindows "windows" ++ optional final.isWasm "wasm";
+
+              # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
+              vendor =
+                let
+                  inherit (final.parsed) vendor;
+                in
+                rust.platform.vendor or {
+                  "w64" = "pc";
+                }
+                .${vendor.name} or vendor.name;
+            };
 
           # The name of the rust target, even if it is custom. Adjustments are
           # because rust has slightly different naming conventions than we do.
@@ -497,18 +500,19 @@ let
                   "gnu"
                 else
                   abi.name;
+
+              inferred =
+                # Rust uses `wasm32-wasip?` rather than `wasm32-unknown-wasi`.
+                # We cannot know which subversion does the user want, and
+                # currently use WASI 0.1 as default for compatibility. Custom
+                # users can set `rust.rustcTarget` to override it.
+                if final.isWasi then
+                  "${cpu_}-wasip1"
+                else
+                  "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi_}"}";
             in
             # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
-            args.rust.rustcTarget or args.rustc.config or (
-              # Rust uses `wasm32-wasip?` rather than `wasm32-unknown-wasi`.
-              # We cannot know which subversion does the user want, and
-              # currently use WASI 0.1 as default for compatibility. Custom
-              # users can set `rust.rustcTarget` to override it.
-              if final.isWasi then
-                "${cpu_}-wasip1"
-              else
-                "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi_}"}"
-            );
+            args.rust.rustcTarget or args.rustc.config or inferred;
 
           # The name of the rust target if it is standard, or the json file
           # containing the custom target spec.

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -418,7 +418,12 @@ let
       // {
         rust = rust // {
           platform =
-            rust.platform or { }
+            rust.platform or (
+              if lib.hasSuffix ".json" (rust.rustcTargetSpec or "") then
+                lib.importJSON rust.rustcTargetSpec
+              else
+                { }
+            )
 
             # Once args.rustc.platform.target-family is deprecated and
             # removed, there will no longer be any need to modify any
@@ -477,9 +482,10 @@ let
                 .${vendor.name} or vendor.name;
             };
 
-          # The name of the rust target, even if it is custom. Adjustments are
-          # because rust has slightly different naming conventions than we do.
-          rustcTarget =
+          # The name of the rust target if it is standard, or the json file
+          # containing the custom target spec. Adjustments are because rust has
+          # slightly different naming conventions than we do.
+          rustcTargetSpec =
             let
               inherit (final.parsed) cpu kernel abi;
               cpu_ =
@@ -502,27 +508,27 @@ let
                   abi.name;
 
               inferred =
-                # Rust uses `wasm32-wasip?` rather than `wasm32-unknown-wasi`.
-                # We cannot know which subversion does the user want, and
-                # currently use WASI 0.1 as default for compatibility. Custom
-                # users can set `rust.rustcTarget` to override it.
                 if final.isWasi then
+                  # Rust uses `wasm32-wasip?` rather than `wasm32-unknown-wasi`.
+                  # We cannot know which subversion does the user want, and
+                  # currently use WASI 0.1 as default for compatibility. Custom
+                  # users can set `rust.rustcTargetSpec` to override it.
                   "${cpu_}-wasip1"
                 else
                   "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi_}"}";
             in
             # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
-            args.rust.rustcTarget or args.rustc.config or inferred;
-
-          # The name of the rust target if it is standard, or the json file
-          # containing the custom target spec.
-          rustcTargetSpec =
-            rust.rustcTargetSpec or (
+            args.rust.rustcTargetSpec or args.rustc.config or (
               if rust ? platform then
-                builtins.toFile (final.rust.rustcTarget + ".json") (toJSON rust.platform)
+                # TODO: This breaks cc-rs and thus std support, so maybe remove support?
+                builtins.toFile (rust.rustcTarget or inferred + ".json") (toJSON rust.platform)
               else
-                final.rust.rustcTarget
+                args.rust.rustcTarget or inferred
             );
+
+          # Do not use rustcTarget. Use rustcTargetSpec or cargoShortTarget.
+          # TODO: Remove all in-tree usages, and deprecate
+          rustcTarget = rust.rustcTarget or final.rust.cargoShortTarget;
 
           # The name of the rust target if it is standard, or the
           # basename of the file containing the custom target spec,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**For reviewers**: If there's a Rust derivation under some platform that

- Builds with current Nixpkgs
- Has eval changes at all

I consider this a bug in this PR. This is my goal.

- - -

This is what I would call "Project `rustcTarget = cargoShortTarget`". Well, that's the middle step, where the broken and the working coexist. Eventually we should really clean up `*Platform.{rust,rustc}`.

I want to make custom Rust target work in Nixpkgs, with something as "simple" as:

```
import <nixpkgs> {
  crossSystem = {
    config = "mips64el-unknown-linux-gnuabi64";
    gcc = { # Obviously you need to configure the C compiler too
      arch = "mips3";
      float = "hard";
      abi = "64";
    };
    rust.rustcTargetSpec = "${./rust}/mips64el_mips3-unknown-linux-gnuabi64.json";
  };
}
```

The reason I believe that `rust.platform` couldn't work is because we cannot create directories with `builtins.toFile`. I do not believe that the old `toFile` approach is worth preserving - if you're doing custom Rust targets, you most likely have a JSON target specification anyway. It would be easier to use that.

Currently, I have some basic std-using stuff working like microfetch. I also got stc-ng working once upon a time (https://github.com/dramforever/nixos-loongson2f) using this approach to specify basenames.

More observations:

`rustcTarget` is broken. I'm pretty sure nobody knows what it is supposed to be. Every single use in Nixpkgs should be replaced with either `rustcTargetSpec` or `cargoShortTarget`. So, whatever it was supposed to be for, it clearly didn't happen. If it were to come up again somehow, a new name would be better.

This custom target stuff is also *really* undertested, because the only user of custom Rust target in Nixpkgs is `rust-hypervisor-firmware` and that's it.

I also don't know why #95542 says std doesn't work for custom targets...

TODO:

- [X] doc: Explain `"${./path/to/dir}"/target-spec.json"` better (Better enough for review)
- [X] Test `lib` changes for breakages (No changes in `lib.mapAttrs (_: lib.systems.elaborate) lib.systems.examples`)
- [X] Test rust-hypervisor-firmware (No eval changes, tested with `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (cross compiling `microfetch` to ["mips64el_mips3-unknown-linux-gnuabi64"](https://github.com/dramforever/nixos-loongson2f/blob/8b37597eb8ec08b71cb37d2d4c7fd97eab4eccf7/rust/mips64el_mips3-unknown-linux-gnuabi64.json), and running under `qemu-mips64el`, also confirmed that the target has been applied)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
