### PR TITLE
mdserve: init at 0.4.0

### DIFF
--- a/pkgs/by-name/md/mdserve/package.nix
+++ b/pkgs/by-name/md/mdserve/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mdserve";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "jfernandez";
+    repo = "mdserve";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OCdWoQzmCvKo8EfLAczBud1FfY3vRMk7mivjhsqE840=";
+  };
+
+  cargoHash = "sha256-7J+a3Yt5sLtZb6xfWLS/eZXZtZRmeXmTqUcPKXqtOLY=";
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    # times out on darwin during nixpkgs-review
+    "--skip test_file_modification_updates_via_websocket"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast markdown preview server with live reload and theme support";
+    homepage = "https://github.com/jfernandez/mdserve";
+    changelog = "https://github.com/jfernandez/mdserve/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vinnymeller ];
+    mainProgram = "mdserve";
+  };
+})


### PR DESCRIPTION
Adds [mdserve](https://github.com/jfernandez/mdserve), a fast markdown preview server written in rust with live reloads and builtin theme support, and no runtime dependencies 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
