### PR TITLE
rustPlatform.fetchCargoVendor: fix dir name collision

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -172,7 +172,7 @@ def get_manifest_metadata(manifest_path: Path) -> dict[str, Any]:
     return json.loads(output)
 
 
-def try_get_crate_manifest_path_from_mainfest_path(manifest_path: Path, crate_name: str) -> Path | None:
+def try_get_crate_manifest_path_from_manifest_path(manifest_path: Path, crate_name: str) -> Path | None:
     metadata = get_manifest_metadata(manifest_path)
 
     for pkg in metadata["packages"]:
@@ -187,7 +187,7 @@ def find_crate_manifest_in_tree(tree: Path, crate_name: str) -> Path:
     manifest_paths = tree.glob("**/Cargo.toml")
 
     for manifest_path in manifest_paths:
-        res = try_get_crate_manifest_path_from_mainfest_path(manifest_path, crate_name)
+        res = try_get_crate_manifest_path_from_manifest_path(manifest_path, crate_name)
         if res is not None:
             return res
 
@@ -274,13 +274,14 @@ def create_vendor(vendor_staging_dir: Path, out_dir: Path) -> None:
     seen_source_keys = set()
     for pkg in cargo_lock_toml["package"]:
 
-        # ignore local dependenices
+        # ignore local dependencies
         if "source" not in pkg.keys():
             continue
 
         source: str = pkg["source"]
+        source_hash = hashlib.sha256(source.encode()).hexdigest()
 
-        dir_name = f"{pkg["name"]}-{pkg["version"]}"
+        dir_name = f"{pkg["name"]}-{pkg["version"]}-{source_hash}"
         crate_out_dir = out_dir / dir_name
 
         if source.startswith("git+"):


### PR DESCRIPTION
Fix edge case where name and version are the same, but the source URL is different. In that case the dir name will be the same, which causes the build to fail. Also fixed some typos.

https://github.com/netdata/netdata/blob/4f34cf80eef21419387030e2d1cd3ff5c3ab1d4a/src/crates/jf/Cargo.lock#L403-L417
```
...
[[package]]
name = "flatten-serde-json"
version = "1.18.0"
source = "git+https://github.com/meilisearch/meilisearch?branch=main#795045c03a27212549119e5ae9d5ac99ad711c89"
dependencies = [
 "serde_json",
]

[[package]]
name = "flatten-serde-json"
version = "1.18.0"
source = "git+https://github.com/meilisearch/meilisearch#795045c03a27212549119e5ae9d5ac99ad711c89"
dependencies = [
 "serde_json",
]
...
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
