### PR TITLE
python314: support with-tail-call-interp

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -79,6 +79,12 @@
   # https://docs.python.org/3/using/configure.html#cmdoption-enable-optimizations
   enableOptimizations ? false,
 
+  # Enable CPython's tail-call interpreter when supported
+  # https://docs.python.org/3.14/using/configure.html#cmdoption-with-tail-call-interp
+  enableTailCallInterp ? (
+    stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "19" && enableOptimizations
+  ),
+
   # improves performance, but remains reproducible
   enableNoSemanticInterposition ? true,
 
@@ -479,6 +485,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optionals enableOptimizations [
     "--enable-optimizations"
+  ]
+  ++ optionals (pythonAtLeast "3.14" && enableTailCallInterp) [
+    "--with-tail-call-interp"
   ]
   ++ optionals enableDebug [
     "--with-pydebug"


### PR DESCRIPTION
https://docs.python.org/3.14/using/configure.html#cmdoption-with-tail-call-interp

Enabled by default when using Clang 19+ on Python 3.14+ and with optimizations enabled as per:

> If enabled, enabling PGO (--enable-optimizations) is highly recommended

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
