### PR TITLE
octoprint.python.pkgs.octolapse: drop

### DIFF
--- a/pkgs/by-name/oc/octoprint/plugins.nix
+++ b/pkgs/by-name/oc/octoprint/plugins.nix
@@ -647,54 +647,6 @@ in
     };
   };
 
-  octolapse = buildPlugin rec {
-    pname = "octolapse";
-    version = "0.4.2";
-    format = "setuptools";
-
-    src = fetchFromGitHub {
-      owner = "FormerLurker";
-      repo = "Octolapse";
-      rev = "v${version}";
-      sha256 = "sha256-QP6PkKWKUv4uIaYdqTAsZmK7DVes94Q9K/DrBYrWxzY=";
-    };
-
-    patches = [
-      # fix version constraint
-      # https://github.com/FormerLurker/Octolapse/pull/894
-      (fetchpatch {
-        url = "https://github.com/FormerLurker/Octolapse/commit/0bd7db2430aef370f2665c6c7011fc3bb559122e.patch";
-        hash = "sha256-z2aEq5sJGarGtIDbTRCvXdSj+kq8HIVvLRWpKutmJNY=";
-      })
-    ];
-
-    # Test fails due to code executed on import, see #136513
-    #pythonImportsCheck = [ "octoprint_octolapse" ];
-
-    propagatedBuildInputs = with super; [
-      awesome-slugify
-      setuptools
-      pillow
-      sarge
-      six
-      pillow
-      psutil
-      file-read-backwards
-    ];
-
-    meta = with lib; {
-      description = "Stabilized timelapses for Octoprint";
-      homepage = "https://github.com/FormerLurker/OctoLapse";
-      license = licenses.agpl3Plus;
-      maintainers = with maintainers; [
-        illustris
-        j0hax
-      ];
-      # requires pillow >=6.2.0,<7.0.0
-      broken = true;
-    };
-  };
-
   dashboard = buildPlugin rec {
     pname = "dashboard";
     version = "1.18.3";
@@ -716,5 +668,6 @@ in
   };
 }
 // lib.optionalAttrs config.allowAliases {
+  octolapse = throw "octoprint.python.pkgs.octolapse has been removed because it has been marked as broken since at least November 2024."; # Added 2025-09-29
   octoprint-dashboard = super.dashboard;
 }


### PR DESCRIPTION
Broken since at least 24.11 branchoff, dropping per [RFC 180](https://github.com/NixOS/rfcs/blob/master/rfcs/0180-broken-package-removal.md).

* Package drops:
  * [ ] `pkgs/top-level/aliases.nix` entry added.
* Module drops:
  * [ ] `nixos/doc/release-notes` entry added.
  * [ ] `nixos/modules/rename.nix` entry added.
* [X] `rg ${pname}` run and verified to not contain references to this package (outside of aliases.nix, rename.nix, and release notes).
* [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Cc @j0hax @SuperSandro2000 @illustris.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

