### PR TITLE
libwebp: Apply patch to fix behaviour on big-endian

### DIFF
--- a/pkgs/by-name/li/libwebp/package.nix
+++ b/pkgs/by-name/li/libwebp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   threadingSupport ? true, # multi-threading
   openglSupport ? false,
@@ -43,6 +44,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-7i4fGBTsTjAkBzCjVqXqX4n22j6dLgF/0mz4ajNA45U=";
   };
+
+  patches = [
+    # Fixes endianness-related behaviour in build result when targeting big-endian via CMake
+    # https://groups.google.com/a/webmproject.org/g/webp-discuss/c/wvBsO8n8BKA/m/eKpxLuagAQAJ
+    (fetchpatch {
+      name = "0001-libwebp-Fix-endianness-with-CMake.patch";
+      url = "https://github.com/webmproject/libwebp/commit/0e5f4ee3deaba5c4381877764005d981f652791f.patch";
+      hash = "sha256-VNiLv1y3cjSDCNen9KxqbdrldI6EhshTSnsq8g9x8HA=";
+    })
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)


### PR DESCRIPTION
- ~~There are no tests in `libwebp` itself to catch this issue, the problem only showed itself once I got to building [`python3Packages.pillow`](https://github.com/python-pillow/Pillow/issues/8831) and ran its test suite. There *is* a separate project we could maybe add as a `passthru.tests` entry, but I haven't checked if that would've caught this.~~
  ~~https://chromium.googlesource.com/webm/libwebp-test-data~~
  Tried adding that project as a test, but it didn't end up catching this issue. I guess `python3Packages.pillow` is already in `passthru.tests` so that'll have to do…
- ~~I cannot report this to upstream's issue tracker, or submit the included fix to their Gerrit instance. I have sent this to their mailing list: https://groups.google.com/a/webmproject.org/g/webp-discuss/c/wvBsO8n8BKA~~
  ~~If they don't pick up the issue & fix from there, then I would greatly appreciate if anyone else can find the time and energy to open an issue, sign the CLA & submit the patch for me.~~
  See https://github.com/NixOS/nixpkgs/pull/447013#issuecomment-3348061016

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (Native)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
