### PR TITLE
epson-tm-t88vi: init at 3.0.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1343,6 +1343,12 @@
     githubId = 2939703;
     name = "James Hollowell";
   };
+  allsimon = {
+    github = "Allsimon";
+    name = "Allegraud Simon";
+    email = "simon.allegraud@gmail.com";
+    githubId = 8037169;
+  };
   allusive = {
     email = "jasper@allusive.dev";
     name = "Allusive";

--- a/pkgs/by-name/ep/epson-tm-t88vi/package.nix
+++ b/pkgs/by-name/ep/epson-tm-t88vi/package.nix
@@ -1,0 +1,52 @@
+{
+  fetchzip,
+  lib,
+  stdenv,
+  cmake,
+  cups,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "epson-tm-t88vi";
+  version = "3.0.0.0";
+
+  src = fetchzip {
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/15/35/42/b1a708bb8b21d7a68ae7394287db440974b68a0e/tmx-cups-src-ImpactReceipt-${finalAttrs.version}_pck_e.zip";
+    hash = "sha256-c6VpnNXYebkDkK9kcTZ/ILE8pD/qSWKCHYqkHV+WIkc=";
+  };
+
+  buildInputs = [ cups ];
+  nativeBuildInputs = [ cmake ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar xf $src/tmx-cups-src-ThermalReceipt-${finalAttrs.version}.tar.gz --strip-components=1
+
+    runHook postUnpack
+  '';
+
+  postPatch = ''
+    substituteInPlace ./ppd/*.ppd --replace-fail "rastertotmtr" "$out/lib/cups/filter/rastertotmtr"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Ds ./rastertotmtr $out/lib/cups/filter/rastertotmtr
+    install ../ppd/*.ppd -Dt $out/share/cups/model/EPSON
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "EPSON TM Series T88VI Series Printer Driver for Linux";
+    downloadPage = "https://epson.com/Support/Point-of-Sale/OmniLink-Printers/Epson-TM-T88VI-Series/s/SPT_C31CE94061?review-filter=Linux";
+    homepage = "https://www.epson.com/";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ allsimon ];
+  };
+})


### PR DESCRIPTION
This is a driver for Epson thermal printer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
