### PR TITLE
[25.05] shadps4: 0.10.0 -> 0.11.0, xbyak: init at 7.30

### DIFF
--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -28,24 +28,27 @@
   sdl3,
   sndio,
   stb,
+  toml11,
   vulkan-headers,
   vulkan-loader,
   vulkan-memory-allocator,
+  xbyak,
   xorg,
   xxHash,
   zlib-ng,
+  zydis,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadPS4";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-0wvxvKw2XHhnXiM5DiiiY+nWPoze0fvNCJeTsKzoCn0=";
+    hash = "sha256-ZHgwFWSoEaWILTafet5iQvaLwLtXy3HuCxjkQMt4PBA=";
     fetchSubmodules = true;
   };
 
@@ -79,11 +82,14 @@ stdenv.mkDerivation (finalAttrs: {
     sdl3
     sndio
     stb
+    toml11
     vulkan-headers
     vulkan-loader
     vulkan-memory-allocator
+    xbyak
     xxHash
     zlib-ng
+    zydis
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xb/xbyak/package.nix
+++ b/pkgs/by-name/xb/xbyak/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xbyak";
+  version = "7.28";
+
+  src = fetchFromGitHub {
+    owner = "herumi";
+    repo = "xbyak";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jBxpNeA2Ed13zpJ++ODsjKgSC14z/RTFX3px4SapeS0=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "JIT assembler for x86/x64 architectures supporting advanced instruction sets up to AVX10.2";
+    homepage = "https://github.com/herumi/xbyak";
+    changelog = "https://github.com/herumi/xbyak/blob/v${finalAttrs.version}/doc/changelog.md";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+})

--- a/pkgs/by-name/xb/xbyak/package.nix
+++ b/pkgs/by-name/xb/xbyak/package.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xbyak";
-  version = "7.28";
+  version = "7.29.2";
 
   src = fetchFromGitHub {
     owner = "herumi";
     repo = "xbyak";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jBxpNeA2Ed13zpJ++ODsjKgSC14z/RTFX3px4SapeS0=";
+    hash = "sha256-dKUb6zkMLW6VujTscD3aZdkoj5Q2Jlui/o3g8HOhZEc=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/xb/xbyak/package.nix
+++ b/pkgs/by-name/xb/xbyak/package.nix
@@ -6,13 +6,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xbyak";
-  version = "7.29.2";
+  version = "7.30";
 
   src = fetchFromGitHub {
     owner = "herumi";
     repo = "xbyak";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dKUb6zkMLW6VujTscD3aZdkoj5Q2Jlui/o3g8HOhZEc=";
+    hash = "sha256-vHm/xN3n2Xc2zPw2l3q4BXDqPluP9VlndlJIOmLBYGU=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Manual backport of #443965
Needs xbyak to be backported.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
(cherry picked from commit ce9f005)