### PR TITLE
Reinstate boot counting

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -384,6 +384,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `stestrCheckHook` was added: This test hook runs `stestr run`. You can disable tests with `disabledTests` and `disabledTestsRegex`.
 
+- `boot.loader.systemd-boot` gained support for [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) via the new [`boot.loader.systemd-boot.bootCounting`](#opt-boot.loader.systemd-boot.bootCounting.enable) options. As part of this change, boot loader entries on the ESP/XBOOTLDR partition are now named `nixos-<content-hash>.conf` instead of `nixos-generation-<n>.conf`; existing entries are migrated automatically on the next `nixos-rebuild boot`/`switch`.
+
 - `services.frp` now supports multiple instances through `services.frp.instances` to make it possible to run multiple frp clients or servers at the same time.
 
 - `hyphen` now supports over 40 language variants through `hyphenDicts` and now allows to enable all supported languages through `hyphenDicts.all`.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -26,4 +26,6 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `boot.loader.systemd-boot` gained support for [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) via the new [`boot.loader.systemd-boot.bootCounting`](#opt-boot.loader.systemd-boot.bootCounting.enable) options, allowing automatic detection of and recovery from bad NixOS generations. As part of this change, boot loader entries on the ESP/XBOOTLDR partition are now named `nixos-<content-hash>.conf` instead of `nixos-generation-<n>.conf`; existing entries are migrated automatically on the next `nixos-rebuild boot`/`switch`.
+
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -19,9 +19,11 @@ from pathlib import Path
 EFI_SYS_MOUNT_POINT = Path("@efiSysMountPoint@")
 BOOT_MOUNT_POINT = Path("@bootMountPoint@")
 LOADER_CONF = EFI_SYS_MOUNT_POINT / "loader/loader.conf"  # Always stored on the ESP
-NIXOS_DIR = Path("@nixosDir@".strip("/")) # Path relative to the XBOOTLDR or ESP mount point
+NIXOS_DIR = Path(
+    "@nixosDir@".strip("/")
+)  # Path relative to the XBOOTLDR or ESP mount point
 TIMEOUT = "@timeout@"
-EDITOR = "@editor@" == "1" # noqa: PLR0133
+EDITOR = "@editor@" == "1"  # noqa: PLR0133
 CONSOLE_MODE = "@consoleMode@"
 BOOTSPEC_TOOLS = "@bootspecTools@"
 DISTRO_NAME = "@distroName@"
@@ -34,6 +36,7 @@ GRACEFUL = "@graceful@"
 COPY_EXTRA_FILES = "@copyExtraFiles@"
 CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
+
 
 @dataclass
 class BootSpec:
@@ -54,8 +57,12 @@ libc = ctypes.CDLL("libc.so.6")
 
 FILE = None | int
 
-def run(cmd: Sequence[str | Path], stdout: FILE = None) -> subprocess.CompletedProcess[str]:
+
+def run(
+    cmd: Sequence[str | Path], stdout: FILE = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, check=True, text=True, stdout=stdout)
+
 
 class SystemIdentifier(NamedTuple):
     profile: str | None
@@ -73,16 +80,22 @@ def copy_if_not_exists(source: Path, dest: Path) -> None:
 
 def generation_dir(profile: str | None, generation: int) -> Path:
     if profile:
-        return Path(f"/nix/var/nix/profiles/system-profiles/{profile}-{generation}-link")
+        return Path(
+            f"/nix/var/nix/profiles/system-profiles/{profile}-{generation}-link"
+        )
     else:
         return Path(f"/nix/var/nix/profiles/system-{generation}-link")
 
-def system_dir(profile: str | None, generation: int, specialisation: str | None) -> Path:
+
+def system_dir(
+    profile: str | None, generation: int, specialisation: str | None
+) -> Path:
     d = generation_dir(profile, generation)
     if specialisation:
         return d / "specialisation" / specialisation
     else:
         return d
+
 
 BOOT_ENTRY = """title {title}
 sort-key {sort_key}
@@ -92,7 +105,10 @@ initrd {initrd}
 options {kernel_params}
 """
 
-def generation_conf_filename(profile: str | None, generation: int, specialisation: str | None) -> str:
+
+def generation_conf_filename(
+    profile: str | None, generation: int, specialisation: str | None
+) -> str:
     pieces = [
         "nixos",
         profile or None,
@@ -103,11 +119,16 @@ def generation_conf_filename(profile: str | None, generation: int, specialisatio
     return "-".join(p for p in pieces if p) + ".conf"
 
 
-def write_loader_conf(profile: str | None, generation: int, specialisation: str | None) -> None:
+def write_loader_conf(
+    profile: str | None, generation: int, specialisation: str | None
+) -> None:
     tmp = LOADER_CONF.with_suffix(".tmp")
-    with tmp.open('x') as f:
+    with tmp.open("x") as f:
         f.write(f"timeout {TIMEOUT}\n")
-        f.write("default %s\n" % generation_conf_filename(profile, generation, specialisation))
+        f.write(
+            "default %s\n"
+            % generation_conf_filename(profile, generation, specialisation)
+        )
         if not EDITOR:
             f.write("editor 0\n")
         if REBOOT_FOR_BITLOCKER:
@@ -127,7 +148,9 @@ def get_bootspec(profile: str | None, generation: int) -> BootSpec:
             try:
                 bootspec_json = json.load(f)
             except ValueError as e:
-                print(f"error: Malformed Json: {e}, in {boot_json_path}", file=sys.stderr)
+                print(
+                    f"error: Malformed Json: {e}, in {boot_json_path}", file=sys.stderr
+                )
                 sys.exit(1)
     else:
         boot_json_str = run(
@@ -143,17 +166,18 @@ def get_bootspec(profile: str | None, generation: int) -> BootSpec:
         bootspec_json = json.loads(boot_json_str)
     return bootspec_from_json(bootspec_json)
 
+
 def bootspec_from_json(bootspec_json: dict[str, Any]) -> BootSpec:
-    specialisations = bootspec_json['org.nixos.specialisation.v1']
+    specialisations = bootspec_json["org.nixos.specialisation.v1"]
     specialisations = {k: bootspec_from_json(v) for k, v in specialisations.items()}
-    systemdBootExtension = bootspec_json.get('org.nixos.systemd-boot', {})
-    sortKey = systemdBootExtension.get('sortKey', 'nixos')
-    devicetree = systemdBootExtension.get('devicetree')
+    systemdBootExtension = bootspec_json.get("org.nixos.systemd-boot", {})
+    sortKey = systemdBootExtension.get("sortKey", "nixos")
+    devicetree = systemdBootExtension.get("devicetree")
 
     if devicetree:
         devicetree = Path(devicetree)
 
-    main_json = bootspec_json['org.nixos.bootspec.v1']
+    main_json = bootspec_json["org.nixos.bootspec.v1"]
     for attr in ("kernel", "initrd", "toplevel"):
         if attr in main_json:
             main_json[attr] = Path(main_json[attr])
@@ -172,24 +196,35 @@ def copy_from_file(file: Path, dry_run: bool = False) -> Path:
     store_file_path = file.resolve()
     suffix = store_file_path.name
     store_subdir = store_file_path.relative_to(STORE_DIR).parts[0]
-    efi_file_path = NIXOS_DIR / (f"{suffix}.efi" if suffix == store_subdir else f"{store_subdir}-{suffix}.efi")
+    efi_file_path = NIXOS_DIR / (
+        f"{suffix}.efi" if suffix == store_subdir else f"{store_subdir}-{suffix}.efi"
+    )
     if not dry_run:
         copy_if_not_exists(store_file_path, BOOT_MOUNT_POINT / efi_file_path)
     return efi_file_path
 
 
-def write_entry(profile: str | None, generation: int, specialisation: str | None,
-                machine_id: str | None, bootspec: BootSpec, current: bool) -> None:
+def write_entry(
+    profile: str | None,
+    generation: int,
+    specialisation: str | None,
+    machine_id: str | None,
+    bootspec: BootSpec,
+    current: bool,
+) -> None:
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
     kernel = copy_from_file(bootspec.kernel)
     initrd = copy_from_file(bootspec.initrd)
-    devicetree = copy_from_file(bootspec.devicetree) if bootspec.devicetree is not None else None
+    devicetree = (
+        copy_from_file(bootspec.devicetree) if bootspec.devicetree is not None else None
+    )
 
     title = "{name}{profile}{specialisation}".format(
         name=DISTRO_NAME,
         profile=" [" + profile + "]" if profile else "",
-        specialisation=" (%s)" % specialisation if specialisation else "")
+        specialisation=" (%s)" % specialisation if specialisation else "",
+    )
 
     try:
         if bootspec.initrdSecrets is not None:
@@ -199,26 +234,40 @@ def write_entry(profile: str | None, generation: int, specialisation: str | None
             print("failed to create initrd secrets!", file=sys.stderr)
             sys.exit(1)
         else:
-            print("warning: failed to create initrd secrets "
-                  f'for "{title} - Configuration {generation}", an older generation', file=sys.stderr)
-            print("note: this is normal after having removed "
-                  "or renamed a file in `boot.initrd.secrets`", file=sys.stderr)
-    entry_file = BOOT_MOUNT_POINT / "loader/entries" / generation_conf_filename(profile, generation, specialisation)
+            print(
+                "warning: failed to create initrd secrets "
+                f'for "{title} - Configuration {generation}", an older generation',
+                file=sys.stderr,
+            )
+            print(
+                "note: this is normal after having removed "
+                "or renamed a file in `boot.initrd.secrets`",
+                file=sys.stderr,
+            )
+    entry_file = (
+        BOOT_MOUNT_POINT
+        / "loader/entries"
+        / generation_conf_filename(profile, generation, specialisation)
+    )
     tmp_path = entry_file.with_suffix(".tmp")
     kernel_params = "init=%s " % bootspec.init
 
     kernel_params = kernel_params + " ".join(bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
-    build_date = datetime.datetime.fromtimestamp(build_time).strftime('%F')
+    build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
 
     with tmp_path.open("w") as f:
-        f.write(BOOT_ENTRY.format(title=title,
-                    sort_key=bootspec.sortKey,
-                    generation=generation,
-                    kernel=f"/{kernel}",
-                    initrd=f"/{initrd}",
-                    kernel_params=kernel_params,
-                    description=f"{bootspec.label}, built on {build_date}"))
+        f.write(
+            BOOT_ENTRY.format(
+                title=title,
+                sort_key=bootspec.sortKey,
+                generation=generation,
+                kernel=f"/{kernel}",
+                initrd=f"/{initrd}",
+                kernel_params=kernel_params,
+                description=f"{bootspec.label}, built on {build_date}",
+            )
+        )
         if machine_id is not None:
             f.write("machine-id %s\n" % machine_id)
         if devicetree is not None:
@@ -245,9 +294,7 @@ def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
     configurationLimit = CONFIGURATION_LIMIT
     configurations = [
         SystemIdentifier(
-            profile=profile,
-            generation=int(line.split()[0]),
-            specialisation=None
+            profile=profile, generation=int(line.split()[0]), specialisation=None
         )
         for line in gen_lines
     ]
@@ -256,7 +303,9 @@ def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
 
 def remove_old_entries(gens: list[SystemIdentifier]) -> None:
     rex_profile = re.compile(r"^nixos-(.*)-generation-.*\.conf$")
-    rex_generation = re.compile(r"^nixos.*-generation-([0-9]+)(-specialisation-.*)?\.conf$")
+    rex_generation = re.compile(
+        r"^nixos.*-generation-([0-9]+)(-specialisation-.*)?\.conf$"
+    )
     known_paths = []
     for gen in gens:
         bootspec = get_bootspec(gen.profile, gen.generation)
@@ -264,7 +313,9 @@ def remove_old_entries(gens: list[SystemIdentifier]) -> None:
         known_paths.append(copy_from_file(bootspec.initrd, True).name)
         if bootspec.devicetree is not None:
             known_paths.append(copy_from_file(bootspec.devicetree, True).name)
-    for path in (BOOT_MOUNT_POINT / "loader/entries").glob("nixos*-generation-[1-9]*.conf", case_sensitive=False):
+    for path in (BOOT_MOUNT_POINT / "loader/entries").glob(
+        "nixos*-generation-[1-9]*.conf", case_sensitive=False
+    ):
         if rex_profile.match(path.name):
             prof = rex_profile.sub(r"\1", path.name)
         else:
@@ -291,11 +342,12 @@ def cleanup_esp() -> None:
 def get_profiles() -> list[str]:
     system_profiles = Path("/nix/var/nix/profiles/system-profiles/")
     if system_profiles.is_dir():
-        return [x.name
-            for x in system_profiles.iterdir()
-            if not x.name.endswith("-link")]
+        return [
+            x.name for x in system_profiles.iterdir() if not x.name.endswith("-link")
+        ]
     else:
         return []
+
 
 def install_bootloader(args: argparse.Namespace) -> None:
     try:
@@ -307,7 +359,10 @@ def install_bootloader(args: argparse.Namespace) -> None:
         machine_id = None
 
     if os.getenv("NIXOS_INSTALL_GRUB") == "1":
-        warnings.warn("NIXOS_INSTALL_GRUB env var deprecated, use NIXOS_INSTALL_BOOTLOADER", DeprecationWarning)
+        warnings.warn(
+            "NIXOS_INSTALL_GRUB env var deprecated, use NIXOS_INSTALL_BOOTLOADER",
+            DeprecationWarning,
+        )
         os.environ["NIXOS_INSTALL_BOOTLOADER"] = "1"
 
     # flags to pass to bootctl install/update
@@ -351,13 +406,18 @@ def install_bootloader(args: argparse.Namespace) -> None:
         #  ESP: /boot (/dev/disk/by-partuuid/9b39b4c4-c48b-4ebf-bfea-a56b2395b7e0)
         # File: ├─/EFI/systemd/HashTool.efi
         #       └─/EFI/systemd/systemd-bootx64.efi (systemd-boot 255.2)
-        installed_match = re.search(r"^\W+.*/EFI/(?:BOOT|systemd)/.*\.efi \(systemd-boot ([\d.]+[^)]*)\)$",
-                      installed_out, re.IGNORECASE | re.MULTILINE)
+        installed_match = re.search(
+            r"^\W+.*/EFI/(?:BOOT|systemd)/.*\.efi \(systemd-boot ([\d.]+[^)]*)\)$",
+            installed_out,
+            re.IGNORECASE | re.MULTILINE,
+        )
 
         available_match = re.search(r"^\((.*)\)$", available_out)
 
         if installed_match is None:
-            raise Exception("Could not find any previously installed systemd-boot. If you are switching to systemd-boot from a different bootloader, you need to run `nixos-rebuild switch --install-bootloader`")
+            raise Exception(
+                "Could not find any previously installed systemd-boot. If you are switching to systemd-boot from a different bootloader, you need to run `nixos-rebuild switch --install-bootloader`"
+            )
 
         if available_match is None:
             raise Exception("could not determine systemd-boot version")
@@ -366,7 +426,11 @@ def install_bootloader(args: argparse.Namespace) -> None:
         available_version = available_match.group(1)
 
         if installed_version < available_version:
-            print("updating systemd-boot from %s to %s" % (installed_version, available_version), file=sys.stderr)
+            print(
+                "updating systemd-boot from %s to %s"
+                % (installed_version, available_version),
+                file=sys.stderr,
+            )
             run(
                 [f"{SYSTEMD}/bin/bootctl", f"--esp-path={EFI_SYS_MOUNT_POINT}"]
                 + bootctl_flags
@@ -388,14 +452,28 @@ def install_bootloader(args: argparse.Namespace) -> None:
             is_default = Path(bootspec.init).parent == Path(args.default_config)
             write_entry(*gen, machine_id, bootspec, current=is_default)
             for specialisation in bootspec.specialisations.keys():
-                write_entry(gen.profile, gen.generation, specialisation, machine_id, bootspec, current=is_default)
+                write_entry(
+                    gen.profile,
+                    gen.generation,
+                    specialisation,
+                    machine_id,
+                    bootspec,
+                    current=is_default,
+                )
             if is_default:
                 write_loader_conf(*gen)
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552
             if e.errno == errno.EINVAL:
-                profile = f"profile '{gen.profile}'" if gen.profile else "default profile"
-                print("ignoring {} in the list of boot entries because of the following error:\n{}".format(profile, e), file=sys.stderr)
+                profile = (
+                    f"profile '{gen.profile}'" if gen.profile else "default profile"
+                )
+                print(
+                    "ignoring {} in the list of boot entries because of the following error:\n{}".format(
+                        profile, e
+                    ),
+                    file=sys.stderr,
+                )
             else:
                 raise e
 
@@ -425,8 +503,14 @@ def install_bootloader(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=f"Update {DISTRO_NAME}-related systemd-boot files")
-    parser.add_argument('default_config', metavar='DEFAULT-CONFIG', help=f"The default {DISTRO_NAME} config to boot")
+    parser = argparse.ArgumentParser(
+        description=f"Update {DISTRO_NAME}-related systemd-boot files"
+    )
+    parser.add_argument(
+        "default_config",
+        metavar="DEFAULT-CONFIG",
+        help=f"The default {DISTRO_NAME} config to boot",
+    )
     args = parser.parse_args()
 
     run([CHECK_MOUNTPOINTS])
@@ -440,13 +524,18 @@ def main() -> None:
         # event sync the efi filesystem after each update.
         rc = libc.syncfs(os.open(f"{BOOT_MOUNT_POINT}", os.O_RDONLY))
         if rc != 0:
-            print(f"could not sync {BOOT_MOUNT_POINT}: {os.strerror(rc)}", file=sys.stderr)
+            print(
+                f"could not sync {BOOT_MOUNT_POINT}: {os.strerror(rc)}", file=sys.stderr
+            )
 
         if BOOT_MOUNT_POINT != EFI_SYS_MOUNT_POINT:
             rc = libc.syncfs(os.open(EFI_SYS_MOUNT_POINT, os.O_RDONLY))
             if rc != 0:
-                print(f"could not sync {EFI_SYS_MOUNT_POINT}: {os.strerror(rc)}", file=sys.stderr)
+                print(
+                    f"could not sync {EFI_SYS_MOUNT_POINT}: {os.strerror(rc)}",
+                    file=sys.stderr,
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -11,7 +11,8 @@ import sys
 import tempfile
 import warnings
 import json
-from typing import NamedTuple, Any, Sequence
+import glob
+from typing import NamedTuple, Any, Sequence, Type
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -36,6 +37,8 @@ GRACEFUL = "@graceful@"
 COPY_EXTRA_FILES = "@copyExtraFiles@"
 CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
+BOOT_COUNTING_TRIES = "@bootCountingTries@"
+BOOT_COUNTING = "@bootCounting@" == "True"
 
 
 @dataclass
@@ -51,6 +54,135 @@ class BootSpec:
     sortKey: str  # noqa: N815
     devicetree: Path | None = None  # noqa: N815
     initrdSecrets: str | None = None  # noqa: N815
+
+
+@dataclass
+class Entry:
+    profile: str | None
+    generation_number: int
+    specialisation: str | None
+
+    @classmethod
+    def from_path(cls: Type["Entry"], path: Path) -> "Entry":
+        filename = path.name
+        # Matching nixos-$profile-generation-*.conf
+        rex_profile = re.compile(r"^nixos-(.*)-generation-.*\.conf$")
+        # Matching nixos*-generation-$number*.conf
+        rex_generation = re.compile(r"^nixos.*-generation-([0-9]+).*\.conf$")
+        # Matching nixos*-generation-$number-specialisation-$specialisation_name*.conf
+        rex_specialisation = re.compile(
+            r"^nixos.*-generation-([0-9]+)-specialisation-([a-zA-Z0-9]+).*\.conf$"
+        )
+        profile = (
+            rex_profile.sub(r"\1", filename) if rex_profile.match(filename) else None
+        )
+        specialisation = (
+            rex_specialisation.sub(r"\2", filename)
+            if rex_specialisation.match(filename)
+            else None
+        )
+        try:
+            generation_number = int(rex_generation.sub(r"\1", filename))
+        except ValueError:
+            raise
+        return cls(profile, generation_number, specialisation)
+
+
+@dataclass
+class DiskEntry:
+    entry: Entry
+    default: bool
+    counters: str | None
+    title: str | None
+    description: str | None
+    kernel: Path
+    initrd: Path
+    devicetree: Path | None
+    kernel_params: str | None
+    machine_id: str | None
+    sort_key: str
+
+    @classmethod
+    def from_path(cls: Type["DiskEntry"], path: Path) -> "DiskEntry":
+        entry = Entry.from_path(path)
+        data = path.read_text().splitlines()
+        if "" in data:
+            data.remove("")
+        entry_map = dict(lines.split(" ", 1) for lines in data)
+        assert "linux" in entry_map
+        assert "initrd" in entry_map
+        filename = path.name
+        # Matching nixos*-generation-*$counters.conf
+        rex_counters = re.compile(r"^nixos.*-generation-.*(\+\d(-\d)?)\.conf$")
+        counters = (
+            rex_counters.sub(r"\1", filename) if rex_counters.match(filename) else None
+        )
+
+        maybe_devicetree_path = entry_map.get("devicetree")
+        disk_entry = cls(
+            entry=entry,
+            default=(entry_map.get("sort-key") == "default"),
+            counters=counters,
+            title=entry_map.get("title"),
+            description=entry_map.get("version"),
+            kernel=Path(entry_map["linux"]),
+            initrd=Path(entry_map["initrd"]),
+            devicetree=Path(maybe_devicetree_path) if maybe_devicetree_path else None,
+            machine_id=entry_map.get("machine-id"),
+            sort_key=entry_map.get("sort_key", "nixos"),
+            kernel_params=entry_map.get("options"),
+        )
+        return disk_entry
+
+    def write(self, sorted_first: str) -> None:
+        # TODO
+        # Compute a sort-key sorted before sorted_first
+        # This will compute something like: nixos -> nixor-default to make sure we come before other nixos entries,
+        # while allowing users users can pre-pend their own entries before.
+        default_sort_key = (
+            sorted_first[:-1] + chr(ord(sorted_first[-1]) - 1) + "-default"
+        )
+        tmp_path = self.path.with_suffix(".tmp")
+        with tmp_path.open("w") as f:
+            # We use "sort-key" to sort the default generation first.
+            # The "default" string is sorted before "non-default" (alphabetically)
+            boot_entry = [
+                f"title {self.title}" if self.title is not None else None,
+                f"version {self.description}" if self.description is not None else None,
+                f"linux {self.kernel}",
+                f"initrd  {self.initrd}",
+                f"options {self.kernel_params}"
+                if self.kernel_params is not None
+                else None,
+                f"machine-id {self.machine_id}"
+                if self.machine_id is not None
+                else None,
+                f"devicetree /{self.devicetree}"
+                if self.devicetree is not None
+                else None,
+                f"sort-key {default_sort_key if self.default else self.sort_key}",
+            ]
+
+            f.write("\n".join(filter(None, boot_entry)))
+            f.flush()
+            os.fsync(f.fileno())
+        tmp_path.rename(self.path)
+
+    @property
+    def path(self) -> Path:
+        pieces = [
+            "nixos",
+            self.entry.profile or None,
+            "generation",
+            str(self.entry.generation_number),
+            f"specialisation-{self.entry.specialisation}"
+            if self.entry.specialisation
+            else None,
+        ]
+        prefix = "-".join(p for p in pieces if p)
+        return Path(
+            f"{BOOT_MOUNT_POINT}/loader/entries/{prefix}{self.counters if self.counters else ''}.conf"
+        )
 
 
 libc = ctypes.CDLL("libc.so.6")
@@ -72,7 +204,9 @@ class SystemIdentifier(NamedTuple):
 
 def copy_if_not_exists(source: Path, dest: Path) -> None:
     if not dest.exists():
-        tmpfd, tmppath = tempfile.mkstemp(dir=dest.parent, prefix=dest.name, suffix='.tmp.')
+        tmpfd, tmppath = tempfile.mkstemp(
+            dir=dest.parent, prefix=dest.name, suffix=".tmp."
+        )
         shutil.copyfile(source, tmppath)
         os.fsync(tmpfd)
         shutil.move(tmppath, dest)
@@ -97,38 +231,14 @@ def system_dir(
         return d
 
 
-BOOT_ENTRY = """title {title}
-sort-key {sort_key}
-version Generation {generation} {description}
-linux {kernel}
-initrd {initrd}
-options {kernel_params}
-"""
-
-
-def generation_conf_filename(
-    profile: str | None, generation: int, specialisation: str | None
-) -> str:
-    pieces = [
-        "nixos",
-        profile or None,
-        "generation",
-        str(generation),
-        f"specialisation-{specialisation}" if specialisation else None,
-    ]
-    return "-".join(p for p in pieces if p) + ".conf"
-
-
-def write_loader_conf(
-    profile: str | None, generation: int, specialisation: str | None
-) -> None:
+def write_loader_conf(profile: str | None) -> None:
     tmp = LOADER_CONF.with_suffix(".tmp")
     with tmp.open("x") as f:
         f.write(f"timeout {TIMEOUT}\n")
-        f.write(
-            "default %s\n"
-            % generation_conf_filename(profile, generation, specialisation)
-        )
+        if profile:
+            f.write("default nixos-%s-generation-*\n" % profile)
+        else:
+            f.write("default nixos-generation-*\n")
         if not EDITOR:
             f.write("editor 0\n")
         if REBOOT_FOR_BITLOCKER:
@@ -137,6 +247,23 @@ def write_loader_conf(
         f.flush()
         os.fsync(f.fileno())
     os.rename(tmp, LOADER_CONF)
+
+
+def scan_entries() -> list[DiskEntry]:
+    """
+    Scan all entries in $ESP/loader/entries/*
+    Does not support Type 2 entries as we do not support them for now.
+    Returns a generator of Entry.
+    """
+    entries = []
+    for path in Path(f"{EFI_SYS_MOUNT_POINT}/loader/entries/").glob(
+        "nixos*-generation-[1-9]*.conf"
+    ):
+        try:
+            entries.append(DiskEntry.from_path(path))
+        except ValueError:
+            continue
+    return entries
 
 
 def get_bootspec(profile: str | None, generation: int) -> BootSpec:
@@ -210,6 +337,8 @@ def write_entry(
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
+    entries: list[DiskEntry],
+    sorted_first: str,
     current: bool,
 ) -> None:
     if specialisation:
@@ -244,37 +373,35 @@ def write_entry(
                 "or renamed a file in `boot.initrd.secrets`",
                 file=sys.stderr,
             )
-    entry_file = (
-        BOOT_MOUNT_POINT
-        / "loader/entries"
-        / generation_conf_filename(profile, generation, specialisation)
-    )
-    tmp_path = entry_file.with_suffix(".tmp")
     kernel_params = "init=%s " % bootspec.init
 
     kernel_params = kernel_params + " ".join(bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
     build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
 
-    with tmp_path.open("w") as f:
-        f.write(
-            BOOT_ENTRY.format(
-                title=title,
-                sort_key=bootspec.sortKey,
-                generation=generation,
-                kernel=f"/{kernel}",
-                initrd=f"/{initrd}",
-                kernel_params=kernel_params,
-                description=f"{bootspec.label}, built on {build_date}",
-            )
-        )
-        if machine_id is not None:
-            f.write("machine-id %s\n" % machine_id)
-        if devicetree is not None:
-            f.write(f"devicetree /{devicetree}\n")
-        f.flush()
-        os.fsync(f.fileno())
-    tmp_path.rename(entry_file)
+    counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else ""
+    entry = Entry(profile, generation, specialisation)
+    # We check if the entry we are writing is already on disk
+    # and we update its "default entry" status
+    for entry_on_disk in entries:
+        if entry == entry_on_disk.entry:
+            entry_on_disk.default = current
+            entry_on_disk.write(sorted_first)
+            return
+
+    DiskEntry(
+        entry=entry,
+        title=title,
+        kernel=kernel,
+        initrd=initrd,
+        devicetree=devicetree,
+        counters=counters,
+        kernel_params=kernel_params,
+        machine_id=machine_id,
+        description=f"Generation {generation} {bootspec.label}, built on {build_date}",
+        sort_key=bootspec.sortKey,
+        default=current,
+    ).write(sorted_first)
 
 
 def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
@@ -301,11 +428,9 @@ def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
     return configurations[-configurationLimit:]
 
 
-def remove_old_entries(gens: list[SystemIdentifier]) -> None:
-    rex_profile = re.compile(r"^nixos-(.*)-generation-.*\.conf$")
-    rex_generation = re.compile(
-        r"^nixos.*-generation-([0-9]+)(-specialisation-.*)?\.conf$"
-    )
+def remove_old_entries(
+    gens: list[SystemIdentifier], disk_entries: list[DiskEntry]
+) -> None:
     known_paths = []
     for gen in gens:
         bootspec = get_bootspec(gen.profile, gen.generation)
@@ -313,20 +438,16 @@ def remove_old_entries(gens: list[SystemIdentifier]) -> None:
         known_paths.append(copy_from_file(bootspec.initrd, True).name)
         if bootspec.devicetree is not None:
             known_paths.append(copy_from_file(bootspec.devicetree, True).name)
-    for path in (BOOT_MOUNT_POINT / "loader/entries").glob(
-        "nixos*-generation-[1-9]*.conf", case_sensitive=False
-    ):
-        if rex_profile.match(path.name):
-            prof = rex_profile.sub(r"\1", path.name)
-        else:
-            prof = None
-        try:
-            gen_number = int(rex_generation.sub(r"\1", path.name))
-        except ValueError:
-            continue
-        if (prof, gen_number, None) not in gens:
-            path.unlink()
-    for path in (BOOT_MOUNT_POINT / NIXOS_DIR).iterdir():
+
+    for disk_entry in disk_entries:
+        if (
+            disk_entry.entry.profile,
+            disk_entry.entry.generation_number,
+            None,
+        ) not in gens:
+            os.unlink(disk_entry.path)
+    for path_name in glob.iglob(f"{EFI_SYS_MOUNT_POINT}/efi/nixos/*"):
+        path = Path(path_name)
         if path.name not in known_paths and not path.is_dir():
             path.unlink()
 
@@ -444,13 +565,37 @@ def install_bootloader(args: argparse.Namespace) -> None:
     for profile in get_profiles():
         gens += get_generations(profile)
 
-    remove_old_entries(gens)
+    entries = scan_entries()
+    remove_old_entries(gens, entries)
+    # Compute the sort-key that will be sorted first.
+    sorted_first = ""
+    for gen in gens:
+        try:
+            bootspec = get_bootspec(gen.profile, gen.generation)
+            if bootspec.sortKey < sorted_first or sorted_first == "":
+                sorted_first = bootspec.sortKey
+        except OSError as e:
+            # See https://github.com/NixOS/nixpkgs/issues/114552
+            if e.errno == errno.EINVAL:
+                profile = (
+                    f"profile '{gen.profile}'" if gen.profile else "default profile"
+                )
+                print(
+                    "ignoring {} in the list of boot entries because of the following error:\n{}".format(
+                        profile, e
+                    ),
+                    file=sys.stderr,
+                )
+            else:
+                raise e
 
     for gen in gens:
         try:
             bootspec = get_bootspec(gen.profile, gen.generation)
             is_default = Path(bootspec.init).parent == Path(args.default_config)
-            write_entry(*gen, machine_id, bootspec, current=is_default)
+            write_entry(
+                *gen, machine_id, bootspec, entries, sorted_first, current=is_default
+            )
             for specialisation in bootspec.specialisations.keys():
                 write_entry(
                     gen.profile,
@@ -458,10 +603,16 @@ def install_bootloader(args: argparse.Namespace) -> None:
                     specialisation,
                     machine_id,
                     bootspec,
-                    current=is_default,
+                    entries,
+                    sorted_first,
+                    current=(
+                        is_default
+                        and bootspec.specialisations[specialisation].sortKey
+                        == bootspec.sortKey
+                    ),
                 )
             if is_default:
-                write_loader_conf(*gen)
+                write_loader_conf(gen.profile)
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552
             if e.errno == errno.EINVAL:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -3,6 +3,7 @@ import argparse
 import ctypes
 import datetime
 import errno
+import hashlib
 import os
 import re
 import shutil
@@ -11,8 +12,7 @@ import sys
 import tempfile
 import warnings
 import json
-import glob
-from typing import NamedTuple, Any, Sequence, Type
+from typing import NamedTuple, Any, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -32,8 +32,8 @@ NIX = "@nix@"
 SYSTEMD = "@systemd@"
 CONFIGURATION_LIMIT = int("@configurationLimit@")
 REBOOT_FOR_BITLOCKER = bool("@rebootForBitlocker@")
-CAN_TOUCH_EFI_VARIABLES = "@canTouchEfiVariables@"
-GRACEFUL = "@graceful@"
+CAN_TOUCH_EFI_VARIABLES = "@canTouchEfiVariables@" == "1"
+GRACEFUL = "@graceful@" == "1"
 COPY_EXTRA_FILES = "@copyExtraFiles@"
 CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
@@ -41,7 +41,7 @@ BOOT_COUNTING_TRIES = "@bootCountingTries@"
 BOOT_COUNTING = "@bootCounting@" == "True"
 
 
-@dataclass
+@dataclass(frozen=True)
 class BootSpec:
     init: Path
     initrd: Path
@@ -56,44 +56,31 @@ class BootSpec:
     initrdSecrets: str | None = None  # noqa: N815
 
 
-@dataclass
+@dataclass(frozen=True)
+class GcRoot:
+    prefix: Path | None
+    path: Path | None
+
+    @staticmethod
+    def from_prefix(prefix: Path) -> "GcRoot":
+        return GcRoot(prefix=prefix, path=None)
+
+    @staticmethod
+    def from_path(path: Path) -> "GcRoot":
+        return GcRoot(prefix=None, path=path)
+
+
+@dataclass(frozen=True)
 class Entry:
     profile: str | None
     generation_number: int
     specialisation: str | None
 
-    @classmethod
-    def from_path(cls: Type["Entry"], path: Path) -> "Entry":
-        filename = path.name
-        # Matching nixos-$profile-generation-*.conf
-        rex_profile = re.compile(r"^nixos-(.*)-generation-.*\.conf$")
-        # Matching nixos*-generation-$number*.conf
-        rex_generation = re.compile(r"^nixos.*-generation-([0-9]+).*\.conf$")
-        # Matching nixos*-generation-$number-specialisation-$specialisation_name*.conf
-        rex_specialisation = re.compile(
-            r"^nixos.*-generation-([0-9]+)-specialisation-([a-zA-Z0-9]+).*\.conf$"
-        )
-        profile = (
-            rex_profile.sub(r"\1", filename) if rex_profile.match(filename) else None
-        )
-        specialisation = (
-            rex_specialisation.sub(r"\2", filename)
-            if rex_specialisation.match(filename)
-            else None
-        )
-        try:
-            generation_number = int(rex_generation.sub(r"\1", filename))
-        except ValueError:
-            raise
-        return cls(profile, generation_number, specialisation)
 
-
-@dataclass
+@dataclass(frozen=True)
 class DiskEntry:
     entry: Entry
-    default: bool
     counters: str | None
-    title: str | None
     description: str | None
     kernel: Path
     initrd: Path
@@ -102,87 +89,84 @@ class DiskEntry:
     machine_id: str | None
     sort_key: str
 
-    @classmethod
-    def from_path(cls: Type["DiskEntry"], path: Path) -> "DiskEntry":
-        entry = Entry.from_path(path)
-        data = path.read_text().splitlines()
-        if "" in data:
-            data.remove("")
-        entry_map = dict(lines.split(" ", 1) for lines in data)
-        assert "linux" in entry_map
-        assert "initrd" in entry_map
-        filename = path.name
-        # Matching nixos*-generation-*$counters.conf
-        rex_counters = re.compile(r"^nixos.*-generation-.*(\+\d(-\d)?)\.conf$")
-        counters = (
-            rex_counters.sub(r"\1", filename) if rex_counters.match(filename) else None
+    @property
+    def title(self) -> str:
+        return "{name}{profile}{specialisation}".format(
+            name=DISTRO_NAME,
+            profile=" [" + self.entry.profile + "]" if self.entry.profile else "",
+            specialisation=" (%s)" % self.entry.specialisation
+            if self.entry.specialisation
+            else "",
         )
 
-        maybe_devicetree_path = entry_map.get("devicetree")
-        disk_entry = cls(
-            entry=entry,
-            default=(entry_map.get("sort-key") == "default"),
-            counters=counters,
-            title=entry_map.get("title"),
-            description=entry_map.get("version"),
-            kernel=Path(entry_map["linux"]),
-            initrd=Path(entry_map["initrd"]),
-            devicetree=Path(maybe_devicetree_path) if maybe_devicetree_path else None,
-            machine_id=entry_map.get("machine-id"),
-            sort_key=entry_map.get("sort_key", "nixos"),
-            kernel_params=entry_map.get("options"),
-        )
-        return disk_entry
+    def serialise(self) -> str:
+        boot_entry = [
+            f"title {self.title}",
+            f"version {self.description}" if self.description is not None else None,
+            f"linux /{self.kernel}",
+            f"initrd /{self.initrd}",
+            f"options {self.kernel_params}" if self.kernel_params is not None else None,
+            f"machine-id {self.machine_id}" if self.machine_id is not None else None,
+            f"devicetree /{self.devicetree}" if self.devicetree is not None else None,
+            f"sort-key {self.sort_key}",
+        ]
+        return "\n".join(filter(None, boot_entry))
 
-    def write(self, sorted_first: str) -> None:
-        # TODO
-        # Compute a sort-key sorted before sorted_first
-        # This will compute something like: nixos -> nixor-default to make sure we come before other nixos entries,
-        # while allowing users users can pre-pend their own entries before.
-        default_sort_key = (
-            sorted_first[:-1] + chr(ord(sorted_first[-1]) - 1) + "-default"
-        )
+    def write(self) -> GcRoot:
+        # Check first if the file already exists
+        for e in os.scandir(path=BOOT_MOUNT_POINT / "loader" / "entries"):
+            match = re.fullmatch(
+                rf"{self.path_prefix}(\+[0-9]+(-[0-9]+)?)?\.conf", e.name
+            )
+            if match:
+                # Check that the contents match the hash
+                with open(e.path, "r") as f:
+                    hash = hashlib.sha256(f.read().encode("utf-8")).hexdigest()
+                    if hash == self.content_hash:
+                        # The contents match, we are done, there is nothing to write
+                        return GcRoot.from_prefix(
+                            BOOT_MOUNT_POINT / "loader" / "entries" / self.path_prefix
+                        )
+
+        # We didn't find a matching file, so we'll create one
         tmp_path = self.path.with_suffix(".tmp")
         with tmp_path.open("w") as f:
-            # We use "sort-key" to sort the default generation first.
-            # The "default" string is sorted before "non-default" (alphabetically)
-            boot_entry = [
-                f"title {self.title}" if self.title is not None else None,
-                f"version {self.description}" if self.description is not None else None,
-                f"linux {self.kernel}",
-                f"initrd  {self.initrd}",
-                f"options {self.kernel_params}"
-                if self.kernel_params is not None
-                else None,
-                f"machine-id {self.machine_id}"
-                if self.machine_id is not None
-                else None,
-                f"devicetree /{self.devicetree}"
-                if self.devicetree is not None
-                else None,
-                f"sort-key {default_sort_key if self.default else self.sort_key}",
-            ]
+            boot_entry = self.serialise()
 
-            f.write("\n".join(filter(None, boot_entry)))
+            f.write(boot_entry)
             f.flush()
             os.fsync(f.fileno())
         tmp_path.rename(self.path)
+        return GcRoot.from_prefix(
+            BOOT_MOUNT_POINT / "loader" / "entries" / self.path_prefix
+        )
+
+    @property
+    def content_hash(self) -> str:
+        return hashlib.sha256(self.serialise().encode("utf-8")).hexdigest()
+
+    @property
+    def path_prefix(self) -> str:
+        return "-".join(
+            p
+            for p in [
+                "nixos",
+                self.content_hash,
+            ]
+            if p
+        )
 
     @property
     def path(self) -> Path:
-        pieces = [
-            "nixos",
-            self.entry.profile or None,
-            "generation",
-            str(self.entry.generation_number),
-            f"specialisation-{self.entry.specialisation}"
-            if self.entry.specialisation
-            else None,
-        ]
-        prefix = "-".join(p for p in pieces if p)
-        return Path(
-            f"{BOOT_MOUNT_POINT}/loader/entries/{prefix}{self.counters if self.counters else ''}.conf"
-        )
+        return BOOT_MOUNT_POINT / "loader" / "entries" / self.filename
+
+    @property
+    def filename(self) -> str:
+        return f"{self.path_prefix}{self.counters if self.counters else ''}.conf"
+
+    @property
+    def bootctl_id(self) -> str:
+        return f"{self.path_prefix}.conf"
 
 
 libc = ctypes.CDLL("libc.so.6")
@@ -193,7 +177,7 @@ FILE = None | int
 def run(
     cmd: Sequence[str | Path], stdout: FILE = None
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, check=True, text=True, stdout=stdout)
+    return subprocess.run(cmd, check=True, text=True, stdout=stdout, stderr=sys.stderr)
 
 
 class SystemIdentifier(NamedTuple):
@@ -231,14 +215,25 @@ def system_dir(
         return d
 
 
-def write_loader_conf(profile: str | None) -> None:
+def write_loader_conf(default_entry_id: str | None) -> None:
     tmp = LOADER_CONF.with_suffix(".tmp")
     with tmp.open("x") as f:
         f.write(f"timeout {TIMEOUT}\n")
-        if profile:
-            f.write("default nixos-%s-generation-*\n" % profile)
+        if default_entry_id is None:
+            # No generation matched the requested default config; fall back to
+            # the newest entry as determined by Boot Loader Spec sorting.
+            f.write("default nixos-*\n")
+        elif BOOT_COUNTING:
+            # `preferred` (systemd-boot >= 260) honours boot assessment, so a
+            # generation that exhausted its boot counter is skipped and we fall
+            # through to `default`. systemd-boot sorts entries with
+            # tries_left == 0 to the end of the list and resolves the `default`
+            # glob against that order, so `nixos-*` yields the newest entry that
+            # is not bad, or a bad one only if every nixos entry is bad.
+            f.write(f"preferred {default_entry_id}\n")
+            f.write("default nixos-*\n")
         else:
-            f.write("default nixos-generation-*\n")
+            f.write(f"default {default_entry_id}\n")
         if not EDITOR:
             f.write("editor 0\n")
         if REBOOT_FOR_BITLOCKER:
@@ -247,23 +242,6 @@ def write_loader_conf(profile: str | None) -> None:
         f.flush()
         os.fsync(f.fileno())
     os.rename(tmp, LOADER_CONF)
-
-
-def scan_entries() -> list[DiskEntry]:
-    """
-    Scan all entries in $ESP/loader/entries/*
-    Does not support Type 2 entries as we do not support them for now.
-    Returns a generator of Entry.
-    """
-    entries = []
-    for path in Path(f"{EFI_SYS_MOUNT_POINT}/loader/entries/").glob(
-        "nixos*-generation-[1-9]*.conf"
-    ):
-        try:
-            entries.append(DiskEntry.from_path(path))
-        except ValueError:
-            continue
-    return entries
 
 
 def get_bootspec(profile: str | None, generation: int) -> BootSpec:
@@ -316,7 +294,7 @@ def bootspec_from_json(bootspec_json: dict[str, Any]) -> BootSpec:
     )
 
 
-def copy_from_file(file: Path, dry_run: bool = False) -> Path:
+def copy_from_file(file: Path) -> Path:
     """
     Copy a file to the boot filesystem (XBOOTLDR if in use, otherwise ESP), basing the destination filename on the store path that's being copied from. Return the destination path, relative to the boot filesystem mountpoint.
     """
@@ -326,8 +304,7 @@ def copy_from_file(file: Path, dry_run: bool = False) -> Path:
     efi_file_path = NIXOS_DIR / (
         f"{suffix}.efi" if suffix == store_subdir else f"{store_subdir}-{suffix}.efi"
     )
-    if not dry_run:
-        copy_if_not_exists(store_file_path, BOOT_MOUNT_POINT / efi_file_path)
+    copy_if_not_exists(store_file_path, BOOT_MOUNT_POINT / efi_file_path)
     return efi_file_path
 
 
@@ -337,22 +314,41 @@ def write_entry(
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
-    entries: list[DiskEntry],
-    sorted_first: str,
     current: bool,
-) -> None:
+) -> tuple[DiskEntry, set[GcRoot]]:
+    gc_roots = set()
+
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
     kernel = copy_from_file(bootspec.kernel)
+    gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / kernel)))
     initrd = copy_from_file(bootspec.initrd)
+    gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / initrd)))
     devicetree = (
         copy_from_file(bootspec.devicetree) if bootspec.devicetree is not None else None
     )
+    if devicetree is not None:
+        gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / devicetree)))
 
-    title = "{name}{profile}{specialisation}".format(
-        name=DISTRO_NAME,
-        profile=" [" + profile + "]" if profile else "",
-        specialisation=" (%s)" % specialisation if specialisation else "",
+    kernel_params = "init=%s " % bootspec.init
+
+    kernel_params = kernel_params + " ".join(bootspec.kernelParams)
+    build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
+    build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
+
+    counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else None
+    entry = Entry(profile, generation, specialisation)
+
+    disk_entry = DiskEntry(
+        entry=entry,
+        kernel=kernel,
+        initrd=initrd,
+        devicetree=devicetree,
+        counters=counters,
+        kernel_params=kernel_params,
+        machine_id=machine_id,
+        description=f"Generation {generation} {bootspec.label}, built on {build_date}",
+        sort_key=bootspec.sortKey,
     )
 
     try:
@@ -365,7 +361,7 @@ def write_entry(
         else:
             print(
                 "warning: failed to create initrd secrets "
-                f'for "{title} - Configuration {generation}", an older generation',
+                f'for "{disk_entry.title} - Configuration {generation}", an older generation',
                 file=sys.stderr,
             )
             print(
@@ -373,35 +369,9 @@ def write_entry(
                 "or renamed a file in `boot.initrd.secrets`",
                 file=sys.stderr,
             )
-    kernel_params = "init=%s " % bootspec.init
 
-    kernel_params = kernel_params + " ".join(bootspec.kernelParams)
-    build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
-    build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
-
-    counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else ""
-    entry = Entry(profile, generation, specialisation)
-    # We check if the entry we are writing is already on disk
-    # and we update its "default entry" status
-    for entry_on_disk in entries:
-        if entry == entry_on_disk.entry:
-            entry_on_disk.default = current
-            entry_on_disk.write(sorted_first)
-            return
-
-    DiskEntry(
-        entry=entry,
-        title=title,
-        kernel=kernel,
-        initrd=initrd,
-        devicetree=devicetree,
-        counters=counters,
-        kernel_params=kernel_params,
-        machine_id=machine_id,
-        description=f"Generation {generation} {bootspec.label}, built on {build_date}",
-        sort_key=bootspec.sortKey,
-        default=current,
-    ).write(sorted_first)
+    gc_roots.add(disk_entry.write())
+    return disk_entry, gc_roots
 
 
 def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
@@ -428,32 +398,8 @@ def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
     return configurations[-configurationLimit:]
 
 
-def remove_old_entries(
-    gens: list[SystemIdentifier], disk_entries: list[DiskEntry]
-) -> None:
-    known_paths = []
-    for gen in gens:
-        bootspec = get_bootspec(gen.profile, gen.generation)
-        known_paths.append(copy_from_file(bootspec.kernel, True).name)
-        known_paths.append(copy_from_file(bootspec.initrd, True).name)
-        if bootspec.devicetree is not None:
-            known_paths.append(copy_from_file(bootspec.devicetree, True).name)
-
-    for disk_entry in disk_entries:
-        if (
-            disk_entry.entry.profile,
-            disk_entry.entry.generation_number,
-            None,
-        ) not in gens:
-            os.unlink(disk_entry.path)
-    for path_name in glob.iglob(f"{EFI_SYS_MOUNT_POINT}/efi/nixos/*"):
-        path = Path(path_name)
-        if path.name not in known_paths and not path.is_dir():
-            path.unlink()
-
-
 def cleanup_esp() -> None:
-    for path in (EFI_SYS_MOUNT_POINT / "loader/entries").glob("nixos*"):
+    for path in (EFI_SYS_MOUNT_POINT / "loader" / "entries").glob("nixos*"):
         path.unlink()
     nixos_dir = EFI_SYS_MOUNT_POINT / NIXOS_DIR
     if nixos_dir.is_dir():
@@ -492,10 +438,10 @@ def install_bootloader(args: argparse.Namespace) -> None:
     if BOOT_MOUNT_POINT != EFI_SYS_MOUNT_POINT:
         bootctl_flags.append(f"--boot-path={BOOT_MOUNT_POINT}")
 
-    if CAN_TOUCH_EFI_VARIABLES != "1":
+    if not CAN_TOUCH_EFI_VARIABLES:
         bootctl_flags.append("--no-variables")
 
-    if GRACEFUL == "1":
+    if GRACEFUL:
         bootctl_flags.append("--graceful")
 
     if os.getenv("NIXOS_INSTALL_BOOTLOADER") == "1":
@@ -565,15 +511,34 @@ def install_bootloader(args: argparse.Namespace) -> None:
     for profile in get_profiles():
         gens += get_generations(profile)
 
-    entries = scan_entries()
-    remove_old_entries(gens, entries)
-    # Compute the sort-key that will be sorted first.
-    sorted_first = ""
+    gc_roots: set[GcRoot] = set()
+
+    default_config = Path(args.default_config)
+    default_entry_id: str | None = None
+
     for gen in gens:
         try:
             bootspec = get_bootspec(gen.profile, gen.generation)
-            if bootspec.sortKey < sorted_first or sorted_first == "":
-                sorted_first = bootspec.sortKey
+            is_default = Path(bootspec.init).parent == default_config
+            disk_entry, new_gc_roots = write_entry(
+                *gen, machine_id, bootspec, current=is_default
+            )
+            gc_roots.update(new_gc_roots)
+            if is_default:
+                default_entry_id = disk_entry.bootctl_id
+            for specialisation_name, specialisation in bootspec.specialisations.items():
+                is_default = Path(specialisation.init).parent == default_config
+                disk_entry, new_gc_roots = write_entry(
+                    gen.profile,
+                    gen.generation,
+                    specialisation_name,
+                    machine_id,
+                    bootspec,
+                    current=is_default,
+                )
+                gc_roots.update(new_gc_roots)
+                if is_default:
+                    default_entry_id = disk_entry.bootctl_id
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552
             if e.errno == errno.EINVAL:
@@ -589,44 +554,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
             else:
                 raise e
 
-    for gen in gens:
-        try:
-            bootspec = get_bootspec(gen.profile, gen.generation)
-            is_default = Path(bootspec.init).parent == Path(args.default_config)
-            write_entry(
-                *gen, machine_id, bootspec, entries, sorted_first, current=is_default
-            )
-            for specialisation in bootspec.specialisations.keys():
-                write_entry(
-                    gen.profile,
-                    gen.generation,
-                    specialisation,
-                    machine_id,
-                    bootspec,
-                    entries,
-                    sorted_first,
-                    current=(
-                        is_default
-                        and bootspec.specialisations[specialisation].sortKey
-                        == bootspec.sortKey
-                    ),
-                )
-            if is_default:
-                write_loader_conf(gen.profile)
-        except OSError as e:
-            # See https://github.com/NixOS/nixpkgs/issues/114552
-            if e.errno == errno.EINVAL:
-                profile = (
-                    f"profile '{gen.profile}'" if gen.profile else "default profile"
-                )
-                print(
-                    "ignoring {} in the list of boot entries because of the following error:\n{}".format(
-                        profile, e
-                    ),
-                    file=sys.stderr,
-                )
-            else:
-                raise e
+    write_loader_conf(default_entry_id)
 
     if BOOT_MOUNT_POINT != EFI_SYS_MOUNT_POINT:
         # Cleanup any entries in ESP if xbootldrMountPoint is set.
@@ -634,6 +562,16 @@ def install_bootloader(args: argparse.Namespace) -> None:
         # automatically, as we don't have information about the mount point anymore.
         cleanup_esp()
 
+    # Garbage-collect stale kernels/initrds/entries before re-populating extra
+    # files, so that user-supplied extraEntries (which may also live under
+    # loader/entries and start with `nixos-`) are not removed again.
+    garbage_collect(gc_roots)
+
+    remove_extra_files()
+    run([COPY_EXTRA_FILES])
+
+
+def remove_extra_files() -> None:
     extra_files_dir = BOOT_MOUNT_POINT / NIXOS_DIR / ".extra-files"
     for root, _, files in extra_files_dir.walk(top_down=False):
         relative_root = root.relative_to(extra_files_dir)
@@ -650,7 +588,31 @@ def install_bootloader(args: argparse.Namespace) -> None:
 
     extra_files_dir.mkdir(parents=True, exist_ok=True)
 
-    run([COPY_EXTRA_FILES])
+
+def garbage_collect(gc_roots: set[GcRoot]) -> None:
+    # Check if a file is in the list of gc roots.
+    # For prefixes, we need to allow for the potential presence of boot counters.
+    def has_gc_root(p: Path) -> bool:
+        for root in gc_roots:
+            if root.path and root.path == p:
+                return True
+            elif root.prefix and re.fullmatch(
+                rf"{re.escape(str(root.prefix))}(\+[0-9]+(-[0-9]+)?)?\.conf", str(p)
+            ):
+                return True
+        return False
+
+    def delete_path(e: os.DirEntry) -> None:
+        if e.is_file(follow_symlinks=True) and not has_gc_root(Path(e.path)):
+            os.remove(e.path)
+
+    for e in os.scandir(BOOT_MOUNT_POINT / NIXOS_DIR):
+        delete_path(e)
+
+    for e in os.scandir(BOOT_MOUNT_POINT / "loader" / "entries"):
+        match = re.fullmatch(r"nixos-.+\.conf", e.name)
+        if match:
+            delete_path(e)
 
 
 def main() -> None:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -88,29 +88,26 @@ class InitrdWithSecretsWriter:
     initrd_secrets: Path
 
     def write_boot_file(self, path: Path) -> None:
-        if path.exists():
-            # TODO: This is for matching old behavior. Previously, we
-            # appended secrets to initrd every time no matter what, so
-            # we must continue doing that. One potential alternative
-            # would be running the secret script on an empty file and
-            # using the hashed contents of that file as part of the
-            # key that the path name is based on.
-            run([self.initrd_secrets, path])
-        else:
-            with tempfile.NamedTemporaryFile(
-                mode="wb",
-                dir=path.parent,
-                delete=False,
-                prefix=path.name,
-                suffix=".tmp",
-            ) as tmp:
-                with open(self.source, mode="rb") as source_file:
-                    shutil.copyfileobj(source_file, tmp)
-                tmp.flush()
-                run([self.initrd_secrets, tmp.name])
-                os.fsync(tmp.fileno())
-                tmp.close()
-                os.rename(tmp.name, path)
+        # Secrets can change between rebuilds, so always rebuild from the
+        # pristine initrd into a temp file and rename into place.
+        tmp = tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        )
+        try:
+            with open(self.source, mode="rb") as source_file:
+                shutil.copyfileobj(source_file, tmp)
+            tmp.close()
+            run([self.initrd_secrets, tmp.name])
+            with open(tmp.name, "rb") as f:
+                os.fsync(f.fileno())
+        except BaseException:
+            os.unlink(tmp.name)
+            raise
+        os.rename(tmp.name, path)
 
 
 @dataclass

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import warnings
 import json
-from typing import NamedTuple, Any, Sequence
+from typing import NamedTuple, Any, Protocol, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -56,117 +56,150 @@ class BootSpec:
     initrdSecrets: str | None = None  # noqa: N815
 
 
-@dataclass(frozen=True)
-class GcRoot:
-    prefix: Path | None
-    path: Path | None
-
-    @staticmethod
-    def from_prefix(prefix: Path) -> "GcRoot":
-        return GcRoot(prefix=prefix, path=None)
-
-    @staticmethod
-    def from_path(path: Path) -> "GcRoot":
-        return GcRoot(prefix=None, path=path)
+class WriteBootFile(Protocol):
+    def write_boot_file(self, path: Path) -> None: ...
 
 
-@dataclass(frozen=True)
-class Entry:
+@dataclass
+class CopyWriter:
+    source: Path
+
+    def write_boot_file(self, path: Path) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        ) as tmp:
+            with open(self.source, mode="rb") as source_file:
+                shutil.copyfileobj(source_file, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.rename(tmp.name, path)
+
+
+@dataclass
+class InitrdWithSecretsWriter:
+    source: Path
+    initrd_secrets: Path
+
+    def write_boot_file(self, path: Path) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        ) as tmp:
+            with open(self.source, mode="rb") as source_file:
+                shutil.copyfileobj(source_file, tmp)
+            tmp.flush()
+            run([self.initrd_secrets, tmp.name])
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.rename(tmp.name, path)
+
+
+@dataclass
+class ContentsWriter:
+    contents: bytes
+
+    def write_boot_file(self, path: Path) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        ) as tmp:
+            tmp.write(self.contents)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.rename(tmp.name, path)
+
+
+class SystemIdentifier(NamedTuple):
     profile: str | None
-    generation_number: int
+    generation: int
     specialisation: str | None
 
 
-@dataclass(frozen=True)
-class DiskEntry:
-    entry: Entry
-    counters: str | None
-    description: str | None
-    kernel: Path
-    initrd: Path
-    devicetree: Path | None
-    kernel_params: str | None
-    machine_id: str | None
-    sort_key: str
+@dataclass
+class BootFile:
+    system_identifier: SystemIdentifier
+    path: Path
+    writer: WriteBootFile
 
-    @property
-    def title(self) -> str:
-        return "{name}{profile}{specialisation}".format(
-            name=DISTRO_NAME,
-            profile=" [" + self.entry.profile + "]" if self.entry.profile else "",
-            specialisation=" (%s)" % self.entry.specialisation
-            if self.entry.specialisation
-            else "",
+    @staticmethod
+    def from_source(system_identifier: SystemIdentifier, source: Path) -> "BootFile":
+        return BootFile(
+            system_identifier=system_identifier,
+            path=boot_path(source),
+            writer=CopyWriter(source=source),
         )
 
-    def serialise(self) -> str:
-        boot_entry = [
-            f"title {self.title}",
-            f"version {self.description}" if self.description is not None else None,
-            f"linux /{self.kernel}",
-            f"initrd /{self.initrd}",
-            f"options {self.kernel_params}" if self.kernel_params is not None else None,
-            f"machine-id {self.machine_id}" if self.machine_id is not None else None,
-            f"devicetree /{self.devicetree}" if self.devicetree is not None else None,
-            f"sort-key {self.sort_key}",
-        ]
-        return "\n".join(filter(None, boot_entry))
-
-    def write(self) -> GcRoot:
-        # Check first if the file already exists
-        for e in os.scandir(path=BOOT_MOUNT_POINT / "loader" / "entries"):
-            match = re.fullmatch(
-                rf"{self.path_prefix}(\+[0-9]+(-[0-9]+)?)?\.conf", e.name
+    @staticmethod
+    def from_initrd(
+        system_identifier: SystemIdentifier, source: Path, initrd_secrets: Path | None
+    ) -> "BootFile":
+        if initrd_secrets is None:
+            return BootFile.from_source(system_identifier, source)
+        else:
+            # We're trying to calculate a canonical path unique to
+            # this initrd and secret-appender. The boot_path is the
+            # canonical path for files that don't need modifications,
+            # so it serves as a perfect proxy for the unique
+            # information to combine for a combined unique path. The
+            # original paths themselves would have also been fine, but
+            # boot_path is more semantically representative, since
+            # it's the actual path whose uniqueness we're trying to
+            # ensure for other things.
+            combined = "\n".join(
+                [str(boot_path(source)), str(boot_path(initrd_secrets))]
             )
-            if match:
-                # Check that the contents match the hash
-                with open(e.path, "r") as f:
-                    hash = hashlib.sha256(f.read().encode("utf-8")).hexdigest()
-                    if hash == self.content_hash:
-                        # The contents match, we are done, there is nothing to write
-                        return GcRoot.from_prefix(
-                            BOOT_MOUNT_POINT / "loader" / "entries" / self.path_prefix
-                        )
+            combined_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
+            return BootFile(
+                system_identifier=system_identifier,
+                path=NIXOS_DIR / f"{combined_hash}-initrd.efi",
+                writer=InitrdWithSecretsWriter(
+                    source=source, initrd_secrets=initrd_secrets
+                ),
+            )
 
-        # We didn't find a matching file, so we'll create one
-        tmp_path = self.path.with_suffix(".tmp")
-        with tmp_path.open("w") as f:
-            boot_entry = self.serialise()
-
-            f.write(boot_entry)
-            f.flush()
-            os.fsync(f.fileno())
-        tmp_path.rename(self.path)
-        return GcRoot.from_prefix(
-            BOOT_MOUNT_POINT / "loader" / "entries" / self.path_prefix
+    @staticmethod
+    def from_entry(
+        system_identifier: SystemIdentifier, contents: bytes
+    ) -> tuple["BootFile", str]:
+        contents_hash = hashlib.sha256(contents).hexdigest()
+        path_prefix = f"nixos-{contents_hash}"
+        path = None
+        for e in os.scandir(path=BOOT_MOUNT_POINT / "loader" / "entries"):
+            mat = re.fullmatch(
+                rf"{re.escape(path_prefix)}(\+[0-9]+(-[0-9]+)?)?\.conf", e.name
+            )
+            if mat is not None:
+                path = Path("loader/entries") / e.name
+                break
+        if path is None:
+            counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else ""
+            path = Path(f"loader/entries/{path_prefix}{counters}.conf")
+        return (
+            BootFile(
+                system_identifier=system_identifier,
+                path=path,
+                writer=ContentsWriter(contents=contents),
+            ),
+            f"{path_prefix}.conf",
         )
 
-    @property
-    def content_hash(self) -> str:
-        return hashlib.sha256(self.serialise().encode("utf-8")).hexdigest()
 
-    @property
-    def path_prefix(self) -> str:
-        return "-".join(
-            p
-            for p in [
-                "nixos",
-                self.content_hash,
-            ]
-            if p
-        )
-
-    @property
-    def path(self) -> Path:
-        return BOOT_MOUNT_POINT / "loader" / "entries" / self.filename
-
-    @property
-    def filename(self) -> str:
-        return f"{self.path_prefix}{self.counters if self.counters else ''}.conf"
-
-    @property
-    def bootctl_id(self) -> str:
-        return f"{self.path_prefix}.conf"
+# This gets its own type alias to document that the order is very
+# important. The order ensures that entry files are written after
+# their respective kernel / initrd / etc.
+type BootFileList = list[BootFile]
 
 
 libc = ctypes.CDLL("libc.so.6")
@@ -178,22 +211,6 @@ def run(
     cmd: Sequence[str | Path], stdout: FILE = None
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, check=True, text=True, stdout=stdout, stderr=sys.stderr)
-
-
-class SystemIdentifier(NamedTuple):
-    profile: str | None
-    generation: int
-    specialisation: str | None
-
-
-def copy_if_not_exists(source: Path, dest: Path) -> None:
-    if not dest.exists():
-        tmpfd, tmppath = tempfile.mkstemp(
-            dir=dest.parent, prefix=dest.name, suffix=".tmp."
-        )
-        shutil.copyfile(source, tmppath)
-        os.fsync(tmpfd)
-        shutil.move(tmppath, dest)
 
 
 def generation_dir(profile: str | None, generation: int) -> Path:
@@ -294,84 +311,58 @@ def bootspec_from_json(bootspec_json: dict[str, Any]) -> BootSpec:
     )
 
 
-def copy_from_file(file: Path) -> Path:
-    """
-    Copy a file to the boot filesystem (XBOOTLDR if in use, otherwise ESP), basing the destination filename on the store path that's being copied from. Return the destination path, relative to the boot filesystem mountpoint.
-    """
+def boot_path(file: Path) -> Path:
     store_file_path = file.resolve()
     suffix = store_file_path.name
     store_subdir = store_file_path.relative_to(STORE_DIR).parts[0]
-    efi_file_path = NIXOS_DIR / (
+    return NIXOS_DIR / (
         f"{suffix}.efi" if suffix == store_subdir else f"{store_subdir}-{suffix}.efi"
     )
-    copy_if_not_exists(store_file_path, BOOT_MOUNT_POINT / efi_file_path)
-    return efi_file_path
 
 
-def write_entry(
+def boot_file(
     profile: str | None,
     generation: int,
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
-    current: bool,
-) -> tuple[DiskEntry, set[GcRoot]]:
-    gc_roots = set()
-
+) -> tuple[BootFileList, str]:
+    system_identifier = SystemIdentifier(profile, generation, specialisation)
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
-    kernel = copy_from_file(bootspec.kernel)
-    gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / kernel)))
-    initrd = copy_from_file(bootspec.initrd)
-    gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / initrd)))
-    devicetree = (
-        copy_from_file(bootspec.devicetree) if bootspec.devicetree is not None else None
+    kernel = BootFile.from_source(system_identifier, bootspec.kernel)
+    initrd = BootFile.from_initrd(
+        system_identifier,
+        bootspec.initrd,
+        Path(bootspec.initrdSecrets) if bootspec.initrdSecrets is not None else None,
     )
-    if devicetree is not None:
-        gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / devicetree)))
+    devicetree = None
+    if bootspec.devicetree is not None:
+        devicetree = BootFile.from_source(system_identifier, bootspec.devicetree)
 
