### PR TITLE
bcachefs-kernel-module: Nest within bcachefs-tools

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -178,8 +178,20 @@ let
 in
 
 {
-  options.boot.bcachefs.package = lib.mkPackageOption pkgs "bcachefs-tools" { } // {
-    description = "Configured Bcachefs userspace package.";
+  options.boot.bcachefs = {
+    package = lib.mkPackageOption pkgs "bcachefs-tools" {
+      extraDescription = ''
+        This package should also provide a passthru 'kernelModule'
+        attribute to build the out-of-tree kernel module.
+      '';
+    };
+
+    modulePackage = lib.mkOption {
+      type = lib.types.package;
+      # See NOTE in linux-kernels.nix
+      default = config.boot.kernelPackages.callPackage cfg.package.kernelModule { };
+      internal = true;
+    };
   };
 
   options.services.bcachefs.autoScrub = {
@@ -245,8 +257,8 @@ in
         system.fsPackages = [ cfg.package ];
         services.udev.packages = [ cfg.package ];
 
-        boot.extraModulePackages = lib.optionals (!config.boot.kernelPackages.bcachefs.meta.broken) [
-          config.boot.kernelPackages.bcachefs
+        boot.extraModulePackages = lib.optionals (!cfg.modulePackage.meta.broken) [
+          cfg.modulePackage
         ];
 
         systemd = {

--- a/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
@@ -1,7 +1,7 @@
+bcachefs-tools:
 {
   lib,
   stdenv,
-  bcachefs-tools,
   kernelModuleMakeFlags,
   kernel,
 }:

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -118,6 +118,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    # See NOTE in linux-kernels.nix
+    kernelModule = import ./kernel-module.nix finalAttrs.finalPackage;
+
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -375,7 +375,11 @@ in
 
         bbswitch = callPackage ../os-specific/linux/bbswitch { };
 
-        bcachefs = callPackage ../os-specific/linux/bcachefs-kernel-module { };
+        # NOTE: The bcachefs module is called this way to facilitate
+        # easy overriding, as it is expected many users will want to
+        # pull from the upstream git repo, which may include
+        # unreleased changes to the module build process.
+        bcachefs = callPackage pkgs.bcachefs-tools.kernelModule { };
 
         ch9344 = callPackage ../os-specific/linux/ch9344 { };
 


### PR DESCRIPTION
When you set the bcachefs userspace tools with:

```nix
boot.bcachefs.package = /* custom pacakge */;
```

This now also changes the kernel package. The NixOS module now calls on the nested `cfg.package.kernelModule` expression with `kernelPackages.callPackage`. This will enable overriding both userspace and kernel space from e.g. upstream git.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
