### PR TITLE
ghostscan: int at 0-unstable-2025-09-28

### DIFF
--- a/pkgs/by-name/gh/ghostscan/package.nix
+++ b/pkgs/by-name/gh/ghostscan/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  autoconf,
+  automake,
+  gettext,
+  flex,
+  bison,
+  bpftools,
+  vmlinux-to-elf,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ghostscan";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "h2337";
+    repo = "ghostscan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TQESv2qZL/ixcMC767n1VBMUpt6kG6F/SiFbPME8+S4=";
+  };
+
+  cargoHash = "sha256-rnge6Pftpw+C8w9jNVAAq0jY5MpQDxX8G8NV33hqIG0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    autoconf
+    automake
+    gettext
+    flex
+    bison
+    bpftools
+    vmlinux-to-elf
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Unmask hidden rootkits, stealthy eBPF tricks and ghost processes";
+    longDescription = ''
+      ghostscan is the grab-it-run-it-read-it toolkit for responders
+      who need a fast gut check on a Linux host.  Drop the binary on a
+      box, run it once, and ghostscan walks the kernel, procfs, bpffs,
+      systemd, cron, sockets, and more to surface the things an
+      attacker would rather you never notice.
+    '';
+    homepage = "https://github.com/h2337/ghostscan";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "ghostscan";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Related to https://github.com/NixOS/nixpkgs/issues/81418

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
