### PR TITLE
m-cli: 0.3.0 -> 2.0.5

### DIFF
--- a/pkgs/by-name/m-/m-cli/package.nix
+++ b/pkgs/by-name/m-/m-cli/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "m-cli";
-  version = "0.3.0";
+  version = "2.0.5";
 
   src = fetchFromGitHub {
     owner = "rgcr";
     repo = "m-cli";
     rev = "v${version}";
-    sha256 = "sha256-KzlE1DdVMLnGmcOS1a2HK4pASofD1EHpdqbzVVIxeb4=";
+    sha256 = "sha256-41o7RoRlHwAmzSREDhQpq2Lchkz8QPxJRqN42ShUJb8=";
   };
 
   dontBuild = true;
@@ -24,16 +24,17 @@ stdenv.mkDerivation rec {
       gsub(/^\[ -L.*|^\s+\|\| pushd.*|^popd.*/, "");
       gsub(/MPATH=.*/, "MPATH='$MPATH'");
       gsub(/(update|uninstall)_mcli \&\&.*/, "echo NOOP \\&\\& exit 0");
+      gsub(/get_version \&\&.*/, "echo m-cli version: ${version} \\&\\& exit 0");
       print
     }' m
 
-    install -Dt "$MPATH/plugins" -m755 plugins/*
+    install -Dt "$out/bin/plugins" -m755 plugins/*
 
     install -Dm755 m $out/bin/m
 
-    install -Dt "$out/share/bash-completion/completions/" -m444 completion/bash/m
-    install -Dt "$out/share/fish/vendor_completions.d/" -m444 completion/fish/m.fish
-    install -Dt "$out/share/zsh/site-functions/" -m444 completion/zsh/_m
+    install -Dt "$out/share/bash-completion/completions/" -m444 completions/bash/m
+    install -Dt "$out/share/fish/vendor_completions.d/" -m444 completions/fish/m.fish
+    install -Dt "$out/share/zsh/site-functions/" -m444 completions/zsh/_m
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR updates [m-cli](https://github.com/rgcr/m-cli) to the latest version (2.0.5). Two things have changed with this upgrade:

- Plugins are now located in `/bin/plugins` instead of `/share/m/plugins`.
- A new version command has been added to get the currently installed version of m-cli. Normally this uses git commands to get the current tag, but since we can't do that here I used gawk to replace the code to get the tag with the version from the derivation (similarly to how the update and uninstall commands are removed).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