-    kernel_params = "init=%s " % bootspec.init
-
-    kernel_params = kernel_params + " ".join(bootspec.kernelParams)
+    kernel_params = " ".join([f"init={bootspec.init}"] + bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
     build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
 
-    counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else None
-    entry = Entry(profile, generation, specialisation)
-
-    disk_entry = DiskEntry(
-        entry=entry,
-        kernel=kernel,
-        initrd=initrd,
-        devicetree=devicetree,
-        counters=counters,
-        kernel_params=kernel_params,
-        machine_id=machine_id,
-        description=f"Generation {generation} {bootspec.label}, built on {build_date}",
-        sort_key=bootspec.sortKey,
+    title = "{name}{profile}{specialisation}".format(
+        name=DISTRO_NAME,
+        profile=" [" + profile + "]" if profile else "",
+        specialisation=" (%s)" % specialisation if specialisation else "",
     )
-
-    try:
-        if bootspec.initrdSecrets is not None:
-            run([bootspec.initrdSecrets, BOOT_MOUNT_POINT / initrd])
-    except subprocess.CalledProcessError:
-        if current:
-            print("failed to create initrd secrets!", file=sys.stderr)
-            sys.exit(1)
-        else:
-            print(
-                "warning: failed to create initrd secrets "
-                f'for "{disk_entry.title} - Configuration {generation}", an older generation',
-                file=sys.stderr,
-            )
-            print(
-                "note: this is normal after having removed "
-                "or renamed a file in `boot.initrd.secrets`",
-                file=sys.stderr,
-            )
-
-    gc_roots.add(disk_entry.write())
-    return disk_entry, gc_roots
+    description = f"Generation {generation} {bootspec.label}, built on {build_date}"
+    boot_entry = [
+        f"title {title}",
+        f"version {description}",
+        f"linux /{str(kernel.path)}",
+        f"initrd /{str(initrd.path)}",
+        f"options {kernel_params}",
+        f"machine-id {machine_id}" if machine_id is not None else None,
+        f"devicetree /{str(devicetree.path)}" if devicetree is not None else None,
+        f"sort-key {bootspec.sortKey}",
+    ]
+    contents = "\n".join(filter(None, boot_entry))
+    entry, bootctl_id = BootFile.from_entry(system_identifier, contents.encode("utf-8"))
+    return (list(filter(None, [kernel, initrd, devicetree, entry])), bootctl_id)
 
 
 def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
@@ -511,64 +502,48 @@ def install_bootloader(args: argparse.Namespace) -> None:
     for profile in get_profiles():
         gens += get_generations(profile)
 
-    gc_roots: set[GcRoot] = set()
+    boot_files: BootFileList = []
 
     default_config = Path(args.default_config)
     default_entry_id: str | None = None
 
     for gen in gens:
-        try:
-            bootspec = get_bootspec(gen.profile, gen.generation)
-            is_default = Path(bootspec.init).parent == default_config
-            disk_entry, new_gc_roots = write_entry(
-                *gen, machine_id, bootspec, current=is_default
+        bootspec = get_bootspec(gen.profile, gen.generation)
+        is_default = Path(bootspec.init).parent == default_config
+        new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
+        boot_files.extend(new_boot_files)
+        if is_default:
+            default_entry_id = new_bootctl_id
+        for specialisation_name, specialisation in bootspec.specialisations.items():
+            is_default = Path(specialisation.init).parent == default_config
+            new_boot_files, new_bootctl_id = boot_file(
+                gen.profile,
+                gen.generation,
+                specialisation_name,
+                machine_id,
+                bootspec,
             )
-            gc_roots.update(new_gc_roots)
+            boot_files.extend(new_boot_files)
             if is_default:
-                default_entry_id = disk_entry.bootctl_id
-            for specialisation_name, specialisation in bootspec.specialisations.items():
-                is_default = Path(specialisation.init).parent == default_config
-                disk_entry, new_gc_roots = write_entry(
-                    gen.profile,
-                    gen.generation,
-                    specialisation_name,
-                    machine_id,
-                    bootspec,
-                    current=is_default,
-                )
-                gc_roots.update(new_gc_roots)
-                if is_default:
-                    default_entry_id = disk_entry.bootctl_id
-        except OSError as e:
-            # See https://github.com/NixOS/nixpkgs/issues/114552
-            if e.errno == errno.EINVAL:
-                profile = (
-                    f"profile '{gen.profile}'" if gen.profile else "default profile"
-                )
-                print(
-                    "ignoring {} in the list of boot entries because of the following error:\n{}".format(
-                        profile, e
-                    ),
-                    file=sys.stderr,
-                )
-            else:
-                raise e
+                default_entry_id = new_bootctl_id
 
     write_loader_conf(default_entry_id)
+
+    # Garbage-collect stale kernels/initrds/entries before re-populating extra
+    # files, so that user-supplied extraEntries (which may also live under
+    # loader/entries and start with `nixos-`) are not removed again.
+    garbage_collect(boot_files)
+
+    write_boot_files(boot_files)
+
+    remove_extra_files()
+    run([COPY_EXTRA_FILES])
 
     if BOOT_MOUNT_POINT != EFI_SYS_MOUNT_POINT:
         # Cleanup any entries in ESP if xbootldrMountPoint is set.
         # If the user later unsets xbootldrMountPoint, entries in XBOOTLDR will not be cleaned up
         # automatically, as we don't have information about the mount point anymore.
         cleanup_esp()
-
-    # Garbage-collect stale kernels/initrds/entries before re-populating extra
-    # files, so that user-supplied extraEntries (which may also live under
-    # loader/entries and start with `nixos-`) are not removed again.
-    garbage_collect(gc_roots)
-
-    remove_extra_files()
-    run([COPY_EXTRA_FILES])
 
 
 def remove_extra_files() -> None:
@@ -589,16 +564,12 @@ def remove_extra_files() -> None:
     extra_files_dir.mkdir(parents=True, exist_ok=True)
 
 
-def garbage_collect(gc_roots: set[GcRoot]) -> None:
+def garbage_collect(gc_roots: BootFileList) -> None:
     # Check if a file is in the list of gc roots.
-    # For prefixes, we need to allow for the potential presence of boot counters.
     def has_gc_root(p: Path) -> bool:
-        for root in gc_roots:
-            if root.path and root.path == p:
-                return True
-            elif root.prefix and re.fullmatch(
-                rf"{re.escape(str(root.prefix))}(\+[0-9]+(-[0-9]+)?)?\.conf", str(p)
-            ):
+        for gc_root in gc_roots:
+            gc_root_path = BOOT_MOUNT_POINT / gc_root.path
+            if gc_root_path == p:
                 return True
         return False
 
@@ -613,6 +584,30 @@ def garbage_collect(gc_roots: set[GcRoot]) -> None:
         match = re.fullmatch(r"nixos-.+\.conf", e.name)
         if match:
             delete_path(e)
+
+
+def write_boot_files(boot_files: BootFileList) -> None:
+    for boot_file in boot_files:
+        boot_path = BOOT_MOUNT_POINT / boot_file.path
+        try:
+            if not boot_path.exists():
+                boot_file.writer.write_boot_file(boot_path)
+        except OSError as e:
+            # See https://github.com/NixOS/nixpkgs/issues/114552
+            if e.errno == errno.EINVAL:
+                profile = (
+                    f"profile '{boot_file.system_identifier.profile}'"
+                    if boot_file.system_identifier.profile
+                    else "default profile"
+                )
+                print(
+                    "ignoring {} in the list of boot entries because of the following error:\n{}".format(
+                        profile, e
+                    ),
+                    file=sys.stderr,
+                )
+            else:
+                raise e
 
 
 def main() -> None:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -633,6 +633,10 @@ def write_boot_files(boot_files: BootFileList) -> None:
             if boot_file.current:
                 print("failed to create initrd secrets!", file=sys.stderr)
                 sys.exit(1)
+            # Keep the entry bootable by leaving at least a pristine initrd
+            # in place. CopyWriter is a no-op if one already exists.
+            assert isinstance(boot_file.writer, InitrdWithSecretsWriter)
+            CopyWriter(source=boot_file.writer.source).write_boot_file(boot_path)
             print(
                 "warning: failed to create initrd secrets for generation "
                 f"{boot_file.system_identifier.generation}, an older generation",

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -604,16 +604,10 @@ def remove_extra_files() -> None:
 
 
 def garbage_collect(gc_roots: BootFileList) -> None:
-    # Check if a file is in the list of gc roots.
-    def has_gc_root(p: Path) -> bool:
-        for gc_root in gc_roots:
-            gc_root_path = BOOT_MOUNT_POINT / gc_root.path
-            if gc_root_path == p:
-                return True
-        return False
+    keep = {BOOT_MOUNT_POINT / gc_root.path for gc_root in gc_roots}
 
     def delete_path(e: os.DirEntry) -> None:
-        if e.is_file(follow_symlinks=True) and not has_gc_root(Path(e.path)):
+        if e.is_file(follow_symlinks=True) and Path(e.path) not in keep:
             os.remove(e.path)
 
     for e in os.scandir(BOOT_MOUNT_POINT / NIXOS_DIR):

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -194,14 +194,17 @@ class BootFile:
     ) -> tuple["BootFile", str]:
         contents_hash = hashlib.sha256(contents).hexdigest()
         path_prefix = f"nixos-{contents_hash}"
+        pat = re.compile(rf"{re.escape(path_prefix)}(\+[0-9]+(-[0-9]+)?)?\.conf")
         path = None
         for e in os.scandir(path=BOOT_MOUNT_POINT / "loader" / "entries"):
-            mat = re.fullmatch(
-                rf"{re.escape(path_prefix)}(\+[0-9]+(-[0-9]+)?)?\.conf", e.name
-            )
-            if mat is not None:
-                path = Path("loader/entries") / e.name
-                break
+            if pat.fullmatch(e.name) is None:
+                continue
+            # Ignore files whose content does not match the hash in their
+            # name so GC removes them and a fresh entry is written.
+            if hashlib.sha256(Path(e.path).read_bytes()).hexdigest() != contents_hash:
+                continue
+            path = Path("loader/entries") / e.name
+            break
         if path is None:
             counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else ""
             path = Path(f"loader/entries/{path_prefix}{counters}.conf")

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -521,24 +521,35 @@ def install_bootloader(args: argparse.Namespace) -> None:
     default_entry_id: str | None = None
 
     for gen in gens:
-        bootspec = get_bootspec(gen.profile, gen.generation)
-        is_default = Path(bootspec.init).parent == default_config
-        new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
-        boot_files.extend(new_boot_files)
-        if is_default:
-            default_entry_id = new_bootctl_id
-        for specialisation_name, specialisation in bootspec.specialisations.items():
-            is_default = Path(specialisation.init).parent == default_config
-            new_boot_files, new_bootctl_id = boot_file(
-                gen.profile,
-                gen.generation,
-                specialisation_name,
-                machine_id,
-                bootspec,
-            )
+        try:
+            bootspec = get_bootspec(gen.profile, gen.generation)
+            is_default = Path(bootspec.init).parent == default_config
+            new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
             boot_files.extend(new_boot_files)
             if is_default:
                 default_entry_id = new_bootctl_id
+            for specialisation_name, specialisation in bootspec.specialisations.items():
+                is_default = Path(specialisation.init).parent == default_config
+                new_boot_files, new_bootctl_id = boot_file(
+                    gen.profile,
+                    gen.generation,
+                    specialisation_name,
+                    machine_id,
+                    bootspec,
+                )
+                boot_files.extend(new_boot_files)
+                if is_default:
+                    default_entry_id = new_bootctl_id
+        except OSError as e:
+            # See https://github.com/NixOS/nixpkgs/issues/114552
+            if e.errno != errno.EINVAL:
+                raise
+            profile = f"'{gen.profile}'" if gen.profile else "default"
+            print(
+                f"ignoring generation {gen.generation} of the {profile} profile "
+                f"because of the following error:\n{e}",
+                file=sys.stderr,
+            )
 
     write_loader_conf(default_entry_id)
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -3,6 +3,7 @@ import argparse
 import ctypes
 import datetime
 import errno
+import functools
 import hashlib
 import os
 import re
@@ -330,6 +331,7 @@ def bootspec_from_json(bootspec_json: dict[str, Any]) -> BootSpec:
     )
 
 
+@functools.lru_cache(maxsize=None)
 def boot_path(file: Path) -> Path:
     store_file_path = file.resolve()
     suffix = store_file_path.name

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -625,7 +625,14 @@ def garbage_collect(gc_roots: BootFileList) -> None:
 
 
 def write_boot_files(boot_files: BootFileList) -> None:
-    for boot_file in boot_files:
+    # Deduplicate by destination path so shared files are written once.
+    # Prefer the current configuration's entry so its failures are fatal.
+    unique: dict[Path, BootFile] = {}
+    for bf in boot_files:
+        if bf.path not in unique or bf.current:
+            unique[bf.path] = bf
+
+    for boot_file in unique.values():
         boot_path = BOOT_MOUNT_POINT / boot_file.path
         try:
             boot_file.writer.write_boot_file(boot_path)

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -65,6 +65,8 @@ class CopyWriter:
     source: Path
 
     def write_boot_file(self, path: Path) -> None:
+        if path.exists():
+            return
         with tempfile.NamedTemporaryFile(
             mode="wb",
             dir=path.parent,
@@ -86,20 +88,29 @@ class InitrdWithSecretsWriter:
     initrd_secrets: Path
 
     def write_boot_file(self, path: Path) -> None:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=path.parent,
-            delete=False,
-            prefix=path.name,
-            suffix=".tmp",
-        ) as tmp:
-            with open(self.source, mode="rb") as source_file:
-                shutil.copyfileobj(source_file, tmp)
-            tmp.flush()
-            run([self.initrd_secrets, tmp.name])
-            os.fsync(tmp.fileno())
-            tmp.close()
-            os.rename(tmp.name, path)
+        if path.exists():
+            # TODO: This is for matching old behavior. Previously, we
+            # appended secrets to initrd every time no matter what, so
+            # we must continue doing that. One potential alternative
+            # would be running the secret script on an empty file and
+            # using the hashed contents of that file as part of the
+            # key that the path name is based on.
+            run([self.initrd_secrets, path])
+        else:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=path.parent,
+                delete=False,
+                prefix=path.name,
+                suffix=".tmp",
+            ) as tmp:
+                with open(self.source, mode="rb") as source_file:
+                    shutil.copyfileobj(source_file, tmp)
+                tmp.flush()
+                run([self.initrd_secrets, tmp.name])
+                os.fsync(tmp.fileno())
+                tmp.close()
+                os.rename(tmp.name, path)
 
 
 @dataclass
@@ -107,6 +118,8 @@ class ContentsWriter:
     contents: bytes
 
     def write_boot_file(self, path: Path) -> None:
+        if path.exists():
+            return
         with tempfile.NamedTemporaryFile(
             mode="wb",
             dir=path.parent,
@@ -590,8 +603,7 @@ def write_boot_files(boot_files: BootFileList) -> None:
     for boot_file in boot_files:
         boot_path = BOOT_MOUNT_POINT / boot_file.path
         try:
-            if not boot_path.exists():
-                boot_file.writer.write_boot_file(boot_path)
+            boot_file.writer.write_boot_file(boot_path)
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552
             if e.errno == errno.EINVAL:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -140,23 +140,30 @@ class SystemIdentifier(NamedTuple):
 @dataclass
 class BootFile:
     system_identifier: SystemIdentifier
+    current: bool
     path: Path
     writer: WriteBootFile
 
     @staticmethod
-    def from_source(system_identifier: SystemIdentifier, source: Path) -> "BootFile":
+    def from_source(
+        system_identifier: SystemIdentifier, current: bool, source: Path
+    ) -> "BootFile":
         return BootFile(
             system_identifier=system_identifier,
+            current=current,
             path=boot_path(source),
             writer=CopyWriter(source=source),
         )
 
     @staticmethod
     def from_initrd(
-        system_identifier: SystemIdentifier, source: Path, initrd_secrets: Path | None
+        system_identifier: SystemIdentifier,
+        current: bool,
+        source: Path,
+        initrd_secrets: Path | None,
     ) -> "BootFile":
         if initrd_secrets is None:
-            return BootFile.from_source(system_identifier, source)
+            return BootFile.from_source(system_identifier, current, source)
         else:
             # We're trying to calculate a canonical path unique to
             # this initrd and secret-appender. The boot_path is the
@@ -173,6 +180,7 @@ class BootFile:
             combined_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
             return BootFile(
                 system_identifier=system_identifier,
+                current=current,
                 path=NIXOS_DIR / f"{combined_hash}-initrd.efi",
                 writer=InitrdWithSecretsWriter(
                     source=source, initrd_secrets=initrd_secrets
@@ -181,7 +189,7 @@ class BootFile:
 
     @staticmethod
     def from_entry(
-        system_identifier: SystemIdentifier, contents: bytes
+        system_identifier: SystemIdentifier, current: bool, contents: bytes
     ) -> tuple["BootFile", str]:
         contents_hash = hashlib.sha256(contents).hexdigest()
         path_prefix = f"nixos-{contents_hash}"
@@ -199,6 +207,7 @@ class BootFile:
         return (
             BootFile(
                 system_identifier=system_identifier,
+                current=current,
                 path=path,
                 writer=ContentsWriter(contents=contents),
             ),
@@ -336,19 +345,23 @@ def boot_file(
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
+    current: bool,
 ) -> tuple[BootFileList, str]:
     system_identifier = SystemIdentifier(profile, generation, specialisation)
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
-    kernel = BootFile.from_source(system_identifier, bootspec.kernel)
+    kernel = BootFile.from_source(system_identifier, current, bootspec.kernel)
     initrd = BootFile.from_initrd(
         system_identifier,
+        current,
         bootspec.initrd,
         Path(bootspec.initrdSecrets) if bootspec.initrdSecrets is not None else None,
     )
     devicetree = None
     if bootspec.devicetree is not None:
-        devicetree = BootFile.from_source(system_identifier, bootspec.devicetree)
+        devicetree = BootFile.from_source(
+            system_identifier, current, bootspec.devicetree
+        )
 
     kernel_params = " ".join([f"init={bootspec.init}"] + bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
@@ -371,7 +384,9 @@ def boot_file(
         f"sort-key {bootspec.sortKey}",
     ]
     contents = "\n".join(filter(None, boot_entry))
-    entry, bootctl_id = BootFile.from_entry(system_identifier, contents.encode("utf-8"))
+    entry, bootctl_id = BootFile.from_entry(
+        system_identifier, current, contents.encode("utf-8")
+    )
     return (list(filter(None, [kernel, initrd, devicetree, entry])), bootctl_id)
 
 
@@ -521,7 +536,9 @@ def install_bootloader(args: argparse.Namespace) -> None:
         try:
             bootspec = get_bootspec(gen.profile, gen.generation)
             is_default = Path(bootspec.init).parent == default_config
-            new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
+            new_boot_files, new_bootctl_id = boot_file(
+                *gen, machine_id, bootspec, current=is_default
+            )
             boot_files.extend(new_boot_files)
             if is_default:
                 default_entry_id = new_bootctl_id
@@ -533,6 +550,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
                     specialisation_name,
                     machine_id,
                     bootspec,
+                    current=is_default,
                 )
                 boot_files.extend(new_boot_files)
                 if is_default:
@@ -612,6 +630,20 @@ def write_boot_files(boot_files: BootFileList) -> None:
         boot_path = BOOT_MOUNT_POINT / boot_file.path
         try:
             boot_file.writer.write_boot_file(boot_path)
+        except subprocess.CalledProcessError:
+            if boot_file.current:
+                print("failed to create initrd secrets!", file=sys.stderr)
+                sys.exit(1)
+            print(
+                "warning: failed to create initrd secrets for generation "
+                f"{boot_file.system_identifier.generation}, an older generation",
+                file=sys.stderr,
+            )
+            print(
+                "note: this is normal after having removed "
+                "or renamed a file in `boot.initrd.secrets`",
+                file=sys.stderr,
+            )
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552
             if e.errno == errno.EINVAL:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -551,14 +551,14 @@ def install_bootloader(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
 
-    write_loader_conf(default_entry_id)
-
     # Garbage-collect stale kernels/initrds/entries before re-populating extra
     # files, so that user-supplied extraEntries (which may also live under
     # loader/entries and start with `nixos-`) are not removed again.
     garbage_collect(boot_files)
 
     write_boot_files(boot_files)
+
+    write_loader_conf(default_entry_id)
 
     remove_extra_files()
     run([COPY_EXTRA_FILES])

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import warnings
 import json
-from typing import NamedTuple, Any, Sequence
+from typing import NamedTuple, Any, Protocol, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -56,117 +56,150 @@ class BootSpec:
     initrdSecrets: str | None = None  # noqa: N815
 
 
-@dataclass(frozen=True)
-class GcRoot:
-    prefix: Path | None
-    path: Path | None
-
-    @staticmethod
-    def from_prefix(prefix: Path) -> "GcRoot":
-        return GcRoot(prefix=prefix, path=None)
-
-    @staticmethod
-    def from_path(path: Path) -> "GcRoot":
-        return GcRoot(prefix=None, path=path)
+class WriteBootFile(Protocol):
+    def write_boot_file(self, path: Path) -> None: ...
 
 
-@dataclass(frozen=True)
-class Entry:
+@dataclass
+class CopyWriter:
+    source: Path
+
+    def write_boot_file(self, path: Path) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        ) as tmp:
+            with open(self.source, mode="rb") as source_file:
+                shutil.copyfileobj(source_file, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.rename(tmp.name, path)
+
+
+@dataclass
+class InitrdWithSecretsWriter:
+    source: Path
+    initrd_secrets: Path
+
+    def write_boot_file(self, path: Path) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        ) as tmp:
+            with open(self.source, mode="rb") as source_file:
+                shutil.copyfileobj(source_file, tmp)
+            tmp.flush()
+            run([self.initrd_secrets, tmp.name])
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.rename(tmp.name, path)
+
+
+@dataclass
+class ContentsWriter:
+    contents: bytes
+
+    def write_boot_file(self, path: Path) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            delete=False,
+            prefix=path.name,
+            suffix=".tmp",
+        ) as tmp:
+            tmp.write(self.contents)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp.close()
+            os.rename(tmp.name, path)
+
+
+class SystemIdentifier(NamedTuple):
     profile: str | None
-    generation_number: int
+    generation: int
     specialisation: str | None
 
 
-@dataclass(frozen=True)
-class DiskEntry:
-    entry: Entry
-    counters: str | None
-    description: str | None
-    kernel: Path
-    initrd: Path
-    devicetree: Path | None
-    kernel_params: str | None
-    machine_id: str | None
-    sort_key: str
+@dataclass
+class BootFile:
+    system_identifier: SystemIdentifier
+    path: Path
+    writer: WriteBootFile
 
-    @property
-    def title(self) -> str:
-        return "{name}{profile}{specialisation}".format(
-            name=DISTRO_NAME,
-            profile=" [" + self.entry.profile + "]" if self.entry.profile else "",
-            specialisation=" (%s)" % self.entry.specialisation
-            if self.entry.specialisation
-            else "",
+    @staticmethod
+    def from_source(system_identifier: SystemIdentifier, source: Path) -> "BootFile":
+        return BootFile(
+            system_identifier=system_identifier,
+            path=boot_path(source),
+            writer=CopyWriter(source=source),
         )
 
-    def serialise(self) -> str:
-        boot_entry = [
-            f"title {self.title}",
-            f"version {self.description}" if self.description is not None else None,
-            f"linux /{self.kernel}",
-            f"initrd /{self.initrd}",
-            f"options {self.kernel_params}" if self.kernel_params is not None else None,
-            f"machine-id {self.machine_id}" if self.machine_id is not None else None,
-            f"devicetree /{self.devicetree}" if self.devicetree is not None else None,
-            f"sort-key {self.sort_key}",
-        ]
-        return "\n".join(filter(None, boot_entry))
-
-    def write(self) -> GcRoot:
-        # Check first if the file already exists
-        for e in os.scandir(path=BOOT_MOUNT_POINT / "loader" / "entries"):
-            match = re.fullmatch(
-                rf"{self.path_prefix}(\+[0-9]+(-[0-9]+)?)?\.conf", e.name
+    @staticmethod
+    def from_initrd(
+        system_identifier: SystemIdentifier, source: Path, initrd_secrets: Path | None
+    ) -> "BootFile":
+        if initrd_secrets is None:
+            return BootFile.from_source(system_identifier, source)
+        else:
+            # We're trying to calculate a canonical path unique to
+            # this initrd and secret-appender. The boot_path is the
+            # canonical path for files that don't need modifications,
+            # so it serves as a perfect proxy for the unique
+            # information to combine for a combined unique path. The
+            # original paths themselves would have also been fine, but
+            # boot_path is more semantically representative, since
+            # it's the actual path whose uniqueness we're trying to
+            # ensure for other things.
+            combined = "\n".join(
+                [str(boot_path(source)), str(boot_path(initrd_secrets))]
             )
-            if match:
-                # Check that the contents match the hash
-                with open(e.path, "r") as f:
-                    hash = hashlib.sha256(f.read().encode("utf-8")).hexdigest()
-                    if hash == self.content_hash:
-                        # The contents match, we are done, there is nothing to write
-                        return GcRoot.from_prefix(
-                            BOOT_MOUNT_POINT / "loader" / "entries" / self.path_prefix
-                        )
+            combined_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
+            return BootFile(
+                system_identifier=system_identifier,
+                path=NIXOS_DIR / f"{combined_hash}-initrd.efi",
+                writer=InitrdWithSecretsWriter(
+                    source=source, initrd_secrets=initrd_secrets
+                ),
+            )
 
-        # We didn't find a matching file, so we'll create one
-        tmp_path = self.path.with_suffix(".tmp")
-        with tmp_path.open("w") as f:
-            boot_entry = self.serialise()
-
-            f.write(boot_entry)
-            f.flush()
-            os.fsync(f.fileno())
-        tmp_path.rename(self.path)
-        return GcRoot.from_prefix(
-            BOOT_MOUNT_POINT / "loader" / "entries" / self.path_prefix
+    @staticmethod
+    def from_entry(
+        system_identifier: SystemIdentifier, contents: bytes
+    ) -> tuple["BootFile", str]:
+        contents_hash = hashlib.sha256(contents).hexdigest()
+        path_prefix = f"nixos-{contents_hash}"
+        path = None
+        for e in os.scandir(path=BOOT_MOUNT_POINT / "loader" / "entries"):
+            mat = re.fullmatch(
+                rf"{re.escape(path_prefix)}(\+[0-9]+(-[0-9]+)?)?\.conf", e.name
+            )
+            if mat is not None:
+                path = Path("loader/entries") / e.name
+                break
+        if path is None:
+            counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else ""
+            path = Path(f"loader/entries/{path_prefix}{counters}.conf")
+        return (
+            BootFile(
+                system_identifier=system_identifier,
+                path=path,
+                writer=ContentsWriter(contents=contents),
+            ),
+            f"{path_prefix}.conf",
         )
 
-    @property
-    def content_hash(self) -> str:
-        return hashlib.sha256(self.serialise().encode("utf-8")).hexdigest()
 
-    @property
-    def path_prefix(self) -> str:
-        return "-".join(
-            p
-            for p in [
-                "nixos",
-                self.content_hash,
-            ]
-            if p
-        )
-
-    @property
-    def path(self) -> Path:
-        return BOOT_MOUNT_POINT / "loader" / "entries" / self.filename
-
-    @property
-    def filename(self) -> str:
-        return f"{self.path_prefix}{self.counters if self.counters else ''}.conf"
-
-    @property
-    def bootctl_id(self) -> str:
-        return f"{self.path_prefix}.conf"
+# This gets its own type alias to document that the order is very
+# important. The order ensures that entry files are written after
+# their respective kernel / initrd / etc.
+type BootFileList = list[BootFile]
 
 
 libc = ctypes.CDLL("libc.so.6")
@@ -178,22 +211,6 @@ def run(
     cmd: Sequence[str | Path], stdout: FILE = None
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, check=True, text=True, stdout=stdout, stderr=sys.stderr)
-
-
-class SystemIdentifier(NamedTuple):
-    profile: str | None
-    generation: int
-    specialisation: str | None
-
-
-def copy_if_not_exists(source: Path, dest: Path) -> None:
-    if not dest.exists():
-        tmpfd, tmppath = tempfile.mkstemp(
-            dir=dest.parent, prefix=dest.name, suffix=".tmp."
-        )
-        shutil.copyfile(source, tmppath)
-        os.fsync(tmpfd)
-        shutil.move(tmppath, dest)
 
 
 def generation_dir(profile: str | None, generation: int) -> Path:
@@ -294,84 +311,58 @@ def bootspec_from_json(bootspec_json: dict[str, Any]) -> BootSpec:
     )
 
 
-def copy_from_file(file: Path) -> Path:
-    """
-    Copy a file to the boot filesystem (XBOOTLDR if in use, otherwise ESP), basing the destination filename on the store path that's being copied from. Return the destination path, relative to the boot filesystem mountpoint.
-    """
+def boot_path(file: Path) -> Path:
     store_file_path = file.resolve()
     suffix = store_file_path.name
     store_subdir = store_file_path.relative_to(STORE_DIR).parts[0]
-    efi_file_path = NIXOS_DIR / (
+    return NIXOS_DIR / (
         f"{suffix}.efi" if suffix == store_subdir else f"{store_subdir}-{suffix}.efi"
     )
-    copy_if_not_exists(store_file_path, BOOT_MOUNT_POINT / efi_file_path)
-    return efi_file_path
 
 
-def write_entry(
+def boot_file(
     profile: str | None,
     generation: int,
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
-    current: bool,
-) -> tuple[DiskEntry, set[GcRoot]]:
-    gc_roots = set()
-
+) -> tuple[BootFileList, str]:
+    system_identifier = SystemIdentifier(profile, generation, specialisation)
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
-    kernel = copy_from_file(bootspec.kernel)
-    gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / kernel)))
-    initrd = copy_from_file(bootspec.initrd)
-    gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / initrd)))
-    devicetree = (
-        copy_from_file(bootspec.devicetree) if bootspec.devicetree is not None else None
+    kernel = BootFile.from_source(system_identifier, bootspec.kernel)
+    initrd = BootFile.from_initrd(
+        system_identifier,
+        bootspec.initrd,
+        Path(bootspec.initrdSecrets) if bootspec.initrdSecrets is not None else None,
     )
-    if devicetree is not None:
-        gc_roots.add(GcRoot.from_path(path=(BOOT_MOUNT_POINT / devicetree)))
+    devicetree = None
+    if bootspec.devicetree is not None:
+        devicetree = BootFile.from_source(system_identifier, bootspec.devicetree)
 
-    kernel_params = "init=%s " % bootspec.init
-
-    kernel_params = kernel_params + " ".join(bootspec.kernelParams)
+    kernel_params = " ".join([f"init={bootspec.init}"] + bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
     build_date = datetime.datetime.fromtimestamp(build_time).strftime("%F")
 
-    counters = f"+{BOOT_COUNTING_TRIES}" if BOOT_COUNTING else None
-    entry = Entry(profile, generation, specialisation)
-
-    disk_entry = DiskEntry(
-        entry=entry,
-        kernel=kernel,
-        initrd=initrd,
-        devicetree=devicetree,
-        counters=counters,
-        kernel_params=kernel_params,
-        machine_id=machine_id,
-        description=f"Generation {generation} {bootspec.label}, built on {build_date}",
-        sort_key=bootspec.sortKey,
+    title = "{name}{profile}{specialisation}".format(
+        name=DISTRO_NAME,
+        profile=" [" + profile + "]" if profile else "",
+        specialisation=" (%s)" % specialisation if specialisation else "",
     )
-
-    try:
-        if bootspec.initrdSecrets is not None:
-            run([bootspec.initrdSecrets, BOOT_MOUNT_POINT / initrd])
-    except subprocess.CalledProcessError:
-        if current:
-            print("failed to create initrd secrets!", file=sys.stderr)
-            sys.exit(1)
-        else:
-            print(
-                "warning: failed to create initrd secrets "
-                f'for "{disk_entry.title} - Configuration {generation}", an older generation',
-                file=sys.stderr,
-            )
-            print(
-                "note: this is normal after having removed "
-                "or renamed a file in `boot.initrd.secrets`",
-                file=sys.stderr,
-            )
-
-    gc_roots.add(disk_entry.write())
-    return disk_entry, gc_roots
+    description = f"Generation {generation} {bootspec.label}, built on {build_date}"
+    boot_entry = [
+        f"title {title}",
+        f"version {description}",
+        f"linux /{str(kernel.path)}",
+        f"initrd /{str(initrd.path)}",
+        f"options {kernel_params}",
+        f"machine-id {machine_id}" if machine_id is not None else None,
+        f"devicetree /{str(devicetree.path)}" if devicetree is not None else None,
+        f"sort-key {bootspec.sortKey}",
+    ]
+    contents = "\n".join(filter(None, boot_entry))
+    entry, bootctl_id = BootFile.from_entry(system_identifier, contents.encode("utf-8"))
+    return (list(filter(None, [kernel, initrd, devicetree, entry])), bootctl_id)
 
 
 def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
@@ -511,64 +502,48 @@ def install_bootloader(args: argparse.Namespace) -> None:
     for profile in get_profiles():
         gens += get_generations(profile)
 
-    gc_roots: set[GcRoot] = set()
+    boot_files: BootFileList = []
 
     default_config = Path(args.default_config)
     default_entry_id: str | None = None
 
     for gen in gens:
-        try:
-            bootspec = get_bootspec(gen.profile, gen.generation)
-            is_default = Path(bootspec.init).parent == default_config
-            disk_entry, new_gc_roots = write_entry(
-                *gen, machine_id, bootspec, current=is_default
+        bootspec = get_bootspec(gen.profile, gen.generation)
+        is_default = Path(bootspec.init).parent == default_config
+        new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
+        boot_files.extend(new_boot_files)
+        if is_default:
+            default_entry_id = new_bootctl_id
+        for specialisation_name, specialisation in bootspec.specialisations.items():
+            is_default = Path(specialisation.init).parent == default_config
+            new_boot_files, new_bootctl_id = boot_file(
+                gen.profile,
+                gen.generation,
+                specialisation_name,
+                machine_id,
+                bootspec,
             )
-            gc_roots.update(new_gc_roots)
+            boot_files.extend(new_boot_files)
             if is_default:
-                default_entry_id = disk_entry.bootctl_id
-            for specialisation_name, specialisation in bootspec.specialisations.items():
-                is_default = Path(specialisation.init).parent == default_config
-                disk_entry, new_gc_roots = write_entry(
-                    gen.profile,
-                    gen.generation,
-                    specialisation_name,
-                    machine_id,
-                    bootspec,
-                    current=is_default,
-                )
-                gc_roots.update(new_gc_roots)
-                if is_default:
-                    default_entry_id = disk_entry.bootctl_id
-        except OSError as e:
-            # See https://github.com/NixOS/nixpkgs/issues/114552
-            if e.errno == errno.EINVAL:
-                profile = (
-                    f"profile '{gen.profile}'" if gen.profile else "default profile"
-                )
-                print(
-                    "ignoring {} in the list of boot entries because of the following error:\n{}".format(
-                        profile, e
-                    ),
-                    file=sys.stderr,
-                )
-            else:
-                raise e
+                default_entry_id = new_bootctl_id
 
     write_loader_conf(default_entry_id)
+
+    # Garbage-collect stale kernels/initrds/entries before re-populating extra
+    # files, so that user-supplied extraEntries (which may also live under
+    # loader/entries and start with `nixos-`) are not removed again.
+    garbage_collect(boot_files)
+
+    write_boot_files(boot_files)
+
+    remove_extra_files()
+    run([COPY_EXTRA_FILES])
 
     if BOOT_MOUNT_POINT != EFI_SYS_MOUNT_POINT:
         # Cleanup any entries in ESP if xbootldrMountPoint is set.
         # If the user later unsets xbootldrMountPoint, entries in XBOOTLDR will not be cleaned up
         # automatically, as we don't have information about the mount point anymore.
         cleanup_esp()
-
-    # Garbage-collect stale kernels/initrds/entries before re-populating extra
-    # files, so that user-supplied extraEntries (which may also live under
-    # loader/entries and start with `nixos-`) are not removed again.
-    garbage_collect(gc_roots)
-
-    remove_extra_files()
-    run([COPY_EXTRA_FILES])
 
 
 def remove_extra_files() -> None:
@@ -589,16 +564,12 @@ def remove_extra_files() -> None:
     extra_files_dir.mkdir(parents=True, exist_ok=True)
 
 
-def garbage_collect(gc_roots: set[GcRoot]) -> None:
+def garbage_collect(gc_roots: BootFileList) -> None:
     # Check if a file is in the list of gc roots.
-    # For prefixes, we need to allow for the potential presence of boot counters.
     def has_gc_root(p: Path) -> bool:
-        for root in gc_roots:
-            if root.path and root.path == p:
-                return True
-            elif root.prefix and re.fullmatch(
-                rf"{re.escape(str(root.prefix))}(\+[0-9]+(-[0-9]+)?)?\.conf", str(p)
-            ):
+        for gc_root in gc_roots:
+            gc_root_path = BOOT_MOUNT_POINT / gc_root.path
+            if gc_root_path == p:
                 return True
         return False
 
@@ -613,6 +584,13 @@ def garbage_collect(gc_roots: set[GcRoot]) -> None:
         match = re.fullmatch(r"nixos-.+\.conf", e.name)
         if match:
             delete_path(e)
+
+
+def write_boot_files(boot_files: BootFileList) -> None:
+    for boot_file in boot_files:
+        boot_path = BOOT_MOUNT_POINT / boot_file.path
+        if not boot_path.exists():
+            boot_file.writer.write_boot_file(boot_path)
 
 
 def main() -> None:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -634,13 +634,11 @@ def write_boot_files(boot_files: BootFileList) -> None:
             assert isinstance(boot_file.writer, InitrdWithSecretsWriter)
             CopyWriter(source=boot_file.writer.source).write_boot_file(boot_path)
             print(
-                "warning: failed to create initrd secrets for generation "
-                f"{boot_file.system_identifier.generation}, an older generation",
-                file=sys.stderr,
-            )
-            print(
-                "note: this is normal after having removed "
-                "or renamed a file in `boot.initrd.secrets`",
+                "warning: failed to update initrd secrets for an older "
+                f"generation ({boot_file.system_identifier.generation}). The "
+                "previous secrets in this initrd will continue to be used. "
+                "To silence this warning, restore the secret files to their "
+                "original locations or delete this generation.",
                 file=sys.stderr,
             )
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -58,14 +58,14 @@ class BootSpec:
 
 
 class WriteBootFile(Protocol):
-    def write_boot_file(self, path: Path) -> None: ...
+    def write_boot_file(self, path: Path, *, critical: bool) -> None: ...
 
 
 @dataclass
 class CopyWriter:
     source: Path
 
-    def write_boot_file(self, path: Path) -> None:
+    def write_boot_file(self, path: Path, *, critical: bool) -> None:
         if path.exists():
             return
         with tempfile.NamedTemporaryFile(
@@ -87,8 +87,9 @@ class CopyWriter:
 class InitrdWithSecretsWriter:
     source: Path
     initrd_secrets: Path
+    generation: int
 
-    def write_boot_file(self, path: Path) -> None:
+    def write_boot_file(self, path: Path, *, critical: bool) -> None:
         # Secrets can change between rebuilds, so always rebuild from the
         # pristine initrd into a temp file and rename into place.
         with tempfile.NamedTemporaryFile(
@@ -104,6 +105,24 @@ class InitrdWithSecretsWriter:
                 tmp.flush()
                 run([self.initrd_secrets, tmp.name])
                 os.fsync(tmp.fileno())
+            except subprocess.CalledProcessError:
+                os.unlink(tmp.name)
+                if critical:
+                    print("failed to create initrd secrets!", file=sys.stderr)
+                    sys.exit(1)
+                # Keep the entry bootable by leaving at least a pristine
+                # initrd in place. CopyWriter is a no-op if one already
+                # exists.
+                CopyWriter(source=self.source).write_boot_file(path, critical=False)
+                print(
+                    "warning: failed to update initrd secrets for an older "
+                    f"generation ({self.generation}). The previous secrets "
+                    "in this initrd will continue to be used. To silence "
+                    "this warning, restore the secret files to their "
+                    "original locations or delete this generation.",
+                    file=sys.stderr,
+                )
+                return
             except BaseException:
                 os.unlink(tmp.name)
                 raise
@@ -114,7 +133,7 @@ class InitrdWithSecretsWriter:
 class ContentsWriter:
     contents: bytes
 
-    def write_boot_file(self, path: Path) -> None:
+    def write_boot_file(self, path: Path, *, critical: bool) -> None:
         if path.exists():
             return
         with tempfile.NamedTemporaryFile(
@@ -183,7 +202,9 @@ class BootFile:
                 current=current,
                 path=NIXOS_DIR / f"{combined_hash}-initrd.efi",
                 writer=InitrdWithSecretsWriter(
-                    source=source, initrd_secrets=initrd_secrets
+                    source=source,
+                    initrd_secrets=initrd_secrets,
+                    generation=system_identifier.generation,
                 ),
             )
 
@@ -622,25 +643,10 @@ def write_boot_files(boot_files: BootFileList, critical_paths: set[Path]) -> Non
         if boot_file.path in seen:
             continue
         seen.add(boot_file.path)
-        boot_path = BOOT_MOUNT_POINT / boot_file.path
-        try:
-            boot_file.writer.write_boot_file(boot_path)
-        except subprocess.CalledProcessError:
-            if boot_file.path in critical_paths:
-                print("failed to create initrd secrets!", file=sys.stderr)
-                sys.exit(1)
-            # Keep the entry bootable by leaving at least a pristine initrd
-            # in place. CopyWriter is a no-op if one already exists.
-            assert isinstance(boot_file.writer, InitrdWithSecretsWriter)
-            CopyWriter(source=boot_file.writer.source).write_boot_file(boot_path)
-            print(
-                "warning: failed to update initrd secrets for an older "
-                f"generation ({boot_file.system_identifier.generation}). The "
-                "previous secrets in this initrd will continue to be used. "
-                "To silence this warning, restore the secret files to their "
-                "original locations or delete this generation.",
-                file=sys.stderr,
-            )
+        boot_file.writer.write_boot_file(
+            BOOT_MOUNT_POINT / boot_file.path,
+            critical=boot_file.path in critical_paths,
+        )
 
 
 def main() -> None:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -540,14 +540,14 @@ def install_bootloader(args: argparse.Namespace) -> None:
             if is_default:
                 default_entry_id = new_bootctl_id
 
-    write_loader_conf(default_entry_id)
-
     # Garbage-collect stale kernels/initrds/entries before re-populating extra
     # files, so that user-supplied extraEntries (which may also live under
     # loader/entries and start with `nixos-`) are not removed again.
     garbage_collect(boot_files)
 
     write_boot_files(boot_files)
+
+    write_loader_conf(default_entry_id)
 
     remove_extra_files()
     run([COPY_EXTRA_FILES])

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -158,31 +158,24 @@ class SystemIdentifier(NamedTuple):
 
 @dataclass
 class BootFile:
-    system_identifier: SystemIdentifier
-    current: bool
     path: Path
     writer: WriteBootFile
 
     @staticmethod
-    def from_source(
-        system_identifier: SystemIdentifier, current: bool, source: Path
-    ) -> "BootFile":
+    def from_source(source: Path) -> "BootFile":
         return BootFile(
-            system_identifier=system_identifier,
-            current=current,
             path=boot_path(source),
             writer=CopyWriter(source=source),
         )
 
     @staticmethod
     def from_initrd(
-        system_identifier: SystemIdentifier,
-        current: bool,
+        generation: int,
         source: Path,
         initrd_secrets: Path | None,
     ) -> "BootFile":
         if initrd_secrets is None:
-            return BootFile.from_source(system_identifier, current, source)
+            return BootFile.from_source(source)
         else:
             # We're trying to calculate a canonical path unique to
             # this initrd and secret-appender. The boot_path is the
@@ -198,20 +191,16 @@ class BootFile:
             )
             combined_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
             return BootFile(
-                system_identifier=system_identifier,
-                current=current,
                 path=NIXOS_DIR / f"{combined_hash}-initrd.efi",
                 writer=InitrdWithSecretsWriter(
                     source=source,
                     initrd_secrets=initrd_secrets,
-                    generation=system_identifier.generation,
+                    generation=generation,
                 ),
             )
 
     @staticmethod
-    def from_entry(
-        system_identifier: SystemIdentifier, current: bool, contents: bytes
-    ) -> tuple["BootFile", str]:
+    def from_entry(contents: bytes) -> tuple["BootFile", str]:
         contents_hash = hashlib.sha256(contents).hexdigest()
         path_prefix = f"nixos-{contents_hash}"
         pat = re.compile(rf"{re.escape(path_prefix)}(\+[0-9]+(-[0-9]+)?)?\.conf")
@@ -230,8 +219,6 @@ class BootFile:
             path = Path(f"loader/entries/{path_prefix}{counters}.conf")
         return (
             BootFile(
-                system_identifier=system_identifier,
-                current=current,
                 path=path,
                 writer=ContentsWriter(contents=contents),
             ),
@@ -370,23 +357,18 @@ def boot_file(
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
-    current: bool,
 ) -> tuple[BootFileList, str]:
-    system_identifier = SystemIdentifier(profile, generation, specialisation)
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
-    kernel = BootFile.from_source(system_identifier, current, bootspec.kernel)
+    kernel = BootFile.from_source(bootspec.kernel)
     initrd = BootFile.from_initrd(
-        system_identifier,
-        current,
+        generation,
         bootspec.initrd,
         Path(bootspec.initrdSecrets) if bootspec.initrdSecrets is not None else None,
     )
     devicetree = None
     if bootspec.devicetree is not None:
-        devicetree = BootFile.from_source(
-            system_identifier, current, bootspec.devicetree
-        )
+        devicetree = BootFile.from_source(bootspec.devicetree)
 
     kernel_params = " ".join([f"init={bootspec.init}"] + bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
@@ -409,9 +391,7 @@ def boot_file(
         f"sort-key {bootspec.sortKey}",
     ]
     contents = "\n".join(filter(None, boot_entry))
-    entry, bootctl_id = BootFile.from_entry(
-        system_identifier, current, contents.encode("utf-8")
-    )
+    entry, bootctl_id = BootFile.from_entry(contents.encode("utf-8"))
     return (list(filter(None, [kernel, initrd, devicetree, entry])), bootctl_id)
 
 
@@ -561,9 +541,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
     for gen in gens:
         bootspec = get_bootspec(gen.profile, gen.generation)
         is_default = Path(bootspec.init).parent == default_config
-        new_boot_files, new_bootctl_id = boot_file(
-            *gen, machine_id, bootspec, current=is_default
-        )
+        new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
         boot_files.extend(new_boot_files)
         if is_default:
             default_entry_id = new_bootctl_id
@@ -576,7 +554,6 @@ def install_bootloader(args: argparse.Namespace) -> None:
                 specialisation_name,
                 machine_id,
                 bootspec,
-                current=is_default,
             )
             boot_files.extend(new_boot_files)
             if is_default:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -622,6 +622,10 @@ def write_boot_files(boot_files: BootFileList) -> None:
             if boot_file.current:
                 print("failed to create initrd secrets!", file=sys.stderr)
                 sys.exit(1)
+            # Keep the entry bootable by leaving at least a pristine initrd
+            # in place. CopyWriter is a no-op if one already exists.
+            assert isinstance(boot_file.writer, InitrdWithSecretsWriter)
+            CopyWriter(source=boot_file.writer.source).write_boot_file(boot_path)
             print(
                 "warning: failed to create initrd secrets for generation "
                 f"{boot_file.system_identifier.generation}, an older generation",

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -140,23 +140,30 @@ class SystemIdentifier(NamedTuple):
 @dataclass
 class BootFile:
     system_identifier: SystemIdentifier
+    current: bool
     path: Path
     writer: WriteBootFile
 
     @staticmethod
-    def from_source(system_identifier: SystemIdentifier, source: Path) -> "BootFile":
+    def from_source(
+        system_identifier: SystemIdentifier, current: bool, source: Path
+    ) -> "BootFile":
         return BootFile(
             system_identifier=system_identifier,
+            current=current,
             path=boot_path(source),
             writer=CopyWriter(source=source),
         )
 
     @staticmethod
     def from_initrd(
-        system_identifier: SystemIdentifier, source: Path, initrd_secrets: Path | None
+        system_identifier: SystemIdentifier,
+        current: bool,
+        source: Path,
+        initrd_secrets: Path | None,
     ) -> "BootFile":
         if initrd_secrets is None:
-            return BootFile.from_source(system_identifier, source)
+            return BootFile.from_source(system_identifier, current, source)
         else:
             # We're trying to calculate a canonical path unique to
             # this initrd and secret-appender. The boot_path is the
@@ -173,6 +180,7 @@ class BootFile:
             combined_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
             return BootFile(
                 system_identifier=system_identifier,
+                current=current,
                 path=NIXOS_DIR / f"{combined_hash}-initrd.efi",
                 writer=InitrdWithSecretsWriter(
                     source=source, initrd_secrets=initrd_secrets
@@ -181,7 +189,7 @@ class BootFile:
 
     @staticmethod
     def from_entry(
-        system_identifier: SystemIdentifier, contents: bytes
+        system_identifier: SystemIdentifier, current: bool, contents: bytes
     ) -> tuple["BootFile", str]:
         contents_hash = hashlib.sha256(contents).hexdigest()
         path_prefix = f"nixos-{contents_hash}"
@@ -199,6 +207,7 @@ class BootFile:
         return (
             BootFile(
                 system_identifier=system_identifier,
+                current=current,
                 path=path,
                 writer=ContentsWriter(contents=contents),
             ),
@@ -336,19 +345,23 @@ def boot_file(
     specialisation: str | None,
     machine_id: str | None,
     bootspec: BootSpec,
+    current: bool,
 ) -> tuple[BootFileList, str]:
     system_identifier = SystemIdentifier(profile, generation, specialisation)
     if specialisation:
         bootspec = bootspec.specialisations[specialisation]
-    kernel = BootFile.from_source(system_identifier, bootspec.kernel)
+    kernel = BootFile.from_source(system_identifier, current, bootspec.kernel)
     initrd = BootFile.from_initrd(
         system_identifier,
+        current,
         bootspec.initrd,
         Path(bootspec.initrdSecrets) if bootspec.initrdSecrets is not None else None,
     )
     devicetree = None
     if bootspec.devicetree is not None:
-        devicetree = BootFile.from_source(system_identifier, bootspec.devicetree)
+        devicetree = BootFile.from_source(
+            system_identifier, current, bootspec.devicetree
+        )
 
     kernel_params = " ".join([f"init={bootspec.init}"] + bootspec.kernelParams)
     build_time = int(system_dir(profile, generation, specialisation).stat().st_ctime)
@@ -371,7 +384,9 @@ def boot_file(
         f"sort-key {bootspec.sortKey}",
     ]
     contents = "\n".join(filter(None, boot_entry))
-    entry, bootctl_id = BootFile.from_entry(system_identifier, contents.encode("utf-8"))
+    entry, bootctl_id = BootFile.from_entry(
+        system_identifier, current, contents.encode("utf-8")
+    )
     return (list(filter(None, [kernel, initrd, devicetree, entry])), bootctl_id)
 
 
@@ -520,7 +535,9 @@ def install_bootloader(args: argparse.Namespace) -> None:
     for gen in gens:
         bootspec = get_bootspec(gen.profile, gen.generation)
         is_default = Path(bootspec.init).parent == default_config
-        new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
+        new_boot_files, new_bootctl_id = boot_file(
+            *gen, machine_id, bootspec, current=is_default
+        )
         boot_files.extend(new_boot_files)
         if is_default:
             default_entry_id = new_bootctl_id
@@ -532,6 +549,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
                 specialisation_name,
                 machine_id,
                 bootspec,
+                current=is_default,
             )
             boot_files.extend(new_boot_files)
             if is_default:
@@ -599,7 +617,22 @@ def garbage_collect(gc_roots: BootFileList) -> None:
 def write_boot_files(boot_files: BootFileList) -> None:
     for boot_file in boot_files:
         boot_path = BOOT_MOUNT_POINT / boot_file.path
-        boot_file.writer.write_boot_file(boot_path)
+        try:
+            boot_file.writer.write_boot_file(boot_path)
+        except subprocess.CalledProcessError:
+            if boot_file.current:
+                print("failed to create initrd secrets!", file=sys.stderr)
+                sys.exit(1)
+            print(
+                "warning: failed to create initrd secrets for generation "
+                f"{boot_file.system_identifier.generation}, an older generation",
+                file=sys.stderr,
+            )
+            print(
+                "note: this is normal after having removed "
+                "or renamed a file in `boot.initrd.secrets`",
+                file=sys.stderr,
+            )
 
 
 def main() -> None:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -65,6 +65,8 @@ class CopyWriter:
     source: Path
 
     def write_boot_file(self, path: Path) -> None:
+        if path.exists():
+            return
         with tempfile.NamedTemporaryFile(
             mode="wb",
             dir=path.parent,
@@ -86,20 +88,29 @@ class InitrdWithSecretsWriter:
     initrd_secrets: Path
 
     def write_boot_file(self, path: Path) -> None:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=path.parent,
-            delete=False,
-            prefix=path.name,
-            suffix=".tmp",
-        ) as tmp:
-            with open(self.source, mode="rb") as source_file:
-                shutil.copyfileobj(source_file, tmp)
-            tmp.flush()
-            run([self.initrd_secrets, tmp.name])
-            os.fsync(tmp.fileno())
-            tmp.close()
-            os.rename(tmp.name, path)
+        if path.exists():
+            # TODO: This is for matching old behavior. Previously, we
+            # appended secrets to initrd every time no matter what, so
+            # we must continue doing that. One potential alternative
+            # would be running the secret script on an empty file and
+            # using the hashed contents of that file as part of the
+            # key that the path name is based on.
+            run([self.initrd_secrets, path])
+        else:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=path.parent,
+                delete=False,
+                prefix=path.name,
+                suffix=".tmp",
+            ) as tmp:
+                with open(self.source, mode="rb") as source_file:
+                    shutil.copyfileobj(source_file, tmp)
+                tmp.flush()
+                run([self.initrd_secrets, tmp.name])
+                os.fsync(tmp.fileno())
+                tmp.close()
+                os.rename(tmp.name, path)
 
 
 @dataclass
@@ -107,6 +118,8 @@ class ContentsWriter:
     contents: bytes
 
     def write_boot_file(self, path: Path) -> None:
+        if path.exists():
+            return
         with tempfile.NamedTemporaryFile(
             mode="wb",
             dir=path.parent,
@@ -589,8 +602,7 @@ def garbage_collect(gc_roots: BootFileList) -> None:
 def write_boot_files(boot_files: BootFileList) -> None:
     for boot_file in boot_files:
         boot_path = BOOT_MOUNT_POINT / boot_file.path
-        if not boot_path.exists():
-            boot_file.writer.write_boot_file(boot_path)
+        boot_file.writer.write_boot_file(boot_path)
 
 
 def main() -> None:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -614,7 +614,14 @@ def garbage_collect(gc_roots: BootFileList) -> None:
 
 
 def write_boot_files(boot_files: BootFileList) -> None:
-    for boot_file in boot_files:
+    # Deduplicate by destination path so shared files are written once.
+    # Prefer the current configuration's entry so its failures are fatal.
+    unique: dict[Path, BootFile] = {}
+    for bf in boot_files:
+        if bf.path not in unique or bf.current:
+            unique[bf.path] = bf
+
+    for boot_file in unique.values():
         boot_path = BOOT_MOUNT_POINT / boot_file.path
         try:
             boot_file.writer.write_boot_file(boot_path)

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -593,16 +593,10 @@ def remove_extra_files() -> None:
 
 
 def garbage_collect(gc_roots: BootFileList) -> None:
-    # Check if a file is in the list of gc roots.
-    def has_gc_root(p: Path) -> bool:
-        for gc_root in gc_roots:
-            gc_root_path = BOOT_MOUNT_POINT / gc_root.path
-            if gc_root_path == p:
-                return True
-        return False
+    keep = {BOOT_MOUNT_POINT / gc_root.path for gc_root in gc_roots}
 
     def delete_path(e: os.DirEntry) -> None:
-        if e.is_file(follow_symlinks=True) and not has_gc_root(Path(e.path)):
+        if e.is_file(follow_symlinks=True) and Path(e.path) not in keep:
             os.remove(e.path)
 
     for e in os.scandir(BOOT_MOUNT_POINT / NIXOS_DIR):

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -532,6 +532,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
         gens += get_generations(profile)
 
     boot_files: BootFileList = []
+    critical_paths: set[Path] = set()
 
     default_config = Path(args.default_config)
     default_entry_id: str | None = None
@@ -545,6 +546,7 @@ def install_bootloader(args: argparse.Namespace) -> None:
         boot_files.extend(new_boot_files)
         if is_default:
             default_entry_id = new_bootctl_id
+            critical_paths.update(bf.path for bf in new_boot_files)
         for specialisation_name, specialisation in bootspec.specialisations.items():
             is_default = Path(specialisation.init).parent == default_config
             new_boot_files, new_bootctl_id = boot_file(
@@ -558,13 +560,14 @@ def install_bootloader(args: argparse.Namespace) -> None:
             boot_files.extend(new_boot_files)
             if is_default:
                 default_entry_id = new_bootctl_id
+                critical_paths.update(bf.path for bf in new_boot_files)
 
     # Garbage-collect stale kernels/initrds/entries before re-populating extra
     # files, so that user-supplied extraEntries (which may also live under
     # loader/entries and start with `nixos-`) are not removed again.
     garbage_collect(boot_files)
 
-    write_boot_files(boot_files)
+    write_boot_files(boot_files, critical_paths)
 
     write_loader_conf(default_entry_id)
 
@@ -612,20 +615,18 @@ def garbage_collect(gc_roots: BootFileList) -> None:
             delete_path(e)
 
 
-def write_boot_files(boot_files: BootFileList) -> None:
+def write_boot_files(boot_files: BootFileList, critical_paths: set[Path]) -> None:
     # Deduplicate by destination path so shared files are written once.
-    # Prefer the current configuration's entry so its failures are fatal.
-    unique: dict[Path, BootFile] = {}
-    for bf in boot_files:
-        if bf.path not in unique or bf.current:
-            unique[bf.path] = bf
-
-    for boot_file in unique.values():
+    seen: set[Path] = set()
+    for boot_file in boot_files:
+        if boot_file.path in seen:
+            continue
+        seen.add(boot_file.path)
         boot_path = BOOT_MOUNT_POINT / boot_file.path
         try:
             boot_file.writer.write_boot_file(boot_path)
         except subprocess.CalledProcessError:
-            if boot_file.current:
+            if boot_file.path in critical_paths:
                 print("failed to create initrd secrets!", file=sys.stderr)
                 sys.exit(1)
             # Keep the entry bootable by leaving at least a pristine initrd

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -91,24 +91,23 @@ class InitrdWithSecretsWriter:
     def write_boot_file(self, path: Path) -> None:
         # Secrets can change between rebuilds, so always rebuild from the
         # pristine initrd into a temp file and rename into place.
-        tmp = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             mode="wb",
             dir=path.parent,
             delete=False,
             prefix=path.name,
             suffix=".tmp",
-        )
-        try:
-            with open(self.source, mode="rb") as source_file:
-                shutil.copyfileobj(source_file, tmp)
-            tmp.close()
-            run([self.initrd_secrets, tmp.name])
-            with open(tmp.name, "rb") as f:
-                os.fsync(f.fileno())
-        except BaseException:
-            os.unlink(tmp.name)
-            raise
-        os.rename(tmp.name, path)
+        ) as tmp:
+            try:
+                with open(self.source, mode="rb") as source_file:
+                    shutil.copyfileobj(source_file, tmp)
+                tmp.flush()
+                run([self.initrd_secrets, tmp.name])
+                os.fsync(tmp.fileno())
+            except BaseException:
+                os.unlink(tmp.name)
+                raise
+            os.rename(tmp.name, path)
 
 
 @dataclass

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -421,11 +421,22 @@ in
     };
 
     bootCounting = {
-      enable = mkEnableOption "automatic boot assessment";
+      enable = mkEnableOption ''
+        [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/).
+
+        New boot entries are written with a boot counter in the file name. On
+        each boot, systemd-boot decrements the counter; once the booted system
+        reaches `boot-complete.target`, `systemd-bless-boot.service` removes the
+        counter and marks the entry as good. An entry whose counter reaches zero
+        is considered bad and will be skipped in favour of an older generation
+      '';
       tries = mkOption {
         default = 3;
-        type = types.int;
-        description = "number of tries each entry should start with";
+        type = types.ints.positive;
+        description = ''
+          Number of boot attempts a freshly written entry is given before it is
+          considered bad.
+        '';
       };
     };
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -97,6 +97,9 @@ let
           '') cfg.extraEntries
         )}
       '';
+
+      bootCountingTries = cfg.bootCounting.tries;
+      bootCounting = if cfg.bootCounting.enable then "True" else "False";
     };
   };
 
@@ -415,6 +418,15 @@ in
         Only enable this option if `systemd-boot` otherwise fails to install, as the
         scope or implication of the `--graceful` option may change in the future.
       '';
+    };
+
+    bootCounting = {
+      enable = mkEnableOption "automatic boot assessment";
+      tries = mkOption {
+        default = 3;
+        type = types.int;
+        description = "number of tries each entry should start with";
+      };
     };
 
     rebootForBitlocker = mkOption {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1562,7 +1562,10 @@ in
   systemd = runTest ./systemd.nix;
   systemd-analyze = runTest ./systemd-analyze.nix;
   systemd-binfmt = handleTestOn [ "x86_64-linux" ] ./systemd-binfmt.nix { };
-  systemd-boot = import ./systemd-boot.nix { inherit runTest runTestOn; };
+  systemd-boot = import ./systemd-boot.nix {
+    inherit runTest runTestOn;
+    inherit (pkgs) lib;
+  };
   systemd-bpf = runTest ./systemd-bpf.nix;
   systemd-capsules = runTest ./systemd-capsules.nix;
   systemd-confinement = handleTest ./systemd-confinement { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1593,7 +1593,10 @@ in
   systemd = runTest ./systemd.nix;
   systemd-analyze = runTest ./systemd-analyze.nix;
   systemd-binfmt = handleTestOn [ "x86_64-linux" ] ./systemd-binfmt.nix { };
-  systemd-boot = import ./systemd-boot.nix { inherit runTest runTestOn; };
+  systemd-boot = import ./systemd-boot.nix {
+    inherit runTest runTestOn;
+    inherit (pkgs) lib;
+  };
   systemd-bpf = runTest ./systemd-bpf.nix;
   systemd-capsules = runTest ./systemd-capsules.nix;
   systemd-confinement = handleTest ./systemd-confinement { };

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -14,8 +14,10 @@ let
       boot.loader.efi.canTouchEfiVariables = true;
       environment.systemPackages = [ pkgs.efibootmgr ];
       system.switch.enable = true;
-      # Needed for machine-id to be persisted between reboots
-      environment.etc."machine-id".text = "00000000000000000000000000000000";
+      # Needed for machine-id to be persisted between reboots.
+      # Must be a valid (non-zero) ID, otherwise sd_id128_get_machine()
+      # returns -ENOMEDIUM and dbus-broker refuses to start.
+      environment.etc."machine-id".text = "1234567890abcdef1234567890abcdef\n";
     };
 
   commonXbootldr =

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -1,10 +1,37 @@
 {
   runTest,
   runTestOn,
+  lib,
   ...
 }:
 
 let
+  testScriptPreamble =
+    # python
+    ''
+      def check_current_system(system_path):
+          machine.succeed(f'test $(readlink -f /run/current-system) = "{system_path}"')
+
+      def check_generation(generation: int, tries_left=0, tries_failed=0, specialisation=None) -> list[str]:
+          if specialisation:
+              title = f"NixOS ({specialisation})"
+          else:
+              title = "NixOS"
+
+          conf_files = machine.succeed(
+              f"grep --files-with-matches 'version Generation {generation} NixOS' /boot/loader/entries/nixos-*.conf | xargs grep --line-regexp --fixed-strings --files-with-matches 'title {title}'"
+          ).split("\n")
+
+          suffix = ""
+          if tries_left:
+              suffix += f"+{tries_left}"
+          if tries_failed:
+              suffix += f"-{tries_failed}"
+
+          assert conf_files[0].endswith(f"{suffix}.conf"), f"Expected {conf_files[0]} to end with {suffix}.conf"
+          return conf_files
+    '';
+
   common =
     { pkgs, ... }:
     {
@@ -72,39 +99,41 @@ let
       boot.loader.systemd-boot.xbootldrMountPoint = "/boot";
     };
 
-  customDiskImage = nodes: ''
-    import os
-    import subprocess
-    import tempfile
+  customDiskImage =
+    nodes:
+    # python
+    ''
+      import os
+      import subprocess
+      import tempfile
 
-    tmp_disk_image = tempfile.NamedTemporaryFile()
+      tmp_disk_image = tempfile.NamedTemporaryFile()
 
-    subprocess.run([
-      "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
-      "create",
-      "-f",
-      "qcow2",
-      "-b",
-      "${nodes.machine.system.build.diskImage}/nixos.qcow2",
-      "-F",
-      "qcow2",
-      tmp_disk_image.name,
-    ])
+      subprocess.run([
+        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
+        "create",
+        "-f",
+        "qcow2",
+        "-b",
+        "${nodes.machine.system.build.diskImage}/nixos.qcow2",
+        "-F",
+        "qcow2",
+        tmp_disk_image.name,
+      ])
 
-    # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
-    os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
-  '';
+      # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
+    '';
+
   # Check that we are booting the default entry and not the generation with largest version number
   defaultEntry =
     {
-      lib,
-      pkgs,
       withBootCounting ? false,
       ...
     }:
     runTest {
       name = "systemd-boot-default-entry" + lib.optionalString withBootCounting "-with-boot-counting";
-      meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
+      meta.maintainers = with lib.maintainers; [ julienmalka ];
 
       nodes = {
         machine =
@@ -115,11 +144,13 @@ let
             boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
           };
 
-        other_machine = {
-          imports = [ common ];
-          boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
-          environment.systemPackages = [ pkgs.hello ];
-        };
+        other_machine =
+          { pkgs, ... }:
+          {
+            imports = [ common ];
+            boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
+            environment.systemPackages = [ pkgs.hello ];
+          };
       };
       testScript =
         { nodes, ... }:
@@ -127,12 +158,12 @@ let
           orig = nodes.machine.system.build.toplevel;
           other = nodes.other_machine.system.build.toplevel;
         in
+        # python
         ''
+          ${testScriptPreamble}
+
           orig = "${orig}"
           other = "${other}"
-
-          def check_current_system(system_path):
-              machine.succeed(f'test $(readlink -f /run/current-system) = "{system_path}"')
 
           check_current_system(orig)
 
@@ -150,6 +181,7 @@ let
           check_current_system(orig)
         '';
     };
+
   garbage-collect-entry =
     {
       withBootCounting ? false,
@@ -170,6 +202,7 @@ let
               imports = [ common ];
 
               boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
+              boot.loader.systemd-boot.memtest86.enable = true;
 
               # These are configs for different nodes, but we'll use them here in `machine`
               system.extraDependencies = [
@@ -183,22 +216,33 @@ let
           let
             baseSystem = nodes.common.system.build.toplevel;
           in
+          # python
           ''
+            ${testScriptPreamble}
+
             machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${baseSystem}")
             machine.succeed("nix-env -p /nix/var/nix/profiles/system --delete-generations 1")
+
+            conf_file = check_generation(1)[0]
+            new_conf_file = conf_file.replace(".conf", "+1-3.conf")
+
             # At this point generation 1 has already been marked as good so we reintroduce counters artificially
             ${lib.optionalString withBootCounting ''
-              machine.succeed("mv /boot/loader/entries/nixos-generation-1.conf /boot/loader/entries/nixos-generation-1+3.conf")
+              machine.succeed(f"mv {conf_file} {new_conf_file}")
             ''}
             machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
-            machine.fail("test -e /boot/loader/entries/nixos-generation-1*")
-            machine.succeed("test -e /boot/loader/entries/nixos-generation-2.conf")
+            machine.fail(
+              "grep --files-with-matches 'version Generation 1 NixOS' /boot/loader/entries/nixos-*.conf"
+            )
+            check_generation(2)
           '';
       }
     );
 in
 {
-  inherit defaultEntry;
+  defaultEntry = defaultEntry { };
+  garbage-collect-entry = garbage-collect-entry { };
+
   basic = runTest (
     { lib, ... }:
     {
@@ -210,25 +254,26 @@ in
 
       nodes.machine = common;
 
-      testScript = ''
-        machine.start()
-        machine.wait_for_unit("multi-user.target")
+      testScript = # python
+        ''
+          ${testScriptPreamble}
 
-        machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
-        out = machine.succeed("cat /boot/loader/entries/nixos-generation-1.conf")
-        print(out)
-        # our sort-key will uses r to sort before nixos
-        machine.succeed("grep 'sort-key nixor-default' /boot/loader/entries/nixos-generation-1.conf")
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
 
-        # Ensure we actually booted using systemd-boot
-        # Magic number is the vendor UUID used by systemd-boot.
-        machine.succeed(
-            "test -e /sys/firmware/efi/efivars/LoaderEntrySelected-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
-        )
+          conf_file = check_generation(1)[0]
 
-        # "bootctl install" should have created an EFI entry
-        machine.succeed('efibootmgr | grep "Linux Boot Manager"')
-      '';
+          machine.succeed(f"grep 'sort-key nixos' {conf_file}")
+
+          # Ensure we actually booted using systemd-boot
+          # Magic number is the vendor UUID used by systemd-boot.
+          machine.succeed(
+              "test -e /sys/firmware/efi/efivars/LoaderEntrySelected-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+          )
+
+          # "bootctl install" should have created an EFI entry
+          machine.succeed('efibootmgr | grep "Linux Boot Manager"')
+        '';
     }
   );
 
@@ -251,6 +296,7 @@ in
         let
           efiArch = pkgs.stdenv.hostPlatform.efiArch;
         in
+        #python
         ''
           machine.start(allow_reboot=True)
           machine.wait_for_unit("multi-user.target")
@@ -279,14 +325,17 @@ in
 
       testScript =
         { nodes, ... }:
+        #python
         ''
+          ${testScriptPreamble}
+
           ${customDiskImage nodes}
 
           machine.start()
           machine.wait_for_unit("multi-user.target")
 
           machine.succeed("test -e /efi/EFI/systemd/systemd-bootx64.efi")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          check_generation(1)
 
           # Ensure we actually booted using systemd-boot
           # Magic number is the vendor UUID used by systemd-boot.
@@ -334,25 +383,28 @@ in
           };
         };
 
-      testScript = ''
-        machine.start()
-        machine.wait_for_unit("multi-user.target")
+      testScript =
+        # python
+        ''
+          ${testScriptPreamble}
 
-        machine.succeed(
-            "test -e /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-        )
-        machine.succeed(
-            "grep -q 'title NixOS (something)' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-        )
-        machine.succeed(
-            "grep 'sort-key something' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-        )
-      ''
-      + pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isAarch64 ''
-        machine.succeed(
-            r"grep 'devicetree /EFI/nixos/[a-z0-9]\{32\}.*dummy' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-        )
-      '';
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+
+          conf_files = check_generation(1, specialisation="something")
+          machine.succeed(
+              f"grep --fixed-strings --line-regexp 'sort-key something' {" ".join(conf_files)}"
+          )
+
+          ${lib.optionalString pkgs.stdenv.hostPlatform.isAarch64
+            #python
+            ''
+              machine.succeed(
+                  fr"grep 'devicetree /EFI/nixos/[a-z0-9]\{32\}.*dummy' {" ".join(conf_files)}"
+              )
+            ''
+          }
+        '';
     }
   );
 
@@ -373,21 +425,25 @@ in
           boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
         };
 
-      testScript = ''
-        machine.start()
-        machine.wait_for_unit("multi-user.target")
+      testScript =
+        # python
+        ''
+          ${testScriptPreamble}
 
-        machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
 
-        # Ensure we actually booted using systemd-boot
-        # Magic number is the vendor UUID used by systemd-boot.
-        machine.succeed(
-            "test -e /sys/firmware/efi/efivars/LoaderEntrySelected-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
-        )
+          check_generation(1)
 
-        # "bootctl install" should _not_ have created an EFI entry
-        machine.fail('efibootmgr | grep "Linux Boot Manager"')
-      '';
+          # Ensure we actually booted using systemd-boot
+          # Magic number is the vendor UUID used by systemd-boot.
+          machine.succeed(
+              "test -e /sys/firmware/efi/efivars/LoaderEntrySelected-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+          )
+
+          # "bootctl install" should _not_ have created an EFI entry
+          machine.fail('efibootmgr | grep "Linux Boot Manager"')
+        '';
     }
   );
 
@@ -403,35 +459,37 @@ in
 
       nodes.machine = common;
 
-      testScript = ''
-        machine.succeed("mount -o remount,rw /boot")
+      testScript =
+        # python
+        ''
+          machine.succeed("mount -o remount,rw /boot")
 
-        def switch():
-            # Replace version inside sd-boot with something older. See magic[] string in systemd src/boot/efi/boot.c
-            machine.succeed(
-              """
-              find /boot -iname '*boot*.efi' -print0 | \
-              xargs -0 -I '{}' sed -i 's/#### LoaderInfo: systemd-boot .* ####/#### LoaderInfo: systemd-boot 000.0-1-notnixos ####/' '{}'
-              """
-            )
-            return machine.succeed("/run/current-system/bin/switch-to-configuration boot 2>&1")
+          def switch():
+              # Replace version inside sd-boot with something older. See magic[] string in systemd src/boot/efi/boot.c
+              machine.succeed(
+                """
+                find /boot -iname '*boot*.efi' -print0 | \
+                xargs -0 -I '{}' sed -i 's/#### LoaderInfo: systemd-boot .* ####/#### LoaderInfo: systemd-boot 000.0-1-notnixos ####/' '{}'
+                """
+              )
+              return machine.succeed("/run/current-system/bin/switch-to-configuration boot 2>&1")
 
-        output = switch()
-        assert "updating systemd-boot from 000.0-1-notnixos to " in output, "Couldn't find systemd-boot update message"
-        assert 'to "/boot/EFI/systemd/systemd-bootx64.efi"' in output, "systemd-boot not copied to to /boot/EFI/systemd/systemd-bootx64.efi"
-        assert 'to "/boot/EFI/BOOT/BOOTX64.EFI"' in output, "systemd-boot not copied to to /boot/EFI/BOOT/BOOTX64.EFI"
+          output = switch()
+          assert "updating systemd-boot from 000.0-1-notnixos to " in output, "Couldn't find systemd-boot update message"
+          assert 'to "/boot/EFI/systemd/systemd-bootx64.efi"' in output, "systemd-boot not copied to to /boot/EFI/systemd/systemd-bootx64.efi"
+          assert 'to "/boot/EFI/BOOT/BOOTX64.EFI"' in output, "systemd-boot not copied to to /boot/EFI/BOOT/BOOTX64.EFI"
 
-        with subtest("Test that updating works with lowercase bootx64.efi"):
-            machine.succeed(
-                # Move to tmp file name first, otherwise mv complains the new location is the same
-                "mv /boot/EFI/BOOT/BOOTX64.EFI /boot/EFI/BOOT/bootx64.efi.new",
-                "mv /boot/EFI/BOOT/bootx64.efi.new /boot/EFI/BOOT/bootx64.efi",
-            )
-            output = switch()
-            assert "updating systemd-boot from 000.0-1-notnixos to " in output, "Couldn't find systemd-boot update message"
-            assert 'to "/boot/EFI/systemd/systemd-bootx64.efi"' in output, "systemd-boot not copied to to /boot/EFI/systemd/systemd-bootx64.efi"
-            assert 'to "/boot/EFI/BOOT/BOOTX64.EFI"' in output, "systemd-boot not copied to to /boot/EFI/BOOT/BOOTX64.EFI"
-      '';
+          with subtest("Test that updating works with lowercase bootx64.efi"):
+              machine.succeed(
+                  # Move to tmp file name first, otherwise mv complains the new location is the same
+                  "mv /boot/EFI/BOOT/BOOTX64.EFI /boot/EFI/BOOT/bootx64.efi.new",
+                  "mv /boot/EFI/BOOT/bootx64.efi.new /boot/EFI/BOOT/bootx64.efi",
+              )
+              output = switch()
+              assert "updating systemd-boot from 000.0-1-notnixos to " in output, "Couldn't find systemd-boot update message"
+              assert 'to "/boot/EFI/systemd/systemd-bootx64.efi"' in output, "systemd-boot not copied to to /boot/EFI/systemd/systemd-bootx64.efi"
+              assert 'to "/boot/EFI/BOOT/BOOTX64.EFI"' in output, "systemd-boot not copied to to /boot/EFI/BOOT/BOOTX64.EFI"
+        '';
     }
   );
 
