### PR TITLE
zsh: make AGPL dependency configurable

### DIFF
--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -14,6 +14,7 @@
   buildPackages,
   nixosTests,
 
+  # Yodl provides the conversion to troff man pages and to TeXinfo
   enableYodl ? true,
   yodl,
 }:

--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -4,7 +4,6 @@
   fetchurl,
   fetchpatch,
   autoreconfHook,
-  yodl,
   perl,
   groff,
   util-linux,
@@ -14,6 +13,9 @@
   pkg-config,
   buildPackages,
   nixosTests,
+
+  enableYodl ? true,
+  yodl,
 }:
 
 let
@@ -87,6 +89,8 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     util-linux
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && enableYodl) [
     yodl
   ];
 


### PR DESCRIPTION
yodl just recently switched the license to AGPL, users may want to exclude any AGPL software during evaluation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
