### PR TITLE
git-worktree-switcher: 0.2.4 -> 0.2.6

### DIFF
--- a/nixos/modules/programs/git-worktree-switcher.nix
+++ b/nixos/modules/programs/git-worktree-switcher.nix
@@ -12,17 +12,18 @@ let
     shell:
     if (shell == "fish") then
       ''
-        ${lib.getExe pkgs.git-worktree-switcher} init ${shell} | source
+        ${lib.getExe cfg.package} init ${shell} | source
       ''
     else
       ''
-        eval "$(${lib.getExe pkgs.git-worktree-switcher} init ${shell})"
+        eval "$(${lib.getExe cfg.package} init ${shell})"
       '';
 in
 {
   options = {
     programs.git-worktree-switcher = {
       enable = lib.mkEnableOption "git-worktree-switcher, switch between git worktrees with speed.";
+      package = lib.mkPackageOption pkgs "git-worktree-switcher" { };
     };
   };
 

--- a/pkgs/by-name/gi/git-worktree-switcher/package.nix
+++ b/pkgs/by-name/gi/git-worktree-switcher/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "git-worktree-switcher";
-  version = "0.2.4";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "mateusauler";
     repo = "git-worktree-switcher";
     tag = "${finalAttrs.version}-fork";
-    hash = "sha256-N+bDsLEUM6FWhyliUav2n5hwMa5EEuVPoIK+Cja0DxA=";
+    hash = "sha256-vPnAXiizCU5nXce+aE2x2G5ei+7A+eBTUpxcGleSSa8=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: 
- https://github.com/mateusauler/git-worktree-switcher/releases/tag/0.2.5-fork
- https://github.com/mateusauler/git-worktree-switcher/releases/tag/0.2.6-fork

Also copied the fix from nix-community/home-manager#7903

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Maintainer tag: @jiriks74

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
