### PR TITLE
gnutls: enable PQC support

### DIFF
--- a/pkgs/by-name/le/leancrypto/package.nix
+++ b/pkgs/by-name/le/leancrypto/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "leancrypto";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "leancrypto";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tTbjYljI2XRrmVdHyEn6knQV/HDPwBUR3O6OFc6RBPA=";
+  };
+
+  mesonFlags = [
+    (lib.mesonEnable "apps" false)
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  prePatch = ''
+    patchShebangs addon/*.sh apps/tests/*.sh
+  '';
+
+  # activate on version bump, then deactivate (long duration)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Lean cryptographic library usable for bare-metal environments";
+    longDescription = ''
+      leancrypto offers a lean and versatile cryptographic library
+      building on Post Quantum Cryptography.
+    '';
+    homepage = "https://github.com/smuellerDD/leancrypto";
+    changelog = "https://github.com/smuellerDD/leancrypto/blob/master/CHANGES.md";
+    license = [
+      licenses.bsd3
+      licenses.gpl2
+    ];
+    maintainers = [ maintainers.thillux ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
gnutls has support for quantum-safe cryptographic algorithms for some time now. Enable it via the more modern leancrypto backend (analog to what e.g. Arch Linux already does).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
