### PR TITLE
nagiosPlugins.check_ssl_cert: fix /bin/cat

### DIFF
--- a/pkgs/servers/monitoring/nagios-plugins/check_ssl_cert/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/check_ssl_cert/default.nix
@@ -14,6 +14,10 @@
   python3,
   stdenv,
   which,
+  gnugrep,
+  gnused,
+  net-tools,
+  gawk,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,14 +38,21 @@ stdenv.mkDerivation rec {
     "MANDIR=$(out)/share/man"
   ];
 
+  postPatch = ''
+    substituteInPlace check_ssl_cert --replace-fail \
+      /bin/cat \
+      cat
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/check_ssl_cert \
       --prefix PATH : "${
         lib.makeBinPath (
           [
             bc
-            bind # host and dig binary
-            coreutils # date and timeout binary
+            bind.host
+            bind.dnsutils # dig
+            coreutils # date, timeout, cat
             curl
             file
             netcat-gnu
@@ -49,6 +60,10 @@ stdenv.mkDerivation rec {
             openssl
             python3
             which
+            gnugrep
+            gnused
+            net-tools # hostname
+            gawk
           ]
           ++ lib.optional stdenv.hostPlatform.isLinux iproute2
         )


### PR DESCRIPTION
- replace `/bin/cat` with `cat` from coreutils so `-f` can work
- add missing tools to PATH

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
