### PR TITLE
ut-1999: fix build in darwin build sandbox

### DIFF
--- a/pkgs/by-name/ut/ut1999/package.nix
+++ b/pkgs/by-name/ut/ut1999/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  requireFile,
   autoPatchelfHook,
   undmg,
   fetchurl,
@@ -18,6 +17,8 @@
   openal,
   libmpg123,
   libxmp,
+  libiconv,
+  darwin,
 }:
 
 let
@@ -84,6 +85,9 @@ stdenv.mkDerivation (finalAttrs: {
     libmpg123
     libxmp
     stdenv.cc.cc
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
   ];
 
   nativeBuildInputs =
@@ -94,6 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       makeWrapper
       undmg
+      darwin.autoSignDarwinBinariesHook
     ];
 
   installPhase =
@@ -116,6 +121,15 @@ stdenv.mkDerivation (finalAttrs: {
       cp -r "UnrealTournament.app" $out/Applications/
       makeWrapper $out/Applications/UnrealTournament.app/Contents/MacOS/UnrealTournament \
         $out/bin/${finalAttrs.meta.mainProgram}
+      # If the darwin build sandbox is enabled, system libiconv is not available
+      # https://github.com/OldUnreal/UnrealTournamentPatches/issues/1902
+      # Even though ut1999 is able to unpack the map files at runtime, upstream advised to still do it at install time
+      # which is why the UCC binary is fixed to access a copy of iconv from the nix store
+      install_name_tool -change /usr/lib/libiconv.2.dylib \
+        ${libiconv}/lib/libiconv.2.dylib \
+        $out/Applications/UnrealTournament.app/Contents/MacOS/UCC
+      # Needs manual re-signing, as UCC is used during the build, and the auto signer is part of the fixup phase
+      signDarwinBinariesInAllOutputs
     ''
     + ''
       chmod -R 755 $out


### PR DESCRIPTION
## Things done

This fix allows building with the darwin build sandbox enabled. Before this failed because libiconv was not included in the sandbox, and thus the build failed with errors like this:

```
Running phase: installPhase
iconv_open(UCS-4LE, WINDOWS-1252) failed: Invalid argument
iconv_open(UTF-16LE, WINDOWS-1252) failed: Invalid argument
iconv_open(WINDOWS-1252//IGNORE, UCS-4LE) failed: Invalid argument
iconv_open(WINDOWS-1252//IGNORE, UCS-4LE) failed: Invalid argument
iconv_open(UTF-16LE//IGNORE, UCS-4LE) failed: Invalid argument
iconv_open(UTF-16LE//IGNORE, UCS-4LE) failed: Invalid argument
iconv_open(WINDOWS-1252//IGNORE, UTF-16LE) failed: Invalid argument
iconv_open(UCS-4LE//IGNORE, UTF-16LE) failed: Invalid argument
iconv_open(UCS-4LE//IGNORE, UTF-16LE) failed: Invalid argument
iconv_open(UTF-8//IGNORE, UCS-4LE) failed: Invalid argument
iconv_open(UTF-8//IGNORE, UCS-4LE) failed: Invalid argument
iconv_open(UCS-4LE//IGNORE, UTF-8) failed: Invalid argument
iconv_open(UCS-4LE//IGNORE, UTF-8) failed: Invalid argument
Could not initialize iconv. You are probably missing the iconv libraries. UT cannot start without them
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
