### PR TITLE
python-matter-server: bundle dashboard

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -364,6 +364,8 @@
 
 - `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.
 
+- `services.matter-server` now hosts a debug dashboard on the configured port. Open the port on the firewall with `services.matter-server.openFirewall`.
+
 - The new option [networking.ipips](#opt-networking.ipips) has been added to create IP within IP kind of tunnels (including 4in6, ip6ip6 and ipip).
   With the existing [networking.sits](#opt-networking.sits) option (6in4), it is now possible to create all combinations of IPv4 and IPv6 encapsulation.
 

--- a/nixos/modules/services/home-automation/matter-server.nix
+++ b/nixos/modules/services/home-automation/matter-server.nix
@@ -25,6 +25,12 @@ in
       description = "Port to expose the matter-server service on.";
     };
 
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the port in the firewall.";
+    };
+
     logLevel = lib.mkOption {
       type = lib.types.enum [
         "critical"
@@ -48,6 +54,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
     systemd.services.matter-server = {
       after = [ "network-online.target" ];
       before = [ "home-assistant.service" ];

--- a/nixos/tests/matter-server.nix
+++ b/nixos/tests/matter-server.nix
@@ -16,6 +16,7 @@ in
         services.matter-server = {
           enable = true;
           port = 1234;
+          openFirewall = true;
         };
       };
   };
@@ -42,6 +43,9 @@ in
 
         with subtest("Check storage directory is created"):
             machine.succeed("ls /var/lib/matter-server/chip.json")
+
+        with subtest("Check dashboard loads"):
+            machine.succeed("curl -f 127.0.0.1:1234")
 
         with subtest("Check systemd hardening"):
             _, output = machine.execute("systemd-analyze security matter-server.service | grep -v '✓'")

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -5,6 +5,8 @@
   pythonOlder,
   stdenvNoCC,
   replaceVars,
+  buildNpmPackage,
+  python,
 
   # build
   setuptools,
@@ -24,14 +26,25 @@
 
   # tests
   aioresponses,
-  python,
   pytest,
   pytest-aiohttp,
   pytest-cov-stub,
   pytestCheckHook,
+
+  # build options
+  withDashboard ? true,
 }:
 
 let
+  version = "8.1.1";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "python-matter-server";
+    tag = version;
+    hash = "sha256-vTJGe6OGFM+q9+iovsQMPwkrHNg2l4pw9BFEtSA/vmA=";
+  };
+
   paaCerts = stdenvNoCC.mkDerivation rec {
     pname = "matter-server-paa-certificates";
     version = "1.4.0.0";
@@ -52,21 +65,62 @@ let
       runHook postInstall
     '';
   };
-in
 
+  # Maintainer note: building the dashboard requires a python environment with a
+  # built version of python-matter-server. To support bundling the dashboard
+  # with the python-matter-server, the build is parameterized to build without
+  # a dependency on the dashboard, breaking a cyclical dependency. First,
+  # python-matter-server is built without the dashboard, then the dashboard is
+  # built, then python-matter-server is built again with the dashboard.
+  matterServerDashboard =
+    let
+      pythonWithChip = python.withPackages (ps: [
+        ps.home-assistant-chip-clusters
+        (ps.python-matter-server.override { withDashboard = false; })
+      ]);
+    in
+    buildNpmPackage {
+      pname = "python-matter-server-dashboard";
+      inherit src version;
+
+      npmDepsHash = "sha256-IgI1H3VlTq66duplVQqL67SpgxPF2MOowDn+ICMXCik=";
+
+      prePatch = ''
+        ${pythonWithChip.interpreter} scripts/generate_descriptions.py
+
+        # cd before the patch phase sets up the npm install hook to find the
+        # package.json. The script would need to be patched in order to be used
+        # with sourceRoot.
+        cd "dashboard"
+      '';
+
+      # This package does not contain a normal `npm build` step.
+      buildPhase = ''
+        env NODE_ENV=production npm exec -- tsc
+        env NODE_ENV=production npm exec -- rollup -c
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        install -Dt "$out/" public/*
+        # Copy recursive directory structure, which install does not do.
+        cp -r dist/web/* "$out/"
+
+        runHook postInstall
+      '';
+    };
+in
 buildPythonPackage rec {
-  pname = "python-matter-server";
-  version = "8.1.1";
+  pname = if withDashboard then "python-matter-server" else "python-matter-server-without-dashboard";
+  inherit
+    src
+    version
+    ;
+
   pyproject = true;
 
   disabled = pythonOlder "3.12";
-
-  src = fetchFromGitHub {
-    owner = "home-assistant-libs";
-    repo = "python-matter-server";
-    tag = version;
-    hash = "sha256-vTJGe6OGFM+q9+iovsQMPwkrHNg2l4pw9BFEtSA/vmA=";
-  };
 
   patches = [
     (replaceVars ./link-paa-root-certs.patch {
@@ -77,6 +131,10 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail 'version = "0.0.0"' 'version = "${version}"'
+  ''
+  + lib.optionalString withDashboard ''
+    substituteInPlace "matter_server/server/server.py" \
+      --replace-fail 'Path(__file__).parent.joinpath("../dashboard/")' 'Path("${matterServerDashboard}")'
   '';
 
   build-system = [


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/446702.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
