### PR TITLE
vtk: 9.5.1 -> 9.5.2, set CMAKE_INSTALL_RPTH_USE_LINK_PATH true

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -7,7 +7,7 @@ let
 in
 {
   vtk_9_5 = mkVtk {
-    version = "9.5.1";
-    sourceSha256 = "sha256-FEQ2YcewldBbTjdvs/QGE/Fz40/J1GWCNOnsHWJKYY8=";
+    version = "9.5.2";
+    sourceSha256 = "sha256-zuZLmNJw/3MC2vHvE0WN/11awey0XUdyODX399ViyYk=";
   };
 }

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -108,7 +108,6 @@ let
       inherit mpi mpiSupport;
       cppSupport = !mpiSupport;
     };
-    openvdb = self.callPackage openvdb.override { };
     netcdf = self.callPackage netcdf.override { };
     catalyst = self.callPackage catalyst.override { };
     adios2 = self.callPackage adios2.override { };
@@ -156,7 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
     openturns
     libarchive
     libGL
-    vtkPackages.openvdb
+    openvdb
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libXfixes

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -282,7 +282,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Remove thirdparty find module that have been provided in nixpkgs.
     ''
       rm -rf $out/lib/cmake/vtk/patches
-      rm $out/lib/cmake/vtk/Find{EXPAT,Freetype,utf8cpp,LibXml2,FontConfig}.cmake
+      rm $out/lib/cmake/vtk/Find{EXPAT,Freetype,utf8cpp,LibXml2,FontConfig,TBB}.cmake
     ''
     # libvtkglad.so will find and load libGL.so at runtime.
     + lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -224,11 +224,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env = {
-    CMAKE_PREFIX_PATH = "${lib.getDev openvdb}/lib/cmake/OpenVDB";
     NIX_LDFLAGS = "-L${lib.getLib libmysqlclient}/lib/mariadb";
   };
 
   cmakeFlags = [
+    # Required for locating the findOpenVDB.cmake module
+    # TODO: Add a setup hook in openvdb to append CMAKE_MODULE_PATH to cmakeFlagsArray
+    (lib.cmakeFeature "CMAKE_MODULE_PATH" "${lib.getDev openvdb}/lib/cmake/OpenVDB")
     (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -44,8 +44,6 @@
   cgns,
   adios2,
   libLAS,
-  libgeotiff,
-  laszip_2,
   gdal,
   pdal,
   alembic,
@@ -139,8 +137,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libLAS
-    libgeotiff
-    laszip_2
     gdal
     pdal
     alembic
@@ -223,11 +219,10 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  env = {
-    NIX_LDFLAGS = "-L${lib.getLib libmysqlclient}/lib/mariadb";
-  };
-
   cmakeFlags = [
+    # During installPhase, keep rpath that came from target_link_libraries() of imported targets.
+    # Typically libgeotiff,liblaszip propagated from liblas and libmariadb found by pkg-config.
+    (lib.cmakeBool "CMAKE_INSTALL_RPATH_USE_LINK_PATH" true)
     # Required for locating the findOpenVDB.cmake module
     # TODO: Add a setup hook in openvdb to append CMAKE_MODULE_PATH to cmakeFlagsArray
     (lib.cmakeFeature "CMAKE_MODULE_PATH" "${lib.getDev openvdb}/lib/cmake/OpenVDB")


### PR DESCRIPTION
# upgrade: vtk: 9.5.1 -> 9.5.2
Diff: https://gitlab.kitware.com/vtk/vtk/-/compare/v9.5.1...v9.5.2
Changelog: https://docs.vtk.org/en/latest/release_details/9.5.html#id14

#  cleanup
remove openvdb from vtkPackages, remove findTBB.cmake in installed vtk packages.

# fixup
with -DCMAKE_INSTALL_RPTH_USE_LINK_PATH=ON, we can drop the hacky direct dependency on libgeotiff/liblaszip_2 and extra NIX_LDFLAGS for adding these stipped rpath during cmake installPhase.

The correctness can be valid by building python3Packages.vtk. It has a pythonImportHook that tries to load all its IO module libraries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
