### PR TITLE
python3Packages.bloodhound-ce: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15881,6 +15881,12 @@
     githubId = 31626748;
     name = "Martin Ramm";
   };
+  marv963 = {
+    email = "dev+nix@ludwig.homes";
+    github = "Marv963";
+    githubId = 83866612;
+    name = "Marvin Ludwig";
+  };
   marzipankaiser = {
     email = "nixos@gaisseml.de";
     github = "marzipankaiser";

--- a/pkgs/by-name/bl/bloodhound-ce-python/package.nix
+++ b/pkgs/by-name/bl/bloodhound-ce-python/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchPypi,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "bloodhound-ce-py";
+  version = "1.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "bloodhound_ce";
+    hash = "sha256-9mPWGB4qGrjenVeUgBFmLipHiA2MrKm4U2mn767ROnA=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    dnspython
+    impacket
+    ldap3
+    pycryptodome
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "bloodhound" ];
+
+  meta = {
+    description = "Python based ingestor for BloodHound (Community Edition), based on Impacket";
+    mainProgram = "bloodhound-ce-python";
+    homepage = "https://github.com/dirkjanm/BloodHound.py/tree/bloodhound-ce";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marv963 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**BloodHound CE** is a separate PyPI package from the legacy`bloodhound` ingestor, and is the recommended client for use with BloodHound Community Edition. It installs a separate binary `bloodhound-ce-python`, avoiding conflicts with the legacy `bloodhound-python`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