@@ -446,10 +504,12 @@ in
         boot.loader.systemd-boot.memtest86.enable = true;
       };
 
-      testScript = ''
-        machine.succeed("test -e /boot/loader/entries/memtest86.conf")
-        machine.succeed("test -e /boot/efi/memtest86/memtest.efi")
-      '';
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/loader/entries/memtest86.conf")
+          machine.succeed("test -e /boot/efi/memtest86/memtest.efi")
+        '';
     }
   );
 
@@ -464,10 +524,12 @@ in
         boot.loader.systemd-boot.netbootxyz.enable = true;
       };
 
-      testScript = ''
-        machine.succeed("test -e /boot/loader/entries/netbootxyz.conf")
-        machine.succeed("test -e /boot/efi/netbootxyz/netboot.xyz.efi")
-      '';
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/loader/entries/netbootxyz.conf")
+          machine.succeed("test -e /boot/efi/netbootxyz/netboot.xyz.efi")
+        '';
     }
   );
 
@@ -484,10 +546,12 @@ in
           boot.loader.systemd-boot.edk2-uefi-shell.enable = true;
         };
 
-      testScript = ''
-        machine.succeed("test -e /boot/loader/entries/edk2-uefi-shell.conf")
-        machine.succeed("test -e /boot/efi/edk2-uefi-shell/shell.efi")
-      '';
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/loader/entries/edk2-uefi-shell.conf")
+          machine.succeed("test -e /boot/efi/edk2-uefi-shell/shell.efi")
+        '';
     }
   );
 
