### PR TITLE
eigen_5: init at 5.0.1

### DIFF
--- a/pkgs/by-name/ei/eigen_5/package.nix
+++ b/pkgs/by-name/ei/eigen_5/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+
+  stdenv,
+  fetchFromGitLab,
+  fetchpatch,
+  nix-update-script,
+
+  # nativeBuildInputs
+  doxygen,
+  cmake,
+  graphviz,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eigen";
+  version = "5.0.1";
+
+  src = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    tag = finalAttrs.version;
+    hash = "sha256-8TW1MUXt2gWJmu5YbUWhdvzNBiJ/KIVwIRf2XuVZeqo=";
+  };
+
+  patches = [
+    # merged upstream
+    (fetchpatch {
+      name = "fix-doc.patch";
+      url = "https://gitlab.com/libeigen/eigen/-/commit/976f15ebca3f486902c3da4c98b8f92c3c4ed7a4.diff";
+      hash = "sha256-/FSXhY+/ZRKfE/aIDAgP+DoNCtH8ikUItYGmfo+QH0E=";
+    })
+  ];
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    doxygen
+    cmake
+    graphviz
+  ];
+
+  postInstall = ''
+    cmake --build . -t install-doc
+  '';
+
+  # tests are super long and mostly flaky
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://eigen.tuxfamily.org";
+    description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
+    changelog = "https://gitlab.com/libeigen/eigen/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [
+      nim65s
+      pbsds
+      raskin
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Eigen v5.0.0 is out.
I guess simply bumping is not an option.

Many dependent packages I tried fail to compile with it, but I managed to get at least one success out of the box (coal).

I copy-pasted most of the package from eigen (except it looks like the patch is no longer needed), including maintainers. I'm not sure if this is the right thing to do. @svanderburg @7c6f434c @pbsds don't hesitate to tell me if you don't want to be a part of this. Maybe I should also add myself.

I also tried to run tests and install doc, but no luck so far, I'll probably open a couple of issues upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
