### PR TITLE
nixos: remove optional builtins prefixes from prelude functions

### DIFF
--- a/nixos/lib/eval-config-minimal.nix
+++ b/nixos/lib/eval-config-minimal.nix
@@ -39,7 +39,7 @@ let
       inherit prefix modules;
       class = "nixos";
       specialArgs = {
-        modulesPath = builtins.toString ../modules;
+        modulesPath = toString ../modules;
       }
       // specialArgs;
     };

--- a/nixos/lib/make-btrfs-fs.nix
+++ b/nixos/lib/make-btrfs-fs.nix
@@ -65,7 +65,7 @@ pkgs.stdenv.mkDerivation {
       return 1
     fi
 
-    if [ ${builtins.toString compressImage} ]; then
+    if [ ${toString compressImage} ]; then
       echo "Compressing image"
       zstd -v --no-progress ./$img -o $out
     fi

--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -101,7 +101,7 @@ pkgs.stdenv.mkDerivation {
 
     resize2fs $img $new_size
 
-    if [ ${builtins.toString compressImage} ]; then
+    if [ ${toString compressImage} ]; then
       echo "Compressing image"
       zstd -T$NIX_BUILD_CORES -v --no-progress ./$img -o $out
     fi

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -138,7 +138,7 @@ rec {
   toIntBaseDetected =
     value:
     assert (match "[0-9]+|0x[0-9a-fA-F]+" value) != null;
-    (builtins.fromTOML "v=${value}").v;
+    (fromTOML "v=${value}").v;
 
   hexChars = stringToCharacters "0123456789abcdefABCDEF";
 

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -67,8 +67,8 @@ let
         ${lib.optionalString (!config.skipTypeCheck) ''
           # prepend type hints so the test script can be type checked with mypy
           cat "${../test-script-prepend.py}" >> testScriptWithTypes
-          echo "${builtins.toString machineNames}" >> testScriptWithTypes
-          echo "${builtins.toString vlanNames}" >> testScriptWithTypes
+          echo "${toString machineNames}" >> testScriptWithTypes
+          echo "${toString vlanNames}" >> testScriptWithTypes
           echo -n "$testScript" >> testScriptWithTypes
 
           echo "Running type check (enable/disable: config.skipTypeCheck)"

--- a/nixos/modules/config/fanout.nix
+++ b/nixos/modules/config/fanout.nix
@@ -8,7 +8,7 @@ let
   cfg = config.services.fanout;
   mknodCmds =
     n:
-    lib.lists.imap0 (i: s: "mknod /dev/fanout${builtins.toString i} c $MAJOR ${builtins.toString i}") (
+    lib.lists.imap0 (i: s: "mknod /dev/fanout${toString i} c $MAJOR ${toString i}") (
       lib.lists.replicate n ""
     );
 in
@@ -33,7 +33,7 @@ in
     boot.kernelModules = [ "fanout" ];
 
     boot.extraModprobeConfig = ''
-      options fanout buffersize=${builtins.toString cfg.bufferSize}
+      options fanout buffersize=${toString cfg.bufferSize}
     '';
 
     systemd.services.fanout = {

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -16,7 +16,7 @@ let
     (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
     (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
   ]
-  ++ (builtins.map sanitizeUTF8Capitalization (
+  ++ (map sanitizeUTF8Capitalization (
     lib.optionals (builtins.isList config.i18n.extraLocales) config.i18n.extraLocales
   ))
   ++ (lib.optional (builtins.isString config.i18n.extraLocales) config.i18n.extraLocales);

--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -126,7 +126,7 @@ in
     services.zram-generator.enable = true;
 
     services.zram-generator.settings = lib.listToAttrs (
-      builtins.map (dev: {
+      map (dev: {
         name = dev;
         value =
           let

--- a/nixos/modules/hardware/ckb-next.nix
+++ b/nixos/modules/hardware/ckb-next.nix
@@ -37,7 +37,7 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/ckb-next-daemon ${
-          lib.optionalString (cfg.gid != null) "--gid=${builtins.toString cfg.gid}"
+          lib.optionalString (cfg.gid != null) "--gid=${toString cfg.gid}"
         }";
         Restart = "on-failure";
       };

--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -22,8 +22,8 @@ let
       sync_effects_enabled = ${toPyBoolStr cfg.syncEffectsEnabled}
       devices_off_on_screensaver = ${toPyBoolStr cfg.devicesOffOnScreensaver}
       battery_notifier = ${toPyBoolStr cfg.batteryNotifier.enable}
-      battery_notifier_freq = ${builtins.toString cfg.batteryNotifier.frequency}
-      battery_notifier_percent = ${builtins.toString cfg.batteryNotifier.percentage}
+      battery_notifier_freq = ${toString cfg.batteryNotifier.frequency}
+      battery_notifier_percent = ${toString cfg.batteryNotifier.percentage}
 
       [Statistics]
       key_statistics = ${toPyBoolStr cfg.keyStatistics}

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -174,7 +174,7 @@ let
 
   baseIsolinuxCfg = ''
     SERIAL 0 115200
-    TIMEOUT ${builtins.toString syslinuxTimeout}
+    TIMEOUT ${toString syslinuxTimeout}
     UI vesamenu.c32
     MENU BACKGROUND /isolinux/background.png
 

--- a/nixos/modules/misc/mandoc.nix
+++ b/nixos/modules/misc/mandoc.nix
@@ -17,7 +17,7 @@ let
       if lib.isString value || lib.isPath value then
         "output ${name} ${value}"
       else if lib.isInt value then
-        "output ${name} ${builtins.toString value}"
+        "output ${name} ${toString value}"
       else if lib.isBool value then
         lib.optionalString value "output ${name}"
       else if value == null then

--- a/nixos/modules/misc/nixpkgs-flake.nix
+++ b/nixos/modules/misc/nixpkgs-flake.nix
@@ -21,7 +21,7 @@ in
       default = null;
       defaultText = "if (using nixpkgsFlake.lib.nixosSystem) then self.outPath else null";
 
-      example = ''builtins.fetchTarball { name = "source"; sha256 = "${lib.fakeHash}"; url = "https://github.com/nixos/nixpkgs/archive/somecommit.tar.gz"; }'';
+      example = ''fetchTarball { name = "source"; sha256 = "${lib.fakeHash}"; url = "https://github.com/nixos/nixpkgs/archive/somecommit.tar.gz"; }'';
 
       description = ''
         The path to the nixpkgs sources used to build the system. This is automatically set up to be
@@ -30,7 +30,7 @@ in
 
         This can also be optionally set if the NixOS system is not built with a flake but still uses
         pinned sources: set this to the store path for the nixpkgs sources used to build the system,
-        as may be obtained by `builtins.fetchTarball`, for example.
+        as may be obtained by `fetchTarball`, for example.
 
         Note: the name of the store path must be "source" due to
         <https://github.com/NixOS/nix/issues/7075>.

--- a/nixos/modules/programs/atop.nix
+++ b/nixos/modules/programs/atop.nix
@@ -107,7 +107,7 @@ in
       environment.etc = lib.mkIf (cfg.settings != { }) {
         atoprc.text = lib.concatStrings (
           lib.mapAttrsToList (n: v: ''
-            ${n} ${builtins.toString v}
+            ${n} ${toString v}
           '') cfg.settings
         );
       };

--- a/nixos/modules/programs/bash/undistract-me.nix
+++ b/nixos/modules/programs/bash/undistract-me.nix
@@ -27,7 +27,7 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.bash.promptPluginInit = ''
-      export LONG_RUNNING_COMMAND_TIMEOUT=${builtins.toString cfg.timeout}
+      export LONG_RUNNING_COMMAND_TIMEOUT=${toString cfg.timeout}
       export UDM_PLAY_SOUND=${if cfg.playSound then "1" else "0"}
       . "${pkgs.undistract-me}/etc/profile.d/undistract-me.sh"
     '';

--- a/nixos/modules/programs/benchexec.nix
+++ b/nixos/modules/programs/benchexec.nix
@@ -71,7 +71,7 @@ in
     # See <https://github.com/sosy-lab/benchexec/blob/3.18/doc/INSTALL.md#setting-up-cgroups>.
     systemd.services = builtins.listToAttrs (
       map (user: {
-        name = "user@${builtins.toString (uid user)}";
+        name = "user@${toString (uid user)}";
         value = {
           serviceConfig.Delegate = "yes";
           overrideStrategy = "asDropin";

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -305,7 +305,7 @@ in
           }) cfg.preferences
         );
         ExtensionSettings = builtins.listToAttrs (
-          builtins.map (
+          map (
             lang:
             lib.attrsets.nameValuePair "langpack-${lang}@firefox.mozilla.org" {
               installation_mode = "normal_installed";

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -34,14 +34,13 @@ let
                     extraArgs = [ ];
                   };
               args = lib.escapeShellArgs (
-                opts.extraArgs
-                ++ (lib.optional (opts.profile != null) "--profile=${builtins.toString opts.profile}")
+                opts.extraArgs ++ (lib.optional (opts.profile != null) "--profile=${toString opts.profile}")
               );
             in
             ''
               cat <<_EOF >$out/bin/${command}
               #! ${pkgs.runtimeShell} -e
-              exec /run/wrappers/bin/firejail ${args} -- ${builtins.toString opts.executable} "\$@"
+              exec /run/wrappers/bin/firejail ${args} -- ${toString opts.executable} "\$@"
               _EOF
               chmod 0755 $out/bin/${command}
 

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -295,7 +295,7 @@ in
           pkgs.buildEnv {
             name = "system_fish-completions";
             ignoreCollisions = true;
-            paths = builtins.map generateCompletions config.environment.systemPackages;
+            paths = map generateCompletions config.environment.systemPackages;
           };
       })
 

--- a/nixos/modules/programs/fuse.nix
+++ b/nixos/modules/programs/fuse.nix
@@ -58,7 +58,7 @@ in
 
     environment.etc."fuse.conf".text = ''
       ${lib.optionalString (!cfg.userAllowOther) "#"}user_allow_other
-      mount_max = ${builtins.toString cfg.mountMax}
+      mount_max = ${toString cfg.mountMax}
     '';
 
   };

--- a/nixos/modules/programs/gamescope.nix
+++ b/nixos/modules/programs/gamescope.nix
@@ -10,13 +10,13 @@ let
   gamescope =
     let
       wrapperArgs =
-        lib.optional (cfg.args != [ ]) ''--add-flags "${builtins.toString cfg.args}"''
+        lib.optional (cfg.args != [ ]) ''--add-flags "${toString cfg.args}"''
         ++ builtins.attrValues (builtins.mapAttrs (var: val: "--set-default ${var} ${val}") cfg.env);
     in
     pkgs.runCommand "gamescope" { nativeBuildInputs = [ pkgs.makeBinaryWrapper ]; } ''
       mkdir -p $out/bin
       makeWrapper ${cfg.package}/bin/gamescope $out/bin/gamescope --inherit-argv0 \
-        ${builtins.toString wrapperArgs}
+        ${toString wrapperArgs}
       ln -s ${cfg.package}/bin/gamescopectl $out/bin/gamescopectl
     '';
 in

--- a/nixos/modules/programs/htop.nix
+++ b/nixos/modules/programs/htop.nix
@@ -12,13 +12,13 @@ let
   fmt =
     value:
     if builtins.isList value then
-      builtins.concatStringsSep " " (builtins.map fmt value)
+      builtins.concatStringsSep " " (map fmt value)
     else if builtins.isString value then
       value
     else if builtins.isBool value then
       if value then "1" else "0"
     else if builtins.isInt value then
-      builtins.toString value
+      toString value
     else
       throw "Unrecognized type ${builtins.typeOf value} in htop settings";
 

--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -124,7 +124,7 @@ in
     environment.systemPackages = [ cfg.package ];
 
     environment.variables = {
-      LESSKEYIN_SYSTEM = builtins.toString lessKey;
+      LESSKEYIN_SYSTEM = toString lessKey;
     }
     // lib.optionalAttrs (cfg.lessopen != null) {
       LESSOPEN = cfg.lessopen;

--- a/nixos/modules/programs/liboping.nix
+++ b/nixos/modules/programs/liboping.nix
@@ -15,7 +15,7 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [ liboping ];
     security.wrappers = lib.mkMerge (
-      builtins.map
+      map
         (exec: {
           "${exec}" = {
             owner = "root";

--- a/nixos/modules/programs/light.nix
+++ b/nixos/modules/programs/light.nix
@@ -71,8 +71,8 @@ in
       bindings =
         let
           light = "${pkgs.light}/bin/light";
-          step = builtins.toString cfg.brightnessKeys.step;
-          minBrightness = builtins.toString cfg.brightnessKeys.minBrightness;
+          step = toString cfg.brightnessKeys.step;
+          minBrightness = toString cfg.brightnessKeys.minBrightness;
         in
         [
           {

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -171,12 +171,12 @@ in
       builtins.attrValues (
         builtins.mapAttrs (name: value: {
           name = "xdg/nvim/${name}";
-          value = builtins.removeAttrs (
+          value = removeAttrs (
             value
             // {
               target = "xdg/nvim/${value.target}";
             }
-          ) (lib.optionals (builtins.isNull value.source) [ "source" ]);
+          ) (lib.optionals (isNull value.source) [ "source" ]);
         }) cfg.runtime
       )
     );

--- a/nixos/modules/programs/nncp.nix
+++ b/nixos/modules/programs/nncp.nix
@@ -81,7 +81,7 @@ in
       script = ''
         umask 127
         rm -f ${nncpCfgFile}
-        for f in ${jsonCfgFile} ${builtins.toString config.programs.nncp.secrets}
+        for f in ${jsonCfgFile} ${toString config.programs.nncp.secrets}
         do
           ${lib.getExe pkgs.hjson-go} -c <"$f"
         done |${lib.getExe pkgs.jq} --slurp 'reduce .[] as $x ({}; . * $x)' >${nncpCfgFile}

--- a/nixos/modules/programs/proxychains.nix
+++ b/nixos/modules/programs/proxychains.nix
@@ -10,18 +10,16 @@ let
 
   configFile = ''
     ${cfg.chain.type}_chain
-    ${lib.optionalString (
-      cfg.chain.type == "random"
-    ) "chain_len = ${builtins.toString cfg.chain.length}"}
+    ${lib.optionalString (cfg.chain.type == "random") "chain_len = ${toString cfg.chain.length}"}
     ${lib.optionalString cfg.proxyDNS "proxy_dns"}
     ${lib.optionalString cfg.quietMode "quiet_mode"}
-    remote_dns_subnet ${builtins.toString cfg.remoteDNSSubnet}
-    tcp_read_time_out ${builtins.toString cfg.tcpReadTimeOut}
-    tcp_connect_time_out ${builtins.toString cfg.tcpConnectTimeOut}
+    remote_dns_subnet ${toString cfg.remoteDNSSubnet}
+    tcp_read_time_out ${toString cfg.tcpReadTimeOut}
+    tcp_connect_time_out ${toString cfg.tcpConnectTimeOut}
     localnet ${cfg.localnet}
     [ProxyList]
     ${builtins.concatStringsSep "\n" (
-      lib.mapAttrsToList (k: v: "${v.type} ${v.host} ${builtins.toString v.port}") (
+      lib.mapAttrsToList (k: v: "${v.type} ${v.host} ${toString v.port}") (
         lib.filterAttrs (k: v: v.enable) cfg.proxies
       )
     )}

--- a/nixos/modules/programs/spacefm.nix
+++ b/nixos/modules/programs/spacefm.nix
@@ -54,7 +54,7 @@ in
     environment.systemPackages = [ pkgs.spaceFM ];
 
     environment.etc."spacefm/spacefm.conf".text = lib.concatStrings (
-      lib.mapAttrsToList (n: v: "${n}=${builtins.toString v}\n") cfg.settings
+      lib.mapAttrsToList (n: v: "${n}=${toString v}\n") cfg.settings
     );
   };
 }

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -33,7 +33,7 @@ let
   knownHostsFiles = [
     "/etc/ssh/ssh_known_hosts"
   ]
-  ++ builtins.map pkgs.copyPathToStore cfg.knownHostsFiles;
+  ++ map pkgs.copyPathToStore cfg.knownHostsFiles;
 
 in
 {

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -19,7 +19,7 @@ let
     in
     pkgs.writeShellScriptBin "steam-gamescope" ''
       ${builtins.concatStringsSep "\n" exports}
-      gamescope --steam ${builtins.toString cfg.gamescopeSession.args} -- steam ${builtins.toString cfg.gamescopeSession.steamArgs}
+      gamescope --steam ${toString cfg.gamescopeSession.args} -- steam ${toString cfg.gamescopeSession.steamArgs}
     '';
 
   gamescopeSessionFile =

--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -286,7 +286,7 @@ let
               ""
             # just output key if value is `true`
             else if isInt value then
-              "  ${builtins.toString value}"
+              "  ${toString value}"
             else if path.check value then
               "  \"${value}\""
             # enclose path in ".."

--- a/nixos/modules/programs/xfs_quota.nix
+++ b/nixos/modules/programs/xfs_quota.nix
@@ -85,13 +85,13 @@ in
 
     environment.etc.projects.source = pkgs.writeText "etc-project" (
       builtins.concatStringsSep "\n" (
-        lib.mapAttrsToList (name: opts: "${builtins.toString opts.id}:${opts.path}") cfg.projects
+        lib.mapAttrsToList (name: opts: "${toString opts.id}:${opts.path}") cfg.projects
       )
     );
 
     environment.etc.projid.source = pkgs.writeText "etc-projid" (
       builtins.concatStringsSep "\n" (
-        lib.mapAttrsToList (name: opts: "${name}:${builtins.toString opts.id}") cfg.projects
+        lib.mapAttrsToList (name: opts: "${name}:${toString opts.id}") cfg.projects
       )
     );
 

--- a/nixos/modules/programs/xss-lock.nix
+++ b/nixos/modules/programs/xss-lock.nix
@@ -41,7 +41,7 @@ in
           "${pkgs.xss-lock}/bin/xss-lock"
           "--session \${XDG_SESSION_ID}"
         ]
-        ++ (builtins.map lib.escapeShellArg cfg.extraOptions)
+        ++ (map lib.escapeShellArg cfg.extraOptions)
         ++ [
           "--"
           cfg.lockerCommand

--- a/nixos/modules/programs/yubikey-touch-detector.nix
+++ b/nixos/modules/programs/yubikey-touch-detector.nix
@@ -49,9 +49,9 @@ in
       path = [ pkgs.gnupg ];
 
       environment = {
-        YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY = builtins.toString cfg.libnotify;
-        YUBIKEY_TOUCH_DETECTOR_NOSOCKET = builtins.toString (!cfg.unixSocket);
-        YUBIKEY_TOUCH_DETECTOR_VERBOSE = builtins.toString cfg.verbose;
+        YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY = toString cfg.libnotify;
+        YUBIKEY_TOUCH_DETECTOR_NOSOCKET = toString (!cfg.unixSocket);
+        YUBIKEY_TOUCH_DETECTOR_VERBOSE = toString cfg.verbose;
       };
 
       wantedBy = [ "graphical-session.target" ];

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -254,8 +254,8 @@ in
 
       # Setup command line history.
       # Don't export these, otherwise other shells (bash) will try to use same HISTFILE.
-      SAVEHIST=${builtins.toString cfg.histSize}
-      HISTSIZE=${builtins.toString cfg.histSize}
+      SAVEHIST=${toString cfg.histSize}
+      HISTSIZE=${toString cfg.histSize}
       HISTFILE=${cfg.histFile}
 
       # Configure sane keyboard defaults.

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -302,7 +302,7 @@ let
       # We need to collect all the ACME webroots to grant them write
       # access in the systemd service.
       webroots = lib.remove null (
-        lib.unique (builtins.map (certAttrs: certAttrs.webroot) (lib.attrValues config.security.acme.certs))
+        lib.unique (map (certAttrs: certAttrs.webroot) (lib.attrValues config.security.acme.certs))
       );
 
       certificateKey = if data.csrKey != null then "${data.csrKey}" else "certificates/${keyName}.key";

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -90,7 +90,7 @@ let
     else if lib.isList v then
       lib.concatStringsSep " " (map prepareConfigValue v)
     else
-      builtins.toString v;
+      toString v;
   prepareConfigText =
     conf:
     lib.concatLines (

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -168,7 +168,7 @@ let
       chmod "u${if setuid then "+" else "-"}s,g${if setgid then "+" else "-"}s,${permissions}" "$wrapperDir/${program}"
     '';
 
-  mkWrappedPrograms = builtins.map (
+  mkWrappedPrograms = map (
     opts: if opts.capabilities != "" then mkSetcapProgram opts else mkSetuidProgram opts
   ) (lib.attrValues wrappers);
 in

--- a/nixos/modules/services/audio/lavalink.nix
+++ b/nixos/modules/services/audio/lavalink.nix
@@ -237,9 +237,9 @@ in
       );
 
       pluginExtraConfigs = builtins.listToAttrs (
-        builtins.map (
-          pluginConfig: lib.attrsets.nameValuePair pluginConfig.configName pluginConfig.extraConfig
-        ) (lib.lists.filter (pluginCfg: pluginCfg.configName != null) cfg.plugins)
+        map (pluginConfig: lib.attrsets.nameValuePair pluginConfig.configName pluginConfig.extraConfig) (
+          lib.lists.filter (pluginCfg: pluginCfg.configName != null) cfg.plugins
+        )
       );
 
       config = lib.attrsets.recursiveUpdate cfg.extraConfig {
@@ -250,9 +250,9 @@ in
 
         plugins = pluginExtraConfigs;
         lavalink.plugins = (
-          builtins.map (
+          map (
             pluginConfig:
-            builtins.removeAttrs pluginConfig [
+            removeAttrs pluginConfig [
               "name"
               "extraConfig"
               "hash"

--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -27,7 +27,7 @@ let
       )
     ) a;
   nonBlockSettings = lib.filterAttrs (n: v: !(builtins.isAttrs v || builtins.isList v)) cfg.settings;
-  pureBlockSettings = builtins.removeAttrs cfg.settings (builtins.attrNames nonBlockSettings);
+  pureBlockSettings = removeAttrs cfg.settings (builtins.attrNames nonBlockSettings);
   blocks =
     pureBlockSettings
     // lib.optionalAttrs cfg.fluidsynth {

--- a/nixos/modules/services/audio/pulseaudio.nix
+++ b/nixos/modules/services/audio/pulseaudio.nix
@@ -282,11 +282,9 @@ in
       (lib.mkIf (cfg.extraModules != [ ]) {
         services.pulseaudio.daemon.config.dl-search-path =
           let
-            overriddenModules = builtins.map (
-              drv: drv.override { pulseaudio = overriddenPackage; }
-            ) cfg.extraModules;
+            overriddenModules = map (drv: drv.override { pulseaudio = overriddenPackage; }) cfg.extraModules;
             modulePaths =
-              builtins.map (drv: "${drv}/lib/pulseaudio/modules")
+              map (drv: "${drv}/lib/pulseaudio/modules")
                 # User-provided extra modules take precedence
                 (overriddenModules ++ [ overriddenPackage ]);
           in

--- a/nixos/modules/services/audio/squeezelite.nix
+++ b/nixos/modules/services/audio/squeezelite.nix
@@ -51,7 +51,7 @@ in
       serviceConfig = {
         DynamicUser = true;
         ExecStart = "${bin} -N ${dataDir}/player-name ${cfg.extraArguments}";
-        StateDirectory = builtins.baseNameOf dataDir;
+        StateDirectory = baseNameOf dataDir;
         SupplementaryGroups = "audio";
       };
     };

--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -50,7 +50,7 @@ let
           (lib.concatStringsSep "," permissions)
           dataset
         ]}
-      ${lib.optionalString ((builtins.dirOf dataset) != ".") ''
+      ${lib.optionalString ((dirOf dataset) != ".") ''
         else
           ${lib.escapeShellArgs [
             "/run/booted-system/sw/bin/zfs"
@@ -58,7 +58,7 @@ let
             cfg.user
             (lib.concatStringsSep "," permissions)
             # Remove the last part of the path
-            (builtins.dirOf dataset)
+            (dirOf dataset)
           ]}
       ''}
       fi
@@ -82,14 +82,14 @@ let
         (lib.concatStringsSep "," permissions)
         dataset
       ]}
-      ${lib.optionalString ((builtins.dirOf dataset) != ".") (
+      ${lib.optionalString ((dirOf dataset) != ".") (
         lib.escapeShellArgs [
           "/run/booted-system/sw/bin/zfs"
           "unallow"
           cfg.user
           (lib.concatStringsSep "," permissions)
           # Remove the last part of the path
-          (builtins.dirOf dataset)
+          (dirOf dataset)
         ]
       )}
     ''}";

--- a/nixos/modules/services/cluster/hadoop/conf.nix
+++ b/nixos/modules/services/cluster/hadoop/conf.nix
@@ -9,7 +9,7 @@ let
     lib.optionalString (value != null) ''
       <property>
         <name>${name}</name>
-        <value>${builtins.toString value}</value>
+        <value>${toString value}</value>
       </property>
     '';
   siteXml =
@@ -22,7 +22,7 @@ let
       </configuration>
     '';
   cfgLine = name: value: ''
-    ${name}=${builtins.toString value}
+    ${name}=${toString value}
   '';
   cfgFile =
     fileName: properties:

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -169,7 +169,7 @@ let
         # source is a store path containing the complete manifest file
         source = mkManifestSource "auto-deploy-chart-${name}" (
           lib.singleton (mkHelmChartCR name value)
-          ++ builtins.map (x: fromYaml (mkExtraDeployManifest x)) value.extraDeploy
+          ++ map (x: fromYaml (mkExtraDeployManifest x)) value.extraDeploy
         );
       };
 
@@ -384,7 +384,7 @@ let
             target = lib.mkDefault (mkManifestTarget name);
             source = lib.mkIf (config.content != null) (
               let
-                name' = "${name}-manifest-" + builtins.baseNameOf name;
+                name' = "${name}-manifest-" + baseNameOf name;
                 mkSource = mkManifestSource name';
               in
               lib.mkDerivedConfig options.content mkSource

--- a/nixos/modules/services/continuous-integration/buildkite-agents.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agents.nix
@@ -213,7 +213,7 @@ in
             tagStr =
               name: value:
               if lib.isList value then
-                lib.concatStringsSep "," (builtins.map (v: "${name}=${v}") value)
+                lib.concatStringsSep "," (map (v: "${name}=${v}") value)
               else
                 "${name}=${value}";
             tagsStr = lib.concatStringsSep "," (lib.mapAttrsToList tagStr cfg.tags);

--- a/nixos/modules/services/continuous-integration/radicle/adapters/native.nix
+++ b/nixos/modules/services/continuous-integration/radicle/adapters/native.nix
@@ -129,7 +129,7 @@ in
     systemd.tmpfiles.settings.radicle-native-ci = lib.listToAttrs (
       map (
         instance:
-        lib.nameValuePair (builtins.dirOf instance.settings.log) {
+        lib.nameValuePair (dirOf instance.settings.log) {
           d = {
             user = config.users.users.radicle.name;
             group = config.users.groups.radicle.name;

--- a/nixos/modules/services/databases/foundationdb.nix
+++ b/nixos/modules/services/databases/foundationdb.nix
@@ -442,7 +442,7 @@ in
             cf=/etc/foundationdb/fdb.cluster
             desc=$(tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null | head -c8)
             rand=$(tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null | head -c8)
-            echo ''${desc}:''${rand}@${initialIpAddr}:${builtins.toString cfg.listenPortStart} > $cf
+            echo ''${desc}:''${rand}@${initialIpAddr}:${toString cfg.listenPortStart} > $cf
             chmod 0664 $cf
             touch "${cfg.dataDir}/.first_startup"
         fi

--- a/nixos/modules/services/databases/hbase-standalone.nix
+++ b/nixos/modules/services/databases/hbase-standalone.nix
@@ -15,7 +15,7 @@ let
       lib.mapAttrsToList (name: value: ''
         <property>
           <name>${name}</name>
-          <value>${builtins.toString value}</value>
+          <value>${toString value}</value>
         </property>
       '') configAttr
     ));

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -52,7 +52,7 @@ let
     else if isString value then
       "'${lib.replaceStrings [ "'" ] [ "''" ] value}'"
     else
-      builtins.toString value;
+      toString value;
 
   # The main PostgreSQL configuration file.
   configFile = pkgs.writeTextDir "postgresql.conf" (
@@ -83,7 +83,7 @@ let
       else if builtins.isString v then
         "${directive} '${v}'"
       else
-        "${directive} ${builtins.toString v}"
+        "${directive} ${toString v}"
     ) user.ensureClauses;
 
   generateAlterRoleSQL =
@@ -882,7 +882,7 @@ in
       };
 
       path = [ cfg.finalPackage ];
-      environment.PGPORT = builtins.toString cfg.settings.port;
+      environment.PGPORT = toString cfg.settings.port;
 
       # Wait for PostgreSQL to be ready to accept connections.
       script = ''

--- a/nixos/modules/services/databases/tigerbeetle.nix
+++ b/nixos/modules/services/databases/tigerbeetle.nix
@@ -91,7 +91,7 @@ in
 
     systemd.services.tigerbeetle =
       let
-        replicaDataPath = "/var/lib/tigerbeetle/${builtins.toString cfg.clusterId}_${builtins.toString cfg.replicaIndex}.tigerbeetle";
+        replicaDataPath = "/var/lib/tigerbeetle/${toString cfg.clusterId}_${toString cfg.replicaIndex}.tigerbeetle";
       in
       {
         description = "TigerBeetle server";
@@ -101,7 +101,7 @@ in
 
         preStart = ''
           if ! test -e "${replicaDataPath}"; then
-            ${lib.getExe cfg.package} format --cluster="${builtins.toString cfg.clusterId}" --replica="${builtins.toString cfg.replicaIndex}" --replica-count="${builtins.toString cfg.replicaCount}" "${replicaDataPath}"
+            ${lib.getExe cfg.package} format --cluster="${toString cfg.clusterId}" --replica="${toString cfg.replicaIndex}" --replica-count="${toString cfg.replicaCount}" "${replicaDataPath}"
           fi
         '';
 

--- a/nixos/modules/services/games/quake3-server.nix
+++ b/nixos/modules/services/games/quake3-server.nix
@@ -16,7 +16,7 @@ let
   cfg = config.services.quake3-server;
 
   configFile = pkgs.writeText "q3ds-extra.cfg" ''
-    set net_port ${builtins.toString cfg.port}
+    set net_port ${toString cfg.port}
 
     ${cfg.extraConfig}
   '';

--- a/nixos/modules/services/games/xonotic.nix
+++ b/nixos/modules/services/games/xonotic.nix
@@ -22,7 +22,7 @@ let
 
           value = (
             if lib.isList option then
-              builtins.concatStringsSep " " (builtins.map (x: toValue x) option)
+              builtins.concatStringsSep " " (map (x: toValue x) option)
             else
               toValue option
           );

--- a/nixos/modules/services/hardware/arsenik.nix
+++ b/nixos/modules/services/hardware/arsenik.nix
@@ -114,9 +114,9 @@ in
         enable = true;
         keyboards.arsenik.config = ''
           (defvar
-            tap_timeout ${builtins.toString cfg.tap_timeout}
-            hold_timeout ${builtins.toString cfg.hold_timeout}
-            long_hold_timeout ${builtins.toString cfg.long_hold_timeout}
+            tap_timeout ${toString cfg.tap_timeout}
+            hold_timeout ${toString cfg.hold_timeout}
+            long_hold_timeout ${toString cfg.long_hold_timeout}
           )
           (include ${src}/defsrc/${defsrc}.kbd)
           (include ${src}/deflayer/${base}.kbd)

--- a/nixos/modules/services/hardware/bitbox-bridge.nix
+++ b/nixos/modules/services/hardware/bitbox-bridge.nix
@@ -56,7 +56,7 @@ in
 
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${cfg.package}/bin/bitbox-bridge -p ${builtins.toString cfg.port}";
+        ExecStart = "${cfg.package}/bin/bitbox-bridge -p ${toString cfg.port}";
         User = "bitbox";
       };
     };

--- a/nixos/modules/services/hardware/display.nix
+++ b/nixos/modules/services/hardware/display.nix
@@ -124,7 +124,7 @@ in
                   builtins.stringLength name <= 12
                 ) "Modeline name must be 12 characters or less" ''Modeline "${name}" ${value}''
               ))
-              (builtins.map (line: "${line}\n"))
+              (map (line: "${line}\n"))
               (lib.strings.concatStringsSep "")
             ];
           };

--- a/nixos/modules/services/hardware/trezord.nix
+++ b/nixos/modules/services/hardware/trezord.nix
@@ -57,7 +57,7 @@ in
       path = [ ];
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${pkgs.trezord}/bin/trezord-go ${lib.optionalString cfg.emulator.enable "-e ${builtins.toString cfg.emulator.port}"}";
+        ExecStart = "${pkgs.trezord}/bin/trezord-go ${lib.optionalString cfg.emulator.enable "-e ${toString cfg.emulator.port}"}";
         User = "trezord";
       };
     };

--- a/nixos/modules/services/logging/promtail.nix
+++ b/nixos/modules/services/logging/promtail.nix
@@ -85,7 +85,7 @@ in
         RestrictSUIDSGID = true;
         PrivateMounts = true;
         CacheDirectory = "promtail";
-        ReadWritePaths = lib.optional allowPositionsFile (builtins.dirOf positionsFile);
+        ReadWritePaths = lib.optional allowPositionsFile (dirOf positionsFile);
 
         User = "promtail";
         Group = "promtail";

--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -74,7 +74,7 @@ in
         {
           ExecStart = "${lib.getExe cfg.package} --config ${
             if cfg.validateConfig then (validatedConfig conf) else conf
-          }  --graceful-shutdown-limit-secs ${builtins.toString cfg.gracefulShutdownLimitSecs}";
+          }  --graceful-shutdown-limit-secs ${toString cfg.gracefulShutdownLimitSecs}";
           DynamicUser = true;
           Restart = "always";
           StateDirectory = "vector";

--- a/nixos/modules/services/mail/cyrus-imap.nix
+++ b/nixos/modules/services/mail/cyrus-imap.nix
@@ -39,7 +39,7 @@ let
           p: q:
           if (q != null) then
             if builtins.isInt q then
-              "${p}=${builtins.toString q}"
+              "${p}=${toString q}"
             else
               "${p}=\"${if builtins.isList q then (concatStringsSep " " q) else q}\""
           else
@@ -336,7 +336,7 @@ in
       startLimitIntervalSec = 60;
       environment = {
         CYRUS_VERBOSE = mkIf cfg.debug "1";
-        LISTENQUEUE = builtins.toString cfg.listenQueue;
+        LISTENQUEUE = toString cfg.listenQueue;
       };
       serviceConfig = {
         User = if (cfg.user == null) then "cyrus" else cfg.user;

--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -55,7 +55,7 @@ in
                 Due to hardening on the systemd unit the socket can never be created world readable/writable.
                 :::
               '';
-              apply = value: (builtins.fromTOML "v=0o${value}").v;
+              apply = value: (fromTOML "v=0o${value}").v;
             };
 
             log-level = mkOption {

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -17,7 +17,7 @@ let
       splitAddress = addr: lib.splitString ":" addr;
       extractPort = addr: lib.toInt (builtins.foldl' (a: b: b) "" (splitAddress addr));
     in
-    builtins.map (address: extractPort address) (parseAddresses listeners);
+    map (address: extractPort address) (parseAddresses listeners);
 
 in
 {

--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -325,10 +325,10 @@ in
             "--config /run/dendrite/dendrite.yaml"
           ]
           ++ lib.optionals (cfg.httpPort != null) [
-            "--http-bind-address :${builtins.toString cfg.httpPort}"
+            "--http-bind-address :${toString cfg.httpPort}"
           ]
           ++ lib.optionals (cfg.httpsPort != null) [
-            "--https-bind-address :${builtins.toString cfg.httpsPort}"
+            "--https-bind-address :${toString cfg.httpsPort}"
             "--tls-cert ${cfg.tlsCert}"
             "--tls-key ${cfg.tlsKey}"
           ]

--- a/nixos/modules/services/matrix/synapse-auto-compressor.nix
+++ b/nixos/modules/services/matrix/synapse-auto-compressor.nix
@@ -136,7 +136,7 @@ in
           "-n"
           cfg.settings.chunks_to_compress
           "-l"
-          (lib.concatStringsSep "," (builtins.map builtins.toString cfg.settings.levels))
+          (lib.concatStringsSep "," (map toString cfg.settings.levels))
         ];
         LockPersonality = true;
         MemoryDenyWriteExecute = true;

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -68,7 +68,7 @@ let
         ${lib.concatMapStringsSep " " (x: "-c ${x}") ([ configFile ] ++ cfg.extraConfigFiles)} \
         "${listenerProtocol}://${
           if (isIpv6 bindAddress) then "[${bindAddress}]" else "${bindAddress}"
-        }:${builtins.toString clientListener.port}/"
+        }:${toString clientListener.port}/"
     '';
 
   defaultExtras = [

--- a/nixos/modules/services/misc/autofs.nix
+++ b/nixos/modules/services/misc/autofs.nix
@@ -96,7 +96,7 @@ in
       serviceConfig = {
         Type = "forking";
         PIDFile = "/run/autofs.pid";
-        ExecStart = "${pkgs.autofs5}/bin/automount ${lib.optionalString cfg.debug "-d"} -p /run/autofs.pid -t ${builtins.toString cfg.timeout} ${autoMaster}";
+        ExecStart = "${pkgs.autofs5}/bin/automount ${lib.optionalString cfg.debug "-d"} -p /run/autofs.pid -t ${toString cfg.timeout} ${autoMaster}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };
     };

--- a/nixos/modules/services/misc/devpi-server.nix
+++ b/nixos/modules/services/misc/devpi-server.nix
@@ -94,7 +94,7 @@ in
               "--request-timeout=5"
               "--serverdir=${serverDir}"
               "--host=${cfg.host}"
-              "--port=${builtins.toString cfg.port}"
+              "--port=${toString cfg.port}"
             ]
             ++ lib.optionals (!isNull cfg.secretFile) [
               "--secretfile=${runtimeDir}/${secretsFileName}"

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -18,7 +18,7 @@ let
     }
     // (lib.optionalAttrs (cfg.storagePath != null) { filesystem.rootdirectory = cfg.storagePath; });
     http = {
-      addr = "${cfg.listenAddress}:${builtins.toString cfg.port}";
+      addr = "${cfg.listenAddress}:${toString cfg.port}";
       headers.X-Content-Type-Options = [ "nosniff" ];
     };
     health.storagedriver = {

--- a/nixos/modules/services/misc/duckling.nix
+++ b/nixos/modules/services/misc/duckling.nix
@@ -29,7 +29,7 @@ in
       after = [ "network.target" ];
 
       environment = {
-        PORT = builtins.toString cfg.port;
+        PORT = toString cfg.port;
       };
 
       serviceConfig = {

--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -188,7 +188,7 @@ in
       "d '${cfg.dataDir}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
     ]
     ++ lib.optionals (cfg.unixSocket != null) [
-      "d '${builtins.dirOf cfg.unixSocket}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
+      "d '${dirOf cfg.unixSocket}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
     ];
 
     systemd.services.etebase-server = {

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -961,7 +961,7 @@ in
       puma.workers = mkOption {
         type = types.int;
         default = 2;
-        apply = x: builtins.toString x;
+        apply = x: toString x;
         description = ''
           The number of worker processes Puma should spawn. This
           controls the amount of parallel Ruby code can be
@@ -977,7 +977,7 @@ in
       puma.threadsMin = mkOption {
         type = types.int;
         default = 0;
-        apply = x: builtins.toString x;
+        apply = x: toString x;
         description = ''
           The minimum number of threads Puma should use per
           worker.
@@ -992,7 +992,7 @@ in
       puma.threadsMax = mkOption {
         type = types.int;
         default = 4;
-        apply = x: builtins.toString x;
+        apply = x: toString x;
         description = ''
           The maximum number of threads Puma should use per
           worker. This limits how many threads Puma will automatically
@@ -1033,7 +1033,7 @@ in
       sidekiq.memoryKiller.maxMemory = mkOption {
         type = types.int;
         default = 2000;
-        apply = x: builtins.toString (x * 1024);
+        apply = x: toString (x * 1024);
         description = ''
           The maximum amount of memory, in MiB, a Sidekiq worker is
           allowed to consume before being killed.
@@ -1043,7 +1043,7 @@ in
       sidekiq.memoryKiller.graceTime = mkOption {
         type = types.int;
         default = 900;
-        apply = x: builtins.toString x;
+        apply = x: toString x;
         description = ''
           The time MemoryKiller waits after noticing excessive memory
           consumption before killing Sidekiq.
@@ -1053,7 +1053,7 @@ in
       sidekiq.memoryKiller.shutdownWait = mkOption {
         type = types.int;
         default = 30;
-        apply = x: builtins.toString x;
+        apply = x: toString x;
         description = ''
           The time allowed for all jobs to finish before Sidekiq is
           killed forcefully.

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -409,7 +409,7 @@ in
           '';
           script = ''
             exec ${lib.getExe' package "guix"} publish \
-              --user=${cfg.publish.user} --port=${builtins.toString cfg.publish.port} \
+              --user=${cfg.publish.user} --port=${toString cfg.publish.port} \
               ${lib.escapeShellArgs cfg.publish.extraArgs}
           '';
 

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -70,7 +70,7 @@ in
       serviceConfig = {
         Type = "idle";
         KillSignal = "SIGINT";
-        ExecStart = "${cfg.package}/bin/llama-server --log-disable --host ${cfg.host} --port ${builtins.toString cfg.port} -m ${cfg.model} ${utils.escapeSystemdExecArgs cfg.extraFlags}";
+        ExecStart = "${cfg.package}/bin/llama-server --log-disable --host ${cfg.host} --port ${toString cfg.port} -m ${cfg.model} ${utils.escapeSystemdExecArgs cfg.extraFlags}";
         Restart = "on-failure";
         RestartSec = 300;
 

--- a/nixos/modules/services/misc/paisa.nix
+++ b/nixos/modules/services/misc/paisa.nix
@@ -14,7 +14,7 @@ let
 
   settings =
     if (cfg.settings != null) then
-      builtins.removeAttrs
+      removeAttrs
         (
           cfg.settings
           // {

--- a/nixos/modules/services/misc/pinchflat.nix
+++ b/nixos/modules/services/misc/pinchflat.nix
@@ -129,7 +129,7 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.selfhosted || !builtins.isNull cfg.secretsFile;
+        assertion = cfg.selfhosted || !isNull cfg.secretsFile;
         message = "Either `selfhosted` must be true, or a `secretsFile` must be configured.";
       }
     ];
@@ -146,7 +146,7 @@ in
 
         StateDirectory = baseNameOf stateDir;
         Environment = [
-          "PORT=${builtins.toString cfg.port}"
+          "PORT=${toString cfg.port}"
           "MEDIA_PATH=${cfg.mediaDir}"
           "CONFIG_PATH=${stateDir}"
           "DATABASE_PATH=${stateDir}/db/pinchflat.db"
@@ -160,7 +160,7 @@ in
         ]
         ++ optional cfg.selfhosted [ "RUN_CONTEXT=selfhosted" ]
         ++ optional (!isNull config.time.timeZone) "TZ=${config.time.timeZone}"
-        ++ attrValues (mapAttrs (name: value: name + "=" + builtins.toString value) cfg.extraConfig);
+        ++ attrValues (mapAttrs (name: value: name + "=" + toString value) cfg.extraConfig);
         EnvironmentFile = optional (cfg.secretsFile != null) cfg.secretsFile;
         ExecStartPre = "${lib.getExe' cfg.package "migrate"}";
         ExecStart = "${getExe cfg.package} start";

--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -181,8 +181,8 @@ in
       environment = {
         # Configuration for our FHS userenv script
         PLEX_DATADIR = cfg.dataDir;
-        PLEX_PLUGINS = lib.concatMapStringsSep ":" builtins.toString cfg.extraPlugins;
-        PLEX_SCANNERS = lib.concatMapStringsSep ":" builtins.toString cfg.extraScanners;
+        PLEX_PLUGINS = lib.concatMapStringsSep ":" toString cfg.extraPlugins;
+        PLEX_SCANNERS = lib.concatMapStringsSep ":" toString cfg.extraScanners;
 
         # The following variables should be set by the FHS userenv script:
         #   PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR

--- a/nixos/modules/services/misc/renovate.nix
+++ b/nixos/modules/services/misc/renovate.nix
@@ -169,7 +169,7 @@ in
 
       script = ''
         ${lib.concatStringsSep "\n" (
-          builtins.map (name: ''
+          map (name: ''
             ${name}="$(systemd-creds cat 'SECRET-${name}')"
             export ${name}
           '') (lib.attrNames cfg.credentials)

--- a/nixos/modules/services/misc/rshim.nix
+++ b/nixos/modules/services/misc/rshim.nix
@@ -13,8 +13,8 @@ let
   ]
   ++ lib.optionals (cfg.backend != null) [ "--backend ${cfg.backend}" ]
   ++ lib.optionals (cfg.device != null) [ "--device ${cfg.device}" ]
-  ++ lib.optionals (cfg.index != null) [ "--index ${builtins.toString cfg.index}" ]
-  ++ [ "--log-level ${builtins.toString cfg.log-level}" ];
+  ++ lib.optionals (cfg.index != null) [ "--index ${toString cfg.index}" ]
+  ++ [ "--log-level ${toString cfg.log-level}" ];
 in
 {
   options.services.rshim = {

--- a/nixos/modules/services/misc/taskchampion-sync-server.nix
+++ b/nixos/modules/services/misc/taskchampion-sync-server.nix
@@ -85,10 +85,10 @@ in
         DynamicUser = false;
         ExecStart = ''
           ${lib.getExe cfg.package} \
-            --listen "${cfg.host}:${builtins.toString cfg.port}" \
+            --listen "${cfg.host}:${toString cfg.port}" \
             --data-dir ${cfg.dataDir} \
-            --snapshot-versions ${builtins.toString cfg.snapshot.versions} \
-            --snapshot-days ${builtins.toString cfg.snapshot.days} \
+            --snapshot-versions ${toString cfg.snapshot.versions} \
+            --snapshot-days ${toString cfg.snapshot.days} \
             ${lib.concatMapStringsSep " " (id: "--allow-client-id ${id}") cfg.allowClientIds}
         '';
       };

--- a/nixos/modules/services/misc/tee-supplicant/default.nix
+++ b/nixos/modules/services/misc/tee-supplicant/default.nix
@@ -25,7 +25,7 @@ let
         # This is safe since we are using it as the path value, so the context
         # will still ensure that this nix store path exists on the running
         # system.
-        taFile = builtins.baseNameOf (builtins.unsafeDiscardStringContext ta);
+        taFile = baseNameOf (builtins.unsafeDiscardStringContext ta);
       in
       {
         name = "lib/${taDir}/${taFile}";

--- a/nixos/modules/services/monitoring/grafana-image-renderer.nix
+++ b/nixos/modules/services/monitoring/grafana-image-renderer.nix
@@ -25,7 +25,7 @@ let
 
     generate = lib.flip lib.pipe [
       # Remove legacy option prefixes that only exist for backwards-compat
-      (lib.flip builtins.removeAttrs [
+      (lib.flip removeAttrs [
         "service"
         "rendering"
         "assertions"

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -13,7 +13,7 @@ let
   opt = options.services.grafana;
   provisioningSettingsFormat = pkgs.formats.yaml { };
   declarativePlugins = pkgs.linkFarm "grafana-plugins" (
-    builtins.map (pkg: {
+    map (pkg: {
       name = pkg.pname;
       path = pkg;
     }) cfg.declarativePlugins

--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -404,7 +404,7 @@ in
           "batch_size"
         ];
       in
-      builtins.map deprecationWarning (builtins.filter hasImapOpt movedOptions);
+      map deprecationWarning (builtins.filter hasImapOpt movedOptions);
 
     services.elasticsearch.enable = lib.mkDefault cfg.provision.elasticsearch;
 

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -92,7 +92,7 @@ let
     cfg.extraFlags
     ++ [
       "--config.file=${if cfg.enableReload then "/etc/prometheus/prometheus.yaml" else prometheusYml}"
-      "--web.listen-address=${cfg.listenAddress}:${builtins.toString cfg.port}"
+      "--web.listen-address=${cfg.listenAddress}:${toString cfg.port}"
     ]
     ++ (
       if (cfg.enableAgentMode) then

--- a/nixos/modules/services/monitoring/prometheus/exporters/dmarc.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/dmarc.nix
@@ -14,7 +14,7 @@ let
     inherit (cfg) folders port;
     listen_addr = cfg.listenAddress;
     storage_path = "$STATE_DIRECTORY";
-    imap = (builtins.removeAttrs cfg.imap [ "passwordFile" ]) // {
+    imap = (removeAttrs cfg.imap [ "passwordFile" ]) // {
       password = "$IMAP_PASSWORD";
       use_ssl = true;
     };

--- a/nixos/modules/services/monitoring/prometheus/exporters/sabnzbd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/sabnzbd.nix
@@ -48,7 +48,7 @@ in
       }) servers.apiKeyFile;
     in
     {
-      serviceConfig.LoadCredential = builtins.map ({ name, path }: "${name}:${path}") credentials;
+      serviceConfig.LoadCredential = map ({ name, path }: "${name}:${path}") credentials;
 
       environment = {
         METRICS_PORT = toString cfg.port;
@@ -59,7 +59,7 @@ in
       script =
         let
           apiKeys = lib.concatStringsSep "," (
-            builtins.map (cred: "$(< $CREDENTIALS_DIRECTORY/${cred.name})") credentials
+            map (cred: "$(< $CREDENTIALS_DIRECTORY/${cred.name})") credentials
           );
         in
         ''

--- a/nixos/modules/services/monitoring/prometheus/sachet.nix
+++ b/nixos/modules/services/monitoring/prometheus/sachet.nix
@@ -72,7 +72,7 @@ in
       ];
       script = ''
         ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /tmp/sachet.yaml
-        exec ${pkgs.prometheus-sachet}/bin/sachet -config /tmp/sachet.yaml -listen-address ${cfg.address}:${builtins.toString cfg.port}
+        exec ${pkgs.prometheus-sachet}/bin/sachet -config /tmp/sachet.yaml -listen-address ${cfg.address}:${toString cfg.port}
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -25,7 +25,7 @@ let
   # Remove the PeerID (an attribute of "Identity") of the temporary Kubo repo.
   # The "Pinning" section contains the "RemoteServices" section, which would prevent
   # the daemon from starting as that setting can't be changed via ipfs config replace.
-  defaultConfig = builtins.removeAttrs rawDefaultConfig [
+  defaultConfig = removeAttrs rawDefaultConfig [
     "Identity"
     "Pinning"
   ];

--- a/nixos/modules/services/network-filesystems/openafs/server.nix
+++ b/nixos/modules/services/network-filesystems/openafs/server.nix
@@ -303,12 +303,12 @@ in
 
     warnings =
       lib.optional ((builtins.attrNames cfg.cellServDB) != [ cfg.cellName ]) ''
-        config.services.openafsServer.cellServDB should normally only contain servers for one cell. It currently contains servers for ${builtins.toString (builtins.attrNames cfg.cellServDB)}.
+        config.services.openafsServer.cellServDB should normally only contain servers for one cell. It currently contains servers for ${toString (builtins.attrNames cfg.cellServDB)}.
       ''
       ++
         lib.optional (useBuCellServDB && (builtins.attrNames cfg.backup.cellServDB) != [ cfg.cellName ])
           ''
-            config.services.openafsServer.backup.cellServDB should normally only contain servers for one cell. It currently contains servers for ${builtins.toString (builtins.attrNames cfg.cellServDB)}.
+            config.services.openafsServer.backup.cellServDB should normally only contain servers for one cell. It currently contains servers for ${toString (builtins.attrNames cfg.cellServDB)}.
           '';
 
     assertions = [

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -15,13 +15,7 @@ let
   portRangesToString =
     ranges:
     lib.concatStringsSep "," (
-      map (
-        x:
-        if x.from == x.to then
-          builtins.toString x.from
-        else
-          builtins.toString x.from + "-" + builtins.toString x.to
-      ) ranges
+      map (x: if x.from == x.to then toString x.from else toString x.from + "-" + toString x.to) ranges
     );
 
   customToKeyValue = lib.generators.toKeyValue {

--- a/nixos/modules/services/networking/chisel-server.nix
+++ b/nixos/modules/services/networking/chisel-server.nix
@@ -63,7 +63,7 @@ in
           "${pkgs.chisel}/bin/chisel server "
           + lib.concatStringsSep " " (
             lib.optional (cfg.host != null) "--host ${cfg.host}"
-            ++ lib.optional (cfg.port != null) "--port ${builtins.toString cfg.port}"
+            ++ lib.optional (cfg.port != null) "--port ${toString cfg.port}"
             ++ lib.optional (cfg.authfile != null) "--authfile ${cfg.authfile}"
             ++ lib.optional (cfg.keepalive != null) "--keepalive ${cfg.keepalive}"
             ++ lib.optional (cfg.backend != null) "--backend ${cfg.backend}"

--- a/nixos/modules/services/networking/ddclient.nix
+++ b/nixos/modules/services/networking/ddclient.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.ddclient;
   dataDir = "/var/lib/ddclient";
-  StateDirectory = builtins.baseNameOf dataDir;
+  StateDirectory = baseNameOf dataDir;
   RuntimeDirectory = StateDirectory;
 
   configFile' = pkgs.writeText "ddclient.conf" ''

--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -333,7 +333,7 @@ in
               ];
               RestrictNamespaces = true;
               RestrictRealtime = true;
-              SocketBindAllow = "udp:${builtins.toString cfg.api_iroh.port}";
+              SocketBindAllow = "udp:${toString cfg.api_iroh.port}";
               SystemCallArchitectures = "native";
               SystemCallFilter = [
                 "@system-service"
@@ -359,14 +359,14 @@ in
               enableACME = mkOverride 99 true;
               forceSSL = mkOverride 99 true;
               locations.${cfg.nginx.path_ws} = {
-                proxyPass = "http://127.0.0.1:${builtins.toString cfg.api_ws.port}/";
+                proxyPass = "http://127.0.0.1:${toString cfg.api_ws.port}/";
                 proxyWebsockets = true;
                 extraConfig = ''
                   proxy_pass_header Authorization;
                 '';
               };
               locations.${cfg.nginx.path_ui} = {
-                proxyPass = "http://127.0.0.1:${builtins.toString cfg.ui.port}/";
+                proxyPass = "http://127.0.0.1:${toString cfg.ui.port}/";
                 extraConfig = ''
                   proxy_pass_header Authorization;
                 '';

--- a/nixos/modules/services/networking/firewalld/service.nix
+++ b/nixos/modules/services/networking/firewalld/service.nix
@@ -105,12 +105,12 @@ in
               (toXmlAttrs { inherit (value) version; })
               {
                 inherit (value) short description;
-                port = builtins.map toXmlAttrs value.ports;
-                protocol = builtins.map (mkXmlAttr "value") value.protocols;
-                source-port = builtins.map toXmlAttrs value.sourcePorts;
+                port = map toXmlAttrs value.ports;
+                protocol = map (mkXmlAttr "value") value.protocols;
+                source-port = map toXmlAttrs value.sourcePorts;
                 destination = toXmlAttrs value.destination;
-                include = builtins.map (mkXmlAttr "service") value.includes;
-                helper = builtins.map (mkXmlAttr "name") value.helpers;
+                include = map (mkXmlAttr "service") value.includes;
+                helper = map (mkXmlAttr "name") value.helpers;
               }
             ]
           );

--- a/nixos/modules/services/networking/firewalld/zone.nix
+++ b/nixos/modules/services/networking/firewalld/zone.nix
@@ -249,7 +249,7 @@ in
         source = format.generate "firewalld-zone-${name}.xml" {
           zone =
             let
-              mkXmlAttrList = name: builtins.map (mkXmlAttr name);
+              mkXmlAttrList = name: map (mkXmlAttr name);
               mkXmlTag = value: if value then "" else null;
             in
             filterNullAttrs (
@@ -259,17 +259,17 @@ in
                 (mkXmlAttr "egress-priority" value.egressPriority)
                 {
                   interface = mkXmlAttrList "name" value.interfaces;
-                  source = builtins.map toXmlAttrs value.sources;
+                  source = map toXmlAttrs value.sources;
                   icmp-block-inversion = mkXmlTag value.icmpBlockInversion;
                   forward = mkXmlTag value.forward;
                   inherit (value) short description;
                   service = mkXmlAttrList "name" value.services;
-                  port = builtins.map toXmlAttrs value.ports;
+                  port = map toXmlAttrs value.ports;
                   protocol = mkXmlAttrList "value" value.protocols;
                   icmp-block = mkXmlAttrList "name" value.icmpBlocks;
                   masquerade = mkXmlTag value.masquerade;
-                  forward-port = builtins.map toXmlAttrs (builtins.map filterNullAttrs value.forwardPorts);
-                  source-port = builtins.map toXmlAttrs value.sourcePorts;
+                  forward-port = map toXmlAttrs (map filterNullAttrs value.forwardPorts);
+                  source-port = map toXmlAttrs value.sourcePorts;
                   rule = value.rules;
                 }
               ]

--- a/nixos/modules/services/networking/harmonia.nix
+++ b/nixos/modules/services/networking/harmonia.nix
@@ -10,7 +10,7 @@ let
 
   signKeyPaths = cfg.signKeyPaths ++ lib.optional (cfg.signKeyPath != null) cfg.signKeyPath;
   credentials = lib.imap0 (i: signKeyPath: {
-    id = "sign-key-${builtins.toString i}";
+    id = "sign-key-${toString i}";
     path = signKeyPath;
   }) signKeyPaths;
 in
@@ -82,7 +82,7 @@ in
         DeviceAllow = [ "" ];
         UMask = "0066";
         RuntimeDirectory = "harmonia";
-        LoadCredential = builtins.map (credential: "${credential.id}:${credential.path}") credentials;
+        LoadCredential = map (credential: "${credential.id}:${credential.path}") credentials;
         SystemCallFilter = [
           "@system-service"
           "~@privileged"

--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -31,7 +31,7 @@ let
 
     inherit (pkgs.formats.yaml { }) type;
   };
-  initrdInterfaceTypes = builtins.map (interface: interface.link.kind) (
+  initrdInterfaceTypes = map (interface: interface.link.kind) (
     builtins.attrValues initrdCfg.settings.interfaces
   );
   # IfState interface kind to kernel modules mapping
@@ -228,7 +228,7 @@ in
               type:
               if builtins.hasAttr type interfaceKernelModules then interfaceKernelModules."${type}" else [ ];
           in
-          lib.flatten (builtins.map enableModule initrdInterfaceTypes);
+          lib.flatten (map enableModule initrdInterfaceTypes);
 
         systemd = {
           storePaths = [

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -140,7 +140,7 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           script = "exec ${pkgs.iodine}/bin/iodine -f -u ${iodinedUser} ${cfg.extraConfig} ${
-            lib.optionalString (cfg.passwordFile != "") "< \"${builtins.toString cfg.passwordFile}\""
+            lib.optionalString (cfg.passwordFile != "") "< \"${toString cfg.passwordFile}\""
           } ${cfg.relay} ${cfg.server}";
           serviceConfig = {
             RestartSec = "30s";
@@ -177,9 +177,7 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           script = "exec ${pkgs.iodine}/bin/iodined -f -u ${iodinedUser} ${cfg.server.extraConfig} ${
-            lib.optionalString (
-              cfg.server.passwordFile != ""
-            ) "< \"${builtins.toString cfg.server.passwordFile}\""
+            lib.optionalString (cfg.server.passwordFile != "") "< \"${toString cfg.server.passwordFile}\""
           } ${cfg.server.ip} ${cfg.server.domain}";
           serviceConfig = {
             # Filesystem access

--- a/nixos/modules/services/networking/meshtasticd.nix
+++ b/nixos/modules/services/networking/meshtasticd.nix
@@ -115,7 +115,7 @@ in
         AmbientCapabilities = [
           "CAP_NET_BIND_SERVICE"
         ];
-        ExecStart = "${lib.getExe cfg.package} --port=${builtins.toString cfg.port} --fsdir=${cfg.dataDir} --config=${configFile} --verbose";
+        ExecStart = "${lib.getExe cfg.package} --port=${toString cfg.port} --fsdir=${cfg.dataDir} --config=${configFile} --verbose";
         Restart = "always";
         RestartSec = "3";
       };

--- a/nixos/modules/services/networking/nat-iptables.nix
+++ b/nixos/modules/services/networking/nat-iptables.nix
@@ -88,13 +88,11 @@ let
       ${concatMapStrings (fwd: ''
         ${iptables} -w -t nat -A nixos-nat-pre \
           -i ${toString cfg.externalInterface} -p ${fwd.proto} \
-          ${
-            optionalString (externalIp != null) "-d ${externalIp}"
-          } --dport ${builtins.toString fwd.sourcePort} \
+          ${optionalString (externalIp != null) "-d ${externalIp}"} --dport ${toString fwd.sourcePort} \
           -j DNAT --to-destination ${fwd.destination}
         ${iptables} -w -t filter -A nixos-filter-forward \
           -i ${toString cfg.externalInterface} -p ${fwd.proto} \
-          --dport ${builtins.toString fwd.sourcePort} -j ACCEPT
+          --dport ${toString fwd.sourcePort} -j ACCEPT
 
         ${concatMapStrings (
           loopbackip:
@@ -112,14 +110,14 @@ let
             # Allow connections to ${loopbackip}:${toString fwd.sourcePort} from the host itself
             ${iptables} -w -t nat -A nixos-nat-out \
               -d ${loopbackip} -p ${fwd.proto} \
-              --dport ${builtins.toString fwd.sourcePort} \
+              --dport ${toString fwd.sourcePort} \
               -j DNAT --to-destination ${fwd.destination}
 
             # Allow connections to ${loopbackip}:${toString fwd.sourcePort} from other hosts behind NAT
             ${concatMapStrings (range: ''
               ${iptables} -w -t nat -A nixos-nat-pre \
                 -d ${loopbackip} -p ${fwd.proto} -s '${range}' \
-                --dport ${builtins.toString fwd.sourcePort} \
+                --dport ${toString fwd.sourcePort} \
                 -j DNAT --to-destination ${fwd.destination}
               ${iptables} -w -t nat -A nixos-nat-post \
                 -d ${destinationIP} -p ${fwd.proto} \
@@ -132,7 +130,7 @@ let
             ${concatMapStrings (iface: ''
               ${iptables} -w -t nat -A nixos-nat-pre \
                 -d ${loopbackip} -p ${fwd.proto} -i '${iface}' \
-                --dport ${builtins.toString fwd.sourcePort} \
+                --dport ${toString fwd.sourcePort} \
                 -j DNAT --to-destination ${fwd.destination}
               ${iptables} -w -t nat -A nixos-nat-post \
                 -d ${destinationIP} -p ${fwd.proto} \

--- a/nixos/modules/services/networking/nebula.nix
+++ b/nixos/modules/services/networking/nebula.nix
@@ -51,7 +51,7 @@ let
       lib.warnIf
         ((settings.lighthouse.am_lighthouse || settings.relay.am_relay) && settings.listen.port == 0)
         ''
-          Nebula network '${netName}' is configured as a lighthouse or relay, and its port is ${builtins.toString settings.listen.port}.
+          Nebula network '${netName}' is configured as a lighthouse or relay, and its port is ${toString settings.listen.port}.
           You will likely experience connectivity issues: https://nebula.defined.net/docs/config/listen/#listenport
         ''
         settings

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -206,7 +206,7 @@ in
                     NB_SERVICE = client.service.name;
                     NB_WIREGUARD_PORT = toString client.port;
                   } // optionalAttrs (client.dns-resolver.address != null) {
-                    NB_DNS_RESOLVER_ADDRESS = "''${client.dns-resolver.address}:''${builtins.toString client.dns-resolver.port}";
+                    NB_DNS_RESOLVER_ADDRESS = "''${client.dns-resolver.address}:''${toString client.dns-resolver.port}";
                   }
                 '';
                 description = ''
@@ -356,7 +356,7 @@ in
                     WgIface = client.interface;
                     WgPort = client.port;
                   } // optionalAttrs (client.dns-resolver.address != null) {
-                    CustomDNSAddress = "''${client.dns-resolver.address}:''${builtins.toString client.dns-resolver.port}";
+                    CustomDNSAddress = "''${client.dns-resolver.address}:''${toString client.dns-resolver.port}";
                   }
                 '';
                 description = ''
@@ -447,7 +447,7 @@ in
               NB_WIREGUARD_PORT = toString client.port;
             }
             // optionalAttrs (client.dns-resolver.address != null) {
-              NB_DNS_RESOLVER_ADDRESS = "${client.dns-resolver.address}:${builtins.toString client.dns-resolver.port}";
+              NB_DNS_RESOLVER_ADDRESS = "${client.dns-resolver.address}:${toString client.dns-resolver.port}";
             };
 
             config.config = {
@@ -456,7 +456,7 @@ in
               WgPort = client.port;
             }
             // optionalAttrs (client.dns-resolver.address != null) {
-              CustomDNSAddress = "${client.dns-resolver.address}:${builtins.toString client.dns-resolver.port}";
+              CustomDNSAddress = "${client.dns-resolver.address}:${toString client.dns-resolver.port}";
             };
           }
         )

--- a/nixos/modules/services/networking/netbird/management.nix
+++ b/nixos/modules/services/networking/netbird/management.nix
@@ -48,7 +48,7 @@ let
       Turns = [
         {
           Proto = "udp";
-          URI = "turn:${cfg.turnDomain}:${builtins.toString cfg.turnPort}";
+          URI = "turn:${cfg.turnDomain}:${toString cfg.turnPort}";
           Username = "netbird";
           Password = "netbird";
         }
@@ -79,7 +79,7 @@ let
     };
 
     HttpConfig = {
-      Address = "127.0.0.1:${builtins.toString cfg.port}";
+      Address = "127.0.0.1:${toString cfg.port}";
       IdpSignKeyRefreshEnabled = true;
       OIDCConfigEndpoint = cfg.oidcConfigEndpoint;
     };
@@ -263,7 +263,7 @@ in
           StoreConfig = { Engine = "sqlite"; };
 
           HttpConfig = {
-            Address = "127.0.0.1:''${builtins.toString cfg.port}";
+            Address = "127.0.0.1:''${toString cfg.port}";
             IdpSignKeyRefreshEnabled = true;
             OIDCConfigEndpoint = cfg.oidcConfigEndpoint;
           };
@@ -457,7 +457,7 @@ in
 
       virtualHosts.${cfg.domain} = {
         locations = {
-          "/api".proxyPass = "http://localhost:${builtins.toString cfg.port}";
+          "/api".proxyPass = "http://localhost:${toString cfg.port}";
 
           "/management.ManagementService/".extraConfig = ''
             # This is necessary so that grpc connections do not get closed early
@@ -466,7 +466,7 @@ in
 
             grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-            grpc_pass grpc://localhost:${builtins.toString cfg.port};
+            grpc_pass grpc://localhost:${toString cfg.port};
             grpc_read_timeout 1d;
             grpc_send_timeout 1d;
             grpc_socket_keepalive on;

--- a/nixos/modules/services/networking/netbird/server.nix
+++ b/nixos/modules/services/networking/netbird/server.nix
@@ -62,7 +62,7 @@ in
           TURNConfig.Turns = mkDefault [
             {
               Proto = "udp";
-              URI = "turn:${turnDomain}:${builtins.toString turnPort}";
+              URI = "turn:${turnDomain}:${toString turnPort}";
               Username = "netbird";
               Password =
                 if (cfg.coturn.password != null) then

--- a/nixos/modules/services/networking/netbird/signal.nix
+++ b/nixos/modules/services/networking/netbird/signal.nix
@@ -145,7 +145,7 @@ in
 
           grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          grpc_pass grpc://localhost:${builtins.toString cfg.port};
+          grpc_pass grpc://localhost:${toString cfg.port};
           grpc_read_timeout 1d;
           grpc_send_timeout 1d;
           grpc_socket_keepalive on;

--- a/nixos/modules/services/networking/nghttpx/default.nix
+++ b/nixos/modules/services/networking/nghttpx/default.nix
@@ -10,10 +10,7 @@ let
   # renderHost :: Either ServerOptions Path -> String
   renderHost =
     server:
-    if builtins.isString server then
-      "unix://${server}"
-    else
-      "${server.host},${builtins.toString server.port}";
+    if builtins.isString server then "unix://${server}" else "${server.host},${toString server.port}";
 
   # Filter out submodule parameters whose value is null or false or is
   # the key _module.
@@ -43,7 +40,7 @@ let
         else if builtins.isString v then
           "${n}=${v}"
         else
-          "${n}=${builtins.toString v}"
+          "${n}=${toString v}"
       ) (filterParams backend.params);
 
       # NB: params are delimited by a ";" which is the same delimiter
@@ -86,11 +83,11 @@ let
     ${lib.concatMapStringsSep "\n" renderFrontend cfg.frontends}
     ${lib.concatMapStringsSep "\n" renderBackend cfg.backends}
 
-    backlog=${builtins.toString cfg.backlog}
+    backlog=${toString cfg.backlog}
     backend-address-family=${cfg.backend-address-family}
 
-    workers=${builtins.toString cfg.workers}
-    rlimit-nofile=${builtins.toString cfg.rlimit-nofile}
+    workers=${toString cfg.workers}
+    rlimit-nofile=${toString cfg.rlimit-nofile}
 
     ${lib.optionalString cfg.single-thread "single-thread=yes"}
     ${lib.optionalString cfg.single-process "single-process=yes"}

--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -11,7 +11,7 @@ let
   enabled = (lib.length cfg.ensureProfiles.secrets.entries) > 0;
 
   nmFileSecretAgentConfig = {
-    entry = builtins.map (
+    entry = map (
       i:
       {
         key = i.key;

--- a/nixos/modules/services/networking/ntp/chrony.nix
+++ b/nixos/modules/services/networking/ntp/chrony.nix
@@ -28,7 +28,7 @@ let
     ${lib.optionalString (cfg.enableRTCTrimming) "rtcfile ${rtcFile}"}
     ${lib.optionalString (cfg.enableNTS) "ntsdumpdir ${stateDir}"}
 
-    ${lib.optionalString (cfg.enableRTCTrimming) "rtcautotrim ${builtins.toString cfg.autotrimThreshold}"}
+    ${lib.optionalString (cfg.enableRTCTrimming) "rtcautotrim ${toString cfg.autotrimThreshold}"}
     ${lib.optionalString (!config.time.hardwareClockInLocalTime) "rtconutc"}
 
     ${cfg.extraConfig}
@@ -236,7 +236,7 @@ in
       };
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${chronyPkg}/bin/chronyd ${builtins.toString chronyFlags}";
+        ExecStart = "${chronyPkg}/bin/chronyd ${toString chronyFlags}";
 
         # Proc filesystem
         ProcSubset = "pid";

--- a/nixos/modules/services/networking/ntp/ntpd.nix
+++ b/nixos/modules/services/networking/ntp/ntpd.nix
@@ -159,7 +159,7 @@ in
       before = [ "time-sync.target" ];
 
       serviceConfig = {
-        ExecStart = "@${ntp}/bin/ntpd ntpd -g ${builtins.toString ntpFlags}";
+        ExecStart = "@${ntp}/bin/ntpd ntpd -g ${toString ntpFlags}";
         Type = "forking";
 
         # Hardening options

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -551,7 +551,7 @@ let
       };
 
       disco_items = {
-      ${lib.concatStringsSep "\n" (builtins.map (x: ''{ "${x.url}", "${x.description}"};'') discoItems)}
+      ${lib.concatStringsSep "\n" (map (x: ''{ "${x.url}", "${x.description}"};'') discoItems)}
       };
 
       allow_registration = ${toLua cfg.allowRegistration}

--- a/nixos/modules/services/networking/pyload.nix
+++ b/nixos/modules/services/networking/pyload.nix
@@ -86,7 +86,7 @@ in
       environment = {
         HOME = stateDir;
         PYLOAD__WEBUI__HOST = cfg.listenAddress;
-        PYLOAD__WEBUI__PORT = builtins.toString cfg.port;
+        PYLOAD__WEBUI__PORT = toString cfg.port;
       };
 
       serviceConfig = {

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -14,7 +14,7 @@ let
   cfg = config.services.searx;
 
   settingsFile = pkgs.writeText "settings.yml" (
-    builtins.toJSON (builtins.removeAttrs cfg.settings [ "redis" ])
+    builtins.toJSON (removeAttrs cfg.settings [ "redis" ])
   );
 
   faviconsSettingsFile = (pkgs.formats.toml { }).generate "favicons.toml" cfg.faviconsSettings;

--- a/nixos/modules/services/networking/snowflake-proxy.nix
+++ b/nixos/modules/services/networking/snowflake-proxy.nix
@@ -56,7 +56,7 @@ in
           "${pkgs.snowflake}/bin/proxy "
           + concatStringsSep " " (
             optional (cfg.broker != null) "-broker ${cfg.broker}"
-            ++ optional (cfg.capacity != null) "-capacity ${builtins.toString cfg.capacity}"
+            ++ optional (cfg.capacity != null) "-capacity ${toString cfg.capacity}"
             ++ optional (cfg.relay != null) "-relay ${cfg.relay}"
             ++ optional (cfg.stun != null) "-stun ${cfg.stun}"
             ++ cfg.extraFlags

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -200,7 +200,7 @@ let
                   jsonPreSecretsFile = pkgs.writeTextFile {
                     name = "${conf_type}-${new_cfg.id}-conf-pre-secrets.json";
                     # Remove the ignorePatterns attribute, it is handled separately
-                    text = builtins.toJSON (builtins.removeAttrs new_cfg [ "ignorePatterns" ]);
+                    text = builtins.toJSON (removeAttrs new_cfg [ "ignorePatterns" ]);
                   };
                   injectSecretsJqCmd =
                     {

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -147,7 +147,7 @@ in
       after = lib.mkIf (config.networking.networkmanager.enable) [ "NetworkManager-wait-online.service" ];
       wantedBy = [ "multi-user.target" ];
       path = [
-        (builtins.dirOf config.security.wrapperDir) # for `su` to use taildrive with correct access rights
+        (dirOf config.security.wrapperDir) # for `su` to use taildrive with correct access rights
         pkgs.procps # for collecting running services (opt-in feature)
         pkgs.getent # for `getent` to look up user shells
         pkgs.kmod # required to pass tailscale's v6nat check

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -14,7 +14,7 @@ let
     "module.exports = " + builtins.toJSON ({ inherit (cfg) public port; } // cfg.extraConfig);
   pluginManifest = {
     dependencies = builtins.listToAttrs (
-      builtins.map (pkg: {
+      map (pkg: {
         name = getName pkg;
         value = getVersion pkg;
       }) cfg.plugins

--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -31,10 +31,10 @@ let
       throw (traceSeq v "services.unbound.settings: unexpected type");
 
   confNoServer = concatStringsSep "\n" (
-    (mapAttrsToList (toConf "") (builtins.removeAttrs cfg.settings [ "server" ])) ++ [ "" ]
+    (mapAttrsToList (toConf "") (removeAttrs cfg.settings [ "server" ])) ++ [ "" ]
   );
   confServer = concatStringsSep "\n" (
-    mapAttrsToList (toConf "  ") (builtins.removeAttrs cfg.settings.server [ "define-tag" ])
+    mapAttrsToList (toConf "  ") (removeAttrs cfg.settings.server [ "define-tag" ])
   );
 
   confFileUnchecked = pkgs.writeText "unbound.conf" ''

--- a/nixos/modules/services/networking/vsftpd.nix
+++ b/nixos/modules/services/networking/vsftpd.nix
@@ -321,7 +321,7 @@ in
       tmpfiles.rules =
         optional cfg.anonymousUser
           #Type Path                       Mode User   Gr    Age Arg
-          "d    '${builtins.toString cfg.anonymousUserHome}' 0555 'ftp'  'ftp' -   -";
+          "d    '${toString cfg.anonymousUserHome}' 0555 'ftp'  'ftp' -   -";
       services.vsftpd = {
         description = "Vsftpd Server";
 

--- a/nixos/modules/services/networking/whoogle-search.nix
+++ b/nixos/modules/services/networking/whoogle-search.nix
@@ -53,7 +53,7 @@ in
         ExecStart =
           "${lib.getExe pkgs.whoogle-search}"
           + " --host '${cfg.listenAddress}'"
-          + " --port '${builtins.toString cfg.port}'";
+          + " --port '${toString cfg.port}'";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         StateDirectory = "whoogle-search";
         StateDirectoryMode = "0750";

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -31,10 +31,7 @@ let
 
   fwMarkFromHexOrNum =
     fwMark:
-    if (lib.hasPrefix "0x" fwMark) then
-      lib.fromHexString fwMark
-    else
-      (builtins.fromTOML "v=${fwMark}").v;
+    if (lib.hasPrefix "0x" fwMark) then lib.fromHexString fwMark else (fromTOML "v=${fwMark}").v;
 
   privateKeyCredential = interfaceName: escapeCredentialName "wireguard-${interfaceName}-private-key";
   presharedKeyCredential =

--- a/nixos/modules/services/printing/cups-pdf.nix
+++ b/nixos/modules/services/printing/cups-pdf.nix
@@ -134,7 +134,7 @@ let
       };
       config.confFileText = lib.pipe config.settings [
         (lib.filterAttrs (key: value: value != null))
-        (lib.mapAttrs (key: builtins.toString))
+        (lib.mapAttrs (key: toString))
         (lib.mapAttrsToList (key: value: "${key} ${value}\n"))
         lib.concatStrings
       ];

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -140,7 +140,7 @@ let
       splitAddress = addr: strings.splitString ":" addr;
       extractPort = addr: builtins.foldl' (a: b: b) "" (splitAddress addr);
     in
-    builtins.map (address: strings.toInt (extractPort address)) addresses;
+    map (address: strings.toInt (extractPort address)) addresses;
 
 in
 

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -11,7 +11,7 @@ let
 
   # These secrets are used in the config file and can be set to paths.
   secrets-with-path =
-    builtins.map
+    map
       (
         { environment, name }:
         {
@@ -43,11 +43,11 @@ let
   master-key-placeholder = "@MASTER_KEY@";
 
   configFile = settingsFormat.generate "config.toml" (
-    builtins.removeAttrs (
+    removeAttrs (
       if cfg.masterKeyFile != null then
         cfg.settings // { master_key = master-key-placeholder; }
       else
-        builtins.removeAttrs cfg.settings [ "master_key" ]
+        removeAttrs cfg.settings [ "master_key" ]
     ) (map (secret: secret.name) secrets-with-path)
   );
 
@@ -139,7 +139,7 @@ in
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
 
-        imports = builtins.map (secret: {
+        imports = map (secret: {
           # give them proper types, just so they're easier to consume from this file
           options.${secret.name} = lib.mkOption {
             # but they should not show up in documentation as special in any way.
@@ -202,7 +202,7 @@ in
       ];
 
       environment = builtins.listToAttrs (
-        builtins.map (secret: {
+        map (secret: {
           name = secret.environment;
           value = lib.mkIf (secret.setting != null) "%d/${secret.name}";
         }) secrets-with-path
@@ -216,7 +216,7 @@ in
           [
             (lib.mkIf (cfg.masterKeyFile != null) [ "master_key:${cfg.masterKeyFile}" ])
           ]
-          ++ builtins.map (
+          ++ map (
             secret: lib.mkIf (secret.setting != null) [ "${secret.name}:${secret.setting}" ]
           ) secrets-with-path
         );

--- a/nixos/modules/services/security/crowdsec.nix
+++ b/nixos/modules/services/security/crowdsec.nix
@@ -875,7 +875,7 @@ in
           // builtins.listToAttrs (
             map (scenarioFile: {
               inherit cfg;
-              name = lib.strings.normalizePath "${localScenariosDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf scenarioFile)}";
+              name = lib.strings.normalizePath "${localScenariosDir}/${builtins.unsafeDiscardStringContext (baseNameOf scenarioFile)}";
               value = {
                 link = {
                   type = "L+";
@@ -887,7 +887,7 @@ in
           // builtins.listToAttrs (
             map (parser: {
               inherit cfg;
-              name = lib.strings.normalizePath "${localParsersS00RawDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf parser)}";
+              name = lib.strings.normalizePath "${localParsersS00RawDir}/${builtins.unsafeDiscardStringContext (baseNameOf parser)}";
               value = {
                 link = {
                   type = "L+";
@@ -899,7 +899,7 @@ in
           // builtins.listToAttrs (
             map (parser: {
               inherit cfg;
-              name = lib.strings.normalizePath "${localParsersS01ParseDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf parser)}";
+              name = lib.strings.normalizePath "${localParsersS01ParseDir}/${builtins.unsafeDiscardStringContext (baseNameOf parser)}";
               value = {
                 link = {
                   type = "L+";
@@ -911,7 +911,7 @@ in
           // builtins.listToAttrs (
             map (parser: {
               inherit cfg;
-              name = lib.strings.normalizePath "${localParsersS02EnrichDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf parser)}";
+              name = lib.strings.normalizePath "${localParsersS02EnrichDir}/${builtins.unsafeDiscardStringContext (baseNameOf parser)}";
               value = {
                 link = {
                   type = "L+";
@@ -923,7 +923,7 @@ in
           // builtins.listToAttrs (
             map (postoverflow: {
               inherit cfg;
-              name = lib.strings.normalizePath "${localPostOverflowsS01WhitelistDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf postoverflow)}";
+              name = lib.strings.normalizePath "${localPostOverflowsS01WhitelistDir}/${builtins.unsafeDiscardStringContext (baseNameOf postoverflow)}";
               value = {
                 link = {
                   type = "L+";
@@ -935,7 +935,7 @@ in
           // builtins.listToAttrs (
             map (context: {
               inherit cfg;
-              name = lib.strings.normalizePath "${localContextsDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf context)}";
+              name = lib.strings.normalizePath "${localContextsDir}/${builtins.unsafeDiscardStringContext (baseNameOf context)}";
               value = {
                 link = {
                   type = "L+";
@@ -947,7 +947,7 @@ in
           // builtins.listToAttrs (
             map (notification: {
               inherit cfg;
-              name = lib.strings.normalizePath "${notificationsDir}/${builtins.unsafeDiscardStringContext (builtins.baseNameOf notification)}";
+              name = lib.strings.normalizePath "${notificationsDir}/${builtins.unsafeDiscardStringContext (baseNameOf notification)}";
               value = {
                 link = {
                   type = "L+";

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -452,7 +452,7 @@ in
       # Block SSH if there are too many failing connection attempts.
       (lib.mkIf config.services.openssh.enable {
         sshd.settings.port = lib.mkDefault (
-          lib.concatMapStringsSep "," builtins.toString config.services.openssh.ports
+          lib.concatMapStringsSep "," toString config.services.openssh.ports
         );
       })
     ];

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -65,13 +65,12 @@ let
   # Merge bind mount paths and remove paths where a prefix is already mounted.
   # This makes sure that if e.g. the tls_chain is in the nix store and /nix/store is already in the mount
   # paths, no new bind mount is added. Adding subpaths caused problems on ofborg.
-  hasPrefixInList =
-    list: newPath: any (path: hasPrefix (builtins.toString path) (builtins.toString newPath)) list;
+  hasPrefixInList = list: newPath: any (path: hasPrefix (toString path) (toString newPath)) list;
   mergePaths = foldl' (
     merged: newPath:
     let
       # If the new path is a prefix to some existing path, we need to filter it out
-      filteredPaths = filter (p: !hasPrefix (builtins.toString newPath) (builtins.toString p)) merged;
+      filteredPaths = filter (p: !hasPrefix (toString newPath) (toString p)) merged;
       # If a prefix of the new path is already in the list, do not add it
       filteredNew = optional (!hasPrefixInList filteredPaths newPath) newPath;
     in

--- a/nixos/modules/services/security/oauth2-proxy-nginx.nix
+++ b/nixos/modules/services/security/oauth2-proxy-nginx.nix
@@ -113,10 +113,7 @@ in
               let
                 maybeQueryArg =
                   name: value:
-                  if value == null then
-                    null
-                  else
-                    "${name}=${lib.concatStringsSep "," (builtins.map lib.escapeURL value)}";
+                  if value == null then null else "${name}=${lib.concatStringsSep "," (map lib.escapeURL value)}";
                 allArgs = lib.mapAttrsToList maybeQueryArg conf;
                 cleanArgs = builtins.filter (x: x != null) allArgs;
                 cleanArgsStr = lib.concatStringsSep "&" cleanArgs;

--- a/nixos/modules/services/security/sks.nix
+++ b/nixos/modules/services/security/sks.nix
@@ -114,7 +114,7 @@ in
     systemd.services =
       let
         hkpAddress = "'" + (builtins.concatStringsSep " " cfg.hkpAddress) + "'";
-        hkpPort = builtins.toString cfg.hkpPort;
+        hkpPort = toString cfg.hkpPort;
       in
       {
         sks-db = {

--- a/nixos/modules/services/system/nix-daemon-firewall.nix
+++ b/nixos/modules/services/system/nix-daemon-firewall.nix
@@ -117,14 +117,14 @@ in
 
           # TCP
           ${lib.optionalString (cfg.allowedTCPPorts != [ ]) ''
-            tcp dport { ${lib.concatStringsSep ", " (map builtins.toString cfg.allowedTCPPorts)} } accept
+            tcp dport { ${lib.concatStringsSep ", " (map toString cfg.allowedTCPPorts)} } accept
             ip protocol tcp counter drop
             ip6 nexthdr tcp counter drop
           ''}
 
           # UDP
           ${lib.optionalString (cfg.allowedUDPPorts != [ ]) ''
-            udp dport { ${lib.concatStringsSep ", " (map builtins.toString cfg.allowedUDPPorts)} } accept
+            udp dport { ${lib.concatStringsSep ", " (map toString cfg.allowedUDPPorts)} } accept
             ip protocol udp counter drop
             ip6 nexthdr udp counter drop
           ''}

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -965,12 +965,12 @@ in
                     type = types.nonEmptyStr;
                     default =
                       if versionOlder config.system.stateVersion "24.05" then
-                        "${httpConf.scheme}://${httpConf.host}:${builtins.toString httpConf.port}/media/"
+                        "${httpConf.scheme}://${httpConf.host}:${toString httpConf.port}/media/"
                       else
                         null;
                     defaultText = literalExpression ''
                       if lib.versionOlder config.system.stateVersion "24.05"
-                      then "$\{httpConf.scheme}://$\{httpConf.host}:$\{builtins.toString httpConf.port}/media/"
+                      then "$\{httpConf.scheme}://$\{httpConf.host}:$\{toString httpConf.port}/media/"
                       else null;
                     '';
                     description = ''
@@ -1019,12 +1019,12 @@ in
                     type = types.nullOr types.nonEmptyStr;
                     default =
                       if versionOlder config.system.stateVersion "24.05" then
-                        "${httpConf.scheme}://${httpConf.host}:${builtins.toString httpConf.port}"
+                        "${httpConf.scheme}://${httpConf.host}:${toString httpConf.port}"
                       else
                         null;
                     defaultText = literalExpression ''
                       if lib.versionOlder config.system.stateVersion "24.05"
-                      then "$\{httpConf.scheme}://$\{httpConf.host}:$\{builtins.toString httpConf.port}"
+                      then "$\{httpConf.scheme}://$\{httpConf.host}:$\{toString httpConf.port}"
                       else null;
                     '';
                     description = ''

--- a/nixos/modules/services/web-apps/artalk.nix
+++ b/nixos/modules/services/web-apps/artalk.nix
@@ -116,7 +116,7 @@ in
         User = cfg.user;
         Group = cfg.group;
         Type = "simple";
-        ExecStart = "${lib.getExe cfg.package} server --config ${cfg.configFile} --workdir ${cfg.workdir} --host ${cfg.settings.host} --port ${builtins.toString cfg.settings.port}";
+        ExecStart = "${lib.getExe cfg.package} server --config ${cfg.configFile} --workdir ${cfg.workdir} --host ${cfg.settings.host} --port ${toString cfg.settings.port}";
         Restart = "on-failure";
         RestartSec = "5s";
         ConfigurationDirectory = [ "artalk" ];

--- a/nixos/modules/services/web-apps/cryptpad.nix
+++ b/nixos/modules/services/web-apps/cryptpad.nix
@@ -186,8 +186,8 @@ in
           RestrictSUIDSGID = true;
           RuntimeDirectoryMode = "700";
           SocketBindAllow = [
-            "tcp:${builtins.toString cfg.settings.httpPort}"
-            "tcp:${builtins.toString cfg.settings.websocketPort}"
+            "tcp:${toString cfg.settings.httpPort}"
+            "tcp:${toString cfg.settings.websocketPort}"
           ];
           SocketBindDeny = [ "any" ];
           StateDirectoryMode = "0700";
@@ -277,13 +277,13 @@ in
               enableACME = lib.mkDefault true;
               forceSSL = true;
               locations."/" = {
-                proxyPass = "http://${cfg.settings.httpAddress}:${builtins.toString cfg.settings.httpPort}";
+                proxyPass = "http://${cfg.settings.httpAddress}:${toString cfg.settings.httpPort}";
                 extraConfig = ''
                   client_max_body_size 150m;
                 '';
               };
               locations."/cryptpad_websocket" = {
-                proxyPass = "http://${cfg.settings.httpAddress}:${builtins.toString cfg.settings.websocketPort}";
+                proxyPass = "http://${cfg.settings.httpAddress}:${toString cfg.settings.websocketPort}";
                 proxyWebsockets = true;
               };
             };

--- a/nixos/modules/services/web-apps/dex.nix
+++ b/nixos/modules/services/web-apps/dex.nix
@@ -13,7 +13,7 @@ let
     client:
     if client ? secretFile then
       (
-        (builtins.removeAttrs client [ "secretFile" ])
+        (removeAttrs client [ "secretFile" ])
         // {
           secret = client.secretFile;
         }
@@ -21,10 +21,10 @@ let
     else
       client;
   filteredSettings = mapAttrs (
-    n: v: if n == "staticClients" then (builtins.map fixClient v) else v
+    n: v: if n == "staticClients" then (map fixClient v) else v
   ) cfg.settings;
   secretFiles = flatten (
-    builtins.map (c: optional (c ? secretFile) c.secretFile) (cfg.settings.staticClients or [ ])
+    map (c: optional (c ? secretFile) c.secretFile) (cfg.settings.staticClients or [ ])
   );
 
   settingsFormat = pkgs.formats.yaml { };

--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -755,8 +755,8 @@ in
         cfg.package.rake
       ];
       environment = cfg.package.runtimeEnv // {
-        UNICORN_TIMEOUT = builtins.toString cfg.unicornTimeout;
-        UNICORN_SIDEKIQS = builtins.toString cfg.sidekiqProcesses;
+        UNICORN_TIMEOUT = toString cfg.unicornTimeout;
+        UNICORN_SIDEKIQS = toString cfg.sidekiqProcesses;
         MALLOC_ARENA_MAX = "2";
       };
 

--- a/nixos/modules/services/web-apps/filebrowser.nix
+++ b/nixos/modules/services/web-apps/filebrowser.nix
@@ -140,7 +140,7 @@ in
           inherit (cfg) user group;
           mode = "0700";
         };
-        "${builtins.dirOf cfg.settings.database}".d = {
+        "${dirOf cfg.settings.database}".d = {
           inherit (cfg) user group;
           mode = "0700";
         };

--- a/nixos/modules/services/web-apps/haven.nix
+++ b/nixos/modules/services/web-apps/haven.nix
@@ -6,7 +6,7 @@
 }:
 let
   # Load default values from package. See https://github.com/bitvora/haven/blob/master/.env.example
-  defaultSettings = builtins.fromTOML (builtins.readFile "${cfg.package}/share/haven/.env.example");
+  defaultSettings = fromTOML (builtins.readFile "${cfg.package}/share/haven/.env.example");
 
   import_relays_file = "${pkgs.writeText "import_relays.json" (builtins.toJSON cfg.importRelays)}";
   blastr_relays_file = "${pkgs.writeText "blastr_relays.json" (builtins.toJSON cfg.blastrRelays)}";

--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -19,7 +19,7 @@ let
     PYTHONPATH = pkg.pythonPath;
     STATIC_ROOT = cfg.dataDir + "/static";
   }
-  // lib.filterAttrs (_: v: !builtins.isNull v) cfg.settings;
+  // lib.filterAttrs (_: v: !isNull v) cfg.settings;
 
   environmentFile = pkgs.writeText "healthchecks-environment" (
     lib.generators.toKeyValue { } environment

--- a/nixos/modules/services/web-apps/ifm.nix
+++ b/nixos/modules/services/web-apps/ifm.nix
@@ -65,7 +65,7 @@ in
         StandardOutput = "journal";
         BindPaths = "${cfg.dataDir}:/data";
         PrivateTmp = true;
-        ExecStart = "${lib.getExe pkgs.ifm-web} ${lib.escapeShellArg cfg.listenAddress} ${builtins.toString cfg.port} /data";
+        ExecStart = "${lib.getExe pkgs.ifm-web} ${lib.escapeShellArg cfg.listenAddress} ${toString cfg.port} /data";
       };
     };
   };

--- a/nixos/modules/services/web-apps/immich-public-proxy.nix
+++ b/nixos/modules/services/web-apps/immich-public-proxy.nix
@@ -53,7 +53,7 @@ in
       wantedBy = [ "multi-user.target" ];
       environment = {
         IMMICH_URL = cfg.immichUrl;
-        IPP_PORT = builtins.toString cfg.port;
+        IPP_PORT = toString cfg.port;
         IPP_CONFIG = "${format.generate "config.json" cfg.settings}";
       };
       serviceConfig = {

--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -127,7 +127,7 @@ let
   serviceConfig = {
     systemd.services = builtins.listToAttrs (
       builtins.genList (scaleIndex: {
-        name = "invidious" + lib.optionalString (scaleIndex > 0) "-${builtins.toString scaleIndex}";
+        name = "invidious" + lib.optionalString (scaleIndex > 0) "-${toString scaleIndex}";
         value = mkInvidiousService scaleIndex;
       }) cfg.serviceScale
     );

--- a/nixos/modules/services/web-apps/jirafeau.nix
+++ b/nixos/modules/services/web-apps/jirafeau.nix
@@ -19,7 +19,7 @@ let
       $cfg['admin_password'] = '${cfg.adminPasswordSha256}';
       $cfg['web_root'] = 'http://${withTrailingSlash cfg.hostName}';
       $cfg['var_root'] = '${withTrailingSlash cfg.dataDir}';
-      $cfg['maximal_upload_size'] = ${builtins.toString cfg.maxUploadSizeMegabytes};
+      $cfg['maximal_upload_size'] = ${toString cfg.maxUploadSizeMegabytes};
       $cfg['installation_done'] = true;
 
       ${cfg.extraConfig}

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -701,7 +701,7 @@ in
           mkTarget =
             file:
             let
-              baseName = builtins.baseNameOf file;
+              baseName = baseNameOf file;
               name = if lib.hasSuffix ".json" baseName then baseName else "${baseName}.json";
             in
             "/run/keycloak/data/import/${name}";

--- a/nixos/modules/services/web-apps/komga.nix
+++ b/nixos/modules/services/web-apps/komga.nix
@@ -111,7 +111,7 @@ in
           inherit (cfg) user group;
         };
         "${cfg.stateDir}/application.yml"."L+" = {
-          argument = builtins.toString (settingsFormat.generate "application.yml" cfg.settings);
+          argument = toString (settingsFormat.generate "application.yml" cfg.settings);
         };
       };
 

--- a/nixos/modules/services/web-apps/librechat.nix
+++ b/nixos/modules/services/web-apps/librechat.nix
@@ -205,7 +205,7 @@ in
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        StateDirectory = builtins.baseNameOf cfg.dataDir;
+        StateDirectory = baseNameOf cfg.dataDir;
         WorkingDirectory = cfg.dataDir;
         LoadCredential = getLoadCredentialList;
         EnvironmentFile = cfg.credentialsFile;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -160,7 +160,7 @@ let
     name: processCfg:
     lib.nameValuePair "mastodon-sidekiq-${name}" (
       let
-        jobClassArgs = toString (builtins.map (c: "-q ${c}") processCfg.jobClasses);
+        jobClassArgs = toString (map (c: "-q ${c}") processCfg.jobClasses);
         jobClassLabel = toString ([ "" ] ++ processCfg.jobClasses);
         threads = toString (if processCfg.threads == null then cfg.sidekiqThreads else processCfg.threads);
       in

--- a/nixos/modules/services/web-apps/mealie.nix
+++ b/nixos/modules/services/web-apps/mealie.nix
@@ -96,7 +96,7 @@ in
         DynamicUser = true;
         User = "mealie";
         ExecStartPre = "${pkg}/libexec/init_db";
-        ExecStart = "${lib.getExe pkg} -b ${cfg.listenAddress}:${builtins.toString cfg.port} ${lib.escapeShellArgs cfg.extraOptions}";
+        ExecStart = "${lib.getExe pkg} -b ${cfg.listenAddress}:${toString cfg.port} ${lib.escapeShellArgs cfg.extraOptions}";
         EnvironmentFile = lib.mkIf (cfg.credentialsFile != null) cfg.credentialsFile;
         StateDirectory = "mealie";
         StandardOutput = "journal";

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -111,7 +111,7 @@ let
             inherit (cfg.precompressStaticFiles) brotli gzip;
 
             findTextFileNames = lib.concatStringsSep " -o " (
-              builtins.map (n: ''-iname "*.${n}"'') [
+              map (n: ''-iname "*.${n}"'') [
                 "css"
                 "ini"
                 "js"
@@ -129,7 +129,7 @@ let
                 echo -n "Precompressing static files with Brotli …"
                 find ${appDir}/public -type f ${findTextFileNames} -print0 \
                   | xargs -0 -P$NIX_BUILD_CORES -n1 -I{} \
-                      ${lib.getExe brotli.package} --keep --quality=${builtins.toString brotli.compressionLevel} --output={}.br {}
+                      ${lib.getExe brotli.package} --keep --quality=${toString brotli.compressionLevel} --output={}.br {}
                 echo " done."
               ''
             )
@@ -138,7 +138,7 @@ let
                 echo -n "Precompressing static files with Gzip …"
                 find ${appDir}/public -type f ${findTextFileNames} -print0 \
                   | xargs -0 -P$NIX_BUILD_CORES -n1 -I{} \
-                      ${lib.getExe gzip.package} -c -${builtins.toString gzip.compressionLevel} {} > {}.gz
+                      ${lib.getExe gzip.package} -c -${toString gzip.compressionLevel} {} > {}.gz
                 echo " done."
               ''
             )
@@ -653,7 +653,7 @@ in
                 "/ws/" = {
                   "proxy.preserve-host" = "ON";
                   "proxy.tunnel" = "ON";
-                  "proxy.reverse.url" = "http://${cfg.settings.DAEMON_INTERFACE}:${builtins.toString cfg.port}/";
+                  "proxy.reverse.url" = "http://${cfg.settings.DAEMON_INTERFACE}:${toString cfg.port}/";
                 };
                 "/" = {
                   "file.dir" = "${package}/share/php/movim/public";
@@ -764,7 +764,7 @@ in
                 };
                 "/ws/" = {
                   priority = 900;
-                  proxyPass = "http://${cfg.settings.DAEMON_INTERFACE}:${builtins.toString cfg.port}/";
+                  proxyPass = "http://${cfg.settings.DAEMON_INTERFACE}:${toString cfg.port}/";
                   proxyWebsockets = true;
                   recommendedProxySettings = true;
                   extraConfig = # nginx
@@ -922,7 +922,7 @@ in
         ++ lib.optional (webServerService != null) webServerService;
         environment = {
           PUBLIC_URL = "//${cfg.domain}";
-          WS_PORT = builtins.toString cfg.port;
+          WS_PORT = toString cfg.port;
         };
 
         serviceConfig = {

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1713,7 +1713,7 @@ in
                 fastcgi_pass unix:${fpm.socket};
                 fastcgi_intercept_errors on;
                 fastcgi_request_buffering ${if cfg.nginx.enableFastcgiRequestBuffering then "on" else "off"};
-                fastcgi_read_timeout ${builtins.toString cfg.fastcgiTimeout}s;
+                fastcgi_read_timeout ${toString cfg.fastcgiTimeout}s;
               '';
             };
             "~ \\.(?:css|js|mjs|svg|gif|ico|jpg|jpeg|png|webp|wasm|tflite|map|html|ttf|bcmap|mp4|webm|ogg|flac)$".extraConfig =

--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -696,12 +696,12 @@ in
 
             REDIS_URL = if cfg.redisUrl == "local" then localRedisUrl else cfg.redisUrl;
             URL = cfg.publicUrl;
-            PORT = builtins.toString cfg.port;
+            PORT = toString cfg.port;
 
             CDN_URL = cfg.cdnUrl;
-            FORCE_HTTPS = builtins.toString cfg.forceHttps;
-            ENABLE_UPDATES = builtins.toString cfg.enableUpdateCheck;
-            WEB_CONCURRENCY = builtins.toString cfg.concurrency;
+            FORCE_HTTPS = toString cfg.forceHttps;
+            ENABLE_UPDATES = toString cfg.enableUpdateCheck;
+            WEB_CONCURRENCY = toString cfg.concurrency;
             DEBUG = cfg.debugOutput;
             GOOGLE_ANALYTICS_ID = lib.optionalString (cfg.googleAnalyticsId != null) cfg.googleAnalyticsId;
             SENTRY_DSN = lib.optionalString (cfg.sentryDsn != null) cfg.sentryDsn;
@@ -709,13 +709,13 @@ in
             TEAM_LOGO = lib.optionalString (cfg.logo != null) cfg.logo;
             DEFAULT_LANGUAGE = cfg.defaultLanguage;
 
-            RATE_LIMITER_ENABLED = builtins.toString cfg.rateLimiter.enable;
-            RATE_LIMITER_REQUESTS = builtins.toString cfg.rateLimiter.requests;
-            RATE_LIMITER_DURATION_WINDOW = builtins.toString cfg.rateLimiter.durationWindow;
+            RATE_LIMITER_ENABLED = toString cfg.rateLimiter.enable;
+            RATE_LIMITER_REQUESTS = toString cfg.rateLimiter.requests;
+            RATE_LIMITER_DURATION_WINDOW = toString cfg.rateLimiter.durationWindow;
 
             FILE_STORAGE = cfg.storage.storageType;
-            FILE_STORAGE_IMPORT_MAX_SIZE = builtins.toString cfg.maximumImportSize;
-            FILE_STORAGE_UPLOAD_MAX_SIZE = builtins.toString cfg.storage.uploadMaxSize;
+            FILE_STORAGE_IMPORT_MAX_SIZE = toString cfg.maximumImportSize;
+            FILE_STORAGE_UPLOAD_MAX_SIZE = toString cfg.storage.uploadMaxSize;
             FILE_STORAGE_LOCAL_ROOT_DIR = cfg.storage.localRootDir;
           }
 
@@ -724,7 +724,7 @@ in
             AWS_REGION = cfg.storage.region;
             AWS_S3_UPLOAD_BUCKET_URL = cfg.storage.uploadBucketUrl;
             AWS_S3_UPLOAD_BUCKET_NAME = cfg.storage.uploadBucketName;
-            AWS_S3_FORCE_PATH_STYLE = builtins.toString cfg.storage.forcePathStyle;
+            AWS_S3_FORCE_PATH_STYLE = toString cfg.storage.forcePathStyle;
             AWS_S3_ACL = cfg.storage.acl;
           })
 
@@ -757,7 +757,7 @@ in
 
           (lib.mkIf (cfg.slackIntegration != null) {
             SLACK_APP_ID = cfg.slackIntegration.appId;
-            SLACK_MESSAGE_ACTIONS = builtins.toString cfg.slackIntegration.messageActions;
+            SLACK_MESSAGE_ACTIONS = toString cfg.slackIntegration.messageActions;
           })
 
           (lib.mkIf (cfg.discordAuthentication != null) {
@@ -768,12 +768,12 @@ in
 
           (lib.mkIf (cfg.smtp != null) {
             SMTP_HOST = cfg.smtp.host;
-            SMTP_PORT = builtins.toString cfg.smtp.port;
+            SMTP_PORT = toString cfg.smtp.port;
             SMTP_USERNAME = cfg.smtp.username;
             SMTP_FROM_EMAIL = cfg.smtp.fromEmail;
             SMTP_REPLY_EMAIL = cfg.smtp.replyEmail;
             SMTP_TLS_CIPHERS = cfg.smtp.tlsCiphers;
-            SMTP_SECURE = builtins.toString cfg.smtp.secure;
+            SMTP_SECURE = toString cfg.smtp.secure;
           })
         ];
 

--- a/nixos/modules/services/web-apps/pgpkeyserver-lite.nix
+++ b/nixos/modules/services/web-apps/pgpkeyserver-lite.nix
@@ -61,7 +61,7 @@ in
 
     services.nginx.virtualHosts =
       let
-        hkpPort = builtins.toString cfg.hkpPort;
+        hkpPort = toString cfg.hkpPort;
       in
       {
         ${cfg.hostname} = {

--- a/nixos/modules/services/web-apps/pict-rs.nix
+++ b/nixos/modules/services/web-apps/pict-rs.nix
@@ -87,7 +87,7 @@ in
             snippet should work:
 
                 services.pict-rs.package =
-                  (import (builtins.fetchTarball {
+                  (import (fetchTarball {
                     url = "https://github.com/NixOS/nixpkgs/archive/9b19f5e77dd906cb52dade0b7bd280339d2a1f3d.tar.gz";
                     sha256 = "sha256:0939vbhln9d33xkqw63nsk908k03fxihj85zaf70i3il9z42q8mc";
                   }) pkgs.config).pict-rs;

--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -108,7 +108,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       environment = {
-        PLANTUML_LIMIT_SIZE = builtins.toString cfg.plantumlLimitSize;
+        PLANTUML_LIMIT_SIZE = toString cfg.plantumlLimitSize;
         GRAPHVIZ_DOT = "${cfg.graphvizPackage}/bin/dot";
         PLANTUML_STATS = if cfg.plantumlStats then "on" else "off";
         HTTP_AUTHORIZATION = cfg.httpAuthorization;
@@ -120,7 +120,7 @@ in
             jetty.home=${cfg.packages.jetty} \
             jetty.base=${cfg.package} \
             jetty.http.host=${cfg.listenHost} \
-            jetty.http.port=${builtins.toString cfg.listenPort}
+            jetty.http.port=${toString cfg.listenPort}
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/web-apps/privatebin.nix
+++ b/nixos/modules/services/web-apps/privatebin.nix
@@ -17,9 +17,9 @@ let
         else if v == false then
           ''false''
         else if builtins.isInt v then
-          ''${builtins.toString v}''
+          ''${toString v}''
         else if builtins.isPath v then
-          ''"${builtins.toString v}"''
+          ''"${toString v}"''
         else if builtins.isString v then
           ''"${v}"''
         else
@@ -167,7 +167,7 @@ in
         "pm.max_spare_servers" = lib.mkDefault 4;
         "pm.max_requests" = lib.mkDefault 500;
       };
-      phpEnv.CONFIG_PATH = lib.strings.removeSuffix "/conf.php" (builtins.toString privatebinSettings);
+      phpEnv.CONFIG_PATH = lib.strings.removeSuffix "/conf.php" (toString privatebinSettings);
     };
 
     services.nginx = lib.mkIf cfg.enableNginx {

--- a/nixos/modules/services/web-apps/reposilite.nix
+++ b/nixos/modules/services/web-apps/reposilite.nix
@@ -18,7 +18,7 @@ let
     if useEmbeddedDb then
       "${cfg.database.type} ${cfg.database.path}"
     else
-      "${cfg.database.type} ${cfg.database.host}:${builtins.toString cfg.database.port} ${cfg.database.dbname} ${cfg.database.user} $(<${cfg.database.passwordFile})";
+      "${cfg.database.type} ${cfg.database.host}:${toString cfg.database.port} ${cfg.database.dbname} ${cfg.database.user} $(<${cfg.database.passwordFile})";
 
   certDir = config.security.acme.certs.${cfg.useACMEHost}.directory;
 
@@ -412,8 +412,8 @@ in
         '';
 
       serviceConfig = lib.mkMerge [
-        (lib.mkIf (builtins.dirOf cfg.workingDirectory == "/var/lib") {
-          StateDirectory = builtins.baseNameOf cfg.workingDirectory;
+        (lib.mkIf (dirOf cfg.workingDirectory == "/var/lib") {
+          StateDirectory = baseNameOf cfg.workingDirectory;
           StateDirectoryMode = "700";
         })
         {

--- a/nixos/modules/services/web-apps/sillytavern.nix
+++ b/nixos/modules/services/web-apps/sillytavern.nix
@@ -105,7 +105,7 @@ in
         Type = "simple";
         ExecStart =
           let
-            f = x: name: lib.optional (x != null) "--${name}=${builtins.toString x}";
+            f = x: name: lib.optional (x != null) "--${name}=${toString x}";
           in
           lib.concatStringsSep " " (
             [

--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -96,7 +96,7 @@ let
   + lib.optionalString cfg.smtp.enable ''
     EMAIL_HOST = "${cfg.smtp.host}"
     EMAIL_USE_TLS = True
-    EMAIL_PORT = ${builtins.toString cfg.smtp.port}
+    EMAIL_PORT = ${toString cfg.smtp.port}
     SERVER_EMAIL = "${cfg.smtp.from}"
     DEFAULT_FROM_EMAIL = "${cfg.smtp.from}"
   ''

--- a/nixos/modules/services/web-apps/windmill.nix
+++ b/nixos/modules/services/web-apps/windmill.nix
@@ -223,7 +223,7 @@ in
           };
 
           environment = {
-            PORT = builtins.toString cfg.serverPort;
+            PORT = toString cfg.serverPort;
             WM_BASE_URL = cfg.baseUrl;
             RUST_LOG = cfg.logLevel;
             MODE = "server";

--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -183,12 +183,12 @@ in
 
     adapter = mkOption {
       default =
-        if ((cfg.configFile != configFile) || (builtins.baseNameOf cfg.configFile) == "Caddyfile") then
+        if ((cfg.configFile != configFile) || (baseNameOf cfg.configFile) == "Caddyfile") then
           "caddyfile"
         else
           null;
       defaultText = literalExpression ''
-        if ((cfg.configFile != configFile) || (builtins.baseNameOf cfg.configFile) == "Caddyfile") then "caddyfile" else null
+        if ((cfg.configFile != configFile) || (baseNameOf cfg.configFile) == "Caddyfile") then "caddyfile" else null
       '';
       example = literalExpression "nginx";
       type = with types; nullOr str;

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -121,7 +121,7 @@ let
           acmeChallengePath = "/.well-known/acme-challenge";
         in
         {
-          "${names.server}:${builtins.toString acmePort}" = {
+          "${names.server}:${toString acmePort}" = {
             listen.port = acmePort;
             paths."${acmeChallengePath}/" = {
               "file.dir" = value.acme.root + acmeChallengePath;
@@ -132,17 +132,17 @@ let
 
       httpSettings =
         lib.optionalAttrs (value.tls == null || value.tls.policy == "add") {
-          "${names.server}:${builtins.toString port.HTTP}" = value.settings // {
+          "${names.server}:${toString port.HTTP}" = value.settings // {
             listen.port = port.HTTP;
           };
         }
         // lib.optionalAttrs (value.tls != null && value.tls.policy == "force") {
-          "${names.server}:${builtins.toString port.HTTP}" = {
+          "${names.server}:${toString port.HTTP}" = {
             listen.port = port.HTTP;
             paths."/" = {
               redirect = {
                 status = value.tls.redirectCode;
-                url = "https://${names.server}:${builtins.toString port.TLS}";
+                url = "https://${names.server}:${toString port.TLS}";
               };
             };
           };
@@ -159,7 +159,7 @@ let
             ]
           )
           {
-            "${names.server}:${builtins.toString port.TLS}" =
+            "${names.server}:${toString port.TLS}" =
               let
                 tlsRecommendations = lib.attrByPath [ "tls" "recommendations" ] cfg.defaultTLSRecommendations value;
 
@@ -208,7 +208,7 @@ let
                       let
                         headerSet = value.settings."header.set" or [ ];
                         recs = mozTLSRecs.${tlsRecommendations};
-                        hsts = "Strict-Transport-Security: max-age=${builtins.toString recs.hsts_min_age}; includeSubDomains; preload";
+                        hsts = "Strict-Transport-Security: max-age=${toString recs.hsts_min_age}; includeSubDomains; preload";
                       in
                       {
                         "header.set" =
@@ -409,7 +409,7 @@ in
         '';
       }
     ]
-    ++ builtins.map (
+    ++ map (
       name:
       mkCertOwnershipAssertion {
         cert = certs.${name};
@@ -436,11 +436,11 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = lib.concatLists (map (certName: [ "acme-${certName}.service" ]) acmeCertNames.all);
       # Since H2O will be hosting the challenges, H2O must be started
-      before = builtins.map (certName: "acme-order-renew-${certName}.service") acmeCertNames.all;
+      before = map (certName: "acme-order-renew-${certName}.service") acmeCertNames.all;
       after = [
         "network.target"
       ]
-      ++ builtins.map (certName: "acme-${certName}.service") acmeCertNames.all;
+      ++ map (certName: "acme-${certName}.service") acmeCertNames.all;
 
       serviceConfig = {
         ExecStart = "${h2oExe} --mode 'master'";

--- a/nixos/modules/services/web-servers/stargazer.nix
+++ b/nixos/modules/services/web-servers/stargazer.nix
@@ -31,7 +31,7 @@ let
         section:
         let
           name = section.route;
-          params = builtins.removeAttrs section [ "route" ];
+          params = removeAttrs section [ "route" ];
         in
         genINI {
           "${name}" = params;

--- a/nixos/modules/services/web-servers/tomcat.nix
+++ b/nixos/modules/services/web-servers/tomcat.nix
@@ -425,8 +425,8 @@ in
           "CATALINA_BASE=${cfg.baseDir}"
           "CATALINA_PID=/run/tomcat/tomcat.pid"
           "JAVA_HOME='${cfg.jdk}'"
-          "JAVA_OPTS='${builtins.toString cfg.javaOpts}'"
-          "CATALINA_OPTS='${builtins.toString cfg.catalinaOpts}'"
+          "JAVA_OPTS='${toString cfg.javaOpts}'"
+          "CATALINA_OPTS='${toString cfg.catalinaOpts}'"
         ]
         ++ cfg.extraEnvironment;
         ExecStart = "${tomcat}/bin/startup.sh";

--- a/nixos/modules/services/x11/desktop-managers/phosh.nix
+++ b/nixos/modules/services/x11/desktop-managers/phosh.nix
@@ -95,7 +95,7 @@ let
     };
   };
 
-  optionalKV = k: v: lib.optionalString (v != null) "${k} = ${builtins.toString v}";
+  optionalKV = k: v: lib.optionalString (v != null) "${k} = ${toString v}";
 
   renderPhocOutput =
     name: output:

--- a/nixos/modules/services/x11/desktop-managers/surf-display.nix
+++ b/nixos/modules/services/x11/desktop-managers/surf-display.nix
@@ -25,7 +25,7 @@ let
 
     # Setting for internal inactivity timer to restart surf-display
     # if the user goes inactive/idle.
-    INACTIVITY_INTERVAL="${builtins.toString cfg.inactivityInterval}"
+    INACTIVITY_INTERVAL="${toString cfg.inactivityInterval}"
 
     # log to syslog instead of .xsession-errors
     LOG_TO_SYSLOG="yes"

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -165,7 +165,7 @@ in
           path
         else
           let
-            name = builtins.baseNameOf path;
+            name = baseNameOf path;
           in
           builtins.unsafeDiscardStringContext ("/etc/ssh/" + substring 1 (stringLength name) name);
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -602,7 +602,7 @@ let
             ++ optional (v.header != null) "header=${v.header}"
             ++ optional (v.keyFileOffset != null) "keyfile-offset=${toString v.keyFileOffset}"
             ++ optional (v.keyFileSize != null) "keyfile-size=${toString v.keyFileSize}"
-            ++ optional (v.keyFileTimeout != null) "keyfile-timeout=${builtins.toString v.keyFileTimeout}s"
+            ++ optional (v.keyFileTimeout != null) "keyfile-timeout=${toString v.keyFileTimeout}s"
             ++ optional (v.tryEmptyPassphrase) "try-empty-password=true";
         in
         "${n} ${v.device} ${if v.keyFile == null then "-" else v.keyFile} ${lib.concatStringsSep "," opts}"

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -583,7 +583,7 @@ in
         "${pkgs.bashNonInteractive}/bin"
       ]
       ++ jobScripts
-      ++ map (c: builtins.removeAttrs c [ "text" ]) (builtins.attrValues cfg.contents)
+      ++ map (c: removeAttrs c [ "text" ]) (builtins.attrValues cfg.contents)
       ++ lib.optional (pkgs.stdenv.hostPlatform.libc == "glibc") "${pkgs.glibc}/lib/libnss_files.so.2";
 
       targets.initrd.aliases = [ "default.target" ];

--- a/nixos/modules/system/boot/systemd/shutdown.nix
+++ b/nixos/modules/system/boot/systemd/shutdown.nix
@@ -65,7 +65,7 @@ in
     ++ lib.optionals cfg.shell.enable [
       pkgs.runtimeShell
     ]
-    ++ map (c: builtins.removeAttrs c [ "text" ]) (builtins.attrValues cfg.contents);
+    ++ map (c: removeAttrs c [ "text" ]) (builtins.attrValues cfg.contents);
 
     systemd.mounts = [
       {

--- a/nixos/modules/system/boot/systemd/sysusers.nix
+++ b/nixos/modules/system/boot/systemd/sysusers.nix
@@ -152,7 +152,7 @@ in
           # systemd-sysusers cannot find it when we also pass another flag.
           ExecStart = lib.mkIf immutableEtc [
             ""
-            "${config.systemd.package}/bin/systemd-sysusers --root ${builtins.dirOf immutablePasswordFilesLocation} /etc/sysusers.d/00-nixos.conf"
+            "${config.systemd.package}/bin/systemd-sysusers --root ${dirOf immutablePasswordFilesLocation} /etc/sysusers.d/00-nixos.conf"
           ];
 
           # Make the source files writable before executing sysusers.

--- a/nixos/modules/system/boot/uki.nix
+++ b/nixos/modules/system/boot/uki.nix
@@ -101,7 +101,7 @@ in
         name = config.boot.uki.name;
         version = config.boot.uki.version;
         versionInfix = if version != null then "_${version}" else "";
-        triesInfix = if cfg.tries != null then "+${builtins.toString cfg.tries}" else "";
+        triesInfix = if cfg.tries != null then "+${toString cfg.tries}" else "";
       in
       name + versionInfix + triesInfix + ".efi";
 

--- a/nixos/modules/virtualisation/azure-common.nix
+++ b/nixos/modules/virtualisation/azure-common.nix
@@ -60,7 +60,7 @@ in
       linkConfig.Unmanaged = "yes";
     };
     networking.networkmanager.unmanaged = lib.mkIf cfg.acceleratedNetworking (
-      builtins.map (drv: "driver:${drv}") mlxDrivers
+      map (drv: "driver:${drv}") mlxDrivers
     );
 
     # Allow root logins only using the SSH key that the user specified

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -1044,7 +1044,7 @@ in
                   serviceConfig = serviceDirectives containerConfig;
                   unitConfig.RequiresMountsFor =
                     lib.optional (!containerConfig.ephemeral) "${stateDirectory}/%i"
-                    ++ builtins.map (d: if d.hostPath != null then d.hostPath else d.mountPoint) (
+                    ++ map (d: if d.hostPath != null then d.hostPath else d.mountPoint) (
                       builtins.attrValues cfg.bindMounts
                     );
                   environment.root =

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -555,7 +555,7 @@ in
       backend = "docker";
       containers = lib.mapAttrs (
         n: v:
-        builtins.removeAttrs (
+        removeAttrs (
           v
           // {
             extraOptions = v.extraDockerOptions or [ ];

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -213,7 +213,7 @@ with lib;
     let
       cfg = config.proxmox;
       cfgLine = name: value: ''
-        ${name}: ${builtins.toString value}
+        ${name}: ${toString value}
       '';
       virtio0Storage = builtins.head (builtins.split ":" cfg.qemuConf.virtio0);
       cfgFile =

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -300,7 +300,7 @@ let
         idx:
         { size, ... }:
         ''
-          test -e "empty${builtins.toString idx}.qcow2" || ${qemu}/bin/qemu-img create -f qcow2 "empty${builtins.toString idx}.qcow2" "${builtins.toString size}M"
+          test -e "empty${toString idx}.qcow2" || ${qemu}/bin/qemu-img create -f qcow2 "empty${toString idx}.qcow2" "${toString size}M"
         ''
       ))
       (builtins.concatStringsSep "")

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -26,7 +26,7 @@ let
     set:
     if builtins.isAttrs set then
       if (set.type or "") == "derivation" then
-        set // { meta = builtins.removeAttrs (set.meta or { }) [ "maintainers" ]; }
+        set // { meta = removeAttrs (set.meta or { }) [ "maintainers" ]; }
       else
         pkgs.lib.mapAttrs (n: v: removeMaintainers v) set
     else
@@ -43,7 +43,7 @@ rec {
     }
   );
 
-  nixpkgs = builtins.removeAttrs (removeMaintainers (
+  nixpkgs = removeAttrs (removeMaintainers (
     import ../pkgs/top-level/release.nix {
       inherit supportedSystems;
       nixpkgs = nixpkgsSrc;

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -32,7 +32,7 @@ let
     nixpkgs = nixpkgsSrc;
   };
 
-  nixpkgs' = builtins.removeAttrs (import ../pkgs/top-level/release.nix {
+  nixpkgs' = removeAttrs (import ../pkgs/top-level/release.nix {
     inherit supportedSystems;
     nixpkgs = nixpkgsSrc;
   }) [ "unstable" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -118,7 +118,7 @@ let
       findTests =
         tree:
         if tree ? recurseForDerivations && tree.recurseForDerivations then
-          mapAttrs (k: findTests) (builtins.removeAttrs tree [ "recurseForDerivations" ])
+          mapAttrs (k: findTests) (removeAttrs tree [ "recurseForDerivations" ])
         else
           callTest tree;
 

--- a/nixos/tests/benchexec.nix
+++ b/nixos/tests/benchexec.nix
@@ -18,7 +18,7 @@ in
     { ... }:
     let
       runexec = lib.getExe' pkgs.benchexec "runexec";
-      echo = builtins.toString pkgs.benchexec;
+      echo = toString pkgs.benchexec;
       test = lib.getExe (
         pkgs.writeShellApplication rec {
           name = "test";

--- a/nixos/tests/ceph-single-node-bluestore-dmcrypt.nix
+++ b/nixos/tests/ceph-single-node-bluestore-dmcrypt.nix
@@ -139,7 +139,7 @@ in
           };
         in
         lib.pipe config.services.ceph.osd.daemons [
-          (builtins.map map-osd)
+          (map map-osd)
           builtins.listToAttrs
         ];
     };

--- a/nixos/tests/common/acme/server/default.nix
+++ b/nixos/tests/common/acme/server/default.nix
@@ -89,8 +89,7 @@ in
                 (
                   cfg:
                   lib.attrsets.mapAttrsToList (
-                    domain: cfg:
-                    builtins.map (builtins.replaceStrings [ "*." ] [ "" ]) ([ domain ] ++ cfg.extraDomainNames)
+                    domain: cfg: map (builtins.replaceStrings [ "*." ] [ "" ]) ([ domain ] ++ cfg.extraDomainNames)
                   ) cfg.configuration.security.acme.certs
                 )
                 # A specialisation's config is nested under its configuration attribute.
@@ -99,7 +98,7 @@ in
             )
           );
         in
-        builtins.listToAttrs (builtins.map (ip: lib.attrsets.nameValuePair ip names) ips)
+        builtins.listToAttrs (map (ip: lib.attrsets.nameValuePair ip names) ips)
       ) nodes;
     };
 

--- a/nixos/tests/devpi-server.nix
+++ b/nixos/tests/devpi-server.nix
@@ -34,8 +34,8 @@ in
   testScript = ''
     start_all()
     devpi.wait_for_unit("devpi-server.service")
-    devpi.wait_for_open_port(${builtins.toString server-port})
+    devpi.wait_for_open_port(${toString server-port})
 
-    client1.succeed("devpi getjson http://devpi:${builtins.toString server-port}")
+    client1.succeed("devpi getjson http://devpi:${toString server-port}")
   '';
 }

--- a/nixos/tests/ergochat.nix
+++ b/nixos/tests/ergochat.nix
@@ -25,7 +25,7 @@ in
     };
   }
   // lib.listToAttrs (
-    builtins.map (
+    map (
       client:
       lib.nameValuePair client {
         imports = [
@@ -83,7 +83,7 @@ in
           ''
           # check that all greetings arrived on all clients
         ]
-        ++ builtins.map (other: ''
+        ++ map (other: ''
           ${client}.succeed(
               "grep '${msg other}$' ${iiDir}/${server}/#${channel}/out"
           )
@@ -101,5 +101,5 @@ in
       # entry is executed by every client before advancing
       # to the next one.
     ''
-    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (builtins.map clientScript clients));
+    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (map clientScript clients));
 }

--- a/nixos/tests/fsck.nix
+++ b/nixos/tests/fsck.nix
@@ -27,10 +27,7 @@
 
       with subtest("root fs is fsckd"):
           machine.succeed("journalctl -b | grep '${
-            if systemdStage1 then
-              "fsck.*${builtins.baseNameOf rootDevice}.*clean"
-            else
-              "fsck.ext4.*${rootDevice}"
+            if systemdStage1 then "fsck.*${baseNameOf rootDevice}.*clean" else "fsck.ext4.*${rootDevice}"
           }'")
 
       with subtest("mnt fs is fsckd"):

--- a/nixos/tests/galene.nix
+++ b/nixos/tests/galene.nix
@@ -57,17 +57,17 @@ in
         with subtest("galene starts"):
             # Starts?
             machine.wait_for_unit("galene")
-            machine.wait_for_open_port(${builtins.toString galenePort})
+            machine.wait_for_open_port(${toString galenePort})
 
             # Reponds fine?
-            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}' >&2")
+            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${toString galenePort}' >&2")
 
         machine.succeed("cp -v /etc/${galeneTestGroupFile} ${galeneTestGroupsDir}/test.json >&2")
-        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}/group/test/' >&2")
+        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${toString galenePort}/group/test/' >&2")
 
         with subtest("galene can join group"):
             # Open site
-            machine.succeed("firefox --new-window 'http://localhost:${builtins.toString galenePort}/group/test/' >&2 &")
+            machine.succeed("firefox --new-window 'http://localhost:${toString galenePort}/group/test/' >&2 &")
             # Note: Firefox doesn't use a regular "-" in the window title, but "—" (Hex: 0xe2 0x80 0x94)
             machine.wait_for_window("Test — Mozilla Firefox")
             machine.send_key("ctrl-minus")
@@ -141,17 +141,17 @@ in
         with subtest("galene starts"):
             # Starts?
             machine.wait_for_unit("galene")
-            machine.wait_for_open_port(${builtins.toString galenePort})
+            machine.wait_for_open_port(${toString galenePort})
 
             # Reponds fine?
-            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}' >&2")
+            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${toString galenePort}' >&2")
 
         machine.succeed("cp -v /etc/${galeneTestGroupFile} ${galeneTestGroupsDir}/test.json >&2")
-        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}/group/test/' >&2")
+        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${toString galenePort}/group/test/' >&2")
 
         with subtest("galene can join group"):
             # Open site
-            machine.succeed("firefox --new-window 'http://localhost:${builtins.toString galenePort}/group/test/' >&2 &")
+            machine.succeed("firefox --new-window 'http://localhost:${toString galenePort}/group/test/' >&2 &")
             # Note: Firefox doesn't use a regular "-" in the window title, but "—" (Hex: 0xe2 0x80 0x94)
             machine.wait_for_window("Test — Mozilla Firefox")
             machine.send_key("ctrl-minus")
@@ -176,7 +176,7 @@ in
             machine.succeed(
                 "galene-file-transfer "
                 + "-to '${galeneTestGroupAdminName}' "
-                + "-insecure 'http://localhost:${builtins.toString galenePort}/group/test/' "
+                + "-insecure 'http://localhost:${toString galenePort}/group/test/' "
                 + "${galeneTestGroupsDir}/test.json " # just try sending the groups file
                 + " >&2 &"
             )
@@ -276,20 +276,20 @@ in
         with subtest("galene starts"):
             # Starts?
             machine.wait_for_unit("galene")
-            machine.wait_for_open_port(${builtins.toString galenePort})
+            machine.wait_for_open_port(${toString galenePort})
 
             # Reponds fine?
-            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}' >&2")
+            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${toString galenePort}' >&2")
 
         machine.succeed("cp -v /etc/${galeneTestGroupFile} ${galeneTestGroupsDir}/test.json >&2")
-        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}/group/test/' >&2")
+        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${toString galenePort}/group/test/' >&2")
 
         with subtest("galene-stream works"):
             # Start interface for stream data
             machine.succeed(
                 "galene-stream "
-                + "--input 'srt://localhost:${builtins.toString galeneStreamSrtPort}?mode=listener' "
-                + "--insecure --output 'http://localhost:${builtins.toString galenePort}/group/test/' "
+                + "--input 'srt://localhost:${toString galeneStreamSrtPort}?mode=listener' "
+                + "--insecure --output 'http://localhost:${toString galenePort}/group/test/' "
                 + "--username ${galeneTestGroupBotName} --password ${galeneTestGroupBotPassword} "
                 + ">&2 &"
             )
@@ -304,13 +304,13 @@ in
                 + "-c:a mp2 " # stream audio codec
                 + "-c:v libx264 -pix_fmt yuv420p " # stream video codec
                 + "-f mpegts " # stream format
-                + "'srt://localhost:${builtins.toString galeneStreamSrtPort}' "
+                + "'srt://localhost:${toString galeneStreamSrtPort}' "
                 + ">/dev/null 2>&1 &"
             )
             machine.wait_for_console_text("Setting remote session description")
 
             # Open site
-            machine.succeed("firefox --new-window 'http://localhost:${builtins.toString galenePort}/group/test/' >&2 &")
+            machine.succeed("firefox --new-window 'http://localhost:${toString galenePort}/group/test/' >&2 &")
             # Note: Firefox doesn't use a regular "-" in the window title, but "—" (Hex: 0xe2 0x80 0x94)
             machine.wait_for_window("Test — Mozilla Firefox")
             machine.send_key("ctrl-minus")

--- a/nixos/tests/gitlab/runner/podman-runner/nix-image.nix
+++ b/nixos/tests/gitlab/runner/podman-runner/nix-image.nix
@@ -219,7 +219,7 @@ let
         cat > $out <<EOF
         [
         ${lib.concatStringsSep "\n" (
-          builtins.map (
+          map (
             drv:
             let
               outputs = drv.outputsToInstall or [ "out" ];
@@ -227,11 +227,11 @@ let
             ''
               {
                 ${lib.concatStringsSep "\n" (
-                  builtins.map (output: ''
+                  map (output: ''
                     ${output} = { outPath = "${lib.getOutput output drv}"; };
                   '') outputs
                 )}
-                outputs = [ ${lib.concatStringsSep " " (builtins.map (x: "\"${x}\"") outputs)} ];
+                outputs = [ ${lib.concatStringsSep " " (map (x: "\"${x}\"") outputs)} ];
                 name = "${drv.name}";
                 outPath = "${drv}";
                 system = "${drv.system}";

--- a/nixos/tests/glance.nix
+++ b/nixos/tests/glance.nix
@@ -17,9 +17,7 @@
       let
         # Do not use this in production. This will make the secret world-readable
         # in the Nix store
-        secrets.glance-location.path = builtins.toString (
-          pkgs.writeText "location-secret" "Nivelles, Belgium"
-        );
+        secrets.glance-location.path = toString (pkgs.writeText "location-secret" "Nivelles, Belgium");
       in
       {
         services.glance = {

--- a/nixos/tests/hydra/common.nix
+++ b/nixos/tests/hydra/common.nix
@@ -3,7 +3,7 @@
     { pkgs, ... }:
     let
       trivialJob = pkgs.writeTextDir "trivial.nix" ''
-        { trivial = builtins.derivation {
+        { trivial = derivation {
             name = "trivial";
             system = "${pkgs.stdenv.hostPlatform.system}";
             builder = "/bin/sh";

--- a/nixos/tests/ifstate/initrd-partial-broken-config.nix
+++ b/nixos/tests/ifstate/initrd-partial-broken-config.nix
@@ -2,7 +2,7 @@ let
   mkIfStateConfig = id: {
     enable = true;
     settings.interfaces.eth1 = {
-      addresses = [ "2001:0db8::${builtins.toString id}/64" ];
+      addresses = [ "2001:0db8::${toString id}/64" ];
       link = {
         state = "up";
         kind = "physical";

--- a/nixos/tests/ifstate/initrd-wireguard.nix
+++ b/nixos/tests/ifstate/initrd-wireguard.nix
@@ -11,7 +11,7 @@ let
       enable = true;
       settings = {
         namespaces.outside.interfaces.eth1 = {
-          addresses = [ "2001:0db8:a::${builtins.toString id}/64" ];
+          addresses = [ "2001:0db8:a::${toString id}/64" ];
           link = {
             state = "up";
             kind = "physical";
@@ -19,7 +19,7 @@ let
         };
         interfaces = {
           wg0 = {
-            addresses = [ "2001:0db8:b::${builtins.toString id}/64" ];
+            addresses = [ "2001:0db8:b::${toString id}/64" ];
             link = {
               state = "up";
               kind = "wireguard";
@@ -29,7 +29,7 @@ let
               private_key = "!include ${pkgs.writeText "wg_priv.key" wgPriv}";
               listen_port = 51820;
               peers."${wgPeerPubKey}" = {
-                endpoint = "[2001:0db8:a::${builtins.toString wgPeerId}]:51820";
+                endpoint = "[2001:0db8:a::${toString wgPeerId}]:51820";
                 allowedips = [ "::/0" ];
               };
             };

--- a/nixos/tests/ifstate/initrd.nix
+++ b/nixos/tests/ifstate/initrd.nix
@@ -2,7 +2,7 @@ let
   mkIfStateConfig = id: {
     enable = true;
     settings.interfaces.eth1 = {
-      addresses = [ "2001:0db8::${builtins.toString id}/64" ];
+      addresses = [ "2001:0db8::${toString id}/64" ];
       link = {
         state = "up";
         kind = "physical";

--- a/nixos/tests/ifstate/ping.nix
+++ b/nixos/tests/ifstate/ping.nix
@@ -7,7 +7,7 @@ let
     networking.ifstate = {
       enable = true;
       settings.interfaces.eth1 = {
-        addresses = [ "2001:0db8::${builtins.toString id}/64" ];
+        addresses = [ "2001:0db8::${toString id}/64" ];
         link = {
           state = "up";
           kind = "physical";

--- a/nixos/tests/ifstate/wireguard.nix
+++ b/nixos/tests/ifstate/wireguard.nix
@@ -20,7 +20,7 @@ let
             enable = true;
             settings = {
               namespaces.outside.interfaces.eth1 = {
-                addresses = [ "2001:0db8:a::${builtins.toString id}/64" ];
+                addresses = [ "2001:0db8:a::${toString id}/64" ];
                 link = {
                   state = "up";
                   kind = "physical";
@@ -28,7 +28,7 @@ let
               };
               interfaces = {
                 wg0 = {
-                  addresses = [ "2001:0db8:b::${builtins.toString id}/64" ];
+                  addresses = [ "2001:0db8:b::${toString id}/64" ];
                   link = {
                     state = "up";
                     kind = "wireguard";
@@ -38,7 +38,7 @@ let
                     private_key = "!include ${pkgs.writeText "wg_priv.key" wgPriv}";
                     listen_port = 51820;
                     peers."${wgPeerPubKey}" = {
-                      endpoint = "[2001:0db8:a::${builtins.toString wgPeerId}]:51820";
+                      endpoint = "[2001:0db8:a::${toString wgPeerId}]:51820";
                       allowedips = [ "::/0" ];
                     };
                   };

--- a/nixos/tests/inspircd.nix
+++ b/nixos/tests/inspircd.nix
@@ -26,7 +26,7 @@ in
     };
   }
   // lib.listToAttrs (
-    builtins.map (
+    map (
       client:
       lib.nameValuePair client {
         imports = [
@@ -80,7 +80,7 @@ in
           ''
           # check that all greetings arrived on all clients
         ]
-        ++ builtins.map (other: ''
+        ++ map (other: ''
           ${client}.succeed(
               "grep '${msg other}$' ${iiDir}/${server}/#${channel}/out"
           )
@@ -97,5 +97,5 @@ in
       # entry is executed by every client before advancing
       # to the next one.
     ''
-    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (builtins.map clientScript clients));
+    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (map clientScript clients));
 }

--- a/nixos/tests/intune.nix
+++ b/nixos/tests/intune.nix
@@ -20,7 +20,7 @@
       ];
       test-support.displayManager.auto.user = user.name;
       environment = {
-        variables.DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/${builtins.toString user.uid}/bus";
+        variables.DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/${toString user.uid}/bus";
       };
     };
   nodes.pam =

--- a/nixos/tests/legit.nix
+++ b/nixos/tests/legit.nix
@@ -26,7 +26,7 @@ in
   testScript =
     { nodes, ... }:
     let
-      strPort = builtins.toString port;
+      strPort = toString port;
     in
     ''
       start_all()

--- a/nixos/tests/lomiri-gallery-app.nix
+++ b/nixos/tests/lomiri-gallery-app.nix
@@ -101,8 +101,8 @@ let
         testScript = ''
           machine.wait_for_x()
 
-          machine.succeed("mkdir /root/${builtins.dirOf file}")
-          machine.succeed("cp -vr /etc/${imageDataDir}/${file} /root/${builtins.dirOf file}")
+          machine.succeed("mkdir /root/${dirOf file}")
+          machine.succeed("cp -vr /etc/${imageDataDir}/${file} /root/${dirOf file}")
 
           # Start thumbnailer, wait for idle shutdown
           machine.systemctl("start dbus-com.lomiri.Thumbnailer", "root")
@@ -174,7 +174,7 @@ let
   makeFormatTests =
     detailsList:
     builtins.listToAttrs (
-      builtins.map (
+      map (
         {
           name,
           file,

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -274,7 +274,7 @@ let
       titleOcr = "r\"(${builtins.concatStringsSep "|" titles})\"";
     in
     builtins.listToAttrs (
-      builtins.map (
+      map (
         {
           name,
           left,

--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -67,7 +67,7 @@ lib.listToAttrs (
                 kernelPackages = pkgs."linuxPackages_${v'}";
                 inherit mkXfsFlags;
               }
-              // builtins.removeAttrs t [
+              // removeAttrs t [
                 "test"
                 "kernelFilter"
               ]

--- a/nixos/tests/man.nix
+++ b/nixos/tests/man.nix
@@ -5,7 +5,7 @@ let
     "man-db"
   ];
 
-  machineNames = builtins.map machineSafe manImplementations;
+  machineNames = map machineSafe manImplementations;
 
   makeConfig = useImpl: {
     # Note: mandoc currently can't index symlinked section directories.
@@ -26,7 +26,7 @@ let
         generateCaches = true;
       }
       // lib.listToAttrs (
-        builtins.map (impl: {
+        map (impl: {
           name = impl;
           value = {
             enable = useImpl == impl;
@@ -43,7 +43,7 @@ in
   meta.maintainers = [ lib.maintainers.sternenseemann ];
 
   nodes = lib.listToAttrs (
-    builtins.map (i: {
+    map (i: {
       name = machineSafe i;
       value = makeConfig i;
     }) manImplementations

--- a/nixos/tests/ncps.nix
+++ b/nixos/tests/ncps.nix
@@ -27,7 +27,7 @@
 
         cache = {
           hostName = "ncps";
-          secretKeyPath = builtins.toString (
+          secretKeyPath = toString (
             pkgs.writeText "ncps-cache-key" "ncps:dcrGsrku0KvltFhrR5lVIMqyloAdo0y8vYZOeIFUSLJS2IToL7dPHSSCk/fi+PJf8EorpBn8PU7MNhfvZoI8mA=="
           );
         };

--- a/nixos/tests/networking/meshtasticd.nix
+++ b/nixos/tests/networking/meshtasticd.nix
@@ -38,8 +38,8 @@ in
   testScript = ''
     with subtest("Test meshtasticd service"):
       machine.wait_for_unit("meshtasticd.service")
-      machine.wait_for_open_port(${builtins.toString mainPort})
-      machine.wait_for_open_port(${builtins.toString webPort})
-      machine.succeed("curl -fvvv -Ls http://localhost:${builtins.toString webPort} | grep -q 'Meshtastic Web Client'")
+      machine.wait_for_open_port(${toString mainPort})
+      machine.wait_for_open_port(${toString webPort})
+      machine.succeed("curl -fvvv -Ls http://localhost:${toString webPort} | grep -q 'Meshtastic Web Client'")
   '';
 }

--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -1418,7 +1418,7 @@ let
         nodes.machine = {
           networking.useNetworkd = networkd;
           networking.bridges = lib.listToAttrs (
-            lib.flip builtins.map ifnames (name: {
+            lib.flip map ifnames (name: {
               inherit name;
               value.interfaces = [ ];
             })

--- a/nixos/tests/nginx-http3.nix
+++ b/nixos/tests/nginx-http3.nix
@@ -6,7 +6,7 @@ let
 
 in
 builtins.listToAttrs (
-  builtins.map
+  map
     (nginxPackage: {
       name = pkgs.lib.getName nginxPackage;
       value = runTest {

--- a/nixos/tests/nginx-variants.nix
+++ b/nixos/tests/nginx-variants.nix
@@ -1,6 +1,6 @@
 { pkgs, runTest, ... }:
 builtins.listToAttrs (
-  builtins.map
+  map
     (packageName: {
       name = packageName;
       value = runTest {

--- a/nixos/tests/onlyoffice.nix
+++ b/nixos/tests/onlyoffice.nix
@@ -24,7 +24,7 @@ in
   testScript = ''
     machine.wait_for_unit("onlyoffice-docservice.service")
     machine.wait_for_unit("onlyoffice-converter.service")
-    machine.wait_for_open_port(${builtins.toString port})
+    machine.wait_for_open_port(${toString port})
     machine.succeed("curl --fail http://office.example.com/healthcheck")
   '';
 }

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -22,7 +22,7 @@ let
   };
 in
 pkgs.lib.listToAttrs (
-  builtins.map (
+  map (
     {
       predictable,
       withNetworkd,

--- a/nixos/tests/rosenpass.nix
+++ b/nixos/tests/rosenpass.nix
@@ -101,7 +101,7 @@ in
           {
             AllowedIPs = [ "::/0" ];
             PublicKey = server.wg.public;
-            Endpoint = "server:${builtins.toString server.wg.listen}";
+            Endpoint = "server:${toString server.wg.listen}";
           }
         ];
 

--- a/nixos/tests/silverbullet.nix
+++ b/nixos/tests/silverbullet.nix
@@ -33,7 +33,7 @@
   testScript =
     { nodes, ... }:
     ''
-      PORT = ${builtins.toString nodes.simple.services.silverbullet.listenPort}
+      PORT = ${toString nodes.simple.services.silverbullet.listenPort}
       ADDRESS = "${nodes.simple.services.silverbullet.listenAddress}"
       SPACEDIR = "${nodes.simple.services.silverbullet.spaceDir}"
       simple.wait_for_unit("silverbullet.service")
@@ -41,7 +41,7 @@
       simple.succeed(f"curl --max-time 5 -s -v -o /dev/null --fail http://{ADDRESS}:{PORT}/")
       simple.succeed(f"test -d '{SPACEDIR}'")
 
-      PORT = ${builtins.toString nodes.configured.services.silverbullet.listenPort}
+      PORT = ${toString nodes.configured.services.silverbullet.listenPort}
       ADDRESS = "${nodes.configured.services.silverbullet.listenAddress}"
       SPACEDIR = "${nodes.configured.services.silverbullet.spaceDir}"
       configured.wait_for_unit("silverbullet.service")

--- a/nixos/tests/solanum.nix
+++ b/nixos/tests/solanum.nix
@@ -25,7 +25,7 @@ in
     };
   }
   // lib.listToAttrs (
-    builtins.map (
+    map (
       client:
       lib.nameValuePair client {
         imports = [
@@ -83,7 +83,7 @@ in
           ''
           # check that all greetings arrived on all clients
         ]
-        ++ builtins.map (other: ''
+        ++ map (other: ''
           ${client}.succeed(
               "grep '${msg other}$' ${iiDir}/${server}/#${channel}/out"
           )
@@ -101,5 +101,5 @@ in
       # entry is executed by every client before advancing
       # to the next one.
     ''
-    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (builtins.map clientScript clients));
+    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (map clientScript clients));
 }

--- a/nixos/tests/syncthing/many-devices.nix
+++ b/nixos/tests/syncthing/many-devices.nix
@@ -42,9 +42,9 @@ let
     # Generates a few folders with IDs and paths as written...
     folders = lib.pipe 6 [
       (builtins.genList (x: {
-        name = "/var/lib/syncthing/test_folder${builtins.toString x}";
+        name = "/var/lib/syncthing/test_folder${toString x}";
         value = {
-          id = "DontDeleteMe${builtins.toString x}";
+          id = "DontDeleteMe${toString x}";
         };
       }))
       builtins.listToAttrs
@@ -198,7 +198,7 @@ in
       checkSettingWithoutId {
         t = (builtins.elemAt path 0);
         n = (builtins.elemAt path 1);
-        v = (builtins.toString value);
+        v = (toString value);
       }
     ))
     # Get all the values we applied the above function upon

--- a/nixos/tests/systemd-user-linger-purge.nix
+++ b/nixos/tests/systemd-user-linger-purge.nix
@@ -15,7 +15,7 @@ rec {
 
   testScript =
     let
-      uidStrings = builtins.mapAttrs (k: v: builtins.toString v.uid) nodes.machine.users.users;
+      uidStrings = builtins.mapAttrs (k: v: toString v.uid) nodes.machine.users.users;
     in
     ''
       machine.fail("test -e /var/lib/systemd/linger/bob")

--- a/nixos/tests/systemd-user-linger.nix
+++ b/nixos/tests/systemd-user-linger.nix
@@ -19,7 +19,7 @@ rec {
 
   testScript =
     let
-      uidStrings = builtins.mapAttrs (k: v: builtins.toString v.uid) nodes.machine.users.users;
+      uidStrings = builtins.mapAttrs (k: v: toString v.uid) nodes.machine.users.users;
     in
     ''
       machine.wait_for_file("/var/lib/systemd/linger/alice")

--- a/nixos/tests/taskchampion-sync-server.nix
+++ b/nixos/tests/taskchampion-sync-server.nix
@@ -18,7 +18,7 @@
     { nodes, ... }:
     let
       cfg = nodes.server.services.taskchampion-sync-server;
-      port = builtins.toString cfg.port;
+      port = toString cfg.port;
       # Generated with uuidgen
       uuid = "bf01376e-04a4-435a-9263-608567531af3";
       password = "nixos-test";

--- a/nixos/tests/web-apps/movim/ejabberd-h2o.nix
+++ b/nixos/tests/web-apps/movim/ejabberd-h2o.nix
@@ -245,7 +245,7 @@ in
 
       server.wait_for_unit("phpfpm-movim.service")
       server.wait_for_unit("h2o.service")
-      server.wait_for_open_port(${builtins.toString movim.port})
+      server.wait_for_open_port(${toString movim.port})
       server.wait_for_open_port(80)
 
       server.wait_for_unit("ejabberd.service")

--- a/nixos/tests/web-apps/movim/prosody-nginx.nix
+++ b/nixos/tests/web-apps/movim/prosody-nginx.nix
@@ -87,7 +87,7 @@ in
     ''
       server.wait_for_unit("phpfpm-movim.service")
       server.wait_for_unit("nginx.service")
-      server.wait_for_open_port(${builtins.toString movim.port})
+      server.wait_for_open_port(${toString movim.port})
       server.wait_for_open_port(80)
 
       server.wait_for_unit("prosody.service")

--- a/nixos/tests/web-servers/h2o/basic.nix
+++ b/nixos/tests/web-servers/h2o/basic.nix
@@ -135,8 +135,8 @@ in
     { nodes, ... }:
     let
       inherit (nodes) server;
-      portStrHTTP = builtins.toString server.services.h2o.defaultHTTPListenPort;
-      portStrTLS = builtins.toString server.services.h2o.defaultTLSListenPort;
+      portStrHTTP = toString server.services.h2o.defaultHTTPListenPort;
+      portStrTLS = toString server.services.h2o.defaultTLSListenPort;
     in
     # python
     ''

--- a/nixos/tests/web-servers/h2o/mruby.nix
+++ b/nixos/tests/web-servers/h2o/mruby.nix
@@ -59,7 +59,7 @@ in
     { nodes, ... }:
     let
       inherit (nodes) server;
-      portStr = builtins.toString server.services.h2o.settings.listen;
+      portStr = toString server.services.h2o.settings.listen;
       origin = "http://server:${portStr}";
     in
     # python

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -90,9 +90,9 @@ in
     { nodes, ... }:
     let
       inherit (nodes) server_modern server_intermediate server_old;
-      modernPortStr = builtins.toString server_modern.services.h2o.hosts.${domain}.tls.port;
-      intermediatePortStr = builtins.toString server_intermediate.services.h2o.hosts.${domain}.tls.port;
-      oldPortStr = builtins.toString server_old.services.h2o.hosts.${domain}.tls.port;
+      modernPortStr = toString server_modern.services.h2o.hosts.${domain}.tls.port;
+      intermediatePortStr = toString server_intermediate.services.h2o.hosts.${domain}.tls.port;
+      oldPortStr = toString server_old.services.h2o.hosts.${domain}.tls.port;
     in
     # python
     ''


### PR DESCRIPTION
```
Remove optional builtins prefixes from prelude functions by running:

    builtins=(
      abort
      baseNameOf
      break
      derivation
      derivationStrict
      dirOf
      false
      fetchGit
      fetchMercurial
      fetchTarball
      fetchTree
      fromTOML
      import
      isNull
      map
      null
      placeholder
      removeAttrs
      scopedImport
      throw
      toString
      true
    )

    fd \
      --exclude doc/manual/release-notes \
      --type file \
      . \
      nixos \
      --exec-batch sed --in-place --regexp-extended "
        s/\<builtins\.($(
          printf '%s\n' "${builtins[@]}" |
            paste --delimiter '|' --serial -
        ))\>/\1/g
      "

    nix fmt
```

Related PRs intentionally split up to simplify review and merging:

1. https://github.com/NixOS/nixpkgs/pull/447401
2. https://github.com/NixOS/nixpkgs/pull/447402
3. https://github.com/NixOS/nixpkgs/pull/447404
4. https://github.com/NixOS/nixpkgs/pull/447403
5. https://github.com/NixOS/nixpkgs/pull/444432

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
