### PR TITLE
flutter: set permissions on the frameworks when codesign and lipo are called. set permissions on the built app bundle.

### DIFF
--- a/pkgs/development/compilers/flutter/versions/3_35/patches/macos-ios-set-perissions.patch
+++ b/pkgs/development/compilers/flutter/versions/3_35/patches/macos-ios-set-perissions.patch
@@ -1,0 +1,112 @@
+Subject: [PATCH] Set permissions on the frameworks when codesign and lipo are called. Set permissions on the built app bundle.
+---
+Index: packages/flutter_tools/bin/xcode_backend.dart
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/packages/flutter_tools/bin/xcode_backend.dart b/packages/flutter_tools/bin/xcode_backend.dart
+--- a/packages/flutter_tools/bin/xcode_backend.dart	(revision d693b4b9dbac2acd4477aea4555ca6dcbea44ba2)
++++ b/packages/flutter_tools/bin/xcode_backend.dart	(revision 5e10f063458657b478441565205aba357fa0ace2)
+@@ -378,6 +378,12 @@
+   }
+ 
+   void _codesignFramework(String expandedCodeSignIdentity, String frameworkPath) {
++    final frameworkDir = File(frameworkPath).parent.path;
++    runSync('chmod', <String>[
++      '-R',
++      'u+w',
++      frameworkDir
++    ]);
+     runSync('codesign', <String>[
+       '--force',
+       '--verbose',
+@@ -565,6 +571,13 @@
+     streamOutput('done');
+     streamOutput(' └─Compiling, linking and signing...');
+ 
++    // set the permissions so we can deploy to the simulator
++    runSync('chmod', <String>[
++      '-R',
++      '755',
++      projectPath,
++    ]);
++
+     echo('Project $projectPath built and packaged successfully.');
+   }
+ 
+Index: packages/flutter_tools/lib/src/build_system/targets/darwin.dart
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/packages/flutter_tools/lib/src/build_system/targets/darwin.dart b/packages/flutter_tools/lib/src/build_system/targets/darwin.dart
+--- a/packages/flutter_tools/lib/src/build_system/targets/darwin.dart	(revision d693b4b9dbac2acd4477aea4555ca6dcbea44ba2)
++++ b/packages/flutter_tools/lib/src/build_system/targets/darwin.dart	(revision 5e10f063458657b478441565205aba357fa0ace2)
+@@ -3,11 +3,12 @@
+ // found in the LICENSE file.
+ 
+ import 'package:meta/meta.dart';
++import 'package:path/path.dart' as path;
+ 
+ import '../../artifacts.dart';
+ import '../../base/io.dart';
+ import '../../build_info.dart';
+-import '../../globals.dart' as globals show stdio;
++import '../../globals.dart' as globals show stdio, os;
+ import '../build_system.dart';
+ 
+ abstract class UnpackDarwin extends Target {
+@@ -91,6 +92,9 @@
+       return;
+     }
+ 
++    final A_directoryPath = path.dirname(frameworkBinaryPath);
++    globals.os.chmod(environment.fileSystem.directory(A_directoryPath), '755');
++
+     // Thin in-place.
+     final ProcessResult extractResult = await environment.processManager.run(<String>[
+       'lipo',
+Index: packages/flutter_tools/lib/src/build_system/targets/ios.dart
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/packages/flutter_tools/lib/src/build_system/targets/ios.dart b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart	(revision d693b4b9dbac2acd4477aea4555ca6dcbea44ba2)
++++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart	(revision 5e10f063458657b478441565205aba357fa0ace2)
+@@ -3,6 +3,7 @@
+ // found in the LICENSE file.
+ 
+ import 'package:meta/meta.dart';
++import 'package:path/path.dart' as path;
+ import 'package:unified_analytics/unified_analytics.dart';
+ 
+ import '../../artifacts.dart';
+@@ -891,6 +892,26 @@
+   if (codesignIdentity == null || codesignIdentity.isEmpty) {
+     codesignIdentity = '-';
+   }
++  final frameworkDir = path.dirname(binary.path);
++  final ProcessResult chmodResult = environment.processManager.runSync(<String>[
++    'chmod',
++    '-R',
++    '755',
++    frameworkDir,
++  ]);
++  if (chmodResult.exitCode != 0) {
++    final String stdout = (chmodResult.stdout as String).trim();
++    final String stderr = (chmodResult.stderr as String).trim();
++    final output = StringBuffer();
++    output.writeln('Failed ''chmod +R 755 ${frameworkDir}''');
++    if (stdout.isNotEmpty) {
++      output.writeln(stdout);
++    }
++    if (stderr.isNotEmpty) {
++      output.writeln(stderr);
++    }
++    throw Exception(output.toString());
++  }
+   final ProcessResult result = environment.processManager.runSync(<String>[
+     'codesign',
+     '--force',

--- a/pkgs/development/compilers/flutter/versions/3_35/patches/macos-ios-set-permissions.patch
+++ b/pkgs/development/compilers/flutter/versions/3_35/patches/macos-ios-set-permissions.patch
@@ -7,7 +7,7 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/packages/flutter_tools/bin/xcode_backend.dart b/packages/flutter_tools/bin/xcode_backend.dart
 --- a/packages/flutter_tools/bin/xcode_backend.dart	(revision d693b4b9dbac2acd4477aea4555ca6dcbea44ba2)
-+++ b/packages/flutter_tools/bin/xcode_backend.dart	(revision 5e10f063458657b478441565205aba357fa0ace2)
++++ b/packages/flutter_tools/bin/xcode_backend.dart	(revision f50a62d973f7a592fc1167ae37e4d39e9bc1ede4)
 @@ -378,6 +378,12 @@
    }
  
@@ -21,7 +21,7 @@ diff --git a/packages/flutter_tools/bin/xcode_backend.dart b/packages/flutter_to
      runSync('codesign', <String>[
        '--force',
        '--verbose',
-@@ -565,6 +571,13 @@
+@@ -565,6 +571,15 @@
      streamOutput('done');
      streamOutput(' └─Compiling, linking and signing...');
  
@@ -29,8 +29,10 @@ diff --git a/packages/flutter_tools/bin/xcode_backend.dart b/packages/flutter_to
 +    runSync('chmod', <String>[
 +      '-R',
 +      '755',
-+      projectPath,
-+    ]);
++      "${projectPath}/build/${platform.name}/",
++    ],
++      allowFail: true,
++    );
 +
      echo('Project $projectPath built and packaged successfully.');
    }


### PR DESCRIPTION
When building ios and macos, resolves permission errors that occur when trying to codesign frameworks, using the lipo tool and deploying to the simulator.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
