### PR TITLE
kdePackages.qt6ct: 0.10 -> 0.11

### DIFF
--- a/pkgs/tools/misc/qt6ct/default.nix
+++ b/pkgs/tools/misc/qt6ct/default.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qt6ct";
-  version = "0.10";
+  version = "0.11";
 
   src = fetchFromGitLab {
     domain = "www.opencode.net";
     owner = "trialuser";
     repo = "qt6ct";
     tag = finalAttrs.version;
-    hash = "sha256-o2k/b4AGiblS1CkNInqNrlpM1Y7pydIJzEVgVd3ao50=";
+    hash = "sha256-aQmqLpM0vogMsYaDS9OeKVI3N53uY4NBC4FF10hK8Uw=";
   };
 
   nativeBuildInputs = [
@@ -34,10 +34,9 @@ stdenv.mkDerivation (finalAttrs: {
     qtwayland
   ];
 
-  postPatch = ''
-    substituteInPlace src/qt6ct-qtplugin/CMakeLists.txt src/qt6ct-style/CMakeLists.txt \
-      --replace-fail "\''${PLUGINDIR}" "$out/${qtbase.qtPluginPrefix}"
-  '';
+  cmakeFlags = [
+    (lib.cmakeFeature "PLUGINDIR" "$out/${qtbase.qtPluginPrefix}")
+  ];
 
   meta = {
     description = "Qt6 Configuration Tool";


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/446803

Upstream now supports setting PLUGINDIR as a CMake option, removing the
need to patch CMakeLists.txt for our package.

https://www.opencode.net/trialuser/qt6ct/-/releases/0.11

https://www.opencode.net/trialuser/qt6ct/-/compare/0.10...0.11


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
