### PR TITLE
mpvScripts.autosave: init at 0-unstable-2020-10-22

### DIFF
--- a/pkgs/applications/video/mpv/scripts/autosave.nix
+++ b/pkgs/applications/video/mpv/scripts/autosave.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchgit,
+  unstableGitUpdater,
+  buildLua,
+}:
+buildLua {
+  pname = "autosave";
+  version = "0-unstable-2020-10-22";
+
+  src = fetchgit {
+    url = "https://gist.github.com/CyberShadow/2f71a97fb85ed42146f6d9f522bc34ef";
+    rev = "744c3ee61d2f0a8e9bb4e308dec6897215ae4704";
+    hash = "sha256-yxA8wgzdS7SyKLoNTWN87ShsBfPKUflbOu4Y0jS2G3I=";
+  };
+
+  scriptPath = "autosave.lua";
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Periodically saves \"watch later\" data during playback";
+    homepage = "https://gist.github.com/CyberShadow/2f71a97fb85ed42146f6d9f522bc34ef";
+    maintainers = with lib.maintainers; [ arthsmn ];
+    license = lib.licenses.bsd0;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
