### PR TITLE
automerge-repo-sync-server: init at 0.2.8

### DIFF
--- a/pkgs/by-name/au/automerge-repo-sync-server/package.nix
+++ b/pkgs/by-name/au/automerge-repo-sync-server/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYarnPackage,
+  fetchYarnDeps,
+}:
+mkYarnPackage rec {
+  pname = "automerge-repo-sync-server";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "automerge";
+    repo = "automerge-repo-sync-server";
+    rev = "v${version}";
+    hash = "sha256-41aWP0vzAQrppalA8Kw+zBD2ERgQI0mQNnHtnGmAMEU=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-IHIxBnJOLI97vPxcbUdrdXfK/SJBYNZcndME7AzOShc=";
+  };
+
+  doDist = false;
+
+  meta = with lib; {
+    description = "A very simple automerge-repo synchronization server.";
+    homepage = "https://github.com/automerge/automerge-repo-sync-server";
+    changelog = "https://github.com/automerge/automerge-repo-sync-server/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xlambein ];
+    mainProgram = "automerge-repo-sync-server";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
