### PR TITLE
guile: fix build with gcc15

### DIFF
--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -126,6 +126,9 @@ builder rec {
   #  https://github.com/NixOS/nixpkgs/pull/160051#issuecomment-1046193028
   ++ lib.optional (stdenv.hostPlatform.isDarwin) "--disable-lto";
 
+  # Fix build with gcc15
+  env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu17" ];
+
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"
   ''


### PR DESCRIPTION
- add "-std=gnu17" to `env.NIX_CFLAGS_COMPILE`

Fixes build failure with gcc15:
```
backtrace.c: In function 'scm_init_backtrace':
backtrace.c:329:51: error: passing argument 5 of 'scm_c_define_gsubr'
from incompatible pointer type [-Wincompatible-pointer-types]
329 |   scm_c_define_gsubr ("print-exception", 4, 0, 0, boot_print_exception);
    |                                                   ^~~~~~~~~~~~~~~~~~~~
    |                                                   |
    |                                                   struct scm_unused_struct * (*)(struct scm_unused_struct *,
struct scm_unused_struct *, struct scm_unused_struct *, struct scm_unused_struct *)
In file included from backtrace.c:41:
gsubr.h:72:71: note: expected 'scm_t_subr'
{aka 'struct scm_unused_struct * (*)(void)'} but argument is of type
'struct scm_unused_struct * (*)(struct scm_unused_struct *, struct
scm_unused_struct *, struct scm_unused_struct *, struct scm_unused_struct *)'
   72 |                                 int req, int opt, int rst, scm_t_subr fcn);
      |                                                            ~~~~~~~~~~~^~~
backtrace.c:66:1: note: 'boot_print_exception' declared here
   66 | boot_print_exception (SCM port, SCM frame, SCM key, SCM args)
      | ^~~~~~~~~~~~~~~~~~~~
```

---
Tested build with:
```bash
nix-build --expr 'with import ./. {}; guile.override { stdenv = gcc15Stdenv; buildPackages = buildPackages // { stdenv = buildPackages.gcc15Stdenv; }; }'
```
(no idea why package uses `buildPackages.stdenv.cc`)

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

There is a proposed patch with fix on mailing list:
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=78464
that alpine seems to use:
https://gitlab.alpinelinux.org/alpine/aports/-/commit/eb814e8a416833694450dae0c59f4dfc8adf50a9

Other distros settled on `-std=gnu17`:
https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-scheme/guile/guile-3.0.10-r103.ebuild?id=0ad96e879b651cc7e8214159d5841d6b633bef8a#n71
https://src.fedoraproject.org/rpms/guile30/blob/0c285888662c8a2917c876d0c79ab717b30f0e46/f/guile30.spec#_77

Considering there was no acknowledgement of that patch from upstream yet and how "involved" it looks like, `-std=gnu17` seems like a safer way for now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
