### PR TITLE
nixos-init: handle kernels without module support

### DIFF
--- a/pkgs/by-name/ni/nixos-init/src/activate.rs
+++ b/pkgs/by-name/ni/nixos-init/src/activate.rs
@@ -42,16 +42,21 @@ fn setup_modprobe(modprobe_binary: impl AsRef<Path>) -> Result<()> {
     // a procfs in a chroot would.
     const MODPROBE_PATH: &str = "/proc/sys/kernel/modprobe";
 
-    fs::write(
-        MODPROBE_PATH,
-        modprobe_binary.as_ref().as_os_str().as_encoded_bytes(),
-    )
-    .with_context(|| {
-        format!(
-            "Failed to populate modprobe path with {}",
-            modprobe_binary.as_ref().display()
+    if Path::new(MODPROBE_PATH).exists() {
+        fs::write(
+            MODPROBE_PATH,
+            modprobe_binary.as_ref().as_os_str().as_encoded_bytes(),
         )
-    })?;
+        .with_context(|| {
+            format!(
+                "Failed to populate modprobe path with {}",
+                modprobe_binary.as_ref().display()
+            )
+        })?;
+    } else {
+        log::info!("{MODPROBE_PATH} doesn't exist. Not populating it...");
+    }
+
     Ok(())
 }
 
@@ -74,6 +79,8 @@ fn setup_firmware_search_path(firmware: impl AsRef<Path>) -> Result<()> {
                 firmware.as_ref().display()
             )
         })?;
+    } else {
+        log::info!("{FIRMWARE_SERCH_PATH} doesn't exist. Not populating it...");
     }
 
     Ok(())


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/445803

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
