### PR TITLE
go-test-html-report: init at 0.1.3

### DIFF
--- a/pkgs/by-name/go/go-test-html-report/package.nix
+++ b/pkgs/by-name/go/go-test-html-report/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "go-test-html-report";
+  version = "0.1.3";
+  commit = "7da29ba48cc98393e14968fab1ccfd3f5e9da30e";
+
+  src = fetchFromGitHub {
+    owner = "brpaz";
+    repo = pname;
+    rev = "${version}";
+    hash = "sha256-qPsXYTyoiKV7CondIPUERKmAnPtfZRlxVJ6E5I+ms1I=";
+  };
+  vendorHash = "sha256-KkTloTW0IhdULyOm3OB+LHKa7phYGJa1Pmf6nfmAsd0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+    "-X=main.commit=${commit}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/go-test-html-report" ];
+
+  meta = with lib; {
+    description = "Generate HTML test reports from 'go test -json' output";
+    homepage = "https://github.com/brpaz/go-test-html-report";
+    license = licenses.mit;
+    maintainers = with maintainers; [ brpaz ];
+    mainProgram = "go-test-html-report";
+  };
+}


### PR DESCRIPTION
[Go Test HTML report](https://github.com/brpaz/go-test-html-report) generates an HTML report from `go test` results

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
