### PR TITLE
uxn11: init at 1.0-unstable-2025-09-27

### DIFF
--- a/pkgs/by-name/ux/uxn/package.nix
+++ b/pkgs/by-name/ux/uxn/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wiki.xxiivv.com/site/uxn.html";
     description = "Assembler and emulator for the Uxn stack machine";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ jleightcap ];
     mainProgram = "uxnemu";
     inherit (SDL2.meta) platforms;
   };

--- a/pkgs/by-name/ux/uxn11/package.nix
+++ b/pkgs/by-name/ux/uxn11/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  xorg,
+}:
+
+stdenv.mkDerivation {
+  pname = "uxn11";
+  version = "1.0-unstable-2025-09-27";
+
+  src = fetchFromSourcehut {
+    owner = "~rabbits";
+    repo = "uxn11";
+    rev = "3c16d2acecfe4784dfe75de520e6229fa809b634";
+    hash = "sha256-NKFaj/7V8S+W7c5v4uzPT9hpNHAmP/J7LGR6/0lQ3ds=";
+  };
+
+  buildInputs = [
+    xorg.libX11
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  strictDeps = true;
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://git.sr.ht/~rabbits/uxn11";
+    description = "X11 and standalone text-mode emulators for the Uxn virtual machine";
+    license = lib.licenses.mit;
+    mainProgram = "uxn11";
+    maintainers = with lib.maintainers; [ jleightcap ];
+    inherit (xorg.libX11.meta) platforms;
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Pick up maintainance of uxn-related programs: add `~rabbits/uxn11` emulator suite and `uxn` package maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
