### PR TITLE
claude-code-acp: init at 0.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24755,6 +24755,14 @@
     githubId = 1694705;
     name = "Sam Stites";
   };
+  storopoli = {
+    email = "jose@storopoli.com";
+    github = "storopoli";
+    githubId = 43353831;
+    name = "Jose Storopoli";
+    keys = [ { fingerprint = "B8C0 1A87 C046 33C9 F6CD  0DA2 1BD3 8BE8 D065 3A7A"; } ];
+    matrix = "@jose:storopoli.com";
+  };
   strager = {
     email = "strager.nds@gmail.com";
     github = "strager";

--- a/pkgs/by-name/cl/claude-code-acp/package.nix
+++ b/pkgs/by-name/cl/claude-code-acp/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "claude-code-acp";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "zed-industries";
+    repo = "claude-code-acp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kkAQuYP2S5EwIGJV8TLrlYzHOC54vmxEHwwuZD5P1hI=";
+  };
+
+  npmDepsHash = "sha256-IR88NP1AiR6t/MLDdaZY1Np0AE7wfqEUfmnohaf0ymc=";
+
+  meta = {
+    description = "ACP-compatible coding agent powered by the Claude Code SDK";
+    homepage = "https://github.com/zed-industries/claude-code-acp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ storopoli ];
+    mainProgram = "claude-code-acp";
+  };
+})


### PR DESCRIPTION
adds [`zed-industries/claude-code-acp`](https://github.com/zed-industries/claude-code-acp) at version 0.4.5.

Also adds myself as a maintainer.

You can test with:

```console
$ nix-build -A claude-code-acp
$ echo '{"id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}' | ./result/bin/claude-code-acp
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentCapabilities":{"promptCapabilities":{"image":true,"embeddedContext":true},"mcpCapabilities":{"http":true,"sse":true}},"authMethods":[{"description":"Run `claude /login` in the terminal","name":"Log in with Claude Code","id":"claude-login"}]}}
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
