### PR TITLE
App-Fatpacker-simple and dependnecies

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1176,31 +1176,31 @@ with self;
   };
 
   AppFatPackerSimple = buildPerlModule {
-      pname = "App-FatPacker-Simple";
-      version = "0.20";
-      src = pkgs.fetchurl {
-        url = "mirror://cpan/authors/id/S/SK/SKAJI/${pname}-${version}.tar.gz";
-        sha256 = "sha256-nkSy/gno2PxT5aA3UWCRK0Dnn9fIdcCOtQvoGUZocSo=";
-      };
-      buildInputs = [ 
-        JSON
-        ModuleBuildTiny
-        pkgs.gnumake
-        ClonePP
-        PPI
-        TestLeakTrace
-      ];
-      propagatedBuildInputs = [
-        AppFatPacker
-        YAMLPP
-        JSONPP
-        Mouse
-        MouseXTypes
-        MouseXGetopt
-        DistributionMetadata
-      ];
+    pname = "App-FatPacker-Simple";
+    version = "0.20";
+    src = pkgs.fetchurl {
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/App-FatPacker-Simple-0.20.tar.gz";
+      sha256 = "sha256-nkSy/gno2PxT5aA3UWCRK0Dnn9fIdcCOtQvoGUZocSo=";
     };
+    buildInputs = [
+      JSON
+      ModuleBuildTiny
+      pkgs.gnumake
+      ClonePP
+      PPI
+      TestLeakTrace
+    ];
+    propagatedBuildInputs = [
+      AppFatPacker
+      YAMLPP
+      JSONPP
+      Mouse
+      MouseXTypes
+      MouseXGetopt
+      DistributionMetadata
+    ];
   };
+
 
   Appcpanminus = buildPerlPackage {
     pname = "App-cpanminus";
@@ -10990,10 +10990,10 @@ with self;
     pname = "Distribution-Metadata";
     version = "0.10";
     src = pkgs.fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/${pname}-${version}.tar.gz";
-      sha256 = "sha256-uynMfh26OQphJnYfB9BwQ27fqinrjpBwMCOwXzET6nE=";  
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Distribution-Metadata-0.10.tar.gz";
+      sha256 = "sha256-uynMfh26OQphJnYfB9BwQ27fqinrjpBwMCOwXzET6nE=";
     };
-    buildInputs = [ 
+    buildInputs = [
       ModuleBuildTiny
     ];
     propagatedBuildInputs = [
@@ -11004,9 +11004,9 @@ with self;
     meta = {
       description = "Distribution::Metadata - gather distribution metadata in local";
       homepage = "https://metacpan.org/pod/Distribution::Metadata";
-      license = with lib.licenses; [
-        perl_5
-      ];
+      # license = with lib.licenses; [
+      #   perl5
+      # ];
     };
   };
 
@@ -29123,21 +29123,20 @@ with self;
     pname = "Perl-Strip";
     version = "1.2";
     src = pkgs.fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${pname}-${version}.tar.gz";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Perl-Strip-1.2.tar.gz";
       sha256 = "sha256-PI7buDcjZwzD/RIEFVUW+a18N2nzPnnan4xlxQItixo=";
     };
-    buildInputs = [ 
+    buildInputs = [
       ModuleBuildTiny
       PPI
-      ];
-      propagatedBuildInputs = [
-        commonsense
-      ];
-      meta = {
-        description = "Perl::Strip - reduce file size by stripping whitespace, comments, pod etc";
-        mainProgram = "perlstrip";
-      };
-    
+    ];
+    propagatedBuildInputs = [
+      commonsense
+    ];
+    meta = {
+      description = "Perl::Strip - reduce file size by stripping whitespace, comments, pod etc";
+      mainProgram = "perlstrip";
+    };
   };
 
   PerlVersion = buildPerlPackage {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1175,6 +1175,33 @@ with self;
     };
   };
 
