### PR TITLE
python3Packages.catkin-pkg: (re)init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/catkin-pkg/default.nix
+++ b/pkgs/development/python-modules/catkin-pkg/default.nix
@@ -43,9 +43,7 @@ buildPythonPackage rec {
     homepage = "http://wiki.ros.org/catkin_pkg";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      adhityaravi
-      bepri
-      dstathis
+      wentasah
     ];
   };
 }

--- a/pkgs/development/python-modules/catkin-pkg/default.nix
+++ b/pkgs/development/python-modules/catkin-pkg/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ros-infrastructure";
     repo = "catkin_pkg";
-    rev = version;
+    tag = version;
     hash = "sha256-V4iurFt1WmY2jXy0A4Qa2eKMCWmR+Hs3d9pru0/zUSM=";
   };
 
@@ -28,7 +28,6 @@ buildPythonPackage rec {
     docutils
     pyparsing
     python-dateutil
-    setuptools
   ];
 
   pythonImportsCheck = [ "catkin_pkg" ];
@@ -38,7 +37,7 @@ buildPythonPackage rec {
   disabledTestPaths = [ "test/test_flake8.py" ];
 
   meta = {
-    changelog = "https://github.com/ros-infrastructure/catkin_pkg/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/ros-infrastructure/catkin_pkg/blob/${src.tag}/CHANGELOG.rst";
     description = "Library for retrieving information about catkin packages";
     homepage = "http://wiki.ros.org/catkin_pkg";
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/catkin-pkg/default.nix
+++ b/pkgs/development/python-modules/catkin-pkg/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  docutils,
+  pyparsing,
+  python-dateutil,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "catkin-pkg";
+  version = "1.0.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ros-infrastructure";
+    repo = "catkin_pkg";
+    rev = version;
+    hash = "sha256-lHUKhE9dQLO1MbkstUEiGrHc9Rm+bY/AmgLyh7AbvFQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    docutils
+    pyparsing
+    python-dateutil
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "catkin_pkg" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [ "test/test_flake8.py" ];
+
+  meta = {
+    changelog = "https://github.com/ros-infrastructure/catkin_pkg/blob/${version}/CHANGELOG.rst";
+    description = "Library for retrieving information about catkin packages";
+    homepage = "http://wiki.ros.org/catkin_pkg";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      adhityaravi
+      bepri
+      dstathis
+    ];
+  };
+}

--- a/pkgs/development/python-modules/catkin-pkg/default.nix
+++ b/pkgs/development/python-modules/catkin-pkg/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "catkin-pkg";
-  version = "1.0.0";
+  version = "1.1.0";
 
   pyproject = true;
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "ros-infrastructure";
     repo = "catkin_pkg";
     rev = version;
-    hash = "sha256-lHUKhE9dQLO1MbkstUEiGrHc9Rm+bY/AmgLyh7AbvFQ=";
+    hash = "sha256-V4iurFt1WmY2jXy0A4Qa2eKMCWmR+Hs3d9pru0/zUSM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2392,6 +2392,8 @@ self: super: with self; {
     };
   };
 
+  catkin-pkg = callPackage ../development/python-modules/catkin-pkg { };
+
   catppuccin = callPackage ../development/python-modules/catppuccin { };
 
   cattrs = callPackage ../development/python-modules/cattrs { };


### PR DESCRIPTION
`python3Packages.catkin-pkg` was recently removed in #443998 because nothing else in nixpkgs used it. We use it in [nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay) so I'm re-adding the package, setting myself as a maintainer and upgrading to version 1.1.0.

The [changelog can be seen here](https://github.com/ros-infrastructure/catkin_pkg/blob/1.1.0/CHANGELOG.rst).

Cc @jnsgruk (who [suggested this PR](https://github.com/NixOS/nixpkgs/pull/443998#issuecomment-3345661682)) and former maintainers @adhityaravi, @bepri and @dstathis. If you want to stay in the maintainers filed, let me know.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
