### PR TITLE
netdata: 2.6.3 -> 2.8.0

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -11,13 +11,14 @@ let
     mkdir -p $out/libexec/netdata/plugins.d
     ln -s /run/wrappers/bin/apps.plugin $out/libexec/netdata/plugins.d/apps.plugin
     ln -s /run/wrappers/bin/cgroup-network $out/libexec/netdata/plugins.d/cgroup-network
-    ln -s /run/wrappers/bin/perf.plugin $out/libexec/netdata/plugins.d/perf.plugin
-    ln -s /run/wrappers/bin/slabinfo.plugin $out/libexec/netdata/plugins.d/slabinfo.plugin
+    ln -s /run/wrappers/bin/debugfs.plugin $out/libexec/netdata/plugins.d/debugfs.plugin
     ln -s /run/wrappers/bin/freeipmi.plugin $out/libexec/netdata/plugins.d/freeipmi.plugin
-    ln -s /run/wrappers/bin/systemd-journal.plugin $out/libexec/netdata/plugins.d/systemd-journal.plugin
     ln -s /run/wrappers/bin/logs-management.plugin $out/libexec/netdata/plugins.d/logs-management.plugin
     ln -s /run/wrappers/bin/network-viewer.plugin $out/libexec/netdata/plugins.d/network-viewer.plugin
-    ln -s /run/wrappers/bin/debugfs.plugin $out/libexec/netdata/plugins.d/debugfs.plugin
+    ln -s /run/wrappers/bin/otel-plugin $out/libexec/netdata/plugins.d/otel-plugin
+    ln -s /run/wrappers/bin/perf.plugin $out/libexec/netdata/plugins.d/perf.plugin
+    ln -s /run/wrappers/bin/slabinfo.plugin $out/libexec/netdata/plugins.d/slabinfo.plugin
+    ln -s /run/wrappers/bin/systemd-journal.plugin $out/libexec/netdata/plugins.d/systemd-journal.plugin
   '';
 
   plugins = [
@@ -452,7 +453,6 @@ in
         group = cfg.group;
         permissions = "u+rx,g+x,o-rwx";
       };
