### PR TITLE
lander: init at 0-unstable-2022-08-20

### DIFF
--- a/pkgs/by-name/la/lander/package.nix
+++ b/pkgs/by-name/la/lander/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  groff,
+  installShellFiles,
+  makeWrapper,
+  ncurses,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lander";
+  version = "0-unstable-2022-08-20";
+
+  src = fetchFromGitHub {
+    owner = "staceycampbell";
+    repo = "lander";
+    rev = "e30c175091f108efb7f70d3ae09766e7da3639ec";
+    hash = "sha256-FIt/9F5pWbU0qFalRUEIMQXNnuora81vWN6pMNr/WKg=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-warn 'sudo ' "" \
+      --replace-warn 'chown ' '# chown ' \
+      --replace-warn '-lcurses' '-lncurses'
+  '';
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    groff
+    installShellFiles
+    makeWrapper
+  ];
+  buildInputs = [ ncurses ];
+
+  makeFlags = [
+    "HSFILE=lander.hs"
+    "BIN=${placeholder "out"}/bin"
+  ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  # Store scores in the XDG state dir and install man page
+  postInstall = ''
+    mkdir $out/libexec
+    mv $out/bin/lander $out/libexec/lander
+    makeWrapper $out/libexec/lander $out/bin/lander --run \
+      'set -e; state="''${XDG_STATE_HOME:-$HOME/.local/state}/lander"; mkdir -p "$state"; cd "$state"'
+
+    installManPage lander.6
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Classic curses-based lunar lander arcade game";
+    homepage = "https://github.com/staceycampbell/lander";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "lander";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://github.com/staceycampbell/lander

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
