### PR TITLE
tt-metal: fix `sfpi` hash

### DIFF
--- a/pkgs/by-name/tt/tt-metal/sfpi.nix
+++ b/pkgs/by-name/tt/tt-metal/sfpi.nix
@@ -33,11 +33,11 @@ runCommand "sfpi-${version}"
       {
         aarch64-linux = fetchurl {
           url = "https://github.com/tenstorrent/sfpi/releases/download/v${version}/sfpi_${version}_aarch64.txz";
-          hash = "sha256-3DQrQewrKnbWNCBw3r7lkwylpKZnouLRG/QXcB6OhDU=";
+          hash = "sha256-MzI159hiitk1iyeGfQaDOQZhqGjfafpCMz6zmM3HrYs=";
         };
         x86_64-linux = fetchurl {
           url = "https://github.com/tenstorrent/sfpi/releases/download/v${version}/sfpi_${version}_x86_64.txz";
-          hash = "sha256-eRGNHeKM2T4ZylN4tTghR0vN9F3BY1tfam2puvwVmuM=";
+          hash = "sha256-rQfFveg1ht+jLfk3ZOJadX26+ODE3WW5E0/18eIl7RQ=";
         };
       }
       ."${stdenv.hostPlatform.system}" or (throw "SFPI does not support ${stdenv.hostPlatform.system}");


### PR DESCRIPTION
Without the change the build fails to build as:

    $ nix build --no-link -f. tt-metal
    error: hash mismatch in fixed-output derivation '/nix/store/kh2i38k4yn6a8pqi0d04kngylxxld0di-sfpi_7.1.0_x86_64.txz.drv':
         specified: sha256-eRGNHeKM2T4ZylN4tTghR0vN9F3BY1tfam2puvwVmuM=
            got:    sha256-rQfFveg1ht+jLfk3ZOJadX26+ODE3WW5E0/18eIl7RQ=
    error: Cannot build '/nix/store/hpd2cacvknpwy52znq6bg0cnnpp2izsb-sfpi-7.1.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/a3hivpzb9s0w8k8ff4rgv6sfqk1yyry6-sfpi-7.1.0
    error: Cannot build '/nix/store/34iy9gahhrdc7j1vphlr8jd5aw4fs1xr-tt-metal-0.62.2.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/r3sp4vc5c45i6hfc1kbwivi4lyxw48hm-tt-metal-0.62.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
