### PR TITLE
ffmpeg: Fix on big-endian POWER

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -795,6 +795,25 @@ stdenv.mkDerivation (
       (enableFeature withExtraWarnings "extra-warnings")
       (enableFeature withStripping "stripping")
     ]
+    ++ optionals (stdenv.hostPlatform.isPower) [
+      # FFmpeg expects us to pass `--cpu=` to pick a specific feature set to compile for. If unset, it defaults to `generic`.
+      # For POWER, the default doesn't produce baseline-compliant settings. Passing a baseline-like CPU as a target doesn't
+      # produce entirely correct settings either - POWER4 leaves AltiVec enabled, but that's only guaranteed with POWER6.
+      # Just configure together everything on our own.
+
+      # Easy: Only ppc64le's baseline is recent enough to guarantee all of these.
+      (enableFeature (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian) "altivec")
+      (enableFeature (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian) "vsx")
+      (enableFeature (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian) "power8")
+      (enableFeature (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian) "ldbrx")
+
+      # Instructions that are highly specific to that series of 32-bit embedded CPUs. Never try to enable them.
+      (enableFeature false "ppc4xx")
+
+      # I *think* enabling this on 64-bit POWER is correct? Struggling to find much info on when/where this was introduced.
+      # Definitely present on the Apple G5, and likely Freescale e5500/e6500 as well.
+      (enableFeature (stdenv.hostPlatform.isPower64) "dcbzl")
+    ]
     ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -79,6 +79,7 @@
       && !isAarch32
       && !hostPlatform.isLoongArch64
       && !hostPlatform.isRiscV
+      && !(hostPlatform.isPower && hostPlatform.isBigEndian)
       && hostPlatform == buildPlatform
     ), # dynamically linked Nvidia code
   withFlite ? withFullDeps, # Voice Synthesis


### PR DESCRIPTION
Based on upstream's configure script force-disabling cuvid / ffnvcodec on such platforms: https://github.com/FFmpeg/FFmpeg/blob/8f77695e65a69c8009804e9d457762d2d394403d/configure#L7381-L7399

Fixes the following error when trying to build `ffmpeg-headless` on powerpc64:

