### PR TITLE
octave.withPackages: fix null reference on darwin

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -7,6 +7,7 @@
   ncurses,
   perl,
   flex,
+  testers,
   texinfo,
   qhull,
   libsndfile,
@@ -226,6 +227,12 @@ stdenv.mkDerivation (finalAttrs: {
     withPackages = import ./with-packages.nix { inherit buildEnv octavePackages; };
     pkgs = octavePackages;
     interpreter = "${finalAttrs.finalPackage}/bin/octave";
+    tests = {
+      wrapper = testers.testVersion {
+        package = finalAttrs.finalPackage.withPackages (ps: [ ps.doctest ]);
+        command = "octave --version";
+      };
+    };
   };
 
   meta = {


### PR DESCRIPTION
The following command currently fails on Darwin:

```shell
nix build --impure --expr 'with import ./. {}; octave.withPackages (ps: [ps.doctest])' -L
```

It fails with `error: cannot coerce null to a string: null` in the `postBuild` command.

This PR fixes it by checking for `glibcLocalesUtf8` being `null`, as it is on Darwin; see [here](https://github.com/NixOS/nixpkgs/blob/61dfdcf01595b1b7e7ad6e3097883014a8fa344e/pkgs/top-level/all-packages.nix#L7566-L7583).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
