### PR TITLE
[staging-next] {libuecc,ecdsautils,lensfun,sqlitebrowser}: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/ec/ecdsautils/package.nix
+++ b/pkgs/by-name/ec/ecdsautils/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   doxygen,
@@ -21,6 +22,13 @@ stdenv.mkDerivation {
     rev = "v${version}";
     sha256 = "sha256-vGHLAX/XOtePvdT/rljCOdlILHVO20mCt6p+MUi13dg=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/freifunk-gluon/ecdsautils/commit/19f096f9c10264f4efe4b926fe83126e85642cba.patch";
+      hash = "sha256-oJv47NckFHFONPcG3WfHwgaHRqrz2eWXzbr5SQr+kX4=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ec/ecdsautils/package.nix
+++ b/pkgs/by-name/ec/ecdsautils/package.nix
@@ -1,7 +1,11 @@
 {
   lib,
   stdenv,
-  pkgs,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  doxygen,
+  libuecc,
 }:
 
 let
@@ -11,19 +15,19 @@ in
 stdenv.mkDerivation {
   inherit pname version;
 
-  src = pkgs.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "freifunk-gluon";
     repo = "ecdsautils";
     rev = "v${version}";
     sha256 = "sha256-vGHLAX/XOtePvdT/rljCOdlILHVO20mCt6p+MUi13dg=";
   };
 
-  nativeBuildInputs = with pkgs; [
+  nativeBuildInputs = [
     cmake
     pkg-config
     doxygen
   ];
-  buildInputs = with pkgs; [ libuecc ];
+  buildInputs = [ libuecc ];
 
   meta = with lib; {
     description = "Tiny collection of programs used for ECDSA (keygen, sign, verify)";

--- a/pkgs/by-name/le/lensfun/package.nix
+++ b/pkgs/by-name/le/lensfun/package.nix
@@ -45,6 +45,16 @@ stdenv.mkDerivation {
     mkdir -p data/db
     tar xvf $TMPDIR/db/version_1.tar -C data/db
     date +%s > data/db/timestamp.txt
+  ''
+  # Backport CMake 4 support
+  # This is already on master, but not yet in a stable release:
+  # https://github.com/lensfun/lensfun/issues/2520
+  # https://github.com/lensfun/lensfun/commit/011de2e85813ff496a85404b30891352555de077
+  + ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR )' \
+        'CMAKE_MINIMUM_REQUIRED(VERSION 3.12 FATAL_ERROR)'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libuecc/package.nix
+++ b/pkgs/by-name/li/libuecc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchgit,
+  fetchpatch,
   cmake,
 }:
 
@@ -14,6 +15,14 @@ stdenv.mkDerivation rec {
     tag = "v${version}";
     sha256 = "1sm05aql75sh13ykgsv3ns4x4zzw9lvzid6misd22gfgf6r9n5fs";
   };
+
+  patches = [
+    # Backport CMake 4 support
+    (fetchpatch {
+      url = "https://github.com/neocturne/libuecc/commit/b3812bf5ab1777193c4b85863311c33997d141f9.patch";
+      hash = "sha256-3h+LC5JlSXNiJlEQxSQzC7+5s+nMp+ll2NQQC5HzTf0=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/by-name/sq/sqlitebrowser/package.nix
+++ b/pkgs/by-name/sq/sqlitebrowser/package.nix
@@ -28,6 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail '"Unknown"' '"${finalAttrs.src.rev}"'
+  ''
+  # Fix build with CMake 4
+  # Will be part of the Qt6 port
+  # Note: The vendored version of qhexedit is incompatible with our qhexedit2: https://github.com/sqlitebrowser/sqlitebrowser/issues/1808
+  + ''
+    substituteInPlace libs/qhexedit/CMakeLists.txt \
+      --replace-fail 'cmake_minimum_required(VERSION 2.8.12.2)' 'cmake_minimum_required(VERSION 3.16)'
   '';
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
