### PR TITLE
lib.customisation: add `getFinalPassthruWith` for unified missing `finalAttrs.passthru.<attr>` handling

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -3,6 +3,7 @@
 let
   inherit (builtins)
     intersectAttrs
+    unsafeGetAttrPos
     ;
   inherit (lib)
     functionArgs
@@ -303,7 +304,7 @@ rec {
       errorForArg =
         arg:
         let
-          loc = builtins.unsafeGetAttrPos arg fargs;
+          loc = unsafeGetAttrPos arg fargs;
         in
         "Function called without required argument \"${arg}\" at "
         + "${loc.file}:${toString loc.line}${prettySuggestions (getSuggestions arg)}";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -401,6 +401,8 @@ let
         makeScopeWithSplicing
         makeScopeWithSplicing'
         extendMkDerivation
+        getFinalPassthruMissingMessage
+        getFinalPassthruWith
         ;
       inherit (self.derivations) lazyDerivation optionalDrvAttr warnOnInstantiate;
       inherit (self.generators) mkLuaInline;

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -69,6 +69,12 @@ lib.extendMkDerivation {
 
       ...
     }@args:
+    let
+      getFinalPassthruOr = lib.getFinalPassthruWith {
+        prefix = "buildGoModule: ${finalAttrs.name or finalAttrs.pname}: ";
+        handler = lib.warn;
+      } finalAttrs;
+    in
     {
       inherit
         modRoot
@@ -205,15 +211,7 @@ lib.extendMkDerivation {
             outputHashAlgo = if finalAttrs.vendorHash == "" then "sha256" else null;
             # in case an overlay clears passthru by accident, don't fail evaluation
           }).overrideAttrs
-            (
-              let
-                pos = builtins.unsafeGetAttrPos "passthru" finalAttrs;
-                posString =
-                  if pos == null then "unknown" else "${pos.file}:${toString pos.line}:${toString pos.column}";
-              in
-              finalAttrs.passthru.overrideModAttrs
-                or (lib.warn "buildGoModule: ${finalAttrs.name or finalAttrs.pname}: passthru.overrideModAttrs missing after overrideAttrs. Last overridden at ${posString}." overrideModAttrs)
-            );
+            (getFinalPassthruOr "overrideModAttrs" overrideModAttrs);
 
       nativeBuildInputs = [ go ] ++ nativeBuildInputs;
 


### PR DESCRIPTION
Following the increased adoption of [fixed-point attributes (`finalAttrs: { }`)](https://nixos.org/manual/nixpkgs/stable/#chap-build-helpers-finalAttrs) and [`<pkg>.overrideAttrs`](https://nixos.org/manual/nixpkgs/stable/#sec-pkg-overrideAttrs)-based overriding, some arguments are referenced and overridden under `finalAttrs.passthru`, accidental overriting/emptying of the `passthru` attributes could result in surprising errors/behavioural changes that is hard to identify and debug.

This PR provides two new Nixpkgs Library functions, `getFinalPassthruWith` and `getFinalPassthruMissingMessage`, which gets the attribute from `finalAttrs.passthru` and fall back to specified behaviours with informative error/warning message including the possible position of the last `passthru` overriding.

See the followings for context:
- #339042
- #434546

Aside from `buildGoModule`, recent `buildPythonPackage` overriding improvement will also benefit from this library function.
- #376372

Questions:
- Should these functions be defined under `lib.meta` instead of `lib.customisation`?
- Should `getFinalPassthruWith` has a signature of `{ handler, prefix, finalAttrs } -> attrName -> Any` instead of `{ handler, prefix } -> finalAttrs -> attrName -> Any`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
