### PR TITLE
gnomeExtensions: auto-update

### DIFF
--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -20,6 +20,10 @@
     "FuzzyClock@fire-man-x",
     "FuzzyClock@johngoetz"
   ],
+  "lock-keys": [
+    "lockkeys@febueldo.test",
+    "lockkeys@vaina.lt"
+  ],
   "mouse-follows-focus": [
     "mouse-follows-focus@crisidev.org",
     "mousefollowsfocus@matthes.biz"
@@ -38,6 +42,7 @@
   ],
   "system-monitor": [
     "System_Monitor@bghome.gmail.com",
+    "system-monitor@axet.github.com",
     "system-monitor@gnome-shell-extensions.gcampax.github.com"
   ]
 }


### PR DESCRIPTION
Previous auto-update: 66f1e430c189d89bf8b04a96813b069833533f9e (with `git log extensions.json`)

I actually only wanted to update https://github.com/0ry0n/Resource_Monitor/releases/tag/26, but I guess you have to update everything with the script. I don't know how to check the new collision things. I can reduce the PR to only that extension.

I also don't know why the script updates existing version hashes and stuff.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
