### PR TITLE
librttopo,libspatialite: fix cross compilation

### DIFF
--- a/pkgs/by-name/li/librttopo/package.nix
+++ b/pkgs/by-name/li/librttopo/package.nix
@@ -27,10 +27,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     validatePkgConfig
-    geos # for geos-config
   ];
 
   buildInputs = [ geos ];
+
+  configureFlags = [
+    "--with-geosconfig=${lib.getExe' (lib.getDev geos) "geos-config"}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/li/libspatialite/package.nix
+++ b/pkgs/by-name/li/libspatialite/package.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     validatePkgConfig
-    geos # for geos-config
   ];
 
   buildInputs = [
@@ -60,6 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
+  ];
+
+  configureFlags = [
+    "--with-geosconfig=${lib.getExe' (lib.getDev geos) "geos-config"}"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fix cross compilation error:
```sh
       > checking for geos-config... /nix/store/d2ibs3vvdx8wrqrl156f9vw8xly0f164-geos-3.13.1/bin/geos-config
       > checking for geos_c.h... yes
       > checking for library containing GEOSContext_setErrorMessageHandler_r... no
       > configure: error: could not find libgeos_c (or obsolete 'libgeos_c' < v.3.5.0 found) - you may need to specify the directory of a geos-config file using --with-geosconfig
       For full logs, run:
         nix log /nix/store/m3nyf7019wn4nixjyvgkn3pv3z25lp90-librttopo-armv7l-unknown-linux-gnueabihf-1.1.0.drv
```

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
