### PR TITLE
qqmusic: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/by-name/qq/qqmusic/package.nix
+++ b/pkgs/by-name/qq/qqmusic/package.nix
@@ -21,6 +21,7 @@
   libdbusmenu,
   libglvnd,
   libpulseaudio,
+  mesa,
   nspr,
   nss,
   pango,
@@ -34,10 +35,11 @@
 ################################################################################
 stdenv.mkDerivation (finalAttrs: {
   pname = "qqmusic";
-  version = "1.1.7";
+  version = "1.1.8";
   src = fetchurl {
-    url = "https://dldir1.qq.com/music/clntupate/linux/qqmusic_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-NPJHH7VwTzdNY87jFh28GaPjT7kRMweGI/XTOBAzM5E=";
+    url = "https://c.y.qq.com/cgi-bin/file_redirect.fcg?bid=dldir&file=ecosfile_plink%2Fmusic_clntupate%2Flinux%2Fother%2Fqqmusic_${finalAttrs.version}_amd64.deb&sign=1-d1ca4d5c5a8369b26af88e881ba3ac544066a899dcaea29778b35c9f648e6fee-68cb7c1c";
+    name = "qqmusic.deb";
+    hash = "sha256-QtGNaow8F0FOW228DDrIk7slQMHFwJzpDSQYQ8xZN4g=";
   };
 
   nativeBuildInputs = [
@@ -61,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     libdbusmenu
     libglvnd
     libpulseaudio
+    mesa
     nspr
     nss
     pango
@@ -119,9 +122,9 @@ stdenv.mkDerivation (finalAttrs: {
       categories = [ "AudioVideo" ];
       extraConfig = {
         "Name[zh_CN]" = "QQ音乐";
-        "Name[zh_TW]" = "QQ音乐";
+        "Name[zh_TW]" = "QQ音樂";
         "Comment[zh_CN]" = "腾讯QQ音乐";
-        "Comment[zh_TW]" = "腾讯QQ音乐";
+        "Comment[zh_TW]" = "騰訊QQ音樂";
       };
     })
   ];
@@ -133,5 +136,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "qqmusic";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Starting from 1.1.8, QQ Music's download link is a signed URL from <https://y.qq.com/download/download.html>. Fortunately the URL is static for now and works for all users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
