### PR TITLE
cockpit-{files,machines,podman}: init packages

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -141,6 +141,16 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  cockpit = {
+    members = [
+      alexandru0-dev
+      andre4ik3
+      lucasew
+    ];
+    scope = "Maintain Cockpit and official plugins by the Cockpit project.";
+    shortName = "Cockpit";
+  };
+
   coq = {
     members = [
       cohencyril

--- a/pkgs/by-name/co/cockpit-files/package.nix
+++ b/pkgs/by-name/co/cockpit-files/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  cockpit,
+  nodejs,
+  gettext,
+  writeShellScriptBin,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cockpit-files";
+  version = "34";
+
+  src = fetchFromGitHub {
+    owner = "cockpit-project";
+    repo = "cockpit-files";
+    tag = finalAttrs.version;
+    hash = "sha256-nxlPzNrX3mAwhR8mpRfoZ7d6tdfVOBEaTtzEHU14p68=";
+
+    fetchSubmodules = true;
+    postFetch = "cp $out/node_modules/.package-lock.json $out/package-lock.json";
+  };
+
+  buildInputs = [
+    nodejs
+    gettext
+    (writeShellScriptBin "git" "true")
+  ];
+
+  cockpitSrc = cockpit.src;
+
+  postPatch = ''
+    mkdir -p pkg; cp -r $cockpitSrc/pkg/lib pkg
+    mkdir -p test; cp -r $cockpitSrc/test/common test
+
+    substituteInPlace Makefile \
+      --replace-fail '$(MAKE) package-lock.json' 'true' \
+      --replace-fail '$(COCKPIT_REPO_FILES) | tar x' "" \
+      --replace-fail '/usr/local' "$out"
+
+    patchShebangs build.js
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Featureful file browser for Cockpit";
+    homepage = "https://github.com/cockpit-project/cockpit-files";
+    changelog = "https://github.com/cockpit-project/cockpit-files/releases/tag/${finalAttrs.version}";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.lgpl21 ];
+    teams = [ lib.teams.cockpit ];
+  };
+})

--- a/pkgs/by-name/co/cockpit-machines/package.nix
+++ b/pkgs/by-name/co/cockpit-machines/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  cockpit,
+  nodejs,
+  gettext,
+  writeShellScriptBin,
+  fetchFromGitHub,
+  gitUpdater,
+  libosinfo,
+  osinfo-db,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cockpit-machines";
+  version = "346";
+
+  src = fetchFromGitHub {
+    owner = "cockpit-project";
+    repo = "cockpit-machines";
+    tag = finalAttrs.version;
+    hash = "sha256-fsEmxJ/9w4NbjgKhb4JTFY94FFTc735+ZQ8YieLQVpA=";
+
+    fetchSubmodules = true;
+    postFetch = "cp $out/node_modules/.package-lock.json $out/package-lock.json";
+  };
+
+  buildInputs = [
+    nodejs
+    gettext
+    (writeShellScriptBin "git" "true")
+  ];
+
+  cockpitSrc = cockpit.src;
+
+  postPatch = ''
+    mkdir -p pkg; cp -r $cockpitSrc/pkg/lib pkg
+    mkdir -p test; cp -r $cockpitSrc/test/common test
+
+    substituteInPlace Makefile \
+      --replace-fail '$(MAKE) package-lock.json' 'true' \
+      --replace-fail '$(COCKPIT_REPO_FILES) | tar x' "" \
+      --replace-fail '/usr/local' "$out"
+
+    substituteInPlace src/manifest.json \
+      --replace-fail '"/usr/share/dbus-1/system.d/org.libvirt.conf"' '"/etc/systemd/system/libvirt-dbus.service"'
+
+    patchShebangs build.js
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+    cockpitPath = [
+      libosinfo
+      osinfo-db
+    ];
+  };
+
+  meta = {
+    description = "Cockpit UI for virtual machines";
+    homepage = "https://github.com/cockpit-project/cockpit-machines";
+    changelog = "https://github.com/cockpit-project/cockpit-machines/releases/tag/${finalAttrs.version}";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.lgpl21 ];
+    teams = [ lib.teams.cockpit ];
+  };
+})

--- a/pkgs/by-name/co/cockpit-podman/package.nix
+++ b/pkgs/by-name/co/cockpit-podman/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  cockpit,
+  nodejs,
+  gettext,
+  writeShellScriptBin,
+  fetchFromGitHub,
+  gitUpdater,
+  podman,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cockpit-podman";
+  version = "119.1";
+
+  src = fetchFromGitHub {
+    owner = "cockpit-project";
+    repo = "cockpit-podman";
+    tag = finalAttrs.version;
+    hash = "sha256-XAOHkul9oh1mUJ27ghJgZLtriBGjofyoGhQ3gb7Gunc=";
+
+    fetchSubmodules = true;
+    postFetch = "cp $out/node_modules/.package-lock.json $out/package-lock.json";
+  };
+
+  buildInputs = [
+    nodejs
+    gettext
+    (writeShellScriptBin "git" "true")
+  ];
+
+  cockpitSrc = cockpit.src;
+
+  postPatch = ''
+    mkdir -p pkg; cp -r $cockpitSrc/pkg/lib pkg
+    mkdir -p test; cp -r $cockpitSrc/test/common test
+
+    substituteInPlace Makefile \
+      --replace-fail '$(MAKE) package-lock.json' 'true' \
+      --replace-fail '$(COCKPIT_REPO_FILES) | tar x' "" \
+      --replace-fail '/usr/local' "$out"
+
+    substituteInPlace src/manifest.json \
+      --replace-fail '"/lib/systemd' '"/run/current-system/sw/lib/systemd'
+
+    patchShebangs build.js
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+    cockpitPath = [ podman ];
+  };
+
+  meta = {
+    description = "Cockpit UI for podman containers";
+    homepage = "https://github.com/cockpit-project/cockpit-podman";
+    changelog = "https://github.com/cockpit-project/cockpit-podman/releases/tag/${finalAttrs.version}";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.lgpl21 ];
+    teams = [ lib.teams.cockpit ];
+  };
+})

--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -264,9 +264,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://cockpit-project.org/";
     changelog = "https://cockpit-project.org/blog/cockpit-${finalAttrs.version}.html";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [
-      lucasew
-      andre4ik3
-    ];
+    teams = [ lib.teams.cockpit ];
   };
 })


### PR DESCRIPTION
Adds the [files][1], [machines][2], and [podman][3] Cockpit plugins, along with creating a team `cockpit` that maintains them. Based on the previous cockpit-machines derivation from #357323.

The plugins can be used by putting them into `systemPackages` and then Cockpit will pick them up. In the future I plan to add a `plugins` option to the Cockpit module so they don't have to be added to `systemPackages`.

Closes #287644
Closes #357323

CC @lucasew

- **teams/cockpit: init**
- **cockpit-files: init at 28**
- **cockpit-machines: init at 340**
- **cockpit-podman: init at 113**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[1]: https://github.com/cockpit-project/cockpit-files
[2]: https://github.com/cockpit-project/cockpit-machines
[3]: https://github.com/cockpit-project/cockpit-podman
