### PR TITLE
llvmPackages: clean up rebuild avoidance

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -95,15 +95,16 @@ stdenv.mkDerivation (
       (lib.cmakeFeature "CLANG_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/clang")
       (lib.cmakeBool "CLANGD_BUILD_XPC" false)
       (lib.cmakeBool "LLVM_ENABLE_RTTI" true)
+      (lib.cmakeBool "LLVM_INCLUDE_TESTS" false)
       (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
       (lib.cmakeFeature "CLANG_TABLEGEN" "${buildLlvmTools.tblgen}/bin/clang-tblgen")
+      (lib.cmakeFeature "CLANG_TIDY_CONFUSABLE_CHARS_GEN" "${buildLlvmTools.tblgen}/bin/clang-tidy-confusable-chars-gen")
     ]
+    ++ lib.optional (lib.versionAtLeast release_version "20") (
+      lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm"
+    )
     ++ lib.optionals (lib.versionAtLeast release_version "21") [
       (lib.cmakeFeature "CLANG_RESOURCE_DIR" "${placeholder "lib"}/lib/clang/${lib.versions.major release_version}")
-    ]
-    # TODO: Clean up on `staging`.
-    ++ [
-      (lib.cmakeBool "LLVM_INCLUDE_TESTS" false)
     ]
     ++ lib.optionals enableManpages [
       (lib.cmakeBool "CLANG_INCLUDE_DOCS" true)
@@ -112,20 +113,10 @@ stdenv.mkDerivation (
       (lib.cmakeBool "SPHINX_OUTPUT_HTML" false)
       (lib.cmakeBool "SPHINX_WARNINGS_AS_ERRORS" false)
     ]
-    # TODO: Clean up on `staging`.
-    ++ [
-      # Added in LLVM15:
-      # `clang-tidy-confusable-chars-gen`: https://github.com/llvm/llvm-project/commit/c3574ef739fbfcc59d405985a3a4fa6f4619ecdb
-      # `clang-pseudo-gen`: https://github.com/llvm/llvm-project/commit/cd2292ef824591cc34cc299910a3098545c840c7
-      (lib.cmakeFeature "CLANG_TIDY_CONFUSABLE_CHARS_GEN" "${buildLlvmTools.tblgen}/bin/clang-tidy-confusable-chars-gen")
-    ]
     ++ lib.optionals (lib.versionOlder release_version "20") [
       # clang-pseudo removed in LLVM20: https://github.com/llvm/llvm-project/commit/ed8f78827895050442f544edef2933a60d4a7935
       (lib.cmakeFeature "CLANG_PSEUDO_GEN" "${buildLlvmTools.tblgen}/bin/clang-pseudo-gen")
     ]
-    ++ lib.optional (lib.versionAtLeast release_version "20") (
-      lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm"
-    )
     ++ devExtraCmakeFlags;
 
     postPatch = ''
@@ -173,20 +164,13 @@ stdenv.mkDerivation (
       patchShebangs $python/bin
 
       mkdir -p $dev/bin
-    ''
-    # TODO(@LunNova): Clean up this rebuild avoidance in staging
-    + lib.optionalString enableClangToolsExtra (
-      if lib.versionOlder release_version "20" then
-        ''
-          cp bin/{clang-tblgen,clang-tidy-confusable-chars-gen,clang-pseudo-gen} $dev/bin
-        ''
-      else
-        ''
-          cp bin/{clang-tblgen,clang-tidy-confusable-chars-gen} $dev/bin
-        ''
-    )
-    + lib.optionalString (!enableClangToolsExtra) ''
       cp bin/clang-tblgen $dev/bin
+    ''
+    + lib.optionalString enableClangToolsExtra ''
+      cp bin/clang-tidy-confusable-chars-gen $dev/bin
+    ''
+    + lib.optionalString (enableClangToolsExtra && lib.versionOlder release_version "20") ''
+      cp bin/clang-pseudo-gen $dev/bin
     '';
 
     env =

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -374,18 +374,14 @@ let
 
       # This is an "oddly ordered" bootstrap just for Darwin. Probably
       # don't want it otherwise.
-      clangNoCompilerRtWithLibc =
-        wrapCCWith rec {
-          cc = tools.clang-unwrapped;
-          libcxx = null;
-          bintools = bintools';
-          extraPackages = [ ];
-          extraBuildCommands = mkExtraBuildCommands0 cc;
-        }
-        # FIXME: This should be inside the `wrapCCWith` call.
-        // lib.optionalAttrs stdenv.targetPlatform.isWasm {
-          nixSupport.cc-cflags = [ "-fno-exceptions" ];
-        };
+      clangNoCompilerRtWithLibc = wrapCCWith rec {
+        cc = tools.clang-unwrapped;
+        libcxx = null;
+        bintools = bintools';
+        extraPackages = [ ];
+        extraBuildCommands = mkExtraBuildCommands0 cc;
+        nixSupport.cc-cflags = lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
+      };
 
       # Aliases
       clangNoCompilerRt = tools.clangNoLibcNoRt;

--- a/pkgs/development/compilers/llvm/common/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/common/libcxx/default.nix
@@ -143,9 +143,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs utils/cat_files.py
   '';
 
-  # TODO: Remove on `staging`.
-  patches = [ ];
-
   nativeBuildInputs = [
     cmake
     ninja

--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   inherit version;
 
-  # TODO: Remove on `staging`.
-  patches = [ ];
-
   src =
     if monorepoSrc != null then
       runCommand "libunwind-src-${version}" { inherit (monorepoSrc) passthru; } ''
@@ -59,10 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "libunwind")
   ]
   ++ devExtraCmakeFlags;
-
-  # TODO: Remove on `staging`.
-  prePatch = "";
-  postPatch = "";
 
   postInstall =
     lib.optionalString (enableShared && !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isWindows)

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -63,9 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ devExtraCmakeFlags;
 
-  # TODO: Remove on `staging`.
-  postPatch = "";
-
   # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation (
 
     nativeBuildInputs = [
       cmake
+      ninja
       python3
       which
       swig
@@ -84,10 +85,6 @@ stdenv.mkDerivation (
     ++ lib.optionals enableManpages [
       python3.pkgs.sphinx
       python3.pkgs.myst-parser
-    ]
-    # TODO: Clean up on `staging`.
-    ++ [
-      ninja
     ];
 
     buildInputs = [
@@ -112,16 +109,13 @@ stdenv.mkDerivation (
       (lib.cmakeBool "LLVM_ENABLE_RTTI" false)
       (lib.cmakeFeature "Clang_DIR" "${lib.getDev libclang}/lib/cmake")
       (lib.cmakeFeature "LLVM_EXTERNAL_LIT" "${lit}/bin/lit")
+      (lib.cmakeFeature "CLANG_RESOURCE_DIR" "../../../../${lib.getLib libclang}")
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       (lib.cmakeBool "LLDB_USE_SYSTEM_DEBUGSERVER" true)
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       (lib.cmakeFeature "LLDB_CODESIGN_IDENTITY" "") # codesigning makes nondeterministic
-    ]
-    # TODO: Clean up on `staging`.
-    ++ [
-      (lib.cmakeFeature "CLANG_RESOURCE_DIR" "../../../../${lib.getLib libclang}")
     ]
     ++ lib.optionals enableManpages [
       (lib.cmakeBool "LLVM_ENABLE_SPHINX" true)
@@ -183,9 +177,6 @@ stdenv.mkDerivation (
   }
   // lib.optionalAttrs enableManpages {
     pname = "lldb-manpages";
-
-    # TODO: Remove on `staging`.
-    buildPhase = "";
 
     ninjaFlags = [ "docs-lldb-man" ];
 

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -85,9 +85,6 @@ stdenv.mkDerivation (
     pname = "llvm";
     inherit version;
 
-    # TODO: Remove on `staging`.
-    shortVersion = lib.concatStringsSep "." (lib.take 1 (lib.splitString "." release_version));
-
     src =
       if monorepoSrc != null then
         runCommand "llvm-src-${version}" { inherit (monorepoSrc) passthru; } (

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -46,9 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  # TODO: Remove on `staging`.
-  patchFlags = null;
-
   patches =
     lib.optional (lib.versionOlder release_version "19") (getVersionFile "openmp/fix-find-tool.patch")
     ++ [


### PR DESCRIPTION
Rebuild avoidance cleanup for `llvmPackages` TODOs from #440273 (@emilazy's big obsolete LLVM version drop PR) and #446207 (my `enableClangToolsExtra` PR)

I hope #442017 lands so there's not a need to worry about rebuilds from `cmakeFlags` ordering in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - `.#llvmPackages_{git,19}.lib{clang,llvm}{.tests.withoutOptionalFeatures,} .#llvmPackages_{git,19}.{lldb,lld,libunwind,openmp,libcxx,bolt,clangNoCompilerRtWithLibc}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
