### PR TITLE
haskell.compiler.ghc{948,967,984,9101,9121,9122}: fix build with gcc15

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -261,6 +261,22 @@
           hash = "sha256-L3FQvcm9QB59BOiR2g5/HACAufIG08HiT53EIOjj64g=";
         })
       ]
+      # Fix build with gcc15
+      # https://gitlab.haskell.org/ghc/ghc/-/issues/25662
+      # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13863
+      ++
+        lib.optionals
+          (
+            lib.versionOlder version "9.12.3"
+            && !(lib.versionAtLeast version "9.10.2" && lib.versionOlder version "9.12")
+          )
+          [
+            (fetchpatch {
+              name = "ghc-hp2ps-c-gnu17.patch";
+              url = "https://src.fedoraproject.org/rpms/ghc/raw/9c26d7c3c3de73509a25806e5663b37bcf2e0b4e/f/hp2ps-C-gnu17.patch";
+              hash = "sha256-Vr5wkiSE1S5e+cJ8pWUvG9KFpxtmvQ8wAy08ElGNp5E=";
+            })
+          ]
       # Fixes stack overrun in rts which crashes an process whenever
       # freeHaskellFunPtr is called with nixpkgs' hardening flags.
       # https://gitlab.haskell.org/ghc/ghc/-/issues/25485

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -345,6 +345,17 @@ stdenv.mkDerivation (
       })
     ]
 
+    # Fix build with gcc15
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/25662
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13863
+    ++ lib.optionals (lib.versions.majorMinor version == "9.4") [
+      (fetchpatch {
+        name = "ghc-hp2ps-c-gnu17.patch";
+        url = "https://src.fedoraproject.org/rpms/ghc/raw/9c26d7c3c3de73509a25806e5663b37bcf2e0b4e/f/hp2ps-C-gnu17.patch";
+        hash = "sha256-Vr5wkiSE1S5e+cJ8pWUvG9KFpxtmvQ8wAy08ElGNp5E=";
+      })
+    ]
+
     ++ [
       # Don't generate code that doesn't compile when --enable-relocatable is passed to Setup.hs
       # Can be removed if the Cabal library included with ghc backports the linked fix


### PR DESCRIPTION
- add patch from fedora (rebase of latest fix from upstream):
https://gitlab.haskell.org/ghc/ghc/-/issues/25662
https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13863

ghc versions excluded from patch:
9.10.2 - has previous fix with `extern void* malloc(size_t);`
9.10.3 - has latest fix with `#include <stdlib.h>`
9.12.3 - has latest fix with `#include <stdlib.h>`

Fixes build failure with gcc15, building utils/hp2ps/Utilities.c:
```
utils/hp2ps/Utilities.c:6:14: error:
warning: conflicting types for built-in function ‘malloc’;
expected ‘void *(long unsigned int)’ [-Wbuiltin-declaration-mismatch]
        6 | extern void* malloc();
          |              ^~~~~~
...
utils/hp2ps/Utilities.c:92:18: error:
warning: conflicting types for built-in function ‘realloc’;
expected ‘void *(void *, long unsigned int)’ [-Wbuiltin-declaration-mismatch]
       92 |     extern void *realloc();
          |                  ^~~~~~~
```

---

Tested with:
```bash
nix-build --expr 'with import ./. {}; let hc = haskell.compiler; in lib.mapAttrs (name: value: value.override { stdenv = gcc15Stdenv; }) (lib.filterAttrs (n: v: (builtins.tryEval v).success && lib.isDerivation v) hc)'
nix-build --expr 'with import ./. {}; let hc = haskell.compiler.native-bignum; in lib.mapAttrs (name: value: value.override { stdenv = gcc15Stdenv; }) (lib.filterAttrs (n: v: (builtins.tryEval v).success && lib.isDerivation v) hc)'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

---

Patch from fedora (rebase) is needed, because of previous fix attempts on same lines:
https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13838
https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13853
https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13863
Could not find patch from "no fix" to "third fix" anywhere upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
