### PR TITLE
Allow disabling the sudoers rule of SSM

### DIFF
--- a/nixos/modules/services/misc/amazon-ssm-agent.nix
+++ b/nixos/modules/services/misc/amazon-ssm-agent.nix
@@ -43,6 +43,7 @@ in
 
   options.services.amazon-ssm-agent = {
     enable = lib.mkEnableOption "Amazon SSM agent";
+    disableSudoersRule = lib.mkEnableOption "Whether to disable automatic generation of sudoers entry";
     package = lib.mkPackageOption pkgs "amazon-ssm-agent" { };
   };
 
@@ -74,8 +75,10 @@ in
 
     # Add user that Session Manager needs, and give it sudo.
     # This is consistent with Amazon Linux 2 images.
-    security.sudo.extraRules = [ sudoRule ];
-    security.sudo-rs.extraRules = [ sudoRule ];
+    security = lib.mkIf (!cfg.disableSudoersRule) {
+      sudo.extraRules = [ sudoRule ];
+      sudo-rs.extraRules = [ sudoRule ];
+    };
 
     # On Amazon Linux 2 images, the ssm-user user is pretty much a
     # normal user with its own group. We do the same.

--- a/nixos/modules/services/misc/amazon-ssm-agent.nix
+++ b/nixos/modules/services/misc/amazon-ssm-agent.nix
@@ -43,7 +43,11 @@ in
 
   options.services.amazon-ssm-agent = {
     enable = lib.mkEnableOption "Amazon SSM agent";
-    disableSudoersRule = lib.mkEnableOption "Whether to disable automatic generation of sudoers entry";
+    enableSudoersRule = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "automatic generation of sudoers entry";
+    };
     package = lib.mkPackageOption pkgs "amazon-ssm-agent" { };
   };
 
@@ -75,7 +79,7 @@ in
 
     # Add user that Session Manager needs, and give it sudo.
     # This is consistent with Amazon Linux 2 images.
-    security = lib.mkIf (!cfg.disableSudoersRule) {
+    security = lib.mkIf cfg.enableSudoersRule {
       sudo.extraRules = [ sudoRule ];
       sudo-rs.extraRules = [ sudoRule ];
     };


### PR DESCRIPTION
The Amazon Systems Manager package does not strictly require a sudoers file to be present. Without the sudoers file it still works and shows a defined behavior.  I was surprised to find this sudoers rule being added without the possibility to deactivate it. Yet I decided to not change the default behavior and instead add an option to disable the generation of the sudoers rule.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
