### PR TITLE
maintainers/README: mention GitHub team creation

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -155,7 +155,8 @@ When reviewing changes to a team, read the team's scope and the context around t
 In any case, request reviews from the existing team members.
 If the team lists no specific membership policy, feel free to merge changes to the team after giving the existing members a few days to respond.
 
-*Important:* If a team says it is a closed group, do not merge additions to the team without an approval by at least one existing member.
+> [!IMPORTANT]
+> If a team says it is a closed group, do not merge additions to the team without an approval by at least one existing member.
 
 A corresponding GitHub team can be created by any org member.
 When creating the team it should be created with the `nixpkgs-maintainers` team as parent.

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -157,6 +157,12 @@ If the team lists no specific membership policy, feel free to merge changes to t
 
 *Important:* If a team says it is a closed group, do not merge additions to the team without an approval by at least one existing member.
 
+A corresponding GitHub team can be created by any org member.
+When creating the team it should be created with the `nixpkgs-maintainers` team as parent.
+Once approved, the team will have the right privileges to be pinged and requested for review in Nixpkgs.
+
+> [!TIP]
+> The team name should be as short as possible; because it is nested under the maintainers group, no -maintainers suffix is needed.
 
 # Maintainer scripts
 


### PR DESCRIPTION
We recently introduced a [mostly-self-service onboarding workflow for new GitHub teams](https://github.com/NixOS/org/issues/178), which is as simple as creating the team with the right parent team.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
