### PR TITLE
claude-code-bin: init at 2.0.1

### DIFF
--- a/pkgs/by-name/cl/claude-code-bin/manifest.json
+++ b/pkgs/by-name/cl/claude-code-bin/manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": "2.0.1",
+  "buildDate": "2025-09-30T01:53:13Z",
+  "platforms": {
+    "darwin-arm64": {
+      "checksum": "7bb86f84cf3ef3fdc6d2cd37d6c150198fa37a974e94ea32ec21506063985d25",
+      "size": 74021136
+    },
+    "darwin-x64": {
+      "checksum": "ea59456624a678155d5e42d5c38dc15c3971c3d11622720560c550606079225c",
+      "size": 79662304
+    },
+    "linux-arm64": {
+      "checksum": "1dd10a4dce9e66907476be30cfe5f80f778c04d91086e1da06855897ddd626df",
+      "size": 108962618
+    },
+    "linux-x64": {
+      "checksum": "f22d62d0d0893fe9be472a2c808136971accfb433f3ee74d3c89800814c196cc",
+      "size": 115564748
+    },
+    "linux-arm64-musl": {
+      "checksum": "3fe2a8231f1137f2b26f7c9f0564f2f22ab4c1634b2118e4c706c77c96aa58d7",
+      "size": 103804914
+    },
+    "linux-x64-musl": {
+      "checksum": "1247d493150205b8c1c3bb4605e584afd60e05ab7ae933068f80c9a76ae4a1de",
+      "size": 107938436
+    },
+    "win32-x64": {
+      "checksum": "eb045cb52d30d5c16ace261649c902d183ee3e8e20eb7e71b5c44494afd3b1df",
+      "size": 0
+    }
+  }
+}

--- a/pkgs/by-name/cl/claude-code-bin/package.nix
+++ b/pkgs/by-name/cl/claude-code-bin/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  makeBinaryWrapper,
+  installShellFiles,
+  writeScript,
+  updateChannel ? "stable",
+  manifestFile ? ./manifest.json,
+}:
+let
+  gcsBucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+  manifest = lib.importJSON manifestFile;
+  platforms = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+  platform = platforms.${stdenvNoCC.hostPlatform.system};
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "claude-code-bin";
+  version = manifest.version or "unstable";
+
+  src = fetchurl {
+    url = "${gcsBucket}/${finalAttrs.version}/${platform}/claude";
+    sha256 = manifest.platforms.${platform}.checksum;
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  # otherwise the bun runtime is executed instead of the binary
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals (!stdenvNoCC.isDarwin) [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin $src
+    wrapProgram $out/bin/claude \
+      --set DISABLE_AUTOUPDATER 1
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "--version";
+  # does not work with sandbox enabled on darwin
+  # TypeError: failed to initialize Segmenter at /$bunfs/root/claude
+  doInstallCheck = !stdenvNoCC.isDarwin;
+
+  passthru.updateScript = writeScript "update-claude-code-bin" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell --pure -i bash -p curl cacert
+
+    set -euo pipefail
+
+    # https://claude.ai/install.sh
+    version="$(curl -fsSL "${gcsBucket}/${updateChannel}")"
+    curl -fsSL "${gcsBucket}/$version/manifest.json" -o "${toString manifestFile}"
+  '';
+
+  meta = {
+    description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
+    homepage = "https://github.com/anthropics/claude-code";
+    downloadPage = "https://www.npmjs.com/package/@anthropic-ai/claude-code";
+    changelog = "https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      mirkolenz
+      xiaoxiangmoe
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "claude";
+    platforms = lib.attrNames platforms;
+  };
+})

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -47,6 +47,7 @@ buildNpmPackage (finalAttrs: {
     description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
     homepage = "https://github.com/anthropics/claude-code";
     downloadPage = "https://www.npmjs.com/package/@anthropic-ai/claude-code";
+    changelog = "https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       malo

--- a/pkgs/by-name/cl/claude-code/update.sh
+++ b/pkgs/by-name/cl/claude-code/update.sh
@@ -6,5 +6,6 @@ set -euo pipefail
 version=$(npm view @anthropic-ai/claude-code version)
 
 # Update version and hashes
-AUTHORIZED=1 NIXPKGS_ALLOW_UNFREE=1 nix-update claude-code --version="$version" --generate-lockfile
-nix-update vscode-extensions.anthropic.claude-code --use-update-script --version "$version"
+AUTHORIZED=1 NIXPKGS_ALLOW_UNFREE=1 nix-update claude-code --version "$version" --generate-lockfile
+nix-update vscode-extensions.anthropic.claude-code --use-update-script
+nix-update claude-code-bin --use-update-script


### PR DESCRIPTION
Currently, claude-code uses a vendored package lock to build the npm package because its source code is not publicly available. This requires a custom update logic and results in rather large diffs between versions. This PR tries to simplify the derivation as follows:

- Use the binaries published by Anthropic for their install script: <https://claude.ai/install.sh>
- The manifest.json is downloaded and processed with jq to contain only the entries required by nix.
- A sha256 hash is already precomputed and is prefixed with `sha256:` to be used with the hash parameter of nix (i.e., it is given as a digest).
- The updateScript simply replaces the manifest.json file which is idempotent.
- Less workarounds are required for the actual derivation as no build step is required.
- I added myself as a co-maintainer.
- Updated the package to the lastest version (v2.0.0) in a separate commit.

I added the resulting package to my personal configuration and so far had no issues whatsoever and auto-updates work reliably. The only thing I'm not sure about is the `sha256:` prefix. It seems to be supported by nix, but this behavior doesn't seem to be documented anywhere. We could also replace `hash = "sha256:xxx"` with `sha256 = "xxx"`, but it seems that this way of specifying hashes is going to be deprecated in the future.

Happy about any kind of feedback for this since it's basically a rewrite of the package derivation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
