### PR TITLE
python313Packages.benqprojector: 0.1.6 -> 0.1.8

### DIFF
--- a/pkgs/development/python-modules/benqprojector/default.nix
+++ b/pkgs/development/python-modules/benqprojector/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  aiofiles,
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
@@ -10,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "benqprojector";
-  version = "0.1.6";
+  version = "0.1.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rrooggiieerr";
     repo = "benqprojector.py";
     tag = version;
-    hash = "sha256-Ys2C44kr5gd6tXO51OFRx4YVKVRGLfFPCYDFGt+gN0c=";
+    hash = "sha256-BttaLpjiybjeoJhOXfo6Qlox4bRqf9auvNg/wtm9gMQ=";
   };
 
   build-system = [
@@ -26,6 +27,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    aiofiles
     pyserial
     pyserial-asyncio-fast
   ];
@@ -38,7 +40,7 @@ buildPythonPackage rec {
   meta = rec {
     description = "Python library to control BenQ projectors";
     homepage = "https://github.com/rrooggiieerr/benqprojector.py";
-    changelog = "${homepage}/releases/tag/${version}";
+    changelog = "${homepage}/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ sephalon ];
   };


### PR DESCRIPTION
Changelog: https://github.com/rrooggiieerr/benqprojector.py/releases/tag/0.1.8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
