### PR TITLE
qt6: support cross compilation

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -153,17 +153,19 @@ let
       qtspeech = callPackage ./modules/qtspeech.nix { };
       qtquick3d = callPackage ./modules/qtquick3d.nix { };
       qtquick3dphysics = callPackage ./modules/qtquick3dphysics.nix { };
-      qtquickeffectmaker = callPackage ./modules/qtquickeffectmaker.nix { };
+      qtquickeffectmaker = callPackage ./modules/qtquickeffectmaker { };
       qtquicktimeline = callPackage ./modules/qtquicktimeline.nix { };
       qtremoteobjects = callPackage ./modules/qtremoteobjects.nix { };
       qtsvg = callPackage ./modules/qtsvg.nix { };
       qtscxml = callPackage ./modules/qtscxml.nix { };
       qttools = callPackage ./modules/qttools { };
       qttranslations = callPackage ./modules/qttranslations.nix {
-        qttools = self.qttools.override {
-          qtbase = self.qtbase.override { qttranslations = null; };
-          qtdeclarative = null;
-        };
+        qttools = self.qttools.override (
+          lib.optionalAttrs (self.qtbase.stdenv.buildPlatform.canExecute self.qtbase.stdenv.hostPlatform) {
+            qtbase = self.qtbase.override { qttranslations = null; };
+            qtdeclarative = null;
+          }
+        );
       };
       qtvirtualkeyboard = callPackage ./modules/qtvirtualkeyboard.nix { };
       qtwayland = callPackage ./modules/qtwayland.nix { };

--- a/pkgs/development/libraries/qt-6/modules/qtbase/cross-search-host-paths.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/cross-search-host-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/QtToolHelpers.cmake b/cmake/QtToolHelpers.cmake
+index a7e1842c..ee9406ff 100644
+--- a/cmake/QtToolHelpers.cmake
++++ b/cmake/QtToolHelpers.cmake
+@@ -723,6 +723,8 @@ function(qt_internal_find_tool out_var target_name tools_target)
+         endif()
+         set(CMAKE_PREFIX_PATH "${qt_host_path_cmake_dir_absolute}")
+ 
++				list(PREPEND CMAKE_PREFIX_PATH "${_qt_additional_host_packages_prefix_paths}")
++
+         # Look for tools in additional host Qt installations. This is done for conan support where
+         # we have separate installation prefixes per package. For simplicity, we assume here that
+         # all host Qt installations use the same value of INSTALL_LIBDIR.

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -3,12 +3,13 @@
   qtbase,
   qtlanguageserver,
   qtshadertools,
+  qtdeclarative,
   qtsvg,
   openssl,
   darwin,
   stdenv,
   lib,
-  pkgsBuildBuild,
+  pkgsBuildHost,
   replaceVars,
 }:
 