@@ -515,29 +579,31 @@ in
           };
         };
 
-      testScript = ''
-        machine.succeed("test -e /boot/efi/edk2-uefi-shell/shell.efi")
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/efi/edk2-uefi-shell/shell.efi")
 
-        machine.succeed("test -e /boot/loader/entries/windows_7.conf")
-        machine.succeed("test -e /boot/loader/entries/windows_Ten.conf")
-        machine.succeed("test -e /boot/loader/entries/windows_11.conf")
+          machine.succeed("test -e /boot/loader/entries/windows_7.conf")
+          machine.succeed("test -e /boot/loader/entries/windows_Ten.conf")
+          machine.succeed("test -e /boot/loader/entries/windows_11.conf")
 
-        machine.succeed("grep 'efi /efi/edk2-uefi-shell/shell.efi' /boot/loader/entries/windows_7.conf")
-        machine.succeed("grep 'efi /efi/edk2-uefi-shell/shell.efi' /boot/loader/entries/windows_Ten.conf")
-        machine.succeed("grep 'efi /efi/edk2-uefi-shell/shell.efi' /boot/loader/entries/windows_11.conf")
+          machine.succeed("grep 'efi /efi/edk2-uefi-shell/shell.efi' /boot/loader/entries/windows_7.conf")
+          machine.succeed("grep 'efi /efi/edk2-uefi-shell/shell.efi' /boot/loader/entries/windows_Ten.conf")
+          machine.succeed("grep 'efi /efi/edk2-uefi-shell/shell.efi' /boot/loader/entries/windows_11.conf")
 
