### PR TITLE
amber-lsp: init at 0.1.18

### DIFF
--- a/pkgs/by-name/am/amber-lsp/package.nix
+++ b/pkgs/by-name/am/amber-lsp/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "amber-lsp";
+  version = "0.1.18";
+
+  src = fetchFromGitHub {
+    owner = "amber-lang";
+    repo = "amber-lsp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pY8bKWDT0tFEkDsiwxxtbqj754pkbe/HomdMAIwwzgU=";
+  };
+
+  cargoHash = "sha256-KjFvK8rWR+sRlxYPWXNAaOKMjvcmtKyednQGkwacMKA=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    # By default it wants to write to $out/amber-lsp-resources
+    wrapProgram $out/bin/amber-lsp \
+      --run '
+        export AMBER_LSP_RESOURCES_DIR="''${XDG_DATA_HOME:-$HOME/.local/share}/amber-lsp-resources"
+      '
+  '';
+
+  meta = {
+    description = "Official language server for the Amber programming language";
+    mainProgram = "amber-lsp";
+    homepage = "https://github.com/amber-lang/amber-lsp";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tye-exe ];
+  };
+})


### PR DESCRIPTION
I have added the [Amber language server](https://github.com/amber-lang/amber-lsp) for the [Amber programming language](https://github.com/amber-lang/amber). I think this package will be useful, as the amber programming language has over 4.3k GitHub stars (at time of writing). Furthermore, the Amber programming language is already in nixpkgs (as amber-lang), so adding the language server will complement the Amber programming language package as an essential development tool.

~~This commit/PR includes a Cargo.lock file for the amber-lsp that I manually generated as upstream does not contain one. I will create a PR upstream and reference this PR and update this package derivation when upstream includes the lock file in the next release.~~
Upstream now includes a lock file, so including one in nixpkgs is not necessary.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

As part of building with "rustPlatform.buildRustPackage" the tests included in upstream for amber-lsp are executed, which all pass successfully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
