### PR TITLE
mumble: fix build with gcc15

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -161,6 +161,14 @@ let
           url = "https://github.com/mumble-voip/mumble/commit/fbd21bd422367bed19f801bf278562f567cbb8b7.patch";
           sha256 = "sha256-qFhC2j/cOWzAhs+KTccDIdcgFqfr4y4VLjHiK458Ucs=";
         })
+
+        # Fix build with gcc15
+        # https://github.com/mumble-voip/mumble/pull/6775
+        (fetchpatch {
+          name = "mumble-fix-build-with-gcc15.patch";
+          url = "https://github.com/mumble-voip/mumble/commit/f4259722553335d79e9d28948ab7bdb00293a5ec.patch";
+          hash = "sha256-9vrejtyYk448/Z/fHsbGd4pyGJf4IPq7QYNH0kzaY3U=";
+        })
       ];
 
       postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/mumble-voip/mumble/pull/6775
https://github.com/mumble-voip/mumble/commit/f4259722553335d79e9d28948ab7bdb00293a5ec

Fixes build failure with gcc15:
```
In file included from /build/source/build/overlay_gl/CMakeFiles/overlay_gl.dir/Unity/unity_0_c.c:4:
/build/source/overlay_gl/overlay.c:40:23: error: 'bool' cannot be defined via 'typedef'
   40 | typedef unsigned char bool;
      |                       ^~~~
/build/source/overlay_gl/overlay.c:40:23: note: 'bool' is a keyword with '-std=c23' onwards
/build/source/overlay_gl/overlay.c:40:1: warning: useless type name in empty declaration
   40 | typedef unsigned char bool;
      | ^~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; mumble.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