```
configure flags: --disable-static --prefix=/nix/store/jfhdch8vz8w84p39hpkgjrip868bknxl-ffmpeg-headless-7.1.1 --target_os=linux --arch=powerpc64 --pkg-config=pkg-config --enable-gpl --enable-version3 --disable-nonfree --disable-static --enable-shared --enable-pic --disable-thumb --disable-small --enable-runtime-cpudetect --disable-gray --enable-swscale-alpha --enable-hardcoded-tables --enable-safe-bitstream-reader --enable-pthreads --disable-w32threads --disable-os2threads --enable-network --enable-pixelutils --datadir=/nix/store/7463b1n92pngizqdfar7z54sv07cm8ah-ffmpeg-headless-7.1.1-data/share/ffmpeg --enable-ffmpeg --disable-ffplay --enable-ffprobe --bindir=/nix/store/hr4dx3n35fblv84167m2fgrkl57qnzkh-ffmpeg-headless-7.1.1-bin/bin --enable-avcodec --enable-avdevice --enable-avfilter --enable-avformat --enable-avutil --enable-postproc --enable-swresample --enable-swscale --libdir=/nix/store/0c0af3rm1kbgrxx045nycwkqh0jfd21a-ffmpeg-headless-7.1.1-lib/lib --incdir=/nix/store/jc7fp7y9f009rm07nnvyyyr5gm720ycm-ffmpeg-headless-7.1.1-dev/include --enable-doc --enable-htmlpages --enable-manpages --mandir=/nix/store/xs0y1pawja1qxzprjp2b27fhzx1varix-ffmpeg-headless-7.1.1-man/share/man --enable-podpages --enable-txtpages --docdir=/nix/store/zd1izap8wnkp0514q6clyy1wnrqzm97a-ffmpeg-headless-7.1.1-doc/share/doc/ffmpeg --enable-alsa --disable-amf --enable-libaom --disable-libaribb24 --disable-libaribcaption --enable-libass --disable-avisynth --enable-libbluray --disable-libbs2b --enable-bzlib --disable-libcaca --disable-libcdio --disable-libcelt --disable-chromaprint --disable-libcodec2 --disable-cuda --enable-cuda-llvm --disable-cuda-nvcc --enable-cuvid --enable-libdav1d --disable-libdavs2 --disable-libdc1394 --enable-libdrm --disable-libdvdnav --disable-libdvdread --disable-libfdk-aac --enable-ffnvcodec --disable-libflite --enable-fontconfig --enable-libfontconfig --enable-libfreetype --disable-frei0r --enable-libfribidi --disable-libgme --enable-gmp --enable-gnutls --disable-libgsm --enable-libharfbuzz --enable-iconv --disable-libilbc --disable-libjack --disable-libjxl --disable-libkvazaar --disable-ladspa --disable-liblc3 --disable-liblcevc-dec --disable-lcms2 --enable-lzma --disable-metal --disable-libmfx --disable-libmodplug --enable-libmp3lame --disable-libmysofa --disable-libnpp --enable-nvdec --enable-nvenc --disable-openal --enable-opencl --disable-libopencore-amrnb --disable-libopencore-amrwb --disable-opengl --disable-libopenh264 --enable-libopenjpeg --enable-libopenmpt --enable-libopus --disable-libplacebo --disable-libpulse --disable-libqrencode --disable-libquirc --disable-librav1e --enable-librist --disable-librtmp --disable-librubberband --disable-libsmbclient --disable-sdl2 --disable-libshaderc --disable-libshine --disable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --disable-librsvg --enable-libsvtav1 --disable-libtensorflow --enable-libtheora --disable-libtwolame --disable-libuavs3d --enable-libv4l2 --enable-v4l2-m2m --enable-vaapi --disable-vdpau --disable-libvpl --enable-libvidstab --disable-libvmaf --disable-libvo-amrwbenc --enable-libvorbis --enable-libvpx --enable-vulkan --disable-libvvenc --enable-libwebp --enable-libx264 --enable-libx265 --disable-libxavs --disable-libxavs2 --disable-libxcb --disable-libxcb-shape --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxevd --disable-libxeve --disable-xlib --enable-libxml2 --enable-libxvid --enable-libzimg --enable-zlib --disable-libzmq --enable-libzvbi --disable-debug --enable-optimizations --disable-extra-warnings --disable-stripping
ERROR: cuvid requested, but not all dependencies are satisfied: ffnvcodec
```

Maybe that whole block of conditions should be changed to closer align with what upstream is doing in their configure script, instead of us continuously adding platform exclusions to it? Smth like:

```nix
  withNvcodec ?
    withHeadlessDeps
    && hostPlatform == buildPlatform
    && (
      with stdenv;
      # based on checks in upstream's configure script
      (isx86 && !isDarwin)
      || ((isAarch64 || isPower64) && !isBigEndian)
    ), # dynamically linked Nvidia code
```

---

Without specifying a `--cpu=` target, the default `generic` target falls through all of the [POWER target tests](https://github.com/FFmpeg/FFmpeg/blob/8f77695e65a69c8009804e9d457762d2d394403d/configure#L5494-L5554) and ends with a not-baseline set of features - somewhere between ppc64 and ppc64le. The available CPU targets aren't really suitable baseline targets either - `power4` enabled AltiVec, but that was only formally adopted with POWER6 - and even then, the Freescale e5500 is a POWER7 CPU without the AltiVec extension.

So try to configure together a baseline-ish config when targeting POWER.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no difference)
  - [ ] aarch64-linux
  - [x] powerpc64-linux (Native, needs #447226 applied to fix `SIGILL`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
