### PR TITLE
asciijump: init at 1.0.2_beta-12

### DIFF
--- a/pkgs/by-name/as/asciijump/package.nix
+++ b/pkgs/by-name/as/asciijump/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  ctags,
+  fetchFromGitLab,
+  slang,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "asciijump";
+  version = "1.0.2_beta-12";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "games-team";
+    repo = "asciijump";
+    tag = "debian/${finalAttrs.version}";
+    hash = "sha256-fD/5tWg/GzSfVYvUWsz1FHXhLx9ud0JRMkM9NhVePdA=";
+  };
+
+  patchPhase = ''
+    for file in $(cat debian/patches/series); do
+      echo "$file:"
+      patch -p1 < debian/patches/$file
+    done
+  '';
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = [ "-fsigned-char" ];
+
+  nativeBuildInputs = [ ctags ];
+  buildInputs = [ slang ];
+
+  postInstall = ''
+    rm -rf $out/var
+  '';
+
+  meta = {
+    description = "Small and funny ASCII-art game about ski jumping";
+    homepage = "https://salsa.debian.org/games-team/asciijump";
+    changelog = "https://salsa.debian.org/games-team/asciijump/-/blob/${finalAttrs.src.tag}/debian/changelog";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "asciijump";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+})


### PR DESCRIPTION
Packaging for https://delightlylinux.wordpress.com/2015/04/06/asciijump-the-ski-jumping-terminal-game/

https://salsa.debian.org/games-team/asciijump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
