### PR TITLE
[OBSOLETE] docutils: fix source not fetchable from the UK

### DIFF
--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromRepoOrCz,
+  fetchPypi,
   buildPythonPackage,
   flit-core,
   pillow,
@@ -19,10 +19,10 @@ let
 
     disabled = pythonOlder "3.7";
 
-    src = fetchFromRepoOrCz {
-      repo = "docutils";
-      rev = "docutils-${version}";
-      hash = "sha256-Q+9yW+BYUEvPYV504368JsAoKKoaTZTeKh4tVeiNv5Y=";
+    src = fetchPypi {
+      inherit version pname;
+      format = "setuptools";
+      hash = "sha256-OmsYcy7fGC2qPNEndbuzOM9WkUaPke7rEJ3v9uv6mG8=";
     };
 
     build-system = [ flit-core ];

--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -37,6 +37,10 @@ let
       ${python.interpreter} test/alltests.py
     '';
 
+    patches = [
+      ./test_html5_polyglot_parts.patch # fix false positive failure
+    ];
+
     # Create symlinks lacking a ".py" suffix, many programs depend on these names
     postFixup = ''
       for f in $out/bin/*.py; do

--- a/pkgs/development/python-modules/docutils/test_html5_polyglot_parts.patch
+++ b/pkgs/development/python-modules/docutils/test_html5_polyglot_parts.patch
@@ -1,0 +1,13 @@
+--- a/test/test_writers/test_html5_polyglot_parts.py
++++ b/test/test_writers/test_html5_polyglot_parts.py
+@@ -43,10 +43,6 @@
+     REQUIRES_PIL = ''
+     ONLY_LOCAL = 'Can only read local images.'
+     DUMMY_PNG_NOT_FOUND = "[Errno 2] No such file or directory: 'dummy.png'"
+-    # Pillow reports the absolute path since version 10.3.0 (cf. [bugs: 485])
+-    if (tuple(int(i) for i in PIL.__version__.split('.')) >= (10, 3)):
+-        DUMMY_PNG_NOT_FOUND = ("[Errno 2] No such file or directory: '%s'"
+-                               % Path('dummy.png').resolve())
+     SCALING_OUTPUT = 'style="width: 32.0px; height: 32.0px;" '
+     NO_PIL_SYSTEM_MESSAGE = ''
+ else:


### PR DESCRIPTION
fetchFromRepoOrCz silently fails when building packages from the UK.

Attempting to download anything from the mirror whilst your IP is in the UK will redirect the request to

https://repo.or.cz/uk-blocked.html

which is a notice saying that access from the UK is forbidded due to the Online Safety Act.

This commit updates the source of docutils so it can be downloaded from PyPI instead.

See 444342


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
