### PR TITLE
thrift: fix build with gcc15

### DIFF
--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -96,6 +96,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/apache/thrift/commit/eae3ac418f36c73833746bcd53e69ed8a12f0e1a.diff";
       hash = "sha256-0jlN4fo94cfGFUKcLFQgVMI/x7uxn5OiLiFk6txVPzs=";
     })
+    # Fix build with gcc15
+    # https://github.com/apache/thrift/pull/3078
+    (fetchpatch {
+      name = "thrift-add-missing-cstdint-include-gcc15.patch";
+      url = "https://github.com/apache/thrift/commit/947ad66940cfbadd9b24ba31d892dfc1142dd330.patch";
+      hash = "sha256-pWcG6/BepUwc/K6cBs+6d74AWIhZ2/wXvCunb/KyB0s=";
+    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/apache/thrift/pull/3078
https://github.com/apache/thrift/commit/947ad66940cfbadd9b24ba31d892dfc1142dd330

Fixes build failure with gcc15:
```
In file included from /build/thrift-0.18.1/lib/cpp/src/thrift/concurrency/Mutex.cpp:20:
/build/thrift-0.18.1/lib/cpp/src/thrift/concurrency/Mutex.h:47:26:
error: 'int64_t' has not been declared
   47 |   virtual bool timedlock(int64_t milliseconds) const;
      |                          ^~~~~~~
/build/thrift-0.18.1/lib/cpp/src/thrift/concurrency/Mutex.h:25:1:
note: 'int64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   24 | #include <thrift/TNonCopyable.h>
  +++ |+#include <cstdint>
   25 |
/build/thrift-0.18.1/lib/cpp/src/thrift/concurrency/Mutex.h:60:29:
error: 'int64_t' has not been declared
   60 |   Guard(const Mutex& value, int64_t timeout = 0) : mutex_(&value) {
      |                             ^~~~~~~
/build/thrift-0.18.1/lib/cpp/src/thrift/concurrency/Mutex.h:60:29:
note: 'int64_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
In file included from /build/thrift-0.18.1/lib/cpp/src/thrift/transport/TServerSocket.h:25,
                 from /build/thrift-0.18.1/lib/cpp/src/thrift/transport/TSSLServerSocket.h:23,
                 from /build/thrift-0.18.1/lib/cpp/src/thrift/transport/TSSLServerSocket.cpp:21:
/build/thrift-0.18.1/lib/cpp/src/thrift/concurrency/Mutex.h:47:26: error: 'int64_t' has not been declared
   47 |   virtual bool timedlock(int64_t milliseconds) const;
      |                          ^~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; thrift.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
