### PR TITLE
discord: refactor; add client mod tests

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -6,6 +6,7 @@
   stdenv,
   binaryName,
   desktopName,
+  self,
   lib,
   undmg,
   makeWrapper,
@@ -116,5 +117,20 @@ stdenv.mkDerivation {
         lib.optionalString (!stdenv.buildPlatform.isDarwin) "pkgsCross.aarch64-darwin."
       }${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix --version-key=${branch}
     '';
+
+    tests = {
+      withVencord = self.override {
+        withVencord = true;
+      };
+      withEquicord = self.override {
+        withEquicord = true;
+      };
+      withMoonlight = self.override {
+        withMoonlight = true;
+      };
+      withOpenASAR = self.override {
+        withOpenASAR = true;
+      };
+    };
   };
 }

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -3,6 +3,10 @@
   fetchurl,
   lib,
   stdenv,
+  discord,
+  discord-ptb,
+  discord-canary,
+  discord-development,
 }:
 let
   variants = rec {
@@ -18,6 +22,7 @@ let
         branch = "stable";
         binaryName = desktopName;
         desktopName = "Discord";
+        self = discord;
       };
       discord-ptb = rec {
         version = "0.0.161";
@@ -30,6 +35,7 @@ let
         branch = "ptb";
         binaryName = "DiscordPTB";
         desktopName = "Discord PTB";
+        self = discord-ptb;
       };
       discord-canary = rec {
         version = "0.0.761";
@@ -42,6 +48,7 @@ let
         branch = "canary";
         binaryName = "DiscordCanary";
         desktopName = "Discord Canary";
+        self = discord-canary;
       };
       discord-development = rec {
         version = "0.0.89";
@@ -54,6 +61,7 @@ let
         branch = "development";
         binaryName = "DiscordDevelopment";
         desktopName = "Discord Development";
+        self = discord-development;
       };
     };
     x86_64-darwin = {
@@ -68,6 +76,7 @@ let
         branch = "stable";
         binaryName = desktopName;
         desktopName = "Discord";
+        self = discord;
       };
       discord-ptb = rec {
         version = "0.0.192";
@@ -80,6 +89,7 @@ let
         branch = "ptb";
         binaryName = desktopName;
         desktopName = "Discord PTB";
+        self = discord-ptb;
       };
       discord-canary = rec {
         version = "0.0.867";
@@ -92,6 +102,7 @@ let
         branch = "canary";
         binaryName = desktopName;
         desktopName = "Discord Canary";
+        self = discord-canary;
       };
       discord-development = rec {
         version = "0.0.100";
@@ -104,6 +115,7 @@ let
         branch = "development";
         binaryName = desktopName;
         desktopName = "Discord Development";
+        self = discord-development;
       };
     };
 

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,69 +1,115 @@
 {
-  branch ? "stable",
   callPackage,
   fetchurl,
   lib,
   stdenv,
 }:
 let
