### PR TITLE
nixos/steam: add missing ports for remotePlay.openFirewall

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -256,7 +256,16 @@ in
       })
 
       (lib.mkIf cfg.remotePlay.openFirewall {
-        allowedTCPPorts = [ 27036 ];
+        # https://help.steampowered.com/en/faqs/view/3E3D-BE6B-787D-A5D2
+        # https://help.steampowered.com/en/faqs/view/2EA8-4D75-DA21-31EB
+        allowedTCPPorts = [
+          27036
+          27037
+        ];
+        allowedUDPPorts = [
+          10400
+          10401
+        ];
         allowedUDPPortRanges = [
           {
             from = 27031;


### PR DESCRIPTION
With Steam Link adding experimental wireless VR support for Linux hosts (see [under "Frequently Asked Questions" here](https://help.steampowered.com/en/faqs/view/0E2C-406B-9135-38A4) and [this longstanding issue](https://github.com/ValveSoftware/SteamVR-for-Linux/issues/655)), I have noticed that the SteamVR specific network ports were missing from the `remotePlay.openFirewall` option.

This commit adds these ports. I have manually validated that opening UDP ports 10400 and 10401 was the missing part - after doing that, I was able to stream to my VR headset from a NixOS host. I addressed one more discrepancy in adding the TCP port 27037. This port is mentioned in only one of the two Steam articles that I've linked in the source code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
