### PR TITLE
gperftools: 2.17 → 2.17.2

### DIFF
--- a/pkgs/by-name/gp/gperftools/package.nix
+++ b/pkgs/by-name/gp/gperftools/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gperftools";
-  version = "2.17";
+  version = "2.17.2";
 
   src = fetchFromGitHub {
     owner = "gperftools";
     repo = "gperftools";
     tag = "gperftools-${finalAttrs.version}";
-    sha256 = "sha256-Tm+sYKwFSHAxOALgr9UGv7vBMlWqUymXsvNu7Sku6Kk=";
+    hash = "sha256-WCEuiSjNIX/KhEBWndyVhrKlWs7H60mcHoPlWd7YWC4=";
   };
 
   patches = [


### PR DESCRIPTION
Changelog: https://github.com/gperftools/gperftools/compare/gperftools-2.17...gperftools-2.17.2

Fixes build for armv7l:
```sh
$ nix build -L .#pkgsCross.armv7l-hf-multiplatform.gperftools
...
gperftools-armv7l-unknown-linux-gnueabihf> src/stacktrace_libgcc-inl.h: In function '_Unwind_Reason_Code libgcc_backtrace_helper(_Unwind_Context*, void*)':
gperftools-armv7l-unknown-linux-gnueabihf> src/stacktrace_libgcc-inl.h:69:12: error: '_URC_NORMAL_STOP' was not declared in this scope
gperftools-armv7l-unknown-linux-gnueabihf>    69 |     return _URC_NORMAL_STOP;
gperftools-armv7l-unknown-linux-gnueabihf>       |            ^~~~~~~~~~~~~~~~
...
```

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
