### PR TITLE
Fix/vmr build

### DIFF
--- a/pkgs/development/compilers/dotnet/10/bootstrap-sdk.nix
+++ b/pkgs/development/compilers/dotnet/10/bootstrap-sdk.nix
@@ -4,9 +4,7 @@
   buildNetSdk,
   fetchNupkg,
 }:
-
 # v10.0 (go-live)
-
 let
   commonPackages = [
     (fetchNupkg {
@@ -33,6 +31,11 @@ let
       pname = "Microsoft.NET.ILLink.Tasks";
       version = "10.0.0-rc.1.25451.107";
       hash = "sha512-XisyrroZsOir2prziGawVqx8sVAFvyamu5W5ordZYYuHIr/yeLlC6xDCgZ1CMhHE00ElUyc34ChHl6gUgQdCeg==";
+    })
+    (fetchNupkg {
+      pname = "Microsoft.Build.NoTargets";
+      version = "3.7.0";
+      hash = "sha512-5qdJsWhJBNGg6NGg2jqU8BqkSzaPvA5i7rWtYWoIVy4UluXgHwvC2Y0U2CGlZ1TjO82t4cQgtK/7Qeob4b+5Dw==";
     })
   ];
 
@@ -455,9 +458,7 @@ let
       })
     ];
   };
-
-in
-rec {
+in rec {
   release_10_0 = "10.0.0-rc.1";
 
   aspnetcore_10_0 = buildAspNetCore {

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -367,30 +367,6 @@ stdenv.mkDerivation rec {
       cp -Tr ${bootstrapSdk}/share/dotnet .dotnet
       chmod -R +w .dotnet
 
-      ${lib.optionalString (lib.versionAtLeast version "10") ''
-        # seed Microsoft.Build.NoTargets so MSBuild can resolve it during prep
-        if [[ ! -d ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets" ]]; then
-          shopt -s nullglob
-          for packDir in .dotnet/packs/Microsoft.Build.NoTargets.*; do
-            if [[ -d "$packDir/Sdk" ]]; then
-              mkdir -p ".dotnet/sdk/$sdk_version/Sdks"
-              cp -R "$packDir/Sdk" ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets"
-              break
-            fi
-          done
-          shopt -u nullglob
-        fi
-
-        if [[ ! -d ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets" ]] \
-           && [[ -d "${bootstrapSdk.artifacts}" ]]; then
-          no_targets_pkg=$(find "${bootstrapSdk.artifacts}" -maxdepth 6 -type f -name 'Microsoft.Build.NoTargets*.nupkg' -print -quit)
-          if [[ -n "$no_targets_pkg" ]]; then
-            mkdir -p ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets"
-            unzip -qo "$no_targets_pkg" -d ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets"
-          fi
-        fi
-      ''}
-
       export HOME=$(mktemp -d)
     ''
     + lib.optionalString (lib.versionAtLeast version "10") ''

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -367,6 +367,30 @@ stdenv.mkDerivation rec {
       cp -Tr ${bootstrapSdk}/share/dotnet .dotnet
       chmod -R +w .dotnet
 
+      ${lib.optionalString (lib.versionAtLeast version "10") ''
+        # seed Microsoft.Build.NoTargets so MSBuild can resolve it during prep
+        if [[ ! -d ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets" ]]; then
+          shopt -s nullglob
+          for packDir in .dotnet/packs/Microsoft.Build.NoTargets.*; do
+            if [[ -d "$packDir/Sdk" ]]; then
+              mkdir -p ".dotnet/sdk/$sdk_version/Sdks"
+              cp -R "$packDir/Sdk" ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets"
+              break
+            fi
+          done
+          shopt -u nullglob
+        fi
+
+        if [[ ! -d ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets" ]] \
+           && [[ -d "${bootstrapSdk.artifacts}" ]]; then
+          no_targets_pkg=$(find "${bootstrapSdk.artifacts}" -maxdepth 6 -type f -name 'Microsoft.Build.NoTargets*.nupkg' -print -quit)
+          if [[ -n "$no_targets_pkg" ]]; then
+            mkdir -p ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets"
+            unzip -qo "$no_targets_pkg" -d ".dotnet/sdk/$sdk_version/Sdks/Microsoft.Build.NoTargets"
+          fi
+        fi
+      ''}
+
       export HOME=$(mktemp -d)
     ''
     + lib.optionalString (lib.versionAtLeast version "10") ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds  Microsoft.Build.NoTargets package in the dotnet bootstrap sdk to fix a build failure with dotnet vmr package on linux.


## Things done

- Adds  Microsoft.Build.NoTargets package in the dotnet bootstrap sdk
- 
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
