### PR TITLE
ocamlPackages.tuntap: 2.0.0 → 2.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/tuntap/default.nix
+++ b/pkgs/development/ocaml-modules/tuntap/default.nix
@@ -4,26 +4,20 @@
   fetchurl,
   ipaddr,
   macaddr,
-  cmdliner,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "tuntap";
-  version = "2.0.0";
-
-  duneVersion = "3";
-
-  minimalOCamlVersion = "4.04.2";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-tuntap/releases/download/v${version}/tuntap-v${version}.tbz";
-    sha256 = "12wmls28h3jzikwyfw08d5f7ycsc9njwzbhd3qk2l8jnf5rakfsa";
+    url = "https://github.com/mirage/ocaml-tuntap/releases/download/v${finalAttrs.version}/tuntap-${finalAttrs.version}.tbz";
+    hash = "sha256-J8YBl8w7xFloDqt/Xiz03KCIls5BR72VT8X/LYZMDN0=";
   };
 
   propagatedBuildInputs = [
     ipaddr
     macaddr
-    cmdliner
   ];
 
   # tests manipulate network devices and use network
@@ -34,6 +28,5 @@ buildDunePackage rec {
     description = "Bindings to the UNIX tuntap facility";
     homepage = "https://github.com/mirage/ocaml-tuntap";
     license = lib.licenses.isc;
-    mainProgram = "otunctl";
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
