### PR TITLE
oscgoesbrrr: init at 1.42.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25677,6 +25677,11 @@
     githubId = 34945377;
     name = "John Smith";
   };
+  TheButlah = {
+    name = "Ryan Butler";
+    github = "TheButlah";
+    githubId = 6969415;
+  };
   theCapypara = {
     name = "Marco Köpcke";
     email = "hello@capypara.de";

--- a/pkgs/by-name/os/oscgoesbrrr/package.nix
+++ b/pkgs/by-name/os/oscgoesbrrr/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "oscgoesbrrr";
+  version = "1.42.0";
+  src = fetchFromGitHub {
+    owner = "OscToys";
+    repo = "OscGoesBrrr";
+    tag = "release/${finalAttrs.version}";
+    hash = "sha256-KRx8rMsQFU7dYmjO/JCjkUp2JheTkQ8sUT56Q0Q+p8E=";
+  };
+  npmDepsHash = "sha256-HObRprVAnJWSay8x7+Apkp0sKx1CpnjIB1ze4xks/Lo=";
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  postInstall = ''
+    makeWrapper ${lib.getExe electron} $out/bin/OscGoesBrrr \
+      --add-flags $out/lib/node_modules/OscGoesBrrr \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+  '';
+
+  meta = {
+    description = "Make haptics in real life go BRRR from VRChat";
+    downloadPage = "https://github.com/OscToys/OscGoesBrrr";
+    homepage = "https://osc.toys";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [ TheButlah ];
+    mainProgram = "OscGoesBrrr";
+  };
+})


### PR DESCRIPTION
Adds [OscGoesBrrr](https://github.com/OscToys/OscGoesBrrr/), a popular haptic tool for VRChat.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
