### PR TITLE
libomemo-c: 0.5.0 -> 0.5.1; build with meson

### DIFF
--- a/pkgs/by-name/li/libomemo-c/package.nix
+++ b/pkgs/by-name/li/libomemo-c/package.nix
@@ -2,24 +2,39 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  cmake,
+  meson,
+  ninja,
+  pkg-config,
   openssl,
+  protobuf_25,
+  protobufc,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libomemo-c";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "dino";
     repo = "libomemo-c";
     rev = "v${version}";
-    hash = "sha256-GvHMp0FWoApbYLMhKfNxSBel1xxWWF3TZ4lnkLvu2s4=";
+    hash = "sha256-HoZykdGVDsj4L5yN3SHGF5tjMq5exJyC15zTLBlpX/c=";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildsInputs = [ openssl ];
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    protobuf_25
+    protobufc
+  ];
+  buildInputs = [
+    openssl
+    protobufc
+  ];
+  mesonFlags = [
+    "-Dtests=false"
+  ];
 
   meta = with lib; {
     description = "Fork of libsignal-protocol-c adding support for OMEMO XEP-0384 0.5.0+";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

As side effects, this:

- removes a nasty typo: buildsInputs -> buildInputs, which took me several hours to figure out
- Fixes the build on staging-next (which is currently broken because of cmake 4)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
