### PR TITLE
copywrite: use `finalAttrs` pattern

### DIFF
--- a/pkgs/by-name/co/copywrite/package.nix
+++ b/pkgs/by-name/co/copywrite/package.nix
@@ -12,14 +12,14 @@ let
   commitHash = "d5bc935e4801a02fdbd953f8f0ae7989eaef50cf"; # matches tag release
   shortCommitHash = builtins.substring 0 7 commitHash;
 in
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "copywrite";
   version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "copywrite";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-gPVlHgFlLxoAj4pkg3OxD4CGQaLdAL312/Zn/pJ+7fg=";
   };
 
@@ -28,7 +28,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/hashicorp/copywrite/cmd.version=${version}"
+    "-X github.com/hashicorp/copywrite/cmd.version=${finalAttrs.version}"
     "-X github.com/hashicorp/copywrite/cmd.commit=${shortCommitHash}"
   ];
 
@@ -65,8 +65,8 @@ buildGoModule rec {
     description = "Automate copyright headers and license files at scale";
     mainProgram = "copywrite";
     homepage = "https://github.com/hashicorp/copywrite";
-    changelog = "https://github.com/hashicorp/copywrite/releases/tag/v${version}";
+    changelog = "https://github.com/hashicorp/copywrite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ dvcorreia ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
