### PR TITLE
music-assistant: build librespot fork

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -85,7 +85,7 @@ in
           lsof
         ]
         ++ lib.optionals (lib.elem "spotify" cfg.providers) [
-          librespot
+          librespot-ma
         ]
         ++ lib.optionals (lib.elem "snapcast" cfg.providers) [
           snapcast

--- a/pkgs/by-name/li/librespot-ma/package.nix
+++ b/pkgs/by-name/li/librespot-ma/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "librespot-ma";
+  version = "0.6.0-unstable-2025-08-10";
+
+  src = fetchFromGitHub {
+    owner = "music-assistant";
+    repo = "librespot";
+    rev = "accecb60a16334013c0c99a5ded553794ee871b7";
+    hash = "sha256-vPiI8llXB6+ahX+iad/Ut81D3iZcTSVmYGDXXwApk/w=";
+  };
+
+  cargoHash = "sha256-Lujz2revTAok9B0hzdl8NVQ5XMRY9ACJzoQHIkIgKMg=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "Fork of librespot for use in Music Assistant only";
+    homepage = "https://github.com/music-assistant/librespot";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      sweenu
+      emilylange
+    ];
+    mainProgram = "librespot";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/mu/music-assistant/librespot.patch
+++ b/pkgs/by-name/mu/music-assistant/librespot.patch
@@ -1,0 +1,25 @@
+diff --git a/music_assistant/providers/spotify/helpers.py b/music_assistant/providers/spotify/helpers.py
+index 8b6c4e78f5f3f64c9dc6206028177c99ed0542ed..25ed6e468b393d2da74167e3c2ac4bdcd2e2699e 100644
+--- a/music_assistant/providers/spotify/helpers.py
++++ b/music_assistant/providers/spotify/helpers.py
+@@ -4,6 +4,7 @@ from __future__ import annotations
+
+ import os
+ import platform
++from shutil import which
+
+ from music_assistant.helpers.process import check_output
+
+@@ -20,12 +21,8 @@ async def get_librespot_binary() -> str:
+         except OSError:
+             return None
+
+-    base_path = os.path.join(os.path.dirname(__file__), "bin")
+-    system = platform.system().lower().replace("darwin", "macos")
+-    architecture = platform.machine().lower()
+-
+     if bridge_binary := await check_librespot(
+-        os.path.join(base_path, f"librespot-{system}-{architecture}")
++        which("librespot")
+     ):
+         return bridge_binary


### PR DESCRIPTION
Tested it locally.
I know @mweinelt you don't want to maintain the librespot-ma fork, but I'm up for helping to maintain it as I will be using it for the foreseeable future.

I was wondering if we should override the package automatically in the module if spotify is added to the providers?

Closes https://github.com/NixOS/nixpkgs/issues/436670

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
