### PR TITLE
home-assistant-custom-components.powercalc: init at 1.20.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+
+  # dependencies
+  numpy,
+
+  # tests
+  home-assistant,
+  pytestCheckHook,
+  pytest-homeassistant-custom-component,
+  pytest-freezegun,
+  aioresponses,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "bramstroker";
+  domain = "powercalc";
+  version = "1.20.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "homeassistant-powercalc";
+    tag = "v${version}";
+    hash = "sha256-zncgOnoe24xyVoUBuaUvrL0lqT9COkIPhK3H9SOvd84=";
+  };
+
+  dependencies = [ numpy ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+    aioresponses
+    pytest-freezegun
+  ]
+  ++ home-assistant.getPackages "camera" home-assistant.python.pkgs;
+
+  preCheck = ''
+    patchShebangs --build tests/setup.sh
+    tests/setup.sh
+  '';
+
+  meta = {
+    changelog = "https://github.com/bramstroker/homeassistant-powercalc/releases/tag/${src.tag}";
+    description = "Custom Home Assistant component for virtual power sensors";
+    homepage = "https://github.com/bramstroker/homeassistant-powercalc";
+    maintainers = with lib.maintainers; [ CodedNil ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Added home assistant component powercalc https://github.com/bramstroker/homeassistant-powercalc

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