-
     }
     // lib.optionalAttrs (cfg.package.withIpmi) {
       "freeipmi.plugin" = {
@@ -475,6 +475,15 @@ in
     // lib.optionalAttrs (cfg.package.withNdsudo) {
       "ndsudo" = {
         source = "${cfg.package}/libexec/netdata/plugins.d/ndsudo.org";
+        setuid = true;
+        owner = "root";
+        group = cfg.group;
+        permissions = "u+rx,g+x,o-rwx";
+      };
+    }
+    // lib.optionalAttrs (cfg.package.withOtel) {
+      "otel-plugin" = {
+        source = "${cfg.package}/libexec/netdata/plugins.d/otel-plugin.org";
         setuid = true;
         owner = "root";
         group = cfg.group;

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -62,294 +62,298 @@
   withSystemdJournal ? stdenv.hostPlatform.isLinux,
   withSystemdUnits ? stdenv.hostPlatform.isLinux,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "netdata";
-  version = "2.8.0";
+stdenv.mkDerivation (
+  finalAttrs:
+  {
+    pname = "netdata";
+    version = "2.8.0";
 
-  src = fetchFromGitHub {
-    owner = "netdata";
-    repo = "netdata";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-QV9h+TMAuRCkYFr8KMOPhWq5fEnKpmA/HxQ8fV/jKBI=";
-    fetchSubmodules = true;
-  };
+    src = fetchFromGitHub {
+      owner = "netdata";
+      repo = "netdata";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-QV9h+TMAuRCkYFr8KMOPhWq5fEnKpmA/HxQ8fV/jKBI=";
+      fetchSubmodules = true;
+    };
 
-  strictDeps = true;
+    strictDeps = true;
 
-  nativeBuildInputs = [
-    bison
-    cmake
-    flex
-    go
-    makeWrapper
-    ninja
-    pkg-config
-  ]
-  ++ lib.optionals withCups [ cups.dev ]
-  ++ lib.optionals (withOtel || withSystemdJournal) [
-    cargo
-    corrosion
-    rustc
-    rustPlatform.cargoSetupHook
-  ];
-
-  # bash is only used to rewrite shebangs
-  buildInputs = [
-    bash
-    curl
-    jemalloc
-    json_c
-    libuv
-    libyaml
-    lz4
-    protobuf
-    zlib
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libossp_uuid
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libcap
-    libuuid
-    lm_sensors
-  ]
-  ++ lib.optionals withConnPrometheus [ snappy ]
-  ++ lib.optionals withConnPubSub [
-    google-cloud-cpp
-    grpc
-  ]
-  ++ lib.optionals withCups [ cups ]
-  ++ lib.optionals withEbpf [
-    libbpf
-    libelf
-  ]
-  ++ lib.optionals withIpmi [ freeipmi ]
-  ++ lib.optionals withLibbacktrace [ libbacktrace ]
-  ++ lib.optionals withNetfilter [
-    libmnl
-    libnetfilter_acct
-  ]
-  ++ lib.optionals withSsl [ openssl ]
-  ++ lib.optionals (withSystemdJournal || withSystemdUnits) [ systemd ];
-
-  patches = [
-    # Allow ndsudo to use non-hardcoded `PATH`
-    # See https://github.com/netdata/netdata/pull/17377#issuecomment-2183017868
-    #     https://github.com/netdata/netdata/security/advisories/GHSA-pmhq-4cxq-wj93
-    ./ndsudo-fix-path.patch
-
-    ./use-local-corrosion.patch
-    ./use-local-libbacktrace.patch
-  ]
-  ++ lib.optional withCloudUi (
-    replaceVars ./dashboard-v3-add.patch {
-      # FIXME web.archive.org link can be replace once https://github.com/netdata/netdata-cloud/issues/1081 resolved
-      # last update 04/01/2025 04:45:14
-      dashboardTarball = fetchurl {
-        url = "https://web.archive.org/web/20250401044514/https://app.netdata.cloud/agent.tar.gz";
-        hash = "sha256-NtmM1I3VrvFErMoBl+w63Nt0DzOOsaB98cxE/axm8mE=";
-      };
-    }
-  );
-
-  # Guard against unused build-time development inputs in closure. Without
-  # the ./skip-CONFIGURE_COMMAND.patch patch the closure retains inputs up
-  # to bootstrap tools:
-  #   https://github.com/NixOS/nixpkgs/pull/175719
-  # We pick zlib.dev as a simple canary package with pkg-config input.
-  disallowedReferences = lib.optional (!withDebug) zlib.dev;
-
-  donStrip = withDebug || withLibbacktrace;
-  env.NIX_CFLAGS_COMPILE = lib.optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";
-
-  postInstall = ''
-    # Relocate one folder above.
-    mv $out/usr/* $out/
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    # rename this plugin so netdata will look for setuid wrapper
-    mv $out/libexec/netdata/plugins.d/apps.plugin \
-      $out/libexec/netdata/plugins.d/apps.plugin.org
-    mv $out/libexec/netdata/plugins.d/cgroup-network \
-      $out/libexec/netdata/plugins.d/cgroup-network.org
-    mv $out/libexec/netdata/plugins.d/perf.plugin \
-      $out/libexec/netdata/plugins.d/perf.plugin.org
-    mv $out/libexec/netdata/plugins.d/slabinfo.plugin \
-      $out/libexec/netdata/plugins.d/slabinfo.plugin.org
-    mv $out/libexec/netdata/plugins.d/debugfs.plugin \
-      $out/libexec/netdata/plugins.d/debugfs.plugin.org
-    ${lib.optionalString withIpmi ''
-      mv $out/libexec/netdata/plugins.d/freeipmi.plugin \
-        $out/libexec/netdata/plugins.d/freeipmi.plugin.org
-    ''}
-    ${lib.optionalString withNdsudo ''
-      mv $out/libexec/netdata/plugins.d/ndsudo \
-        $out/libexec/netdata/plugins.d/ndsudo.org
-
-      ln -s /var/lib/netdata/ndsudo/ndsudo $out/libexec/netdata/plugins.d/ndsudo
-    ''}
-    ${lib.optionalString withNetworkViewer ''
-      mv $out/libexec/netdata/plugins.d/network-viewer.plugin \
-        $out/libexec/netdata/plugins.d/network-viewer.plugin.org
-    ''}
-    ${lib.optionalString withOtel ''
-      mv $out/libexec/netdata/plugins.d/otel-plugin \
-        $out/libexec/netdata/plugins.d/otel-plugin.org
-    ''}
-    ${lib.optionalString withSystemdJournal ''
-      mv $out/libexec/netdata/plugins.d/systemd-journal.plugin \
-        $out/libexec/netdata/plugins.d/systemd-journal.plugin.org
-    ''}
-    ${lib.optionalString withSystemdUnits ''
-      mv $out/libexec/netdata/plugins.d/systemd-units.plugin \
-        $out/libexec/netdata/plugins.d/systemd-units.plugin.org
-    ''}
-  '';
-
-  preConfigure = ''
-    ${lib.optionalString (withOtel || withSystemdJournal) ''
-      export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
-    ''}
-
-    export GOCACHE=$TMPDIR/go-cache
-    export GOPATH=$TMPDIR/go
-    export GOSUMDB=off
-
-    substituteInPlace packaging/cmake/Modules/NetdataGoTools.cmake \
-      --replace-fail \
-        'GOPROXY=https://proxy.golang.org' \
-        'GOPROXY=file://${finalAttrs.passthru.netdata-go-modules},file://${finalAttrs.passthru.nd-mcp}'
-
-    # Prevent the path to be caught into the Nix store path.
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'set(CACHE_DIR "''${NETDATA_RUNTIME_PREFIX}/var/cache/netdata")' 'set(CACHE_DIR "/var/cache/netdata")' \
-      --replace-fail 'set(CONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/etc/netdata")' 'set(CONFIG_DIR "/etc/netdata")' \
-      --replace-fail 'set(LIBCONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/lib/netdata/conf.d")' 'set(LIBCONFIG_DIR "${placeholder "out"}/share/netdata/conf.d")' \
-      --replace-fail 'set(LOG_DIR "''${NETDATA_RUNTIME_PREFIX}/var/log/netdata")' 'set(LOG_DIR "/var/log/netdata")' \
-      --replace-fail 'set(PLUGINS_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata/plugins.d")' 'set(PLUGINS_DIR "${placeholder "out"}/libexec/netdata/plugins.d")' \
-      --replace-fail 'set(VARLIB_DIR "''${NETDATA_RUNTIME_PREFIX}/var/lib/netdata")' 'set(VARLIB_DIR "/var/lib/netdata")' \
-      --replace-fail 'set(pkglibexecdir_POST "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata")' 'set(pkglibexecdir_POST "${placeholder "out"}/libexec/netdata")' \
-      --replace-fail 'set(localstatedir_POST "''${NETDATA_RUNTIME_PREFIX}/var")' 'set(localstatedir_POST "/var")' \
-      --replace-fail 'set(BINDIR usr/sbin)' 'set(BINDIR "${placeholder "out"}/sbin")' \
-      --replace-fail 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "usr/share/netdata")' 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "${placeholder "out"}/share/netdata")'
-  '';
-
-  cmakeFlags = [
-    "-DWEB_DIR=share/netdata/web"
-    (lib.cmakeBool "ENABLE_DASHBOARD" withCloudUi)
-    (lib.cmakeBool "ENABLE_DBENGINE" withDBengine)
-    (lib.cmakeBool "ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE" withConnPrometheus)
-    (lib.cmakeBool "ENABLE_JEMALLOC" true)
-    (lib.cmakeBool "ENABLE_LIBBACKTRACE" withLibbacktrace)
-    (lib.cmakeBool "ENABLE_ML" withML)
-    (lib.cmakeBool "ENABLE_PLUGIN_CUPS" withCups)
-    (lib.cmakeBool "ENABLE_PLUGIN_EBPF" withEbpf)
-    (lib.cmakeBool "ENABLE_PLUGIN_FREEIPMI" withIpmi)
-    (lib.cmakeBool "ENABLE_PLUGIN_NETWORK_VIEWER" withNetworkViewer)
-    (lib.cmakeBool "ENABLE_PLUGIN_OTEL" withOtel)
-    (lib.cmakeBool "ENABLE_PLUGIN_SYSTEMD_JOURNAL" withSystemdJournal)
-    (lib.cmakeBool "ENABLE_PLUGIN_SYSTEMD_UNITS" withSystemdUnits)
-    (lib.cmakeBool "ENABLE_PLUGIN_XENSTAT" false)
-    # Suggested by upstream.
-    "-G Ninja"
-  ]
-  ++ lib.optional withML "-DNETDATA_DLIB_SOURCE_PATH=${dlib.src}";
-
-  postFixup = ''
-    wrapProgram $out/bin/netdata-claim.sh --prefix PATH : ${lib.makeBinPath [ openssl ]}
-    wrapProgram $out/libexec/netdata/plugins.d/cgroup-network-helper.sh --prefix PATH : ${lib.makeBinPath [ bash ]}
-    wrapProgram $out/bin/netdatacli --set NETDATA_PIPENAME /run/netdata/ipc
-    ${lib.optionalString stdenv.hostPlatform.isLinux ''
-      substituteInPlace $out/lib/netdata/conf.d/go.d/sensors.conf --replace-fail '/usr/bin/sensors' '${lm_sensors}/bin/sensors'
-    ''}
-
-    # Time to cleanup the output directory.
-    unlink $out/sbin
-    cp $out/etc/netdata/edit-config $out/bin/netdata-edit-config
-    mv $out/lib/netdata/conf.d $out/share/netdata/conf.d
-    rm -rf $out/{var,usr,etc}
-  '';
-
-  enableParallelBuilding = true;
-
-  passthru = {
-    nd-mcp =
-      (buildGoModule {
-        pname = "${finalAttrs.pname}-nd-mcp";
-        inherit (finalAttrs) version src;
-
-        sourceRoot = "${finalAttrs.src.name}/src/web/mcp/bridges/stdio-golang";
-
-        vendorHash = "sha256-jyCTp52Dc2IuRwzGT+sHFljO30oqAMfe3xVdEpV+R2c=";
-        proxyVendor = true;
-        doCheck = false;
-
-        subPackages = [ "." ];
-
-        ldflags = [
-          "-s"
-          "-w"
-        ];
-
-        meta = finalAttrs.meta // {
-          description = "Netdata Model Context Protocol (MCP) Integration";
-          license = lib.licenses.gpl3Only;
-        };
-      }).goModules;
-
-    netdata-go-modules =
-      (buildGoModule {
-        pname = "${finalAttrs.pname}-go-plugins";
-        inherit (finalAttrs) version src;
-
-        sourceRoot = "${finalAttrs.src.name}/src/go/plugin/go.d";
-
-        vendorHash = "sha256-AVNUbKCvO+Z3eKE+bJ/VFDo1tS9DdlmMw6M3OSdHiIU=";
-        proxyVendor = true;
-        doCheck = false;
-
-        ldflags = [
-          "-s"
-          "-w"
-          "-X main.version=${finalAttrs.version}"
-        ];
-
-        meta = finalAttrs.meta // {
-          description = "Netdata orchestrator for data collection modules written in Go";
-          mainProgram = "godplugin";
-          license = lib.licenses.gpl3Only;
-        };
-      }).goModules;
-
-    inherit
-      withIpmi
-      withNdsudo
-      withNetworkViewer
-      withOtel
-      withSystemdJournal
-      ;
-
-    tests.netdata = nixosTests.netdata;
-  };
-
-  meta = with lib; {
-    broken = stdenv.buildPlatform != stdenv.hostPlatform || withEbpf;
-    description = "Real-time performance monitoring tool";
-    homepage = "https://www.netdata.cloud/";
-    changelog = "https://github.com/netdata/netdata/releases/tag/v${version}";
-    license = [ licenses.gpl3Plus ] ++ lib.optionals withCloudUi [ licenses.ncul1 ];
-    mainProgram = "netdata";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
-      mkg20001
-      rhoriguchi
+    nativeBuildInputs = [
+      bison
+      cmake
+      flex
+      go
+      makeWrapper
+      ninja
+      pkg-config
+    ]
+    ++ lib.optionals withCups [ cups.dev ]
+    ++ lib.optionals (withOtel || withSystemdJournal) [
+      cargo
+      corrosion
+      rustc
+      rustPlatform.cargoSetupHook
     ];
-  };
-} // lib.optionalAttrs (withOtel || withSystemdJournal) {
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    pname = "${finalAttrs.pname}-nd-jf";
-    inherit (finalAttrs) version src cargoRoot;
-    hash = "sha256-HY6OtKHP75mO9X+F2a6H6e+3M0pgZBOIIaxAI9OhgkQ=";
-  };
-  cargoRoot = "src/crates/jf";
-})
+
+    # bash is only used to rewrite shebangs
+    buildInputs = [
+      bash
+      curl
+      jemalloc
+      json_c
+      libuv
+      libyaml
+      lz4
+      protobuf
+      zlib
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      libossp_uuid
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libcap
+      libuuid
+      lm_sensors
+    ]
+    ++ lib.optionals withConnPrometheus [ snappy ]
+    ++ lib.optionals withConnPubSub [
+      google-cloud-cpp
+      grpc
+    ]
+    ++ lib.optionals withCups [ cups ]
+    ++ lib.optionals withEbpf [
+      libbpf
+      libelf
+    ]
+    ++ lib.optionals withIpmi [ freeipmi ]
+    ++ lib.optionals withLibbacktrace [ libbacktrace ]
+    ++ lib.optionals withNetfilter [
+      libmnl
+      libnetfilter_acct
+    ]
+    ++ lib.optionals withSsl [ openssl ]
+    ++ lib.optionals (withSystemdJournal || withSystemdUnits) [ systemd ];
+
+    patches = [
+      # Allow ndsudo to use non-hardcoded `PATH`
+      # See https://github.com/netdata/netdata/pull/17377#issuecomment-2183017868
+      #     https://github.com/netdata/netdata/security/advisories/GHSA-pmhq-4cxq-wj93
+      ./ndsudo-fix-path.patch
+
+      ./use-local-corrosion.patch
+      ./use-local-libbacktrace.patch
+    ]
+    ++ lib.optional withCloudUi (
+      replaceVars ./dashboard-v3-add.patch {
+        # FIXME web.archive.org link can be replace once https://github.com/netdata/netdata-cloud/issues/1081 resolved
+        # last update 04/01/2025 04:45:14
+        dashboardTarball = fetchurl {
+          url = "https://web.archive.org/web/20250401044514/https://app.netdata.cloud/agent.tar.gz";
+          hash = "sha256-NtmM1I3VrvFErMoBl+w63Nt0DzOOsaB98cxE/axm8mE=";
+        };
+      }
+    );
+
+    # Guard against unused build-time development inputs in closure. Without
+    # the ./skip-CONFIGURE_COMMAND.patch patch the closure retains inputs up
+    # to bootstrap tools:
+    #   https://github.com/NixOS/nixpkgs/pull/175719
+    # We pick zlib.dev as a simple canary package with pkg-config input.
+    disallowedReferences = lib.optional (!withDebug) zlib.dev;
+
+    donStrip = withDebug || withLibbacktrace;
+    env.NIX_CFLAGS_COMPILE = lib.optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";
+
+    postInstall = ''
+      # Relocate one folder above.
+      mv $out/usr/* $out/
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      # rename this plugin so netdata will look for setuid wrapper
+      mv $out/libexec/netdata/plugins.d/apps.plugin \
+        $out/libexec/netdata/plugins.d/apps.plugin.org
+      mv $out/libexec/netdata/plugins.d/cgroup-network \
+        $out/libexec/netdata/plugins.d/cgroup-network.org
+      mv $out/libexec/netdata/plugins.d/perf.plugin \
+        $out/libexec/netdata/plugins.d/perf.plugin.org
+      mv $out/libexec/netdata/plugins.d/slabinfo.plugin \
+        $out/libexec/netdata/plugins.d/slabinfo.plugin.org
+      mv $out/libexec/netdata/plugins.d/debugfs.plugin \
+        $out/libexec/netdata/plugins.d/debugfs.plugin.org
+      ${lib.optionalString withIpmi ''
+        mv $out/libexec/netdata/plugins.d/freeipmi.plugin \
+          $out/libexec/netdata/plugins.d/freeipmi.plugin.org
+      ''}
+      ${lib.optionalString withNdsudo ''
+        mv $out/libexec/netdata/plugins.d/ndsudo \
+          $out/libexec/netdata/plugins.d/ndsudo.org
+
+        ln -s /var/lib/netdata/ndsudo/ndsudo $out/libexec/netdata/plugins.d/ndsudo
+      ''}
+      ${lib.optionalString withNetworkViewer ''
+        mv $out/libexec/netdata/plugins.d/network-viewer.plugin \
+          $out/libexec/netdata/plugins.d/network-viewer.plugin.org
+      ''}
+      ${lib.optionalString withOtel ''
+        mv $out/libexec/netdata/plugins.d/otel-plugin \
+          $out/libexec/netdata/plugins.d/otel-plugin.org
+      ''}
+      ${lib.optionalString withSystemdJournal ''
+        mv $out/libexec/netdata/plugins.d/systemd-journal.plugin \
+          $out/libexec/netdata/plugins.d/systemd-journal.plugin.org
+      ''}
+      ${lib.optionalString withSystemdUnits ''
+        mv $out/libexec/netdata/plugins.d/systemd-units.plugin \
+          $out/libexec/netdata/plugins.d/systemd-units.plugin.org
+      ''}
+    '';
+
+    preConfigure = ''
+      ${lib.optionalString (withOtel || withSystemdJournal) ''
+        export CMAKE_PREFIX_PATH="${corrosion}:$CMAKE_PREFIX_PATH"
+      ''}
+
+      export GOCACHE=$TMPDIR/go-cache
+      export GOPATH=$TMPDIR/go
+      export GOSUMDB=off
+
+      substituteInPlace packaging/cmake/Modules/NetdataGoTools.cmake \
+        --replace-fail \
+          'GOPROXY=https://proxy.golang.org' \
+          'GOPROXY=file://${finalAttrs.passthru.netdata-go-modules},file://${finalAttrs.passthru.nd-mcp}'
+
+      # Prevent the path to be caught into the Nix store path.
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'set(CACHE_DIR "''${NETDATA_RUNTIME_PREFIX}/var/cache/netdata")' 'set(CACHE_DIR "/var/cache/netdata")' \
+        --replace-fail 'set(CONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/etc/netdata")' 'set(CONFIG_DIR "/etc/netdata")' \
+        --replace-fail 'set(LIBCONFIG_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/lib/netdata/conf.d")' 'set(LIBCONFIG_DIR "${placeholder "out"}/share/netdata/conf.d")' \
+        --replace-fail 'set(LOG_DIR "''${NETDATA_RUNTIME_PREFIX}/var/log/netdata")' 'set(LOG_DIR "/var/log/netdata")' \
+        --replace-fail 'set(PLUGINS_DIR "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata/plugins.d")' 'set(PLUGINS_DIR "${placeholder "out"}/libexec/netdata/plugins.d")' \
+        --replace-fail 'set(VARLIB_DIR "''${NETDATA_RUNTIME_PREFIX}/var/lib/netdata")' 'set(VARLIB_DIR "/var/lib/netdata")' \
+        --replace-fail 'set(pkglibexecdir_POST "''${NETDATA_RUNTIME_PREFIX}/usr/libexec/netdata")' 'set(pkglibexecdir_POST "${placeholder "out"}/libexec/netdata")' \
+        --replace-fail 'set(localstatedir_POST "''${NETDATA_RUNTIME_PREFIX}/var")' 'set(localstatedir_POST "/var")' \
+        --replace-fail 'set(BINDIR usr/sbin)' 'set(BINDIR "${placeholder "out"}/sbin")' \
+        --replace-fail 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "usr/share/netdata")' 'set(BUILD_INFO_CMAKE_CACHE_ARCHIVE_PATH "${placeholder "out"}/share/netdata")'
+    '';
+
+    cmakeFlags = [
+      "-DWEB_DIR=share/netdata/web"
+      (lib.cmakeBool "ENABLE_DASHBOARD" withCloudUi)
+      (lib.cmakeBool "ENABLE_DBENGINE" withDBengine)
+      (lib.cmakeBool "ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE" withConnPrometheus)
+      (lib.cmakeBool "ENABLE_JEMALLOC" true)
+      (lib.cmakeBool "ENABLE_LIBBACKTRACE" withLibbacktrace)
+      (lib.cmakeBool "ENABLE_ML" withML)
+      (lib.cmakeBool "ENABLE_PLUGIN_CUPS" withCups)
+      (lib.cmakeBool "ENABLE_PLUGIN_EBPF" withEbpf)
+      (lib.cmakeBool "ENABLE_PLUGIN_FREEIPMI" withIpmi)
+      (lib.cmakeBool "ENABLE_PLUGIN_NETWORK_VIEWER" withNetworkViewer)
+      (lib.cmakeBool "ENABLE_PLUGIN_OTEL" withOtel)
+      (lib.cmakeBool "ENABLE_PLUGIN_SYSTEMD_JOURNAL" withSystemdJournal)
+      (lib.cmakeBool "ENABLE_PLUGIN_SYSTEMD_UNITS" withSystemdUnits)
+      (lib.cmakeBool "ENABLE_PLUGIN_XENSTAT" false)
+      # Suggested by upstream.
+      "-G Ninja"
+    ]
+    ++ lib.optional withML "-DNETDATA_DLIB_SOURCE_PATH=${dlib.src}";
+
+    postFixup = ''
+      wrapProgram $out/bin/netdata-claim.sh --prefix PATH : ${lib.makeBinPath [ openssl ]}
+      wrapProgram $out/libexec/netdata/plugins.d/cgroup-network-helper.sh --prefix PATH : ${lib.makeBinPath [ bash ]}
+      wrapProgram $out/bin/netdatacli --set NETDATA_PIPENAME /run/netdata/ipc
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        substituteInPlace $out/lib/netdata/conf.d/go.d/sensors.conf --replace-fail '/usr/bin/sensors' '${lm_sensors}/bin/sensors'
+      ''}
+
+      # Time to cleanup the output directory.
+      unlink $out/sbin
+      cp $out/etc/netdata/edit-config $out/bin/netdata-edit-config
+      mv $out/lib/netdata/conf.d $out/share/netdata/conf.d
+      rm -rf $out/{var,usr,etc}
+    '';
+
+    enableParallelBuilding = true;
+
+    passthru = {
+      nd-mcp =
+        (buildGoModule {
+          pname = "${finalAttrs.pname}-nd-mcp";
+          inherit (finalAttrs) version src;
+
+          sourceRoot = "${finalAttrs.src.name}/src/web/mcp/bridges/stdio-golang";
+
+          vendorHash = "sha256-jyCTp52Dc2IuRwzGT+sHFljO30oqAMfe3xVdEpV+R2c=";
+          proxyVendor = true;
+          doCheck = false;
+
+          subPackages = [ "." ];
+
+          ldflags = [
+            "-s"
+            "-w"
+          ];
+
+          meta = finalAttrs.meta // {
+            description = "Netdata Model Context Protocol (MCP) Integration";
+            license = lib.licenses.gpl3Only;
+          };
+        }).goModules;
+
+      netdata-go-modules =
+        (buildGoModule {
+          pname = "${finalAttrs.pname}-go-plugins";
+          inherit (finalAttrs) version src;
+
+          sourceRoot = "${finalAttrs.src.name}/src/go/plugin/go.d";
+
+          vendorHash = "sha256-AVNUbKCvO+Z3eKE+bJ/VFDo1tS9DdlmMw6M3OSdHiIU=";
+          proxyVendor = true;
+          doCheck = false;
+
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${finalAttrs.version}"
+          ];
+
+          meta = finalAttrs.meta // {
+            description = "Netdata orchestrator for data collection modules written in Go";
+            mainProgram = "godplugin";
+            license = lib.licenses.gpl3Only;
+          };
+        }).goModules;
+
+      inherit
+        withIpmi
+        withNdsudo
+        withNetworkViewer
+        withOtel
+        withSystemdJournal
+        ;
+
+      tests.netdata = nixosTests.netdata;
+    };
+
+    meta = with lib; {
+      broken = stdenv.buildPlatform != stdenv.hostPlatform || withEbpf;
+      description = "Real-time performance monitoring tool";
+      homepage = "https://www.netdata.cloud/";
+      changelog = "https://github.com/netdata/netdata/releases/tag/v${version}";
+      license = [ licenses.gpl3Plus ] ++ lib.optionals withCloudUi [ licenses.ncul1 ];
+      mainProgram = "netdata";
+      platforms = platforms.unix;
+      maintainers = with maintainers; [
+        mkg20001
+        rhoriguchi
+      ];
+    };
+  }
+  // lib.optionalAttrs (withOtel || withSystemdJournal) {
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      pname = "${finalAttrs.pname}-nd-jf";
+      inherit (finalAttrs) version src cargoRoot;
+      hash = "sha256-HY6OtKHP75mO9X+F2a6H6e+3M0pgZBOIIaxAI9OhgkQ=";
+    };
+    cargoRoot = "src/crates/jf";
+  }
+)

--- a/pkgs/tools/system/netdata/use-local-corrosion.patch
+++ b/pkgs/tools/system/netdata/use-local-corrosion.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 414a3c54b..cf1fcb7b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -230,13 +230,8 @@ cmake_dependent_option(ENABLE_NETDATA_JOURNAL_FILE_READER "Enable netdata's jour
+
+ # Setup Rust/Corrosion for plugins that need it
+ if(ENABLE_NETDATA_JOURNAL_FILE_READER OR ENABLE_PLUGIN_OTEL)
+-    include(FetchContent)
+-    FetchContent_Declare(
+-        Corrosion
+-        GIT_REPOSITORY https://github.com/netdata/corrosion.git
+-        GIT_TAG f3b91559efca32c6b54837866ef35ba98ff5b2ca # stable/v0.5
+-    )
+-    FetchContent_MakeAvailable(Corrosion)
++    find_package(Corrosion REQUIRED)
++
+     corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml
+                            CRATES journal_reader_ffi otel-plugin)
+ endif()


### PR DESCRIPTION
Built and tested package with these flags:
```nix
netdata.override {
  withCloudUi = true;
  withCups = true;
  withDBengine = true;
  withDebug = false;
  withLibbacktrace = false;
  withML = true;
  withNdsudo = true;
  withOtel = false;
  withSystemdJournal = false;
};

netdata.override {
  withCloudUi = false;
  withCups = true;
  withDBengine = false;
  withDebug = false;
  withLibbacktrace = false;
  withML = false;
  withNdsudo = true;
  withOtel = false;
  withSystemdJournal = false;
};
```

I've split the PR into 2 commits so it's easier to review and see the changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
