### PR TITLE
python3Packages.pgpy-dtc: fix building with current cryptography library version

### DIFF
--- a/pkgs/development/python-modules/pgpy-dtc/Fix-compat-with-current-cryptography.patch
+++ b/pkgs/development/python-modules/pgpy-dtc/Fix-compat-with-current-cryptography.patch
@@ -1,0 +1,34 @@
+--- a/pgpy_dtc/_curves.py
++++ b/pgpy_dtc/_curves.py
+@@ -75,26 +75,31 @@
+     class BrainpoolP256R1(ec.EllipticCurve):
+         name = 'brainpoolP256r1'
+         key_size = 256
++        group_order = 0xa9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7
+ 
+ 
+     class BrainpoolP384R1(ec.EllipticCurve):  # noqa: E303
+         name = 'brainpoolP384r1'
+         key_size = 384
++        group_order = 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046565
+ 
+ 
+     class BrainpoolP512R1(ec.EllipticCurve):  # noqa: E303
+         name = 'brainpoolP512r1'
+         key_size = 512
++        group_order = 0xaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90069
+ 
+ 
+     class X25519(ec.EllipticCurve):  # noqa: E303
+         name = 'X25519'
+         key_size = 256
++        group_order = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed
+ 
+ 
+     class Ed25519(ec.EllipticCurve):  # noqa: E303
+         name = 'ed25519'
+         key_size = 256
++        group_order = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed
+ 
+ 
+ # add these curves to the _CURVE_TYPES list

--- a/pkgs/development/python-modules/pgpy-dtc/default.nix
+++ b/pkgs/development/python-modules/pgpy-dtc/default.nix
@@ -30,6 +30,13 @@ buildPythonPackage rec {
     cryptography
   ];
 
+  patches = [
+    # NOTE: This is the same patch file as Fix-compat-with-current-cryptography.patch
+    #       from the pgpy packaging, with the base directory modified for pgpy-dtc.
+    # https://github.com/SecurityInnovation/PGPy/pull/474
+    ./Fix-compat-with-current-cryptography.patch
+  ];
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "pgpy_dtc" ];


### PR DESCRIPTION
Same change as b8e282093d2fd1c336661d6704eae08c85a1362e / https://github.com/NixOS/nixpkgs/pull/424089

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
