### PR TITLE
gradle: remove dependency on EOL jdk23, use jdk11 for test

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -1,8 +1,8 @@
 {
   callPackage,
+  jdk11,
   jdk17,
   jdk21,
-  jdk23,
 }:
 
 let
@@ -56,7 +56,7 @@ let
           tests = {
             toolchains =
               let
-                javaVersion = lib.getVersion jdk23;
+                javaVersion = lib.getVersion jdk11;
                 javaMajorVersion = lib.versions.major javaVersion;
               in
               runCommand "detects-toolchains-from-nix-env"
@@ -65,7 +65,7 @@ let
                   nativeBuildInputs = [
                     (gradle.override {
                       javaToolchains = [
-                        jdk23
+                        jdk11
                       ];
                     })
                   ];


### PR DESCRIPTION
A passthru test of the javaToolchains configuration property was using `jdk23`.

There is a requirement that the JDK version for the test NOT be "the default for any of the gradle versions", so `jdk11` is a good choice for the replacement since `jdk17` and `jdk21` are currently used and `jdk25` will be used in the future.

This should help with the following issue:

* #444846

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
