### PR TITLE
[25.05] smtp4dev: 3.9.0 -> 3.10.2

### DIFF
--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -11,13 +11,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "smtp4dev";
-  version = "3.9.0";
+  version = "3.10.1";
 
   src = fetchFromGitHub {
     owner = "rnwood";
     repo = "smtp4dev";
     tag = finalAttrs.version;
-    hash = "sha256-LGhx+i4PIExC6GbBwDOLi/g1TxNoMFMZomdnbtc/wNc=";
+    hash = "sha256-bhS2/YO7jejw6+qx6EdLH98SnxeqMWajSz8i7ocNVX8=";
   };
 
   patches = [ ./smtp4dev-npm-packages.patch ];
@@ -33,7 +33,7 @@ buildDotnetModule (finalAttrs: {
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src patches;
-    hash = "sha256-Xjx3V5FH72D+CXBRZgmlkbp5evnp6F4zaHMWQB5o61w=";
+    hash = "sha256-c0/6kbMv5CmLxS0S/p3+oZvZsuHP9gt4X43uvGQFjTw=";
     postPatch = "cd ${finalAttrs.npmRoot}";
   };
 
@@ -51,7 +51,7 @@ buildDotnetModule (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    $out/bin/smtp4dev --help | head -1 | grep -F "smtp4dev version ${finalAttrs.version}"
+    $out/bin/smtp4dev --help > /dev/null
 
     runHook postInstallCheck
   '';

--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -11,13 +11,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "smtp4dev";
-  version = "3.10.1";
+  version = "3.10.2";
 
   src = fetchFromGitHub {
     owner = "rnwood";
     repo = "smtp4dev";
     tag = finalAttrs.version;
-    hash = "sha256-bhS2/YO7jejw6+qx6EdLH98SnxeqMWajSz8i7ocNVX8=";
+    hash = "sha256-0j5r5YO1wHg3N/OX81UE2YCqhqIaQuSGZa2uh2y+zqs=";
   };
 
   patches = [ ./smtp4dev-npm-packages.patch ];


### PR DESCRIPTION
Backport of #443246 and #445710 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
