### PR TITLE
libsForQt5.soqt: 2020-12-05-unstable -> 1.6.4; migrate to qt6 and pkgs/by-name

### DIFF
--- a/pkgs/by-name/so/soqt/package.nix
+++ b/pkgs/by-name/so/soqt/package.nix
@@ -4,9 +4,9 @@
   fetchFromGitHub,
   cmake,
   coin3d,
-  qtbase,
+  qt6,
   testers,
-  wrapQtAppsHook,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,17 +27,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [
     coin3d
-    qtbase
+    qt6.qtbase
   ];
 
   dontWrapQtApps = true;
 
-  passthru.tests = {
-    cmake-config = testers.hasCmakeConfigModules {
-      moduleNames = [ "soqt" ];
-      package = finalAttrs.finalPackage;
-      nativeBuildInputs = [ wrapQtAppsHook ];
+  passthru = {
+    tests = {
+      cmake-config = testers.hasCmakeConfigModules {
+        moduleNames = [ "soqt" ];
+        package = finalAttrs.finalPackage;
+        nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+      };
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/development/libraries/soqt/default.nix
+++ b/pkgs/development/libraries/soqt/default.nix
@@ -1,43 +1,50 @@
 {
-  fetchFromGitHub,
   lib,
   stdenv,
+  fetchFromGitHub,
+  cmake,
   coin3d,
   qtbase,
-  cmake,
-  pkg-config,
+  testers,
+  wrapQtAppsHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "soqt";
-  version = "2020-12-05-unstable";
+  version = "1.6.4";
 
   src = fetchFromGitHub {
     owner = "coin3d";
     repo = "soqt";
-    # rev = "SoQt-${version}";
-    rev = "fb8f655632bb9c9c60e0ff9fa69a5ba22d3ff99d";
-    hash = "sha256-YoBq8P3Tag2Sepqxf/qIcJDBhH/gladBmDUj78aacZs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H904mFfrELjB6ZVhypaKJd+pu5y+aVV4foryrsN7IqE=";
     fetchSubmodules = true;
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
     coin3d
     qtbase
   ];
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-  ];
-
   dontWrapQtApps = true;
 
-  meta = with lib; {
-    homepage = "https://github.com/coin3d/soqt";
-    license = licenses.bsd3;
-    description = "Glue between Coin high-level 3D visualization library and Qt";
-    maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+  passthru.tests = {
+    cmake-config = testers.hasCmakeConfigModules {
+      moduleNames = [ "soqt" ];
+      package = finalAttrs.finalPackage;
+      nativeBuildInputs = [ wrapQtAppsHook ];
+    };
   };
-}
+
+  meta = {
+    homepage = "https://github.com/coin3d/soqt";
+    license = lib.licenses.bsd3;
+    description = "Glue between Coin high-level 3D visualization library and Qt";
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -2,7 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
+  python,
+  pythonRecompileBytecodeHook,
   swig,
   cmake,
   coin3d,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "pivy";
   version = "0.6.10";
-  pyproject = true;
+  format = "other";
 
   src = fetchFromGitHub {
     owner = "coin3d";
@@ -22,26 +23,21 @@ buildPythonPackage rec {
     hash = "sha256-DRA4NTAHg2iB/D1CU9pJEpsZwX9GW3X5gpxbIwP54Ko=";
   };
 
-  # https://github.com/coin3d/pivy/pull/138
-  # FindThreads only works if either C or CXX language is enabled
-  postPatch = ''
-    substituteInPlace distutils_cmake/CMakeLists.txt \
-      --replace-fail 'project(pivy_cmake_setup NONE)' 'project(pivy_cmake_setup CXX)'
-  '';
-
-  build-system = [ setuptools ];
-
-  dontUseCmakeConfigure = true;
-
   nativeBuildInputs = [
     swig
     cmake
+    pythonRecompileBytecodeHook
   ];
 
   buildInputs = [
     coin3d
     soqt
     libGLU # dummy buildInput that provides missing header <GL/glu.h>
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "PIVY_USE_QT6" true)
+    (lib.cmakeFeature "PIVY_Python_SITEARCH" "${placeholder "out"}/${python.sitePackages}")
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11849,7 +11849,6 @@ self: super: with self; {
   piqp = callPackage ../development/python-modules/piqp { };
 
   pivy = callPackage ../development/python-modules/pivy {
-    inherit (pkgs.qt5) qtbase qmake;
     inherit (pkgs.libsForQt5) soqt;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11848,9 +11848,7 @@ self: super: with self; {
 
   piqp = callPackage ../development/python-modules/piqp { };
 
-  pivy = callPackage ../development/python-modules/pivy {
-    inherit (pkgs.libsForQt5) soqt;
-  };
+  pivy = callPackage ../development/python-modules/pivy { };
 
   pixcat = callPackage ../development/python-modules/pixcat { };
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -215,8 +215,6 @@ makeScopeWithSplicing' {
           callPackage ../development/libraries/sailfish-access-control-plugin
             { };
 
-        soqt = callPackage ../development/libraries/soqt { };
-
         telepathy = callPackage ../development/libraries/telepathy/qt { };
 
         qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };


### PR DESCRIPTION
The upgrade of soqt fix cmake v4 configuration error on staging-next branch.

cc @LordGrimmauld since you are the maintainer of FreeCAD depend on soqt/pivy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
