### PR TITLE
time: fix build on non-glibc

### DIFF
--- a/pkgs/by-name/ti/time/package.nix
+++ b/pkgs/by-name/ti/time/package.nix
@@ -17,11 +17,9 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # fixes cross-compilation to riscv64-linux
     ./time-1.9-implicit-func-decl-clang.patch
+    # https://lists.gnu.org/archive/html/bug-time/2025-10/msg00000.html
     # fix compilation with gcc15
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/time/raw/191440912c2e9a63af87802e507ca3ccb923e805/f/time-1.9-Fix-compiling-with-GCC15.patch";
-      hash = "sha256-4Qp3mV8XuCmz518GPtrW52gyaPOb+97RE6FDPKNCyJw=";
-    })
+    ./time-1.9-fix-sighandler-prototype-for-c23.patch
   ];
 
   meta = {

--- a/pkgs/by-name/ti/time/time-1.9-fix-sighandler-prototype-for-c23.patch
+++ b/pkgs/by-name/ti/time/time-1.9-fix-sighandler-prototype-for-c23.patch
@@ -1,0 +1,30 @@
+In C23 functions with empty argument list in the prototype are treated
+as taking no arguments. This means that the `int` argument of the
+sighandler must be specified explicitly or the code will fail to
+compile due to mismatched function type.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+This fixes the same issue as
+<https://lists.gnu.org/archive/html/bug-time/2025-01/msg00000.html> and
+<https://lists.gnu.org/archive/html/bug-time/2025-03/msg00000.html> but does not
+rely on `sighandler_t` which is a GNU extension.
+
+ src/time.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/time.c b/src/time.c
+index 7b401bc..88287dd 100644
+--- a/src/time.c
++++ b/src/time.c
+@@ -77,7 +77,7 @@ enum
+
+
+ /* A Pointer to a signal handler.  */
+-typedef RETSIGTYPE (*sighandler) ();
++typedef RETSIGTYPE (*sighandler) (int);
+
+ /* msec = milliseconds = 1/1,000 (1*10e-3) second.
+    usec = microseconds = 1/1,000,000 (1*10e-6) second.  */
+--
+2.51.0


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Turns out that the patch applied in the previous change breaks musl, so I've made it conditional that we are not using musl before applying the patch.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
