### PR TITLE
fig2dev: fix build with gcc15

### DIFF
--- a/pkgs/by-name/fi/fig2dev/package.nix
+++ b/pkgs/by-name/fi/fig2dev/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   fetchurl,
   ghostscript,
   libpng,
@@ -24,6 +25,14 @@ stdenv.mkDerivation rec {
   patches = [
     ./CVE-2025-31162.patch
     ./CVE-2025-31163.patch
+
+    # Fix build with gcc15
+    # https://sourceforge.net/p/mcj/fig2dev/ci/ab4eee3cf0d0c1d861d64b9569a5d1497800cae2
+    (fetchpatch {
+      name = "fig2dev-prototypes.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/fig2dev/files/fig2dev-3.2.9a-prototypes.patch?id=93644497325b6df7a17f8bd05ad0495607aa5c34";
+      hash = "sha256-F6z0m3Ez9JpgZg+TjVjuIZhAyTMHodB7O/l8lDTOL54=";
+    })
   ];
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
- add patch from merged upstream commit:
https://sourceforge.net/p/mcj/fig2dev/ci/ab4eee3cf0d0c1d861d64b9569a5d1497800cae2
(fetchpatch is from gentoo because of upstream hosting on sourceforge)

Fixes build failure with gcc15:
```
transfig.c:140:26: error: too many arguments to function 'str2lang'; expected 0, have 1
  140 |                 tolang = str2lang(optarg);
      |                          ^~~~~~~~ ~~~~~~
transfig.h:63:22: note: declared here
   63 | extern enum language str2lang();
      |                      ^~~~~~~~
transfig.c:171:13: error: too many arguments to function 'parse_arg'; expected 0, have 6
  171 |         a = parse_arg(tolang, arg_f, arg_s, arg_m, arg_o, argv[optind]);
      |             ^~~~~~~~~ ~~~~~~
transfig.c:36:11: note: declared here
   36 | argument *parse_arg(), *arglist = NULL, *lastarg = NULL;
      |           ^~~~~~~~~
transfig.c:259:7: error: too many arguments to function 'strip'; expected 0, have 2
  259 |   if (strip(arg, ".pic"))
      |       ^~~~~ ~~~
transfig.c:37:7: note: declared here
   37 | char *strip();
      |       ^~~~~
transfig.c:261:19: error: too many arguments to function 'mksuff'; expected 0, have 2
  261 |         a->name = mksuff(arg, "");
      |                   ^~~~~~ ~~~
transfig.h:67:24: note: declared here
   67 | extern char *sysls(), *mksuff();
      |                        ^~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; fig2dev.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
