### PR TITLE
ivan: 059 -> 059-unstable-2025-02-20

### DIFF
--- a/pkgs/by-name/iv/ivan/package.nix
+++ b/pkgs/by-name/iv/ivan/package.nix
@@ -13,15 +13,14 @@
 }:
 
 stdenv.mkDerivation rec {
-
   pname = "ivan";
-  version = "059";
+  version = "059-unstable-2025-02-20";
 
   src = fetchFromGitHub {
     owner = "Attnam";
     repo = "ivan";
-    rev = "v${version}";
-    sha256 = "sha256-5Ijy28LLx1TGnZE6ZNQXPYfvW2KprF+91fKx2MzLEms=";
+    rev = "0000b8621bb767b594802e663686d3a1da2c5060";
+    hash = "sha256-vqrQozsNrqW4oqoJ4V5E15AsMEuHq+pyZz7EtiA5euE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates the `ivan` package from its latest release version 059 to the latest commit in the repo, which includes several bug fixes. The most noteworthy fix addresses [this issue](https://github.com/Attnam/ivan/pull/647) regarding missing user data directory. The problem caused crashes on Linux.

Closes #444770    

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
