### PR TITLE
uncomment: init at 2.11.0

### DIFF
--- a/pkgs/by-name/un/uncomment/package.nix
+++ b/pkgs/by-name/un/uncomment/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "uncomment";
+  version = "2.11.0";
+
+  src = fetchFromGitHub {
+    owner = "Goldziher";
+    repo = "uncomment";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HtMH5h/1eZ6dkpjXFswyT52JlQu3cw+gRuv2u5nJvk4=";
+  };
+
+  cargoHash = "sha256-eCwIHrLcWWdRFCndP4aRfgeEF0sC62uhdJCTg+KgUt8=";
+
+  # Do not build `benchmark` and `profile` binaries
+  cargoBuildFlags = [
+    "--bin"
+    "uncomment"
+  ];
+
+  checkFlags = [
+    # Tries to create an access a temp dir
+    "--skip=grammar::loader::tests::test_git_loader_creation"
+    "--skip=grammar::loader::tests::test_is_compiled_cached"
+    "--skip=grammar::loader::tests::test_is_grammar_cached"
+    "--skip=grammar::loader::tests::test_platform_library_extension"
+    "--skip=test_gitignore_with_no_gitignore_flag"
+    "--skip=test_gitignore_from_subdirectory"
+    # Tries to run itself as `./target/debug/uncomment`
+    "--skip=test_comprehensive_config_repositories"
+    "--skip=test_init_command_end_to_end"
+    "--skip=test_init_error_scenarios"
+    "--skip=test_init_help"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI to remove comments from code using tree-sitter grammars";
+    homepage = "https://github.com/Goldziher/uncomment";
+    changelog = "https://github.com/Goldziher/uncomment/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "uncomment";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init package [uncomment](https://github.com/Goldziher/uncomment) at `2.11.0`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
