### PR TITLE
libvirt-dbus: init at 1.4.1

### DIFF
--- a/pkgs/by-name/li/libvirt-dbus/package.nix
+++ b/pkgs/by-name/li/libvirt-dbus/package.nix
@@ -1,0 +1,75 @@
+{
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  pkg-config,
+  docutils,
+  ninja,
+  glib,
+  libvirt,
+  libvirt-glib,
+  systemd,
+  gitUpdater,
+  lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libvirt-dbus";
+  version = "1.4.1";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  src = fetchFromGitLab {
+    owner = "libvirt";
+    repo = "libvirt-dbus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S4QktQmcnTte4XsIcgc5dkA8LjMJaOD2lljS01WT0dk=";
+  };
+
+  postPatch = ''
+    substituteInPlace "data/system/meson.build" \
+      --replace-fail ": systemd_system_unit_dir" ": '$out/lib/systemd/system'"
+
+    substituteInPlace "data/session/meson.build" \
+      --replace-fail ": systemd_user_unit_dir" ": '$out/lib/systemd/user'"
+  '';
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    docutils
+    ninja
+  ];
+
+  buildInputs = [
+    glib
+    libvirt
+    libvirt-glib
+    systemd
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "init_script" "systemd")
+    (lib.mesonOption "unix_socket_group" "qemu-libvirtd")
+    # TODO: uncomment below on next release
+    # (lib.mesonOption "sysusersdir" "${placeholder "out"}/lib/sysusers.d")
+  ];
+
+  doCheck = false; # needs running D-Bus and libvirt
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = {
+    description = "libvirt D-Bus API binding";
+    homepage = "https://libvirt.org/dbus.html";
+    changelog = "https://gitlab.com/libvirt/libvirt-dbus/-/blob/v${finalAttrs.version}/NEWS.rst";
+    license = lib.licenses.lgpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+  };
+})


### PR DESCRIPTION
[Libvirt-dbus](https://www.libvirt.org/dbus.html) is a package that provides a D-Bus API for Libvirt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
