### PR TITLE
ut1999: add dwt as maintainer

### DIFF
--- a/pkgs/by-name/ut/ut1999/package.nix
+++ b/pkgs/by-name/ut/ut1999/package.nix
@@ -198,7 +198,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Unreal Tournament GOTY (1999) with the OldUnreal patch";
     license = licenses.unfree;
     platforms = attrNames srcs;
-    maintainers = with maintainers; [ eliandoran ];
+    maintainers = with maintainers; [
+      eliandoran
+      dwt
+    ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     mainProgram = "ut1999";
   };


### PR DESCRIPTION
## Things done

@eliandoran I would like to support you in maintaining the darwin side of ut-1999. For my qualifications, I would like to point to my existing pull requests to this package:

- #446726
- #429661
- #389068
- #380727
- #377549 

What do you think about that?

As I am not really familiar with this procedure yet, I would also welcome feedback from other maintainers  / contributors on how to approach becoming a maintainer for ut-1999. Sorry if this is the wrong path, I would welcome a pointer to the right procedure.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