-        machine.succeed("grep 'HD0c1:EFI\\\\Microsoft\\\\Boot\\\\Bootmgfw.efi' /boot/loader/entries/windows_7.conf")
-        machine.succeed("grep 'FS0:EFI\\\\Microsoft\\\\Boot\\\\Bootmgfw.efi' /boot/loader/entries/windows_Ten.conf")
-        machine.succeed("grep 'HD0d4:EFI\\\\Microsoft\\\\Boot\\\\Bootmgfw.efi' /boot/loader/entries/windows_11.conf")
+          machine.succeed("grep 'HD0c1:EFI\\\\Microsoft\\\\Boot\\\\Bootmgfw.efi' /boot/loader/entries/windows_7.conf")
+          machine.succeed("grep 'FS0:EFI\\\\Microsoft\\\\Boot\\\\Bootmgfw.efi' /boot/loader/entries/windows_Ten.conf")
+          machine.succeed("grep 'HD0d4:EFI\\\\Microsoft\\\\Boot\\\\Bootmgfw.efi' /boot/loader/entries/windows_11.conf")
 
-        machine.succeed("grep 'sort-key before_all_others' /boot/loader/entries/windows_7.conf")
-        machine.succeed("grep 'sort-key o_windows_Ten' /boot/loader/entries/windows_Ten.conf")
-        machine.succeed("grep 'sort-key zzz' /boot/loader/entries/windows_11.conf")
+          machine.succeed("grep 'sort-key before_all_others' /boot/loader/entries/windows_7.conf")
+          machine.succeed("grep 'sort-key o_windows_Ten' /boot/loader/entries/windows_Ten.conf")
+          machine.succeed("grep 'sort-key zzz' /boot/loader/entries/windows_11.conf")
 
