### PR TITLE
nixos/hddfancontrol: add package option

### DIFF
--- a/nixos/modules/services/hardware/hddfancontrol.nix
+++ b/nixos/modules/services/hardware/hddfancontrol.nix
@@ -42,6 +42,7 @@ in
 
   options = {
     services.hddfancontrol.enable = lib.mkEnableOption "hddfancontrol daemon";
+    services.hddfancontrol.package = lib.mkPackageOption pkgs "hddfancontrol" { };
 
     services.hddfancontrol.settings = lib.mkOption {
       type = lib.types.attrsWith {
@@ -164,7 +165,7 @@ in
           let
             argString = lib.strings.concatStringsSep " " (args cnf);
           in
-          "${lib.getExe pkgs.hddfancontrol} -v ${cnf.logVerbosity} daemon ${argString}";
+          "${lib.getExe cfg.package} -v ${cnf.logVerbosity} daemon ${argString}";
         serviceConfig = {
           CPUSchedulingPolicy = "rr";
           CPUSchedulingPriority = 49;
@@ -189,7 +190,7 @@ in
       ];
     in
     {
-      systemd.packages = [ pkgs.hddfancontrol ];
+      systemd.packages = [ cfg.package ];
 
       hardware.sensor.hddtemp = {
         enable = true;


### PR DESCRIPTION
Adds `services.hddfancontrol.package` to make the package used by the module easier to configure.

I wanted to add this option to make testing of patched/overriden versions of hddfancontrol easier to test. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
