### PR TITLE
windsurf: 1.12.11 -> 1.12.12

### DIFF
--- a/pkgs/by-name/wi/windsurf/info.json
+++ b/pkgs/by-name/wi/windsurf/info.json
@@ -1,20 +1,20 @@
 {
   "aarch64-darwin": {
-    "version": "1.12.11",
+    "version": "1.12.12",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/869df67af2a3134ce6fe3d8395ac0ae23726fd02/Windsurf-darwin-arm64-1.12.11.zip",
-    "sha256": "1303ed86901099beac3ea6a8ac8ca532f238130b032153546252b852d8224d95"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/146732d0c28fe6d8f982f1ebf7ab4101ece88c63/Windsurf-darwin-arm64-1.12.12.zip",
+    "sha256": "dae2809d0d551b1ad4acd03effba65c655d6040b3903e046934b1940e4be063f"
   },
   "x86_64-darwin": {
-    "version": "1.12.11",
+    "version": "1.12.12",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/869df67af2a3134ce6fe3d8395ac0ae23726fd02/Windsurf-darwin-x64-1.12.11.zip",
-    "sha256": "6a0898186f68125c9f1310f8c2e6867f3e54ab6a72e1295799da1bd607af4825"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/146732d0c28fe6d8f982f1ebf7ab4101ece88c63/Windsurf-darwin-x64-1.12.12.zip",
+    "sha256": "8696e119dbabf962d465ea6d2395f165a849b0d8abdd1f62d0ea1d49528e92e1"
   },
   "x86_64-linux": {
-    "version": "1.12.11",
+    "version": "1.12.12",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/869df67af2a3134ce6fe3d8395ac0ae23726fd02/Windsurf-linux-x64-1.12.11.tar.gz",
-    "sha256": "421a27f73c84a6f52bba3cfdc9edd9ea055013ba9c85bdd0777b072ab382637c"
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/146732d0c28fe6d8f982f1ebf7ab4101ece88c63/Windsurf-linux-x64-1.12.12.tar.gz",
+    "sha256": "9f832381f3ea79f3662d728817b05ef33756708e845052d40d1253b7e1a055dc"
   }
 }


### PR DESCRIPTION
Adds Claude Sonnet 4.5.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
