### PR TITLE
python313Packages.aiosonic: 0.24.0 -> 0.26.0

### DIFF
--- a/pkgs/development/python-modules/aiosonic/default.nix
+++ b/pkgs/development/python-modules/aiosonic/default.nix
@@ -1,29 +1,27 @@
 {
-  nodejs,
   lib,
+  stdenv,
+  aiohttp,
   buildPythonPackage,
-  pythonOlder,
-  fetchFromGitHub,
-  poetry-core,
-  # install_requires
   charset-normalizer,
+  fetchFromGitHub,
   h2,
-  onecache,
-  # test dependencies
   httpx,
+  onecache,
+  pkgs,
+  poetry-core,
   pytest-aiohttp,
   pytest-cov-stub,
   pytest-mock,
-  uvicorn,
-  requests,
-  aiohttp,
   pytestCheckHook,
-  stdenv,
+  pythonOlder,
+  requests,
+  uvicorn,
 }:
 
 buildPythonPackage rec {
   pname = "aiosonic";
-  version = "0.24.0";
+  version = "0.26.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -34,7 +32,7 @@ buildPythonPackage rec {
     owner = "sonic182";
     repo = "aiosonic";
     tag = version;
-    hash = "sha256-Yh1AD/tBHQBpwAA86XuP9UuXnCAFcMw/XSv6z46XP0k=";
+    hash = "sha256-sYd7qjOiRENO6hPhJ01RLsr+2RtTITrXjcT6/ZaGfAU=";
   };
 
   postPatch = ''
@@ -47,64 +45,73 @@ buildPythonPackage rec {
 
   dependencies = [
     charset-normalizer
-    onecache
     h2
+    onecache
   ];
 
   nativeCheckInputs = [
     aiohttp
     httpx
+    pkgs.nodejs
     pytest-aiohttp
     pytest-cov-stub
     pytest-mock
-    uvicorn
-    requests
     pytestCheckHook
+    requests
+    uvicorn
   ];
 
   pythonImportsCheck = [ "aiosonic" ];
 
   disabledTests =
     lib.optionals stdenv.hostPlatform.isLinux [
-      # need network
-      "test_simple_get"
-      "test_get_python"
-      "test_post_http2"
-      "test_get_http2"
-      "test_method_lower"
-      "test_keep_alive_smart_pool"
-      "test_keep_alive_cyclic_pool"
-      "test_get_with_params"
-      "test_get_with_params_in_url"
-      "test_get_with_params_tuple"
-      "test_post_form_urlencoded"
-      "test_post_tuple_form_urlencoded"
-      "test_post_json"
-      "test_put_patch"
-      "test_delete"
-      "test_delete_2"
-      "test_get_keepalive"
-      "test_post_multipart_to_django"
-      "test_connect_timeout"
-      "test_read_timeout"
-      "test_timeouts_overriden"
-      "test_pool_acquire_timeout"
-      "test_simple_get_ssl"
-      "test_simple_get_ssl_ctx"
-      "test_simple_get_ssl_no_valid"
-      "test_get_chunked_response"
-      "test_get_chunked_response_and_not_read_it"
-      "test_read_chunks_by_text_method"
-      "test_get_body_gzip"
-      "test_get_body_deflate"
-      "test_post_chunked"
+      # Tests require network access
       "test_close_connection"
       "test_close_old_keeped_conn"
-      "test_get_redirect"
-      "test_max_redirects"
-      "test_get_image"
+      "test_connect_timeout"
+      "test_delete_2"
+      "test_delete"
+      "test_get_body_deflate"
+      "test_get_body_gzip"
+      "test_get_chunked_response_and_not_read_it"
+      "test_get_chunked_response"
+      "test_get_http2"
       "test_get_image_chunked"
+      "test_get_image"
+      "test_get_keepalive"
+      "test_get_python"
+      "test_get_redirect"
       "test_get_with_cookies"
+      "test_get_with_params_in_url"
+      "test_get_with_params_tuple"
+      "test_get_with_params"
+      "test_keep_alive_cyclic_pool"
+      "test_keep_alive_smart_pool"
+      "test_max_conn_idle_ms"
+      "test_max_redirects"
+      "test_method_lower"
+      "test_multipart_backward_compatibility"
+      "test_pool_acquire_timeout"
+      "test_post_chunked"
+      "test_post_form_urlencoded"
+      "test_post_http2"
+      "test_post_json"
+      "test_post_multipart_with_class"
+      "test_post_multipart_with_metadata"
+      "test_post_multipart_with_multipartfile_class"
+      "test_post_multipart_with_multipartfile_path"
+      "test_post_multipart"
+      "test_post_tuple_form_urlencoded"
+      "test_put_patch"
+      "test_read_chunks_by_text_method"
+      "test_read_timeout"
+      "test_simple_get"
+      "test_timeouts_overriden"
+      "test_wrapper_delete_http_serv"
+      "test_wrapper_get_http_serv"
+      # Tests can't trigger server
+      "test_ws"
+      # Test requires proxy
       "test_proxy_request"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
Changelog: https://github.com/sonic182/aiosonic/blob/0.26.0/CHANGELOG.md

https://hydra.nixos.org/build/307239197
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