+  AppFatPackerSimple = buildPerlModule {
+      pname = "App-FatPacker-Simple";
+      version = "0.20";
+      src = pkgs.fetchurl {
+        url = "mirror://cpan/authors/id/S/SK/SKAJI/${pname}-${version}.tar.gz";
+        sha256 = "sha256-nkSy/gno2PxT5aA3UWCRK0Dnn9fIdcCOtQvoGUZocSo=";
+      };
+      buildInputs = [ 
+        JSON
+        ModuleBuildTiny
+        pkgs.gnumake
+        ClonePP
+        PPI
+        TestLeakTrace
+      ];
+      propagatedBuildInputs = [
+        AppFatPacker
+        YAMLPP
+        JSONPP
+        Mouse
+        MouseXTypes
+        MouseXGetopt
+        DistributionMetadata
+      ];
+    };
+  };
+
   Appcpanminus = buildPerlPackage {
     pname = "App-cpanminus";
     version = "1.7047";
@@ -10959,7 +10986,7 @@ with self;
     };
   };
 
-  DistributionMetadata = basePerlPackages.buildPerlModule rec {
+  DistributionMetadata = buildPerlModule {
     pname = "Distribution-Metadata";
     version = "0.10";
     src = pkgs.fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10959,6 +10959,30 @@ with self;
     };
   };
 
+  DistributionMetadata = basePerlPackages.buildPerlModule rec {
+    pname = "Distribution-Metadata";
+    version = "0.10";
+    src = pkgs.fetchurl {
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/${pname}-${version}.tar.gz";
+      sha256 = "sha256-uynMfh26OQphJnYfB9BwQ27fqinrjpBwMCOwXzET6nE=";  
+    };
+    buildInputs = [ 
+      ModuleBuildTiny
+    ];
+    propagatedBuildInputs = [
+      CPANDistnameInfo
+      JSON
+      PerlStrip
+    ];
+    meta = {
+      description = "Distribution::Metadata - gather distribution metadata in local";
+      homepage = "https://metacpan.org/pod/Distribution::Metadata";
+      license = with lib.licenses; [
+        perl_5
+      ];
+    };
+  };
+
   DistZilla = buildPerlPackage {
     pname = "Dist-Zilla";
     version = "6.030";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11004,9 +11004,6 @@ with self;
     meta = {
       description = "Distribution::Metadata - gather distribution metadata in local";
       homepage = "https://metacpan.org/pod/Distribution::Metadata";
-      # license = with lib.licenses; [
-      #   perl5
-      # ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1201,7 +1201,6 @@ with self;
     ];
   };
 
-
   Appcpanminus = buildPerlPackage {
     pname = "App-cpanminus";
     version = "1.7047";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29068,6 +29068,27 @@ with self;
     };
   };
 
+  PerlStrip = buildPerlPackage {
+    pname = "Perl-Strip";
+    version = "1.2";
+    src = pkgs.fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${pname}-${version}.tar.gz";
+      sha256 = "sha256-PI7buDcjZwzD/RIEFVUW+a18N2nzPnnan4xlxQItixo=";
+    };
+    buildInputs = [ 
+      ModuleBuildTiny
+      PPI
+      ];
+      propagatedBuildInputs = [
+        commonsense
+      ];
+      meta = {
+        description = "Perl::Strip - reduce file size by stripping whitespace, comments, pod etc";
+        mainProgram = "perlstrip";
+      };
+    
+  };
+
   PerlVersion = buildPerlPackage {
     pname = "Perl-Version";
     version = "1.013";


### PR DESCRIPTION
Adding the perl module AppFatPackerSimple and the dependencies it needs. Adding it because it's much easier to use than FatPacker. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- AppFatPackerSimple page - https://metacpan.org/dist/App-FatPacker-Simple/view/script/fatpack-simple
- DistributionMetadata page - https://metacpan.org/pod/Distribution::Metadata
- PerlStrip page - https://metacpan.org/pod/Perl::Strip

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
