### PR TITLE
amazon-image: improve metadata fetch script resilience

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -85,12 +85,19 @@ in
 
     systemd.services.fetch-ec2-metadata = {
       wantedBy = [ "multi-user.target" ];
-      wants = [ "network-online.target" ];
+      requires = [ "network-online.target" ];
       after = [ "network-online.target" ];
+
       path = [ pkgs.curl ];
+
       script = builtins.readFile ./ec2-metadata-fetcher.sh;
-      serviceConfig.Type = "oneshot";
-      serviceConfig.StandardOutput = "journal+console";
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        StandardOutput = "journal+console";
+        Restart = "on-failure";
+      };
     };
 
     # Amazon-issued AMIs include the SSM Agent by default, so we do the same.

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -1,7 +1,7 @@
 metaDir=/etc/ec2-metadata
 mkdir -p "$metaDir"
 chmod 0755 "$metaDir"
-rm -f "$metaDir/*"
+rm -f "$metaDir"/*
 
 get_imds_token() {
   # retry-delay of 1 selected to give the system a second to get going,
@@ -35,33 +35,47 @@ preflight_imds_token() {
 
 try=1
 while [ $try -le 3 ]; do
-  echo "(attempt $try/3) getting an EC2 instance metadata service v2 token..."
-  IMDS_TOKEN=$(get_imds_token) && break
+  echo "(attempt $try/3) getting an EC2 instance metadata service IMDSv2 token..."
+  IMDS_TOKEN=$(get_imds_token)
+  RC=$?
+  if [ "$RC" = 0 ] && [ "$IMDS_TOKEN" != "" ]; then
+    break
+  fi
   try=$((try + 1))
   sleep 1
 done
 
 if [ "$IMDS_TOKEN" == "" ]; then
-  echo "failed to fetch an IMDS2v token."
+  echo "failed to fetch an IMDSv2 token."
+  exit 1
 fi
+
+echo "successfully fetched IMDSv2 token"
 
 try=1
 while [ $try -le 10 ]; do
-  echo "(attempt $try/10) validating the EC2 instance metadata service v2 token..."
+  echo "(attempt $try/10) validating the EC2 instance metadata service IMDSv2 token..."
   preflight_imds_token && break
   try=$((try + 1))
   sleep 1
 done
+echo "successfully validated IMDSv2 token"
 
 echo "getting EC2 instance metadata..."
 
 get_imds() {
+  echo "fetching: $*"
   # --fail to avoid populating missing files with 404 HTML response body
   # || true to allow the script to continue even when encountering a 404
-  curl --silent --show-error --fail --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" "$@" || true
+  if ! curl --silent --show-error --fail --header "X-aws-ec2-metadata-token: $IMDS_TOKEN" "$@"; then
+    echo "failed to fetch: $*"
+    true
+  fi
 }
 
 get_imds -o "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path
 (umask 077 && get_imds -o "$metaDir/user-data" http://169.254.169.254/1.0/user-data)
 get_imds -o "$metaDir/hostname" http://169.254.169.254/1.0/meta-data/hostname
 get_imds -o "$metaDir/public-keys-0-openssh-key" http://169.254.169.254/1.0/meta-data/public-keys/0/openssh-key
+
+echo "done"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I'm attempting to fix an issue where fetching metadata fails, but the script completes successfully and then fetching is never done. This leaves the instance in a partially provisioned state.

Note this log where it outputs that we failed to fetch a token, but continues on anyway. This is now a fatal error and systemd will restart the service.

Before:

```
Sep 26 18:54:04 nixos systemd[1]: Starting fetch-ec2-metadata.service...
Sep 26 18:54:04 nixos fetch-ec2-metadata-start[942]: (attempt 1/3) getting an EC2 instance metadata service v2 token...
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[946]: curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Could not connect to server
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[942]: failed to fetch an IMDS2v token.
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[942]: (attempt 1/10) validating the EC2 instance metadata service v2 token...
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[948]: curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Could not connect to server
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[942]: getting EC2 instance metadata...
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[949]: curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Could not connect to server
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[951]: curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Could not connect to server
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[952]: curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Could not connect to server
Sep 26 18:54:05 nixos fetch-ec2-metadata-start[953]: curl: (7) Failed to connect to 169.254.169.254 port 80 after 0 ms: Could not connect to server
Sep 26 18:54:05 nixos systemd[1]: fetch-ec2-metadata.service: Deactivated successfully.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
