### PR TITLE
kbdVlock: split out of kbd

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -36,6 +36,8 @@
 
 - LLVM 12, 13, 14, 15, 16, and 17 have been removed, as they have reached end‐of‐life upstream and are no longer supported.
 
+- The `vlock` output from kbd has been removed. Instead a new package `kbdVlock` has been introduced. Use this package now instead of the output.
+
 - GHCJS 8.10, exposed via `haskell.compiler.ghcjs` and `haskell.compiler.ghcjs810`, has been removed. Downstream users should migrate their projects to the new JavaScript backend of GHC proper which can be used via `pkgsCross.ghcjs` from Nixpkgs. Haskell packaging code, like `haskellPackages.mkDerivation`, `ghcWithPackages` and `hoogleWithPackages`, also no longer supports GHCJS.
 
 - GHC 8.6, 8.10, 9.0, 9.2, and their package sets have been removed.

--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -20,11 +20,12 @@
   zstd,
   gitUpdater,
   pkgsCross,
-  withVlock ? true,
+  withVlock ? false,
+  kbdVlock,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "kbd";
+  pname = "kbd" + lib.optionalString withVlock "-vlock";
   version = "2.9.0";
 
   __structuredAttrs = true;
@@ -35,16 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-uUECxFdm/UhoHKLHLFe6/ygCQ+4mrQOZExKl+ReaTNw=";
   };
 
-  # vlock is moved into its own output, since it depends on pam. This
-  # reduces closure size for most use cases.
   outputs = [
     "out"
     "dev"
     "scripts"
     "man"
-  ]
-  ++ lib.optionals withVlock [
-    "vlock"
   ];
 
   patches = [
@@ -112,10 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     moveToOutput bin/unicode_start $scripts
     moveToOutput bin/unicode_stop $scripts
-  ''
-  + lib.optionalString withVlock ''
-    moveToOutput bin/vlock $vlock
-    moveToOutput etc/pam.d/vlock $vlock
   '';
 
   outputChecks.out.disallowedRequisites = [
@@ -137,6 +129,8 @@ stdenv.mkDerivation (finalAttrs: {
         pkgsCross.${systemString}.kbd;
       inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
     };
+    # For backwards compatibility. Remove after 26.05.
+    vlock = kbdVlock;
   };
 
   meta = {

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -200,8 +200,6 @@ let
   #  $ curl -s https://api.github.com/repos/systemd/systemd/releases/latest | \
   #     jq '.created_at|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime'
   releaseTimestamp = "1734643670";
-
-  kbd' = if withPam then kbd else kbd.override { withVlock = false; };
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
@@ -475,8 +473,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "pkgconfigdatadir" "${placeholder "dev"}/share/pkgconfig")
 
     # Keyboard
-    (lib.mesonOption "loadkeys-path" "${kbd'}/bin/loadkeys")
-    (lib.mesonOption "setfont-path" "${kbd'}/bin/setfont")
+    (lib.mesonOption "loadkeys-path" "${kbd}/bin/loadkeys")
+    (lib.mesonOption "setfont-path" "${kbd}/bin/setfont")
 
     # SBAT
     (lib.mesonOption "sbat-distro" "nixos")
@@ -928,9 +926,8 @@ stdenv.mkDerivation (finalAttrs: {
       withUtmp
       util-linux
       kmod
+      kbd
       ;
-
-    kbd = kbd';
 
     # Many TPM2-related units are only installed if this trio of features are
     # enabled. See https://github.com/systemd/systemd/blob/876ee10e0eb4bbb0920bdab7817a9f06cc34910f/units/meson.build#L521

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3265,6 +3265,8 @@ with pkgs;
 
   kbfs = callPackage ../tools/security/keybase/kbfs.nix { };
 
+  kbdVlock = callPackage ../../pkgs/by-name/kb/kbd/package.nix { withVlock = true; };
+
   keybase-gui = callPackage ../tools/security/keybase/gui.nix { };
 
   keystore-explorer = callPackage ../applications/misc/keystore-explorer {


### PR DESCRIPTION
This removes a dependency cycle from systemd, removing a rebuild. At the same time it is just as convenience for users. They need to include the `kbdVlock` package now instead of the `vlock` output.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