-        machine.succeed("grep 'title Windows 7' /boot/loader/entries/windows_7.conf")
-        machine.succeed("grep 'title Windows Ten' /boot/loader/entries/windows_Ten.conf")
-        machine.succeed('grep "title Title with-_-punctuation ...?!" /boot/loader/entries/windows_11.conf')
-      '';
+          machine.succeed("grep 'title Windows 7' /boot/loader/entries/windows_7.conf")
+          machine.succeed("grep 'title Windows Ten' /boot/loader/entries/windows_Ten.conf")
+          machine.succeed('grep "title Title with-_-punctuation ...?!" /boot/loader/entries/windows_11.conf')
+        '';
     }
   );
 
@@ -553,11 +619,13 @@ in
         boot.loader.systemd-boot.memtest86.sortKey = "apple";
       };
 
-      testScript = ''
-        machine.succeed("test -e /boot/loader/entries/memtest86.conf")
-        machine.succeed("test -e /boot/efi/memtest86/memtest.efi")
-        machine.succeed("grep 'sort-key apple' /boot/loader/entries/memtest86.conf")
-      '';
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/loader/entries/memtest86.conf")
+          machine.succeed("test -e /boot/efi/memtest86/memtest.efi")
+          machine.succeed("grep 'sort-key apple' /boot/loader/entries/memtest86.conf")
+        '';
     }
   );
 
