### PR TITLE
smithy: init at 1.62.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25121,6 +25121,12 @@
     githubId = 143103;
     name = "Attila Sztupak";
   };
+  szympajka = {
+    email = "szymon.pajka@gmail.com";
+    github = "szympajka";
+    githubId = 19807209;
+    name = "Szymon Pajka";
+  };
   t-monaghan = {
     email = "tomaghan@gmail.com";
     github = "t-monaghan";

--- a/pkgs/by-name/sm/smithy/package.nix
+++ b/pkgs/by-name/sm/smithy/package.nix
@@ -1,0 +1,100 @@
+{
+  fetchurl,
+  jre,
+  lib,
+  makeBinaryWrapper,
+  stdenv,
+  testers,
+  unzip,
+}:
+
+let
+  platformMap = {
+    "x86_64-linux" = {
+      arch = "linux-x86_64";
+      hash = "sha256-y2Ryl/HbVsq0V1HNyqTWpehfqrJ2jNmfk2np8izAClo=";
+    };
+    "aarch64-linux" = {
+      arch = "linux-aarch64";
+      hash = "sha256-7zkIYKvnLKIaGqybJYMw5cTtHkN06VuifttsxK2R54c=";
+    };
+    "x86_64-darwin" = {
+      arch = "darwin-x86_64";
+      hash = "sha256-6087IQSVCJ6AG+y797hlTySwdTgOSyrJbX9GZYKdP14=";
+    };
+    "aarch64-darwin" = {
+      arch = "darwin-aarch64";
+      hash = "sha256-w7Jc3zKi+jXRmi9CQEg1RQ+QBpzRDniY2UtaawT2Ai0=";
+    };
+  };
+
+  platform =
+    platformMap.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "smithy";
+  version = "1.62.0";
+
+  src = fetchurl {
+    url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-${platform.arch}.zip";
+    hash = platform.hash;
+  };
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [ jre ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "smithy --version";
+    version = finalAttrs.version;
+  };
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r bin/ lib/ conf/ $out/
+
+    # Replace bundled Java binaries with symlinks to Nix-provided JRE
+    ln -sf ${jre}/bin/java $out/bin/java
+    ln -sf ${jre}/bin/keytool $out/bin/keytool
+
+    if [ -f $out/bin/smithy ]; then
+      wrapProgram $out/bin/smithy \
+        --set JAVA_HOME "${jre}" \
+        --set JAVACMD "${jre}/bin/java" \
+        --set DEFAULT_JVM_OPTS ""
+    else
+      echo "Could not find smithy binary at bin/smithy"
+      exit 1
+    fi
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CLI for Smithy, a language for defining services and SDKs";
+    mainProgram = "smithy";
+    longDescription = ''
+      Smithy is a language for defining services and SDKs. The Smithy CLI
+      provides commands to build, validate, and generate code from Smithy models.
+    '';
+    homepage = "https://smithy.io/";
+    changelog = "https://github.com/smithy-lang/smithy/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ szympajka ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      binaryBytecode
+    ];
+  };
+})


### PR DESCRIPTION
Added package [smithy](https://smithy.io/):
A command line tool that provides commands to build, validate, and generate code from Smithy models.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