-  versions =
-    if stdenv.hostPlatform.isLinux then
-      {
-        stable = "0.0.111";
-        ptb = "0.0.161";
-        canary = "0.0.761";
-        development = "0.0.89";
-      }
-    else
-      {
-        stable = "0.0.362";
-        ptb = "0.0.192";
-        canary = "0.0.867";
-        development = "0.0.100";
-      };
-  version = versions.${branch};
-  srcs = rec {
+  variants = rec {
     x86_64-linux = {
-      stable = fetchurl {
-        url = "https://stable.dl2.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz";
-        hash = "sha256-o4U6i223Agtbt1N9v0GO/Ivx68OQcX/N3mHXUX2gruA=";
+      discord = rec {
+        version = "0.0.111";
+
+        src = fetchurl {
+          url = "https://stable.dl2.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz";
+          hash = "sha256-o4U6i223Agtbt1N9v0GO/Ivx68OQcX/N3mHXUX2gruA=";
+        };
+
+        branch = "stable";
+        binaryName = desktopName;
+        desktopName = "Discord";
       };
-      ptb = fetchurl {
-        url = "https://ptb.dl2.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz";
-        hash = "sha256-pDWOnj8tQK9runi/QzcvEFbNGCwAb/gISM9LrLoTzxM=";
+      discord-ptb = rec {
+        version = "0.0.161";
+
+        src = fetchurl {
+          url = "https://ptb.dl2.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz";
+          hash = "sha256-pDWOnj8tQK9runi/QzcvEFbNGCwAb/gISM9LrLoTzxM=";
+        };
+
+        branch = "ptb";
+        binaryName = "DiscordPTB";
+        desktopName = "Discord PTB";
       };
-      canary = fetchurl {
-        url = "https://canary.dl2.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
-        hash = "sha256-L3MIcrz/xj8zOb2QVXBrBCHGt4BdHhjwKpPZ4iClQYQ=";
+      discord-canary = rec {
+        version = "0.0.761";
+
+        src = fetchurl {
+          url = "https://canary.dl2.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
+          hash = "sha256-L3MIcrz/xj8zOb2QVXBrBCHGt4BdHhjwKpPZ4iClQYQ=";
+        };
+
+        branch = "canary";
+        binaryName = "DiscordCanary";
+        desktopName = "Discord Canary";
       };
-      development = fetchurl {
-        url = "https://development.dl2.discordapp.net/apps/linux/${version}/discord-development-${version}.tar.gz";
-        hash = "sha256-ZMsBR0LAISrM3dib8fehW/eZGkwSCinQF60jJG76O7M=";
+      discord-development = rec {
+        version = "0.0.89";
+
+        src = fetchurl {
+          url = "https://development.dl2.discordapp.net/apps/linux/${version}/discord-development-${version}.tar.gz";
+          hash = "sha256-ZMsBR0LAISrM3dib8fehW/eZGkwSCinQF60jJG76O7M=";
+        };
+
+        branch = "development";
+        binaryName = "DiscordDevelopment";
+        desktopName = "Discord Development";
       };
     };
     x86_64-darwin = {
-      stable = fetchurl {
-        url = "https://stable.dl2.discordapp.net/apps/osx/${version}/Discord.dmg";
-        hash = "sha256-DHe0WwJOB3mm1HbQwEOJ9NWqxzhOBQynhjJXYSNvA/k=";
+      discord = rec {
+        version = "0.0.362";
+
+        src = fetchurl {
+          url = "https://stable.dl2.discordapp.net/apps/osx/${version}/Discord.dmg";
+          hash = "sha256-DHe0WwJOB3mm1HbQwEOJ9NWqxzhOBQynhjJXYSNvA/k=";
+        };
+
+        branch = "stable";
+        binaryName = desktopName;
+        desktopName = "Discord";
       };
-      ptb = fetchurl {
-        url = "https://ptb.dl2.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
-        hash = "sha256-AZ9enKJf6WZLELFLKrzeyAR/Q/pzD8SGvCPcInS8vsk=";
+      discord-ptb = rec {
+        version = "0.0.192";
+
+        src = fetchurl {
+          url = "https://ptb.dl2.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
+          hash = "sha256-AZ9enKJf6WZLELFLKrzeyAR/Q/pzD8SGvCPcInS8vsk=";
+        };
+
+        branch = "ptb";
+        binaryName = desktopName;
+        desktopName = "Discord PTB";
       };
-      canary = fetchurl {
-        url = "https://canary.dl2.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";
-        hash = "sha256-67B2wZRZEOKutMPsrRlc96UZWShYLAgwOoF2/QzBgzE=";
+      discord-canary = rec {
+        version = "0.0.867";
+
+        src = fetchurl {
+          url = "https://canary.dl2.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";
+          hash = "sha256-67B2wZRZEOKutMPsrRlc96UZWShYLAgwOoF2/QzBgzE=";
+        };
+
+        branch = "canary";
+        binaryName = desktopName;
+        desktopName = "Discord Canary";
       };
-      development = fetchurl {
-        url = "https://development.dl2.discordapp.net/apps/osx/${version}/DiscordDevelopment.dmg";
-        hash = "sha256-PknNHr9txxp3+nO7FgHH7n04qx6p6Jzbs92/Hcfh13Y=";
+      discord-development = rec {
+        version = "0.0.100";
+
+        src = fetchurl {
+          url = "https://development.dl2.discordapp.net/apps/osx/${version}/DiscordDevelopment.dmg";
+          hash = "sha256-PknNHr9txxp3+nO7FgHH7n04qx6p6Jzbs92/Hcfh13Y=";
+        };
+
+        branch = "development";
+        binaryName = desktopName;
+        desktopName = "Discord Development";
       };
     };
+
     aarch64-darwin = x86_64-darwin;
+    default = x86_64-linux; # Used for unsupported platforms, so we can return *something* there.
   };
-  src =
-    srcs.${stdenv.hostPlatform.system}.${branch}
-      or (throw "${stdenv.hostPlatform.system} not supported on ${branch}");
 
   meta = {
     description = "All-in-one cross-platform voice and text chat for gamers";
@@ -86,43 +132,23 @@ let
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
   package = if stdenv.hostPlatform.isLinux then ./linux.nix else ./darwin.nix;
-
-  packages = (
-    builtins.mapAttrs
-      (
-        _: value:
-        callPackage package (
-          value
-          // {
-            inherit src version branch;
-            meta = meta // {
-              mainProgram = value.binaryName;
-            };
-          }
-        )
-      )
-      {
-        stable = {
-          pname = "discord";
-          binaryName = "Discord";
-          desktopName = "Discord";
-        };
-        ptb = rec {
-          pname = "discord-ptb";
-          binaryName = if stdenv.hostPlatform.isLinux then "DiscordPTB" else desktopName;
-          desktopName = "Discord PTB";
-        };
-        canary = rec {
-          pname = "discord-canary";
-          binaryName = if stdenv.hostPlatform.isLinux then "DiscordCanary" else desktopName;
-          desktopName = "Discord Canary";
-        };
-        development = rec {
-          pname = "discord-development";
-          binaryName = if stdenv.hostPlatform.isLinux then "DiscordDevelopment" else desktopName;
-          desktopName = "Discord Development";
-        };
-      }
-  );
 in
-packages.${branch}
+lib.genAttrs [ "discord" "discord-ptb" "discord-canary" "discord-development" ] (
+  pname:
+  let
+    args = (variants.${stdenv.hostPlatform.system} or variants.default).${pname};
+  in
+  callPackage package (
+    args
+    // {
+      inherit pname;
+
+      meta = meta // {
+        mainProgram = args.binaryName;
+      };
+    }
+  )
+)
+// {
+  supportedSystems = builtins.attrNames variants;
+}

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -161,6 +161,3 @@ lib.genAttrs [ "discord" "discord-ptb" "discord-canary" "discord-development" ] 
     }
   )
 )
-// {
-  supportedSystems = builtins.attrNames variants;
-}

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -5,6 +5,7 @@
   meta,
   binaryName,
   desktopName,
+  self,
   autoPatchelfHook,
   makeDesktopItem,
   lib,
@@ -260,5 +261,20 @@ stdenv.mkDerivation (finalAttrs: {
       version=$(echo $url | grep -oP '/\K(\d+\.){2}\d+')
       update-source-version ${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix --version-key=${branch}
     '';
+
+    tests = {
+      withVencord = self.override {
+        withVencord = true;
+      };
+      withEquicord = self.override {
+        withEquicord = true;
+      };
+      withMoonlight = self.override {
+        withMoonlight = true;
+      };
+      withOpenASAR = self.override {
+        withOpenASAR = true;
+      };
+    };
   };
 })

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -6,6 +6,10 @@
   pnpm_10,
   stdenv,
   nix-update-script,
+  discord,
+  discord-ptb,
+  discord-canary,
+  discord-development,
   buildWebExtension ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -57,11 +61,16 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "^(\\d{4}-\\d{2}-\\d{2})$"
-    ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^(\\d{4}-\\d{2}-\\d{2})$"
+      ];
+    };
+    tests = lib.genAttrs' [ discord discord-ptb discord-canary discord-development ] (
+      p: lib.nameValuePair p.pname p.tests.withEquicord
+    );
   };
 
   meta = {

--- a/pkgs/by-name/mo/moonlight/package.nix
+++ b/pkgs/by-name/mo/moonlight/package.nix
@@ -5,6 +5,10 @@
   nodejs_22,
   fetchFromGitHub,
   nix-update-script,
+  discord,
+  discord-ptb,
+  discord-canary,
+  discord-development,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "moonlight";
@@ -57,7 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = lib.genAttrs' [ discord discord-ptb discord-canary discord-development ] (
+      p: lib.nameValuePair p.pname p.tests.withMoonlight
+    );
+  };
 
   meta = with lib; {
     description = "Discord client modification, focused on enhancing user and developer experience";

--- a/pkgs/by-name/op/openasar/package.nix
+++ b/pkgs/by-name/op/openasar/package.nix
@@ -6,6 +6,10 @@
   nodejs,
   asar,
   unzip,
+  discord,
+  discord-ptb,
+  discord-canary,
+  discord-development,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,9 +52,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = false;
 
-  passthru.updateScript = unstableGitUpdater {
-    # Only has a "nightly" tag (untaged version 0.2 is latest) see https://github.com/GooseMod/OpenAsar/commit/8f79dcef9b1f7732421235a392f06e5bd7382659
-    hardcodeZeroVersion = true;
+  passthru = {
+    updateScript = unstableGitUpdater {
+      # Only has a "nightly" tag (untaged version 0.2 is latest) see https://github.com/GooseMod/OpenAsar/commit/8f79dcef9b1f7732421235a392f06e5bd7382659
+      hardcodeZeroVersion = true;
+    };
+    tests = lib.genAttrs' [ discord discord-ptb discord-canary discord-development ] (
+      p: lib.nameValuePair p.pname p.tests.withOpenASAR
+    );
   };
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15046,30 +15046,12 @@ with pkgs;
 
   httraqt = libsForQt5.callPackage ../tools/backup/httrack/qt.nix { };
 
-  # Overriding does not work when using callPackage on discord using import instead. (https://github.com/NixOS/nixpkgs/pull/179906)
-  discord = import ../applications/networking/instant-messengers/discord {
-    inherit lib stdenv;
-    inherit (pkgs) callPackage fetchurl;
-    branch = "stable";
-  };
-
-  discord-ptb = import ../applications/networking/instant-messengers/discord {
-    inherit lib stdenv;
-    inherit (pkgs) callPackage fetchurl;
-    branch = "ptb";
-  };
-
-  discord-canary = import ../applications/networking/instant-messengers/discord {
-    inherit lib stdenv;
-    inherit (pkgs) callPackage fetchurl;
-    branch = "canary";
-  };
-
-  discord-development = import ../applications/networking/instant-messengers/discord {
-    inherit lib stdenv;
-    inherit (pkgs) callPackage fetchurl;
-    branch = "development";
-  };
+  inherit (callPackage ../applications/networking/instant-messengers/discord { })
+    discord
+    discord-ptb
+    discord-canary
+    discord-development
+    ;
 
   discord-screenaudio =
     qt6Packages.callPackage ../applications/networking/instant-messengers/discord-screenaudio


### PR DESCRIPTION
This refactors the discord derivations to be `callPackage`-d so we can use the final package to test our client mod overrides.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