@@ -575,6 +643,7 @@ in
 
       testScript =
         { nodes, ... }:
+        # python
         ''
           ${customDiskImage nodes}
 
@@ -603,10 +672,12 @@ in
         };
       };
 
-      testScript = ''
-        machine.succeed("test -e /boot/loader/entries/banana.conf")
-        machine.succeed("test -e /boot/efi/nixos/.extra-files/loader/entries/banana.conf")
-      '';
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/loader/entries/banana.conf")
+          machine.succeed("test -e /boot/efi/nixos/.extra-files/loader/entries/banana.conf")
+        '';
     }
   );
 
@@ -625,10 +696,12 @@ in
           };
         };
 
-      testScript = ''
-        machine.succeed("test -e /boot/efi/fruits/tomato.efi")
-        machine.succeed("test -e /boot/efi/nixos/.extra-files/efi/fruits/tomato.efi")
-      '';
+      testScript =
+        # python
+        ''
+          machine.succeed("test -e /boot/efi/fruits/tomato.efi")
+          machine.succeed("test -e /boot/efi/nixos/.extra-files/efi/fruits/tomato.efi")
+        '';
     }
   );
 
@@ -669,6 +742,7 @@ in
           baseSystem = nodes.common.system.build.toplevel;
           finalSystem = nodes.with_netbootxyz.system.build.toplevel;
         in
