### PR TITLE
libsndfile: fix build with gcc15

### DIFF
--- a/pkgs/by-name/li/libsndfile/package.nix
+++ b/pkgs/by-name/li/libsndfile/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   autogen,
   pkg-config,
@@ -34,6 +35,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-MOOX/O0UaoeMaQPW9PvvE0izVp+6IoE5VbtTx0RvMkI=";
   };
+
+  patches = [
+    # Fix build with gcc15
+    # https://github.com/libsndfile/libsndfile/pull/1055
+    (fetchpatch {
+      url = "https://github.com/libsndfile/libsndfile/commit/2251737b3b175925684ec0d37029ff4cb521d302.patch";
+      hash = "sha256-LaeptEicnjpVBExlK4dNMlN8+AAJhW8dIvemF6S4W2M=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/libsndfile/libsndfile/pull/1055

Fixes build failure with gcc15:
```
src/ALAC/alac_decoder.c:42:9: error: cannot use keyword 'false' as enumeration constant
   42 | {       false = 0,
      |         ^~~~~
src/ALAC/alac_decoder.c:42:9: note: 'false' is a keyword with '-std=c23' onwards
src/ALAC/alac_decoder.c:44:3: error: expected ';', identifier or '(' before 'bool'
   44 | } bool ;
      |   ^~~~
src/ALAC/alac_decoder.c:44:3: warning: useless type name in empty declaration
make[2]: *** [Makefile:2615: src/ALAC/alac_decoder.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
src/ALAC/alac_encoder.c:49:9: error: cannot use keyword 'false' as enumeration constant
   49 |         false = 0,
      |         ^~~~~
src/ALAC/alac_encoder.c:49:9: note: 'false' is a keyword with '-std=c23' onwards
src/ALAC/alac_encoder.c:51:3: error: expected ';', identifier or '(' before 'bool'
   51 | } bool ;
      |   ^~~~
```

Tested build with:
```bash
nix-build --expr 'with import ./. {}; libsndfile.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Build of `moc` in `libsndfile.tests` fails, but seems to be unrelated (also fails without this change on master).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
