### PR TITLE
dmraid: fix build with gcc15

### DIFF
--- a/pkgs/os-specific/linux/dmraid/default.nix
+++ b/pkgs/os-specific/linux/dmraid/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   patches = [
     ./hardening-format.patch
     ./fix-dmevent_tool.patch
+
+    # Fix build with gcc15, based on
+    # https://gitlab.alpinelinux.org/alpine/aports/-/raw/dc5b3135517ede55f5e3530e538ca75048d26565/main/dmraid/008-gcc15.patch
+    ./dmraid-fix-build-with-gcc15.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {

--- a/pkgs/os-specific/linux/dmraid/dmraid-fix-build-with-gcc15.patch
+++ b/pkgs/os-specific/linux/dmraid/dmraid-fix-build-with-gcc15.patch
@@ -1,0 +1,33 @@
+diff --git a/1.0.0.rc16/lib/activate/activate.c b/1.0.0.rc16/lib/activate/activate.c
+index 1d71ea8c0a..0a4ec6afa1 100644
+--- a/1.0.0.rc16/lib/activate/activate.c
++++ b/1.0.0.rc16/lib/activate/activate.c
+@@ -866,7 +866,7 @@
+
+ #define LIB_NAME_LENGTH 255
+ static int
+-do_device(struct lib_context *lc, struct raid_set *rs, int (*f) ())
++do_device(struct lib_context *lc, struct raid_set *rs, int (*f)(char *, char *))
+ {
+        int ret = 0;
+        char lib_name[LIB_NAME_LENGTH];
+diff --git a/1.0.0.rc16/lib/misc/file.c b/1.0.0.rc16/lib/misc/file.c
+index fe74d5c9c2..c060b6e712 100644
+--- a/1.0.0.rc16/lib/misc/file.c
++++ b/1.0.0.rc16/lib/misc/file.c
+@@ -59,12 +59,12 @@
+ 	int fd, ret = 0;
+ 	loff_t o;
+ 	struct {
+-		ssize_t(*func) ();
++		ssize_t(*func)(int, void *, size_t);
+ 		const char *what;
+ 	} rw_spec[] = {
+ 		{
+ 		read, "read"}, {
+-	write, "writ"},}, *rw = rw_spec + ((flags & O_WRONLY) ? 1 : 0);
++	(ssize_t(*)(int, void *, size_t))write, "writ"},}, *rw = rw_spec + ((flags & O_WRONLY) ? 1 : 0);
+ 
+ 	if ((fd = open(path, flags, lc->mode)) == -1)
+ 		LOG_ERR(lc, 0, "opening \"%s\"", path);
+


### PR DESCRIPTION
- add rebased patch from alpine:
https://gitlab.alpinelinux.org/alpine/aports/-/raw/dc5b3135517ede55f5e3530e538ca75048d26565/main/dmraid/008-gcc15.patch
(does not apply with `fetchpatch` even with `stripLen` and `extraPrefix`)

Fixes build failure with gcc15:
```
activate/activate.c:893:34: error: passing argument 3 of 'do_device'
from incompatible pointer type [-Wincompatible-pointer-types]
  893 |         return do_device(lc, rs, dm_register_for_event);
      |                                  ^~~~~~~~~~~~~~~~~~~~~
      |                                  |
      |                                  int (*)(char *, char *)
activate/activate.c:869:62: note: expected 'int (*)(void)' but argument
is of type 'int (*)(char *, char *)'
  869 | do_device(struct lib_context *lc, struct raid_set *rs, int (*f) ())
      |                                                        ~~~~~~^~~~~
activate/activate.c:850:1: note: 'dm_register_for_event' declared here
  850 | dm_register_for_event(char *dev_name, char *lib_name)
      | ^~~~~~~~~~~~~~~~~~~~~
misc/file.c:66:17: error: initialization of 'ssize_t (*)(void)'
{aka 'long int (*)(void)'} from incompatible pointer type
'ssize_t (*)(int,  void *, size_t)' {aka 'long int (*)(int,  void *, long unsigned int)'} [-Wincompatible-pointer-types]
   66 |                 read, "read"}, {
      |                 ^~~~
misc/file.c:67:9: error: initialization of 'ssize_t (*)(void)' {aka 'long int (*)(void)'}
from incompatible pointer type 'ssize_t (*)(int,  const void *, size_t)'
{aka 'long int (*)(int,  const void *, long unsigned int)'} [-Wincompatible-pointer-types]
   67 |         write, "writ"},}, *rw = rw_spec + ((flags & O_WRONLY) ? 1 : 0);
      |         ^~~~~
misc/file.c:67:9: note: (near initialization for 'rw_spec[1].func')
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; dmraid.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Upstream have not had updates in decades.
Other distros started to remove this package (newer versions of fedora, debian, ubuntu), recommending to switch to `mdadm`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