+        # python
         ''
           machine.succeed("test -e /boot/efi/fruits/tomato.efi")
           machine.succeed("test -e /boot/efi/nixos/.extra-files/efi/fruits/tomato.efi")
@@ -709,10 +783,12 @@ in
         boot.bootspec.enable = false;
       };
 
-      testScript = ''
-        machine.start()
-        machine.wait_for_unit("multi-user.target")
-      '';
+      testScript =
+        # python
+        ''
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+        '';
     }
   );
 
@@ -720,21 +796,34 @@ in
     let
       baseConfig = {
         imports = [ common ];
-        boot.loader.systemd-boot.bootCounting.enable = true;
-        boot.loader.systemd-boot.bootCounting.trials = 2;
+
+        boot.loader.systemd-boot.bootCounting = {
+          enable = true;
+          tries = 2;
+        };
       };
     in
-    { pkgs, ... }:
     runTest {
       name = "systemd-boot-counting";
-      meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
+      meta.maintainers = with lib.maintainers; [ julienmalka ];
 
       nodes = {
         machine =
           { nodes, ... }:
           {
             imports = [ baseConfig ];
-            system.extraDependencies = [ nodes.bad_machine.system.build.toplevel ];
+            system.extraDependencies = [
+              nodes.bad_machine.system.build.toplevel
+              nodes.unused_machine.system.build.toplevel
+            ];
+          };
+
+        unused_machine =
+          { pkgs, ... }:
+          {
+            imports = [ baseConfig ];
+            # Distinguish this closure from `machine` without pulling in extra deps.
+            environment.systemPackages = [ pkgs.hello ];
           };
 
         bad_machine = {
@@ -753,13 +842,17 @@ in
         let
           orig = nodes.machine.system.build.toplevel;
           bad = nodes.bad_machine.system.build.toplevel;
+          unused = nodes.unused_machine.system.build.toplevel;
         in
+        # python
         ''
+          ${testScriptPreamble}
+
           orig = "${orig}"
           bad = "${bad}"
+          unused = "${unused}"
 
-          def check_current_system(system_path):
-              machine.succeed(f'test $(readlink -f /run/current-system) = "{system_path}"')
+          machine.start(allow_reboot=True)
 
           # Ensure we booted using an entry with counters enabled
           machine.succeed(
@@ -768,46 +861,104 @@ in
 
           # systemd-bless-boot should have already removed the "+2" suffix from the boot entry
           machine.wait_for_unit("systemd-bless-boot.service")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          conf_file = check_generation(1)
           check_current_system(orig)
 
-          # Switch to bad configuration
+          print(machine.succeed("cat /boot/loader/entries/*.conf"))
+
+          # Register the bad configuration as generation 2 and another good
+          # configuration as generation 3, then make generation 2 the default.
+          # This verifies that `preferred` in loader.conf selects gen 2 even
+          # though gen 3 sorts higher, and that once gen 2 is marked bad we
+          # fall back to the newest non-bad entry (gen 3).
           machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${bad}")
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${unused}")
           machine.succeed(f"{bad}/bin/switch-to-configuration boot")
 
-          # Ensure new bootloader entry has initialized counter
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+2.conf")
-          machine.shutdown()
+          # Ensure new bootloader entries have initialized counters
+          check_generation(1)
+          check_generation(2, 2)
+          check_generation(3, 2)
 
-          machine.start()
+          machine.reboot()
+
           machine.wait_for_unit("multi-user.target")
           check_current_system(bad)
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+1-1.conf")
-          machine.shutdown()
+          check_generation(1)
+          check_generation(2, 1, 1)
+          check_generation(3, 2)
 
-          machine.start()
+          machine.reboot()
+
           machine.wait_for_unit("multi-user.target")
           check_current_system(bad)
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+0-2.conf")
-          machine.shutdown()
+          check_generation(1)
+          check_generation(2, 0, 2)
+          check_generation(3, 2)
 
-          # Should boot back into original configuration
-          machine.start()
-          check_current_system(orig)
+          machine.reboot()
+
           machine.wait_for_unit("multi-user.target")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+0-2.conf")
-          machine.shutdown()
+          # Gen 2 has exhausted its tries; `preferred` skips it and `default
+          # nixos-*` resolves to the newest non-bad entry, which is gen 3.
+          check_current_system(unused)
+          machine.wait_for_unit("systemd-bless-boot.service")
+          check_generation(2, 0, 2)
+          check_generation(3)
         '';
     };
-  defaultEntryWithBootCounting =
-    { lib, pkgs }:
-    defaultEntry {
-      inherit lib pkgs;
-      withBootCounting = true;
+
+  bootCountingSpecialisation =
+    let
+      baseConfig = {
+        imports = [ common ];
+        boot.loader.systemd-boot.bootCounting = {
+          enable = true;
+          tries = 2;
+        };
+      };
+
+      specialisationName = "+something+-+that+-+breaks-parsing+-+";
+    in
+    runTest {
+      name = "systemd-boot-counting-specialisation";
+      meta.maintainers = with lib.maintainers; [ julienmalka ];
+
+      nodes = {
+        machine =
+          { nodes, lib, ... }:
+          {
+            imports = [ baseConfig ];
+            specialisation.${specialisationName}.configuration = {
+              boot.loader.systemd-boot.sortKey = "something";
+            };
+          };
+      };
+      testScript =
+        { nodes, ... }:
+        let
+          orig = nodes.machine.system.build.toplevel;
+        in
+        # python
+        ''
+          ${testScriptPreamble}
+
+          orig = "${orig}"
+
+          # Ensure we booted using an entry with counters enabled
+          machine.succeed(
+              "test -e /sys/firmware/efi/efivars/LoaderBootCountPath-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+          )
+
+          check_generation(1)
+          check_current_system(orig)
+
+          # Ensure the bootloader entry for the specialisation has initialized the boot counter
+          check_generation(1, 2, specialisation="${specialisationName}")
+        '';
     };
+
+  defaultEntryWithBootCounting = defaultEntry { withBootCounting = true; };
+
   garbageCollectEntryWithBootCounting = garbage-collect-entry { withBootCounting = true; };
 }

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -14,6 +14,8 @@ let
       boot.loader.efi.canTouchEfiVariables = true;
       environment.systemPackages = [ pkgs.efibootmgr ];
       system.switch.enable = true;
+      # Needed for machine-id to be persisted between reboots
+      environment.etc."machine-id".text = "00000000000000000000000000000000";
     };
 
   commonXbootldr =
@@ -90,8 +92,111 @@ let
     # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
     os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
   '';
+  # Check that we are booting the default entry and not the generation with largest version number
+  defaultEntry =
+    {
+      lib,
+      pkgs,
+      withBootCounting ? false,
+      ...
+    }:
+    runTest {
+      name = "systemd-boot-default-entry" + lib.optionalString withBootCounting "-with-boot-counting";
+      meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
+
+      nodes = {
+        machine =
+          { nodes, ... }:
+          {
+            imports = [ common ];
+            system.extraDependencies = [ nodes.other_machine.system.build.toplevel ];
+            boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
+          };
+
+        other_machine = {
+          imports = [ common ];
+          boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
+          environment.systemPackages = [ pkgs.hello ];
+        };
+      };
+      testScript =
+        { nodes, ... }:
+        let
+          orig = nodes.machine.system.build.toplevel;
+          other = nodes.other_machine.system.build.toplevel;
+        in
+        ''
+          orig = "${orig}"
+          other = "${other}"
+
+          def check_current_system(system_path):
+              machine.succeed(f'test $(readlink -f /run/current-system) = "{system_path}"')
+
+          check_current_system(orig)
+
+          # Switch to other configuration
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${other}")
+          machine.succeed(f"{other}/bin/switch-to-configuration boot")
+          # Rollback, default entry is now generation 1
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --rollback")
+          machine.succeed(f"{orig}/bin/switch-to-configuration boot")
+          machine.shutdown()
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+          # Check that we booted generation 1 (default)
+          # even though generation 2 comes first in alphabetical order
+          check_current_system(orig)
+        '';
+    };
+  garbage-collect-entry =
+    {
+      withBootCounting ? false,
+      ...
+    }:
+    runTest (
+      { lib, ... }:
+      {
+        name =
+          "systemd-boot-garbage-collect-entry" + lib.optionalString withBootCounting "-with-boot-counting";
+        meta.maintainers = with lib.maintainers; [ julienmalka ];
+
+        nodes = {
+          inherit common;
+          machine =
+            { nodes, ... }:
+            {
+              imports = [ common ];
+
+              boot.loader.systemd-boot.bootCounting.enable = withBootCounting;
+
+              # These are configs for different nodes, but we'll use them here in `machine`
+              system.extraDependencies = [
+                nodes.common.system.build.toplevel
+              ];
+            };
+        };
+
+        testScript =
+          { nodes, ... }:
+          let
+            baseSystem = nodes.common.system.build.toplevel;
+          in
+          ''
+            machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${baseSystem}")
+            machine.succeed("nix-env -p /nix/var/nix/profiles/system --delete-generations 1")
+            # At this point generation 1 has already been marked as good so we reintroduce counters artificially
+            ${lib.optionalString withBootCounting ''
+              machine.succeed("mv /boot/loader/entries/nixos-generation-1.conf /boot/loader/entries/nixos-generation-1+3.conf")
+            ''}
+            machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
+            machine.fail("test -e /boot/loader/entries/nixos-generation-1*")
+            machine.succeed("test -e /boot/loader/entries/nixos-generation-2.conf")
+          '';
+      }
+    );
 in
 {
+  inherit defaultEntry;
   basic = runTest (
     { lib, ... }:
     {
@@ -108,7 +213,10 @@ in
         machine.wait_for_unit("multi-user.target")
 
         machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
-        machine.succeed("grep 'sort-key nixos' /boot/loader/entries/nixos-generation-1.conf")
+        out = machine.succeed("cat /boot/loader/entries/nixos-generation-1.conf")
+        print(out)
+        # our sort-key will uses r to sort before nixos
+        machine.succeed("grep 'sort-key nixor-default' /boot/loader/entries/nixos-generation-1.conf")
 
         # Ensure we actually booted using systemd-boot
         # Magic number is the vendor UUID used by systemd-boot.
@@ -224,33 +332,31 @@ in
           };
         };
 
-      testScript =
-        { nodes, ... }:
-        ''
-          machine.start()
-          machine.wait_for_unit("multi-user.target")
+      testScript = ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
 
-          machine.succeed(
-              "test -e /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-          )
-          machine.succeed(
-              "grep -q 'title NixOS (something)' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-          )
-          machine.succeed(
-              "grep 'sort-key something' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-          )
-        ''
-        + pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isAarch64 ''
-          machine.succeed(
-              r"grep 'devicetree /EFI/nixos/[a-z0-9]\{32\}.*dummy' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
-          )
-        '';
+        machine.succeed(
+            "test -e /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
+        )
+        machine.succeed(
+            "grep -q 'title NixOS (something)' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
+        )
+        machine.succeed(
+            "grep 'sort-key something' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
+        )
+      ''
+      + pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isAarch64 ''
+        machine.succeed(
+            r"grep 'devicetree /EFI/nixos/[a-z0-9]\{32\}.*dummy' /boot/loader/entries/nixos-generation-1-specialisation-something.conf"
+        )
+      '';
     }
   );
 
   # Boot without having created an EFI entry--instead using default "/EFI/BOOT/BOOTX64.EFI"
   fallback = runTest (
-    { pkgs, lib, ... }:
+    { lib, ... }:
     {
       name = "systemd-boot-fallback";
       meta.maintainers = with lib.maintainers; [
@@ -259,7 +365,7 @@ in
       ];
 
       nodes.machine =
-        { pkgs, lib, ... }:
+        { lib, ... }:
         {
           imports = [ common ];
           boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
@@ -333,12 +439,10 @@ in
       name = "systemd-boot-memtest86";
       meta.maintainers = with lib.maintainers; [ julienmalka ];
 
-      nodes.machine =
-        { pkgs, lib, ... }:
-        {
-          imports = [ common ];
-          boot.loader.systemd-boot.memtest86.enable = true;
-        };
+      nodes.machine = {
+        imports = [ common ];
+        boot.loader.systemd-boot.memtest86.enable = true;
+      };
 
       testScript = ''
         machine.succeed("test -e /boot/loader/entries/memtest86.conf")
@@ -353,12 +457,10 @@ in
       name = "systemd-boot-netbootxyz";
       meta.maintainers = with lib.maintainers; [ julienmalka ];
 
-      nodes.machine =
-        { pkgs, lib, ... }:
-        {
-          imports = [ common ];
-          boot.loader.systemd-boot.netbootxyz.enable = true;
-        };
+      nodes.machine = {
+        imports = [ common ];
+        boot.loader.systemd-boot.netbootxyz.enable = true;
+      };
 
       testScript = ''
         machine.succeed("test -e /boot/loader/entries/netbootxyz.conf")
@@ -443,13 +545,11 @@ in
       name = "systemd-boot-memtest-sortkey";
       meta.maintainers = with lib.maintainers; [ julienmalka ];
 
-      nodes.machine =
-        { pkgs, lib, ... }:
-        {
-          imports = [ common ];
-          boot.loader.systemd-boot.memtest86.enable = true;
-          boot.loader.systemd-boot.memtest86.sortKey = "apple";
-        };
+      nodes.machine = {
+        imports = [ common ];
+        boot.loader.systemd-boot.memtest86.enable = true;
+        boot.loader.systemd-boot.memtest86.sortKey = "apple";
+      };
 
       testScript = ''
         machine.succeed("test -e /boot/loader/entries/memtest86.conf")
@@ -466,12 +566,10 @@ in
       name = "systemd-boot-entry-filename-xbootldr";
       meta.maintainers = with lib.maintainers; [ sdht0 ];
 
-      nodes.machine =
-        { pkgs, lib, ... }:
-        {
-          imports = [ commonXbootldr ];
-          boot.loader.systemd-boot.memtest86.enable = true;
-        };
+      nodes.machine = {
+        imports = [ commonXbootldr ];
+        boot.loader.systemd-boot.memtest86.enable = true;
+      };
 
       testScript =
         { nodes, ... }:
@@ -494,16 +592,14 @@ in
       name = "systemd-boot-extra-entries";
       meta.maintainers = with lib.maintainers; [ julienmalka ];
 
-      nodes.machine =
-        { pkgs, lib, ... }:
-        {
-          imports = [ common ];
-          boot.loader.systemd-boot.extraEntries = {
-            "banana.conf" = ''
-              title banana
-            '';
-          };
+      nodes.machine = {
+        imports = [ common ];
+        boot.loader.systemd-boot.extraEntries = {
+          "banana.conf" = ''
+            title banana
+          '';
         };
+      };
 
       testScript = ''
         machine.succeed("test -e /boot/loader/entries/banana.conf")
@@ -519,7 +615,7 @@ in
       meta.maintainers = with lib.maintainers; [ julienmalka ];
 
       nodes.machine =
-        { pkgs, lib, ... }:
+        { pkgs, ... }:
         {
           imports = [ common ];
           boot.loader.systemd-boot.extraFiles = {
@@ -558,12 +654,10 @@ in
             ];
           };
 
-        with_netbootxyz =
-          { pkgs, ... }:
-          {
-            imports = [ common ];
-            boot.loader.systemd-boot.netbootxyz.enable = true;
-          };
+        with_netbootxyz = {
+          imports = [ common ];
+          boot.loader.systemd-boot.netbootxyz.enable = true;
+        };
       };
 
       testScript =
@@ -602,41 +696,6 @@ in
     }
   );
 
-  garbage-collect-entry = runTest (
-    { lib, ... }:
-    {
-      name = "systemd-boot-garbage-collect-entry";
-      meta.maintainers = with lib.maintainers; [ julienmalka ];
-
-      nodes = {
-        inherit common;
-        machine =
-          { pkgs, nodes, ... }:
-          {
-            imports = [ common ];
-
-            # These are configs for different nodes, but we'll use them here in `machine`
-            system.extraDependencies = [
-              nodes.common.system.build.toplevel
-            ];
-          };
-      };
-
-      testScript =
-        { nodes, ... }:
-        let
-          baseSystem = nodes.common.system.build.toplevel;
-        in
-        ''
-          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${baseSystem}")
-          machine.succeed("nix-env -p /nix/var/nix/profiles/system --delete-generations 1")
-          machine.succeed("${baseSystem}/bin/switch-to-configuration boot")
-          machine.fail("test -e /boot/loader/entries/nixos-generation-1.conf")
-          machine.succeed("test -e /boot/loader/entries/nixos-generation-2.conf")
-        '';
-    }
-  );
-
   no-bootspec = runTest (
     { lib, ... }:
     {
@@ -654,4 +713,99 @@ in
       '';
     }
   );
+
+  bootCounting =
+    let
+      baseConfig = {
+        imports = [ common ];
+        boot.loader.systemd-boot.bootCounting.enable = true;
+        boot.loader.systemd-boot.bootCounting.trials = 2;
+      };
+    in
+    { pkgs, ... }:
+    runTest {
+      name = "systemd-boot-counting";
+      meta.maintainers = with pkgs.lib.maintainers; [ julienmalka ];
+
+      nodes = {
+        machine =
+          { nodes, ... }:
+          {
+            imports = [ baseConfig ];
+            system.extraDependencies = [ nodes.bad_machine.system.build.toplevel ];
+          };
+
+        bad_machine = {
+          imports = [ baseConfig ];
+
+          systemd.services."failing" = {
+            script = "exit 1";
+            requiredBy = [ "boot-complete.target" ];
+            before = [ "boot-complete.target" ];
+            serviceConfig.Type = "oneshot";
+          };
+        };
+      };
+      testScript =
+        { nodes, ... }:
+        let
+          orig = nodes.machine.system.build.toplevel;
+          bad = nodes.bad_machine.system.build.toplevel;
+        in
+        ''
+          orig = "${orig}"
+          bad = "${bad}"
+
+          def check_current_system(system_path):
+              machine.succeed(f'test $(readlink -f /run/current-system) = "{system_path}"')
+
+          # Ensure we booted using an entry with counters enabled
+          machine.succeed(
+              "test -e /sys/firmware/efi/efivars/LoaderBootCountPath-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+          )
+
+          # systemd-bless-boot should have already removed the "+2" suffix from the boot entry
+          machine.wait_for_unit("systemd-bless-boot.service")
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          check_current_system(orig)
+
+          # Switch to bad configuration
+          machine.succeed("nix-env -p /nix/var/nix/profiles/system --set ${bad}")
+          machine.succeed(f"{bad}/bin/switch-to-configuration boot")
+
+          # Ensure new bootloader entry has initialized counter
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+2.conf")
+          machine.shutdown()
+
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+          check_current_system(bad)
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+1-1.conf")
+          machine.shutdown()
+
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+          check_current_system(bad)
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+0-2.conf")
+          machine.shutdown()
+
+          # Should boot back into original configuration
+          machine.start()
+          check_current_system(orig)
+          machine.wait_for_unit("multi-user.target")
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-1.conf")
+          machine.succeed("test -e /boot/loader/entries/nixos-generation-2+0-2.conf")
+          machine.shutdown()
+        '';
+    };
+  defaultEntryWithBootCounting =
+    { lib, pkgs }:
+    defaultEntry {
+      inherit lib pkgs;
+      withBootCounting = true;
+    };
+  garbageCollectEntryWithBootCounting = garbage-collect-entry { withBootCounting = true; };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR re-introduces boot counting after #330017 was reverted.

There was a proposal to store information about the ESP entries in a separate state file, written down in #337089. However, in this PR we opted rather to use content hashes to allow for matching generations to their ESP entries without necessitating such a state file.

The idea is that we store boot loader entries as files named `nixos-<hash>.conf` with `<hash>` the content hash of the file.
The `systemd-boot-builder` script will then start by listing the system generations of the system, generate a conf file for each (in memory), and checking whether the file, with name derived from the config, already exists, and has the right content.
Missing files will then be created, and additional files (starting with `nixos-`) will be removed.

_(This work is being sponsored by MSF, aka [Doctors Without Borders](https://www.msf-azg.be/en), to help improve resilience for mission-critical deployments in remote environments. MSF is an international, independent medical humanitarian organisation that provides medical assistance to people affected by conflict, epidemics, disasters, or exclusion from healthcare.)_

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