@@ -26,6 +27,12 @@ qtModule {
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.sigtool
+  ];
+
+  # When cross building, qtdeclarative depends on tools from the host version of itself
+  propagatedNativeBuildInputs = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    qtdeclarative
+    qtshadertools
   ];
 
   patches = [
@@ -51,13 +58,8 @@ qtModule {
     '';
 
   cmakeFlags = [
-    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderTools"
     # for some reason doesn't get found automatically on Darwin
-    "-DPython_EXECUTABLE=${lib.getExe pkgsBuildBuild.python3}"
-  ]
-  # Conditional is required to prevent infinite recursion during a cross build
-  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DPython_EXECUTABLE=${lib.getExe pkgsBuildHost.python3}"
   ];
 
   meta.maintainers = with lib.maintainers; [

--- a/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmultimedia/default.nix
@@ -24,7 +24,6 @@
   elfutils,
   libunwind,
   orc,
-  pkgsBuildBuild,
 }:
 
 qtModule {
@@ -50,7 +49,6 @@ qtModule {
     qtbase
     qtdeclarative
     qtsvg
-    qtshadertools
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [ qtquick3d ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -62,6 +60,8 @@ qtModule {
     gst-vaapi
   ];
 
+  propagatedNativeBuildInputs = [ qtshadertools ];
+
   patches = lib.optionals stdenv.hostPlatform.isMinGW [
     ./windows-no-uppercase-libs.patch
     ./windows-resolve-function-name.patch
@@ -69,7 +69,6 @@ qtModule {
 
   cmakeFlags = [
     "-DENABLE_DYNAMIC_RESOLVE_VAAPI_SYMBOLS=0"
-    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-include AudioToolbox/AudioToolbox.h";

--- a/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3d.nix
@@ -1,7 +1,10 @@
 {
+  lib,
+  stdenv,
   qtModule,
   qtbase,
   qtdeclarative,
+  qtquick3d,
   openssl,
 }:
 
@@ -11,5 +14,11 @@ qtModule {
     qtbase
     qtdeclarative
   ];
+
+  # When cross building, qtquick3d depends on tools from the host version of itself
+  propagatedNativeBuildInputs = lib.optional (
+    !stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  ) qtquick3d;
+
   buildInputs = [ openssl ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker/cross-compile.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker/cross-compile.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b39a73c..31c4a3b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,11 +49,6 @@ if(WASM)
+     return()
+ endif()
+ 
+-if(CMAKE_CROSSCOMPILING)
+-    message(NOTICE "Skipping the build as the condition \"NOT CMAKE_CROSSCOMPILING\" is not met.")
+-    return()
+-endif()
+-
+ # Copy nodes content
+ set(nodes_folders
+     "nodes/basic"

--- a/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquickeffectmaker/default.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   qtModule,
   qtbase,
   qtquick3d,
@@ -10,5 +12,8 @@ qtModule {
     qtbase
     qtquick3d
   ];
+
+  patches = lib.optional (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ./cross-compile.patch;
+
   meta.mainProgram = "qqem";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtremoteobjects.nix
@@ -1,13 +1,22 @@
 {
+  lib,
+  stdenv,
   qtModule,
   qtbase,
   qtdeclarative,
+  qtremoteobjects,
 }:
 
 qtModule {
   pname = "qtremoteobjects";
+
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
   ];
+
+  # When cross building, qtremoteobjects depends on tools from the host version of itself
+  propagatedNativeBuildInputs = lib.optional (
+    !stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  ) qtremoteobjects;
 }

--- a/pkgs/development/libraries/qt-6/modules/qtscxml.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtscxml.nix
@@ -1,7 +1,10 @@
 {
+  lib,
+  stdenv,
   qtModule,
   qtbase,
   qtdeclarative,
+  qtscxml,
 }:
 
 qtModule {
@@ -10,4 +13,9 @@ qtModule {
     qtbase
     qtdeclarative
   ];
+
+  # When cross building, qtscxml depends on tools from the host version of itself
+  propagatedNativeBuildInputs = lib.optional (
+    !stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  ) qtscxml;
 }

--- a/pkgs/development/libraries/qt-6/modules/qtshadertools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtshadertools.nix
@@ -1,16 +1,17 @@
 {
   qtModule,
   qtbase,
+  qtshadertools,
   stdenv,
   lib,
-  pkgsBuildBuild,
 }:
 
 qtModule {
   pname = "qtshadertools";
   propagatedBuildInputs = [ qtbase ];
-  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
-  ];
+  # When cross building, qtshadertools depends on tools from the host version of itself
+  propagatedNativeBuildInputs = lib.optional (
+    !stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  ) qtshadertools;
   meta.mainProgram = "qsb";
 }

--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -1,10 +1,10 @@
 {
-  pkgsBuildBuild,
   stdenv,
   lib,
   qtModule,
   qtbase,
   qtdeclarative,
+  qtwayland,
   wayland,
   wayland-scanner,
   pkg-config,
@@ -26,13 +26,11 @@ qtModule {
   propagatedNativeBuildInputs = [
     wayland
     wayland-scanner
-  ];
+  ]
+  # When cross building, qtwayland depends on tools from the host version of itself
+  ++ lib.optional (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) qtwayland;
   buildInputs = [ libdrm ];
   nativeBuildInputs = [ pkg-config ];
-
-  cmakeFlags = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    "-DQt6WaylandScannerTools_DIR=${pkgsBuildBuild.qt6.qtwayland}/lib/cmake/Qt6WaylandScannerTools"
-  ];
 
   meta = {
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/qt-6/qtModule.nix
+++ b/pkgs/development/libraries/qt-6/qtModule.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation (
       # don't leak OS version into the final output
       # https://bugreports.qt.io/browse/QTBUG-136060
       [ "-DCMAKE_SYSTEM_VERSION=" ]
+      # Qt disables tools such as qmlls when cross compiling by default,
+      # presumably with the assumption of having an embedded target.
+      ++ lib.optional (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+        "-DQT_FORCE_BUILD_TOOLS=ON"
+        "-DQT_BUILD_TOOLS_BY_DEFAULT=ON"
+      ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         "-DQT_NO_XCODE_MIN_VERSION_CHECK=ON"
         # This is only used for the min version check, which we disabled above.


### PR DESCRIPTION
Implements support for cross compilation most of Qt 6.

Cross compilation was tested for riscv64 but all changes here should apply generally. I did not test qtwebengine or qtquick3dphysics as they cannot compile for riscv64. Pyside and Shiboken6 still do not work, and as such all of kde still does not work.

qt6.full still builds as expected for non-cross x86_64. All new patches are applied only when cross compiling to reduce the impact of any future breakage to just things that already didn't work.

The qtbase setup hook has also been changed to account for cross compilation, and a flag to skip running it has been added, as I'm not aware of another way to skip hooks and I've had to rebuild for it quite often.

cc @NickCao @K900 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] riscv64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
