### PR TITLE
woodpecker-server: 3.9.0 -> 3.10.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
@@ -1,4 +1,10 @@
-{ buildGoModule, callPackage }:
+{
+  buildGoModule,
+  callPackage,
+  installShellFiles,
+  lib,
+  stdenv,
+}:
 let
   common = callPackage ./common.nix { };
 in
@@ -8,13 +14,23 @@ buildGoModule {
     version
     src
     ldflags
-    postInstall
     vendorHash
     ;
 
   subPackages = "cmd/cli";
 
+  nativeBuildInputs = [ installShellFiles ];
+
   env.CGO_ENABLED = 0;
+  postInstall = ''
+    ${common.postInstall}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd woodpecker-cli \
+      --bash <($out/bin/woodpecker-cli completion bash) \
+      --fish <($out/bin/woodpecker-cli completion fish ) \
+      --zsh <($out/bin/woodpecker-cli completion zsh)
+  '';
 
   meta = common.meta // {
     description = "Command line client for the Woodpecker Continuous Integration server";

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 let
-  version = "3.9.0";
-  srcHash = "sha256-Ymg6nJr83jt2EAv/p1B1wmZv3jvpx/3xRVRii3S1cNU=";
+  version = "3.10.0";
+  srcHash = "sha256-Z9EGm14q9DySZ0lgw/wwam3NjvicltWBkVJ3cwi/eds=";
   # The tarball contains vendored dependencies
   vendorHash = null;
 in


### PR DESCRIPTION
Changelog: https://github.com/woodpecker-ci/woodpecker/releases/tag/v3.10.0
Also install autcompletion for woodpecker-cli
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
