### PR TITLE
pkgs: remove optional builtins prefixes from prelude functions

### DIFF
--- a/pkgs/applications/audio/mellowplayer/default.nix
+++ b/pkgs/applications/audio/mellowplayer/default.nix
@@ -55,7 +55,7 @@ mkDerivation rec {
   # TODO: The tests are failing because it can't locate QT plugins. Is there a better way to do this?
   + (builtins.concatStringsSep "\n" (
     lib.lists.flatten (
-      builtins.map (pkg: [
+      map (pkg: [
         (lib.optionalString (pkg ? qtPluginPrefix) ''
           export QT_PLUGIN_PATH="${pkg}/${pkg.qtPluginPrefix}"''${QT_PLUGIN_PATH:+':'}$QT_PLUGIN_PATH
         '')

--- a/pkgs/applications/audio/pianoteq/default.nix
+++ b/pkgs/applications/audio/pianoteq/default.nix
@@ -84,7 +84,7 @@ let
       installPhase = ''
         runHook preInstall
         mkdir -p $out/bin
-        mv -t $out/bin ${builtins.concatStringsSep " " (builtins.map (dir: "Pianoteq*/${dir}/*") archdirs)}
+        mv -t $out/bin ${builtins.concatStringsSep " " (map (dir: "Pianoteq*/${dir}/*") archdirs)}
         install -Dm644 ${./pianoteq.svg} $out/share/icons/hicolor/scalable/apps/pianoteq.svg
         for size in 16 22 32 48 64 128 256; do
           dir=$out/share/icons/hicolor/"$size"x"$size"/apps

--- a/pkgs/applications/audio/sonic-pi/update.sh
+++ b/pkgs/applications/audio/sonic-pi/update.sh
@@ -19,7 +19,7 @@ vendorhash() {
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
-    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "fetchGit \"$nixpkgs\"")"
 
     if [ -n "$outpath" ]; then
         path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"

--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
             echo "OK"
           '';
         in
-        builtins.concatStringsSep "\n" (builtins.map script builderKeys);
+        builtins.concatStringsSep "\n" (map script builderKeys);
     in
     ''
       pushd $(mktemp -d)

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
             echo "OK"
           '';
         in
-        builtins.concatStringsSep "\n" (builtins.map script builderKeys);
+        builtins.concatStringsSep "\n" (map script builderKeys);
     in
     ''
       pushd $(mktemp -d)

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
@@ -21,8 +21,8 @@
 
 let
 
-  appPythonDeps = builtins.map (item: item.eafPythonDeps) enabledApps;
-  appOtherDeps = builtins.map (item: item.eafOtherDeps) enabledApps;
+  appPythonDeps = map (item: item.eafPythonDeps) enabledApps;
+  appOtherDeps = map (item: item.eafOtherDeps) enabledApps;
 
   pythonPackageLists = [
     (
@@ -38,7 +38,7 @@ let
     )
   ]
   ++ appPythonDeps;
-  pythonPkgs = ps: builtins.concatLists (builtins.map (f: f ps) pythonPackageLists);
+  pythonPkgs = ps: builtins.concatLists (map (f: f ps) pythonPackageLists);
   pythonEnv = python3.withPackages pythonPkgs;
 
   otherPackageLists = [

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -172,7 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
         {
           backendPath = (
             lib.concatStringsSep " " (
-              builtins.map (x: ''"-B${x}"'') (
+              map (x: ''"-B${x}"'') (
                 [
                   # Paths necessary so the JIT compiler finds its libraries:
                   "${lib.getLib libgccjit}/lib"

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -59,7 +59,7 @@ in
       plugins-for =
         with lib.asserts;
         ide:
-        builtins.map (plugin: plugin.name) (
+        map (plugin: plugin.name) (
           builtins.filter (
             plugin:
             (

--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -185,7 +185,7 @@ let
   mkRepoEntry = entry: {
     name = ".m2/repository/" + entry.path;
     path = fetchurl {
-      urls = builtins.map (url: "${url}/${entry.url}") repositories;
+      urls = map (url: "${url}/${entry.url}") repositories;
       sha256 = entry.hash;
     };
   };

--- a/pkgs/applications/editors/jupyter-kernels/clojupyter/deps.nix
+++ b/pkgs/applications/editors/jupyter-kernels/clojupyter/deps.nix
@@ -18,7 +18,7 @@ rec {
     {
       extraClasspaths ? [ ],
     }:
-    (builtins.map (dep: if builtins.hasAttr "jar" dep.path then dep.path.jar else dep.path) packages)
+    (map (dep: if builtins.hasAttr "jar" dep.path then dep.path.jar else dep.path) packages)
     ++ extraClasspaths;
   makeClasspaths =
     {

--- a/pkgs/applications/editors/kakoune/plugins/build-kakoune-plugin.nix
+++ b/pkgs/applications/editors/kakoune/plugins/build-kakoune-plugin.nix
@@ -18,7 +18,7 @@ rec {
       ...
     }:
     stdenv.mkDerivation (
-      (builtins.removeAttrs attrs [
+      (removeAttrs attrs [
         "namePrefix"
         "path"
       ])

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -230,7 +230,7 @@ let
       nvimGrammars = lib.mapAttrsToList (
         name: value:
         value.origGrammar
-          or (builtins.throw "additions to `pkgs.vimPlugins.nvim-treesitter.grammarPlugins` set should be passed through `pkgs.neovimUtils.grammarToPlugin` first")
+          or (throw "additions to `pkgs.vimPlugins.nvim-treesitter.grammarPlugins` set should be passed through `pkgs.neovimUtils.grammarToPlugin` first")
       ) vimPlugins.nvim-treesitter.grammarPlugins;
       isNvimGrammar = x: builtins.elem x nvimGrammars;
 

--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -42,7 +42,7 @@ let
   ];
   downloadUrl = "https://download.sublimetext.com/sublime_text_3_build_${buildVersion}_${arch}.tar.bz2";
   versionUrl = "https://download.sublimetext.com/latest/${if dev then "dev" else "stable"}";
-  versionFile = builtins.toString ./packages.nix;
+  versionFile = toString ./packages.nix;
   archSha256 = if stdenv.hostPlatform.system == "i686-linux" then x32sha256 else x64sha256;
   arch = if stdenv.hostPlatform.system == "i686-linux" then "x32" else "x64";
 

--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -46,7 +46,7 @@ let
   downloadUrl =
     arch: "https://download.sublimetext.com/sublime_text_build_${buildVersion}_${arch}.tar.xz";
   versionUrl = "https://download.sublimetext.com/latest/${if dev then "dev" else "stable"}";
-  versionFile = builtins.toString ./packages.nix;
+  versionFile = toString ./packages.nix;
 
   neededLibraries = [
     xorg.libX11

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -111,7 +111,7 @@ in
       tree-sitter-queries-are-present-for-custom-grammars =
         let
           pluginsToCheck =
-            builtins.map (grammar: grammarToPlugin grammar)
+            map (grammar: grammarToPlugin grammar)
               # true is here because there is `recurseForDerivations = true`
               (lib.remove true (lib.attrValues tree-sitter-grammars));
         in

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -202,7 +202,7 @@ let
           startWithDeps = findDependenciesRecursively start;
           allPlugins = lib.unique (startWithDeps ++ depsOfOptionalPlugins);
           allPython3Dependencies =
-            ps: lib.flatten (builtins.map (plugin: (plugin.python3Dependencies or (_: [ ])) ps) allPlugins);
+            ps: lib.flatten (map (plugin: (plugin.python3Dependencies or (_: [ ])) ps) allPlugins);
           python3Env = python3.withPackages allPython3Dependencies;
 
           packdirStart = vimFarm "pack/${packageName}/start" "packdir-start" allPlugins;

--- a/pkgs/applications/editors/vscode/extensions/updateSettings.nix
+++ b/pkgs/applications/editors/vscode/extensions/updateSettings.nix
@@ -24,7 +24,7 @@ let
     )'';
 
   createEmptySettingsCmd = ''mkdir -p .vscode && echo "{}" > ${vscodeSettingsFile}'';
-  fileName = builtins.baseNameOf vscodeSettingsFile;
+  fileName = baseNameOf vscodeSettingsFile;
   symlinkFromUserSettingCmd = lib.optionalString symlinkFromUserSetting ''&& mkdir -p "${userSettingsFolder}" && ln -sfv "$(pwd)/${vscodeSettingsFile}" "${userSettingsFolder}/" '';
 in
 

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -127,7 +127,7 @@ let
 
   extensionFromVscodeMarketplace = mktplcExtRefToExtDrv;
   extensionsFromVscodeMarketplace =
-    mktplcExtRefList: builtins.map extensionFromVscodeMarketplace mktplcExtRefList;
+    mktplcExtRefList: map extensionFromVscodeMarketplace mktplcExtRefList;
 
   vscodeWithConfiguration = import ./vscodeWithConfiguration.nix {
     inherit lib extensionsFromVscodeMarketplace writeShellScriptBin;

--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/share/sane/epjitsu
       ln -svT ${scanSnapDriversPackage} $out/share/sane/epjitsu
     ''
-    + lib.concatStrings (builtins.map installFirmware compatFirmware);
+    + lib.concatStrings (map installFirmware compatFirmware);
 
   # parallel install creates a bad symlink at $out/lib/sane/libsane.so.1 which prevents finding plugins
   # https://github.com/NixOS/nixpkgs/issues/224569

--- a/pkgs/applications/misc/sweethome3d/linux.nix
+++ b/pkgs/applications/misc/sweethome3d/linux.nix
@@ -26,7 +26,7 @@ let
 
   # TODO: Should we move this to `lib`? Seems like its would be useful in many cases.
   extensionOf =
-    filePath: lib.concatStringsSep "." (lib.tail (lib.splitString "." (builtins.baseNameOf filePath)));
+    filePath: lib.concatStringsSep "." (lib.tail (lib.splitString "." (baseNameOf filePath)));
 
   installIcons =
     iconName: icons:

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -256,7 +256,7 @@ let
           ''
         else
           ''
-            mkdir -p ${builtins.dirOf path}
+            mkdir -p ${dirOf path}
             cp -r ${dep}/. ${path}
           ''
       )

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -76,7 +76,7 @@ let
       # PCSC-Lite daemon (services.pcscd) also must be enabled for firefox to access smartcards
       smartcardSupport = cfg.smartcardSupport or false;
 
-      allNativeMessagingHosts = builtins.map lib.getBin nativeMessagingHosts;
+      allNativeMessagingHosts = map lib.getBin nativeMessagingHosts;
 
       libs =
         lib.optionals stdenv.hostPlatform.isLinux (
@@ -130,7 +130,7 @@ let
 
       usesNixExtensions = nixExtensions != null;
 
-      nameArray = builtins.map (a: a.name) (lib.optionals usesNixExtensions nixExtensions);
+      nameArray = map (a: a.name) (lib.optionals usesNixExtensions nixExtensions);
 
       # Check that every extension has a unique .name attribute
       # and an extid attribute
@@ -140,7 +140,7 @@ let
         else if browser.requireSigning || !browser.allowAddonSideload then
           throw "Nix addons are only supported with signature enforcement disabled and addon sideloading enabled (eg. LibreWolf)"
         else
-          builtins.map (
+          map (
             a:
             if !(builtins.hasAttr "extid" a) then
               throw "nixExtensions has an invalid entry. Missing extid attribute. Please use fetchFirefoxAddon"
@@ -516,7 +516,7 @@ let
           rm -f "$POL_PATH"
           cat ${policiesJson} >> "$POL_PATH"
 
-          extraPoliciesFiles=(${builtins.toString extraPoliciesFiles})
+          extraPoliciesFiles=(${toString extraPoliciesFiles})
           for extraPoliciesFile in "''${extraPoliciesFiles[@]}"; do
             jq -s '.[0] * .[1]' $extraPoliciesFile "$POL_PATH" > .tmp.json
             mv .tmp.json "$POL_PATH"
@@ -533,7 +533,7 @@ let
           ${mozillaCfg}
           EOF
 
-          extraPrefsFiles=(${builtins.toString extraPrefsFiles})
+          extraPrefsFiles=(${toString extraPrefsFiles})
           for extraPrefsFile in "''${extraPrefsFiles[@]}"; do
             cat "$extraPrefsFile" >> "$libDir/mozilla.cfg"
           done

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -129,11 +129,11 @@ let
   # bundled into the k3s binary
   traefik = {
     chart = fetchurl chartVersions.traefik;
-    name = builtins.baseNameOf chartVersions.traefik.url;
+    name = baseNameOf chartVersions.traefik.url;
   };
   traefik-crd = {
     chart = fetchurl chartVersions.traefik-crd;
-    name = builtins.baseNameOf chartVersions.traefik-crd.url;
+    name = baseNameOf chartVersions.traefik-crd.url;
   };
 
   # a shortcut that provides the images archive for the host platform. Currently only supports

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -9,7 +9,7 @@ let
   #     let k3s_1_23 = (callPackage ./path/to/k3s {
   #       commonK3sArg = ....
   #     }).k3s_1_23;
-  extraArgs = builtins.removeAttrs args [ "callPackage" ];
+  extraArgs = removeAttrs args [ "callPackage" ];
 in
 {
   k3s_1_31 = common (

--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -14,7 +14,7 @@ let
       ...
     }@attrs:
     let
-      attrs' = builtins.removeAttrs attrs [
+      attrs' = removeAttrs attrs [
         "version"
         "sha256"
         "rev"

--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -18,7 +18,7 @@ let
       ...
     }@attrs:
     let
-      attrs' = builtins.removeAttrs attrs [
+      attrs' = removeAttrs attrs [
         "buildGoModule"
         "version"
         "hash"

--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -2,7 +2,7 @@
 
 let
   common = opts: callPackage (import ./builder.nix lib opts);
-  extraArgs = builtins.removeAttrs args [ "callPackage" ];
+  extraArgs = removeAttrs args [ "callPackage" ];
 in
 rec {
   rke2_1_30 = common (

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -21,7 +21,7 @@ let
       ...
     }@attrs:
     let
-      attrs' = builtins.removeAttrs attrs [
+      attrs' = removeAttrs attrs [
         "version"
         "hash"
         "vendorHash"

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -40,7 +40,7 @@
   ...
 }@args:
 let
-  cleanedArgs = builtins.removeAttrs args [
+  cleanedArgs = removeAttrs args [
     "pname"
     "name"
     "version"

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -19,7 +19,7 @@ let
         {
           # Do not include PHP by default, because it bloats the closure, doesn't
           # build on Darwin, and there are no official PHP scripts.
-          plugins = builtins.attrValues (builtins.removeAttrs availablePlugins [ "php" ]);
+          plugins = builtins.attrValues (removeAttrs availablePlugins [ "php" ]);
         },
     }:
 
@@ -122,7 +122,7 @@ let
           ln -sf ${weechat}/share $out/share
         '')
       ];
-      meta = builtins.removeAttrs weechat.meta [ "outputsToInstall" ];
+      meta = removeAttrs weechat.meta [ "outputsToInstall" ];
     };
 
 in

--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -95,7 +95,7 @@ python3Packages.buildPythonApplication rec {
 
   # Actually install plugins
   postInstall = ''
-    for plug in ${builtins.toString userPlugins}; do
+    for plug in ${toString userPlugins}; do
       lndir $plug/${python3Packages.python.sitePackages} $out/${python3Packages.python.sitePackages}
     done
   '';

--- a/pkgs/applications/networking/mailreaders/thunderbird/update.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/update.nix
@@ -7,5 +7,5 @@ callPackage ../../browsers/firefox/update.nix (
   {
     baseUrl = "https://archive.mozilla.org/pub/thunderbird/releases/";
   }
-  // (builtins.removeAttrs args [ "callPackage" ])
+  // (removeAttrs args [ "callPackage" ])
 )

--- a/pkgs/applications/office/libreoffice/darwin/default.nix
+++ b/pkgs/applications/office/libreoffice/darwin/default.nix
@@ -57,8 +57,8 @@ stdenvNoCC.mkDerivation {
 
   passthru.updateScript =
     let
-      defaultNixFile = builtins.toString ./default.nix;
-      updateNix = builtins.toString ./update.nix;
+      defaultNixFile = toString ./default.nix;
+      updateNix = toString ./update.nix;
       aarch64Url = dist."aarch64-darwin".url;
       x86_64Url = dist."x86_64-darwin".url;
     in

--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -67,13 +67,11 @@ let
       "--prefix"
       "QT_PLUGIN_PATH"
       ":"
-      "${lib.makeSearchPath unwrapped.qtbase.qtPluginPrefix (
-        builtins.map lib.getBin unwrapped.qtPackages
-      )}"
+      "${lib.makeSearchPath unwrapped.qtbase.qtPluginPrefix (map lib.getBin unwrapped.qtPackages)}"
       "--prefix"
       "QML2_IMPORT_PATH"
       ":"
-      "${lib.makeSearchPath unwrapped.qtbase.qtQmlPrefix (builtins.map lib.getBin unwrapped.qmlPackages)}"
+      "${lib.makeSearchPath unwrapped.qtbase.qtQmlPrefix (map lib.getBin unwrapped.qmlPackages)}"
     ]
     ++ [
       # Add dictionaries from all NIX_PROFILES

--- a/pkgs/applications/radio/gnuradio/wrapper.nix
+++ b/pkgs/applications/radio/gnuradio/wrapper.nix
@@ -67,7 +67,7 @@ let
       (unwrapped.python.pkgs.toPythonModule unwrapped.passthru.uhd)
     ]
     # Add the extraPackages as python modules as well
-    ++ (builtins.map unwrapped.python.pkgs.toPythonModule extraPackages)
+    ++ (map unwrapped.python.pkgs.toPythonModule extraPackages)
     ++ lib.flatten (
       lib.mapAttrsToList (
         feat: info:
@@ -167,7 +167,7 @@ let
               "QT_PLUGIN_PATH"
               ":"
               "${lib.makeSearchPath unwrapped.qt.qtbase.qtPluginPrefix (
-                builtins.map lib.getBin (
+                map lib.getBin (
                   [
                     unwrapped.qt.qtbase
                   ]
@@ -180,7 +180,7 @@ let
               "QML2_IMPORT_PATH"
               ":"
               "${lib.makeSearchPath unwrapped.qt.qtbase.qtQmlPrefix (
-                builtins.map lib.getBin (
+                map lib.getBin (
                   [
                     unwrapped.qt.qtbase
                   ]
@@ -225,7 +225,7 @@ let
           lndir -silent ${unwrapped}
           ${lib.optionalString (extraPackages != [ ]) (
             builtins.concatStringsSep "\n" (
-              builtins.map (pkg: ''
+              map (pkg: ''
                 if [[ -d ${lib.getBin pkg}/bin/ ]]; then
                   lndir -silent ${pkg}/bin ./bin
                 fi

--- a/pkgs/applications/science/chemistry/quantum-espresso/default.nix
+++ b/pkgs/applications/science/chemistry/quantum-espresso/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       --replace "qe_git_submodule_update(external/d3q)" "" \
       --replace "qe_git_submodule_update(external/qe-gipaw)" ""
 
-    ${builtins.toString (
+    ${toString (
       builtins.attrValues (
         builtins.mapAttrs (name: val: ''
           cp -r ${val}/* external/${name}/.

--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -45,7 +45,7 @@ let
   downloadUrl =
     arch: "https://download.sublimetext.com/sublime_merge_build_${buildVersion}_${arch}.tar.xz";
   versionUrl = "https://www.sublimemerge.com/${if dev then "dev" else "download"}";
-  versionFile = builtins.toString ./default.nix;
+  versionFile = toString ./default.nix;
 
   neededLibraries = [
     xorg.libX11

--- a/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
         package: "--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${lib.getLib package}/lib/gstreamer-1.0";
     in
     with gst_all_1;
-    builtins.map gstreamerHook [
+    map gstreamerHook [
       gstreamer
       gst-plugins-base
       gst-plugins-bad

--- a/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
         package: "--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${lib.getLib package}/lib/gstreamer-1.0";
     in
     with gst_all_1;
-    builtins.map gstreamerHook [
+    map gstreamerHook [
       gstreamer
       gst-plugins-base
       gst-plugins-bad

--- a/pkgs/applications/virtualization/cri-o/wrapper.nix
+++ b/pkgs/applications/virtualization/cri-o/wrapper.nix
@@ -33,7 +33,7 @@ runCommand cri-o-unwrapped.name
 
     preferLocalBuild = true;
 
-    meta = builtins.removeAttrs cri-o-unwrapped.meta [ "outputsToInstall" ];
+    meta = removeAttrs cri-o-unwrapped.meta [ "outputsToInstall" ];
 
     outputs = [
       "out"

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -481,7 +481,7 @@ stdenvNoCC.mkDerivation {
       libc_dev
       libc_lib
       ;
-    default_hardening_flags_str = builtins.toString defaultHardeningFlags;
+    default_hardening_flags_str = toString defaultHardeningFlags;
   }
   // lib.mapAttrs (_: lib.optionalString targetPlatform.isDarwin) {
     # These will become empty strings when not targeting Darwin.

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -79,7 +79,7 @@ lib.makeOverridable (
             [ drv ]
         )
         # Add any extra outputs specified by the caller of `buildEnv`.
-        ++ lib.filter (p: p != null) (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
+        ++ lib.filter (p: p != null) (map (outName: drv.${outName} or null) extraOutputsToInstall);
       priority = drv.meta.priority or lib.meta.defaultPriority;
     }) paths;
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -980,7 +980,7 @@ stdenvNoCC.mkDerivation {
     inherit suffixSalt coreutils_bin bintools;
     inherit libc_bin libc_dev libc_lib;
     inherit darwinPlatformForCC;
-    default_hardening_flags_str = builtins.toString defaultHardeningFlags;
+    default_hardening_flags_str = toString defaultHardeningFlags;
     inherit useMacroPrefixMap;
   }
   // lib.mapAttrs (_: lib.optionalString targetPlatform.isDarwin) {

--- a/pkgs/build-support/compress-drv/default.nix
+++ b/pkgs/build-support/compress-drv/default.nix
@@ -66,7 +66,7 @@ let
     in
     lib.assertMsg (
       matches == 1
-    ) "compressor ${ext} needs to have exactly one '{}', found ${builtins.toString matches}";
+    ) "compressor ${ext} needs to have exactly one '{}', found ${toString matches}";
   mkCmd =
     ext: prog:
     assert validProg ext prog;

--- a/pkgs/build-support/coq/meta-fetch/default.nix
+++ b/pkgs/build-support/coq/meta-fetch/default.nix
@@ -68,7 +68,7 @@ let
           {
             ext = "tar.gz";
             fmt = "tarball";
-            fetchfun = builtins.fetchTarball;
+            fetchfun = fetchTarball;
           };
     in
     with kind;

--- a/pkgs/build-support/dart/build-dart-application/default.nix
+++ b/pkgs/build-support/dart/build-dart-application/default.nix
@@ -130,7 +130,7 @@ let
 
   baseDerivation = stdenv.mkDerivation (
     finalAttrs:
-    (builtins.removeAttrs args [
+    (removeAttrs args [
       "gitHashes"
       "sdkSourceBuilders"
       "pubspecLock"

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -582,7 +582,7 @@ rec {
       ...
     }@args:
     let
-      stream = streamLayeredImage (builtins.removeAttrs args [ "compressor" ]);
+      stream = streamLayeredImage (removeAttrs args [ "compressor" ]);
       compress = compressorForImage compressor name;
     in
     runCommand "${baseNameOf name}.tar${compress.ext}" {
@@ -1043,8 +1043,8 @@ rec {
       );
 
       contentsList = if builtins.isList contents then contents else [ contents ];
-      bind-paths = builtins.toString (
-        builtins.map (path: "--bind=${path}:${path}!") [
+      bind-paths = toString (
+        map (path: "--bind=${path}:${path}!") [
           "/dev/"
           "/proc/"
           "/sys/"
@@ -1413,7 +1413,7 @@ rec {
       ...
     }@args:
     let
-      stream = streamNixShellImage (builtins.removeAttrs args [ "compressor" ]);
+      stream = streamNixShellImage (removeAttrs args [ "compressor" ]);
       compress = compressorForImage compressor drv.name;
     in
     runCommand "${drv.name}-env.tar${compress.ext}" {

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -699,7 +699,7 @@ rec {
               " --program-prefix=layeredImageWithFakeRootCommands-"
             ];
             doCheck = false;
-            versionCheckProgram = "${builtins.placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+            versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
             meta = prevAttrs.meta // {
               mainProgram = "layeredImageWithFakeRootCommands-hello";
             };

--- a/pkgs/build-support/dotnet/add-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/add-nuget-deps/default.nix
@@ -49,7 +49,7 @@ let
       assert (lib.isPath nugetDeps);
       callPackage nugetDeps { fetchNuGet = fetchNupkg; }
     else
-      builtins.map fetchNupkg (lib.importJSON nugetDeps);
+      map fetchNupkg (lib.importJSON nugetDeps);
 
   finalPackage = finalAttrs.finalPackage;
 

--- a/pkgs/build-support/dotnet/build-dotnet-package/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-package/default.nix
@@ -122,4 +122,4 @@ let
     '';
   };
 in
-stdenv.mkDerivation (attrs // (builtins.removeAttrs attrsOrig [ "nativeBuildInputs" ]))
+stdenv.mkDerivation (attrs // (removeAttrs attrsOrig [ "nativeBuildInputs" ]))

--- a/pkgs/build-support/dotnet/make-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-deps/default.nix
@@ -21,7 +21,7 @@ lib.makeOverridable (
             assert (lib.isPath sourceFile);
             import sourceFile
           else
-            { fetchNuGet }: builtins.map fetchNuGet (lib.importJSON sourceFile);
+            { fetchNuGet }: map fetchNuGet (lib.importJSON sourceFile);
       in
       loadDeps {
         fetchNuGet = args: fetchNupkg (args // { inherit installable; });

--- a/pkgs/build-support/fetchdocker/default.nix
+++ b/pkgs/build-support/fetchdocker/default.nix
@@ -29,10 +29,10 @@ assert null == lib.findFirst (c: "/" == c) null (lib.stringToCharacters imageNam
 
 let
   # Abuse paths to collapse possible double slashes
-  repoTag0 = builtins.toString (/. + "/${stripScheme registry}/${repository}/${imageName}");
+  repoTag0 = toString (/. + "/${stripScheme registry}/${repository}/${imageName}");
   repoTag1 = lib.removePrefix "/" repoTag0;
 
-  layers = builtins.map stripNixStore imageLayers;
+  layers = map stripNixStore imageLayers;
 
   manifest = writeText "manifest.json" (
     builtins.toJSON [

--- a/pkgs/build-support/fetchmavenartifact/default.nix
+++ b/pkgs/build-support/fetchmavenartifact/default.nix
@@ -66,7 +66,7 @@ let
     else
       map mkJarUrl repos;
   jar = fetchurl (
-    builtins.removeAttrs args [
+    removeAttrs args [
       "groupId"
       "artifactId"
       "version"

--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -88,8 +88,8 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
 
         filterdiff \
           -p1 \
-          ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
-          ${builtins.toString (builtins.map (x: "-i ${lib.escapeShellArg x}") includes)} \
+          ${toString (map (x: "-x ${lib.escapeShellArg x}") excludes)} \
+          ${toString (map (x: "-i ${lib.escapeShellArg x}") includes)} \
           "$tmpfile" > "$out"
 
         if [ ! -s "$out" ]; then
@@ -106,7 +106,7 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
       ''
       + postFetch;
     }
-    // builtins.removeAttrs args [
+    // removeAttrs args [
       "relative"
       "stripLen"
       "decode"

--- a/pkgs/build-support/fetchpypi/default.nix
+++ b/pkgs/build-support/fetchpypi/default.nix
@@ -43,7 +43,7 @@ let
       );
 
     in
-    compute (builtins.removeAttrs attrs [ "format" ]);
+    compute (removeAttrs attrs [ "format" ]);
 
 in
 makeOverridable (
@@ -55,7 +55,7 @@ makeOverridable (
   }@attrs:
   let
     url = computeUrl (
-      builtins.removeAttrs attrs [
+      removeAttrs attrs [
         "sha256"
         "hash"
       ]

--- a/pkgs/build-support/fetchs3/default.nix
+++ b/pkgs/build-support/fetchs3/default.nix
@@ -6,7 +6,7 @@
 lib.fetchers.withNormalizedHash { } (
   {
     s3url,
-    name ? builtins.baseNameOf s3url,
+    name ? baseNameOf s3url,
     outputHash,
     outputHashAlgo,
     region ? "us-east-1",

--- a/pkgs/build-support/make-impure-test.nix
+++ b/pkgs/build-support/make-impure-test.nix
@@ -45,7 +45,7 @@
 }@args:
 
 let
-  sandboxPathsTests = builtins.map (path: "[[ ! -e '${path}' ]]") sandboxPaths;
+  sandboxPathsTests = map (path: "[[ ! -e '${path}' ]]") sandboxPaths;
   sandboxPathsTest = lib.concatStringsSep " || " sandboxPathsTests;
   sandboxPathsList = lib.concatStringsSep " " sandboxPaths;
 
@@ -71,7 +71,7 @@ let
         passthru.runScript = runScript;
       }
       (
-        builtins.removeAttrs args [
+        removeAttrs args [
           "lib"
           "stdenv"
           "writeShellScript"

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -29,7 +29,7 @@ let
       # this leaves actual dependencies of the derivations in `inputsFrom`, but never the derivations themselves
       (lib.subtractLists inputsFrom (lib.flatten (lib.catAttrs name inputsFrom)));
 
-  rest = builtins.removeAttrs attrs [
+  rest = removeAttrs attrs [
     "name"
     "packages"
     "inputsFrom"

--- a/pkgs/build-support/node/fetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-npm-deps/default.nix
@@ -24,7 +24,7 @@
       filter =
         name: type:
         let
-          name' = builtins.baseNameOf name;
+          name' = baseNameOf name;
         in
         name' != "default.nix" && name' != "target";
     };

--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -52,7 +52,7 @@ let
                 // fetcherOpts
               ))
             else if lib.hasPrefix "git" module.resolved then
-              (builtins.fetchGit (
+              (fetchGit (
                 {
                   url = module.resolved;
                 }

--- a/pkgs/build-support/ocaml/topkg.nix
+++ b/pkgs/build-support/ocaml/topkg.nix
@@ -32,7 +32,7 @@ lib.throwIf (args ? minimalOCamlVersion && lib.versionOlder ocaml.version args.m
       inherit (topkg) buildPhase installPhase;
 
     }
-    // (builtins.removeAttrs args [ "minimalOCamlVersion" ])
+    // (removeAttrs args [ "minimalOCamlVersion" ])
     // {
 
       name = "ocaml${ocaml.version}-${pname}-${version}";

--- a/pkgs/build-support/release/source-tarball.nix
+++ b/pkgs/build-support/release/source-tarball.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (
   }
 
   # Then, the caller-supplied attributes.
-  // (builtins.removeAttrs args [ "lib" ])
+  // (removeAttrs args [ "lib" ])
   //
 
     # And finally, our own stuff.

--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -72,7 +72,7 @@ let
 
   optionalAttrs =
     if (builtins.intersectAttrs attrs forcedAttrs == { }) then
-      builtins.removeAttrs attrs [ "replacements" ]
+      removeAttrs attrs [ "replacements" ]
     else
       throw "Passing any of ${builtins.concatStringsSep ", " (builtins.attrNames forcedAttrs)} to replaceVarsWith is not supported.";
 

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -250,7 +250,7 @@ lib.makeOverridable
         "codegenUnits"
         "links"
       ];
-      extraDerivationAttrs = builtins.removeAttrs crate processedAttrs;
+      extraDerivationAttrs = removeAttrs crate processedAttrs;
       nativeBuildInputs_ = nativeBuildInputs;
       buildInputs_ = buildInputs;
       extraRustcOpts_ = extraRustcOpts;

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -91,7 +91,7 @@ let
   mkTest =
     crateArgs:
     let
-      crate = mkHostCrate (builtins.removeAttrs crateArgs [ "expectedTestOutput" ]);
+      crate = mkHostCrate (removeAttrs crateArgs [ "expectedTestOutput" ]);
       hasTests = crateArgs.buildTests or false;
       expectedTestOutputs = crateArgs.expectedTestOutputs or null;
       binaries = map (v: lib.escapeShellArg v.name) (crateArgs.crateBin or [ ]);
@@ -182,7 +182,7 @@ let
     assert (builtins.isList expectedFiles);
 
     let
-      crate = mkCrate (builtins.removeAttrs crateArgs [ "expectedTestOutput" ]);
+      crate = mkCrate (removeAttrs crateArgs [ "expectedTestOutput" ]);
       crateOutput = if output == null then crate else crate."${output}";
       expectedFilesFile = writeTextFile {
         name = "expected-files-${name}";
@@ -706,7 +706,7 @@ rec {
 
         rustCargoTomlInTopDir =
           let
-            withoutCargoTomlSearch = builtins.removeAttrs rustCargoTomlInSubDir [ "workspace_member" ];
+            withoutCargoTomlSearch = removeAttrs rustCargoTomlInSubDir [ "workspace_member" ];
           in
           withoutCargoTomlSearch
           // {

--- a/pkgs/build-support/rust/build-rust-crate/test/rcgen-crates.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/rcgen-crates.nix
@@ -73,7 +73,7 @@ rec {
       let
         members = builtins.attrValues workspaceMembers;
       in
-      builtins.map (m: m.build) members;
+      map (m: m.build) members;
   };
 
   #
@@ -4347,7 +4347,7 @@ rec {
     sourceFilter =
       name: type:
       let
-        baseName = builtins.baseNameOf (builtins.toString name);
+        baseName = baseNameOf (toString name);
       in
       !(
         # Filter out git
@@ -4603,7 +4603,7 @@ rec {
           let
             features = mergedFeatures."${packageId}" or [ ];
             crateConfig' = crateConfigs."${packageId}";
-            crateConfig = builtins.removeAttrs crateConfig' [
+            crateConfig = removeAttrs crateConfig' [
               "resolvedDefaultFeatures"
               "devDependencies"
             ];
@@ -4657,7 +4657,7 @@ rec {
                     version = package.version;
                   };
               in
-              lib.mapAttrs (name: choices: builtins.map versionAndRename choices) grouped;
+              lib.mapAttrs (name: choices: map versionAndRename choices) grouped;
           in
           buildRustCrateForPkgsFunc pkgs (
             crateConfig
@@ -4715,7 +4715,7 @@ rec {
       if builtins.isAttrs val then
         lib.mapAttrs (n: v: sanitizeForJson v) val
       else if builtins.isList val then
-        builtins.map sanitizeForJson val
+        map sanitizeForJson val
       else if builtins.isFunction val then
         "function"
       else
@@ -4826,7 +4826,7 @@ rec {
       assert (builtins.isAttrs target);
       assert (builtins.isBool runTests);
       let
-        crateConfig = crateConfigs."${packageId}" or (builtins.throw "Package not found: ${packageId}");
+        crateConfig = crateConfigs."${packageId}" or (throw "Package not found: ${packageId}");
         expandedFeatures = expandFeatures (crateConfig.features or { }) features;
         enabledFeatures = enableFeatures (crateConfig.dependencies or [ ]) expandedFeatures;
         depWithResolvedFeatures =
@@ -4984,7 +4984,7 @@ rec {
             dependencyPrefix = (dependency.rename or dependency.name) + "/";
             dependencyFeatures = builtins.filter (f: lib.hasPrefix dependencyPrefix f) features;
           in
-          builtins.map (lib.removePrefix dependencyPrefix) dependencyFeatures;
+          map (lib.removePrefix dependencyPrefix) dependencyFeatures;
       in
       defaultOrNil ++ explicitFeatures ++ additionalDependencyFeatures;
 
@@ -5002,7 +5002,7 @@ rec {
     deprecationWarning =
       message: value:
       if strictDeprecation then
-        builtins.throw "strictDeprecation enabled, aborting: ${message}"
+        throw "strictDeprecation enabled, aborting: ${message}"
       else
         builtins.trace message value;
 

--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -86,7 +86,7 @@ let
       outputHashAlgo = if hash == "" then "sha256" else null;
       outputHashMode = "recursive";
     }
-    // builtins.removeAttrs args removedArgs
+    // removeAttrs args removedArgs
   );
 in
 

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -16,7 +16,7 @@
   # Cargo lock file contents as string
   lockFileContents ? null,
 
-  # Allow `builtins.fetchGit` to be used to not require hashes for git dependencies
+  # Allow `fetchGit` to be used to not require hashes for git dependencies
   allowBuiltinFetchGit ? false,
 
   # Additional registries to pull sources from
@@ -57,7 +57,7 @@ let
   # shadows args.lockFileContents
   lockFileContents = if lockFile != null then builtins.readFile lockFile else args.lockFileContents;
 
-  parsedLockFile = builtins.fromTOML lockFileContents;
+  parsedLockFile = fromTOML lockFileContents;
 
   # lockfile v1 and v2 don't have the `version` key, so assume v2
   # we can implement more fine-grained detection later, if needed
@@ -75,11 +75,11 @@ let
   # Force evaluation of the git SHA -> hash mapping, so that an error is
   # thrown if there are stale hashes. We cannot rely on gitShaOutputHash
   # being evaluated otherwise, since there could be no git dependencies.
-  depCrates = builtins.deepSeq gitShaOutputHash (builtins.map mkCrate depPackages);
+  depCrates = builtins.deepSeq gitShaOutputHash (map mkCrate depPackages);
 
   # Map package name + version to git commit SHA for packages with a git source.
   namesGitShas = builtins.listToAttrs (
-    builtins.map nameGitSha (builtins.filter (pkg: lib.hasPrefix "git+" pkg.source) depPackages)
+    map nameGitSha (builtins.filter (pkg: lib.hasPrefix "git+" pkg.source) depPackages)
   );
 
   nameGitSha =
@@ -188,7 +188,7 @@ let
               sha256 = gitShaOutputHash.${gitParts.sha};
             }
           else if allowBuiltinFetchGit then
-            builtins.fetchGit {
+            fetchGit {
               inherit (gitParts) url;
               rev = gitParts.sha;
               allRefs = true;

--- a/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredArray/tests.nix
+++ b/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredArray/tests.nix
@@ -33,7 +33,7 @@ let
             foo
           ''
         else
-          builtins.throw "Invalid scope: ${scope}";
+          throw "Invalid scope: ${scope}";
     in
     {
       name,

--- a/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredMap/tests.nix
+++ b/pkgs/build-support/setup-hooks/arrayUtilities/isDeclaredMap/tests.nix
@@ -33,7 +33,7 @@ let
             foo
           ''
         else
-          builtins.throw "Invalid scope: ${scope}";
+          throw "Invalid scope: ${scope}";
     in
     {
       name,

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -60,9 +60,9 @@ in
 # If we are passed a derivation (based on stdenv*), we can use overrideAttrs to
 # update the arguments to mkDerivation. This gives us the proper awareness of
 # what arguments were effectively passed *to* mkDerivation as opposed to
-# derivation (by mkDerivation). For example, stdenv.mkDerivation
+# builtins.derivation (by mkDerivation). For example, stdenv.mkDerivation
 # accepts an `env` attribute set which is postprocessed before being passed to
-# derivation. This can lead to evaluation failures, if we assume
+# builtins.derivation. This can lead to evaluation failures, if we assume
 # that drvAttrs is equivalent to the arguments passed to mkDerivation.
 # See https://github.com/NixOS/nixpkgs/issues/269539.
 if lib.isDerivation attrs && attrs ? overrideAttrs then

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -60,9 +60,9 @@ in
 # If we are passed a derivation (based on stdenv*), we can use overrideAttrs to
 # update the arguments to mkDerivation. This gives us the proper awareness of
 # what arguments were effectively passed *to* mkDerivation as opposed to
-# builtins.derivation (by mkDerivation). For example, stdenv.mkDerivation
+# derivation (by mkDerivation). For example, stdenv.mkDerivation
 # accepts an `env` attribute set which is postprocessed before being passed to
-# builtins.derivation. This can lead to evaluation failures, if we assume
+# derivation. This can lead to evaluation failures, if we assume
 # that drvAttrs is equivalent to the arguments passed to mkDerivation.
 # See https://github.com/NixOS/nixpkgs/issues/269539.
 if lib.isDerivation attrs && attrs ? overrideAttrs then

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -225,7 +225,7 @@
       "testers.hasPkgConfigModule has been deprecated in favor of testers.hasPkgConfigModules. It accepts a list of strings via the moduleNames argument instead of a single moduleName."
       (
         testers.hasPkgConfigModules (
-          builtins.removeAttrs args [ "moduleName" ]
+          removeAttrs args [ "moduleName" ]
           // {
             moduleNames = [ moduleName ];
           }

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -94,7 +94,7 @@ rec {
         preferLocalBuild = true;
         allowSubstitutes = false;
       })
-      // builtins.removeAttrs derivationArgs [ "passAsFile" ]
+      // removeAttrs derivationArgs [ "passAsFile" ]
     );
 
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md
@@ -182,7 +182,7 @@ rec {
     path: text:
     writeTextFile {
       inherit text;
-      name = builtins.baseNameOf path;
+      name = baseNameOf path;
       destination = "/${path}";
     };
 
@@ -983,7 +983,7 @@ rec {
 
   # TODO: move copyPathsToStore docs to the Nixpkgs manual
   # Copy a list of paths to the Nix store.
-  copyPathsToStore = builtins.map copyPathToStore;
+  copyPathsToStore = map copyPathToStore;
 
   # TODO: move applyPatches docs to the Nixpkgs manual
   /*
@@ -1009,7 +1009,7 @@ rec {
       name ?
         (
           if builtins.typeOf src == "path" then
-            builtins.baseNameOf src
+            baseNameOf src
           else if builtins.isAttrs src && builtins.hasAttr "name" src then
             src.name
           else

--- a/pkgs/build-support/trivial-builders/test-overriding.nix
+++ b/pkgs/build-support/trivial-builders/test-overriding.nix
@@ -104,7 +104,7 @@ let
   runTest =
     script:
     let
-      name = script.name or (builtins.baseNameOf script);
+      name = script.name or (baseNameOf script);
     in
     writeShellScript "run-${name}" ''
       if [ "$(${script})" != "success" ]; then

--- a/pkgs/build-support/trivial-builders/test/concat-test.nix
+++ b/pkgs/build-support/trivial-builders/test/concat-test.nix
@@ -8,7 +8,7 @@
 let
   stri = writeText "pathToTest";
   txt1 = stri "abc";
-  txt2 = stri (builtins.toString hello);
+  txt2 = stri (toString hello);
   res = concatText "textToTest" [
     txt1
     txt2

--- a/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
+++ b/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
@@ -13,7 +13,7 @@ let
   checkShellApplication =
     args@{ name, expected, ... }:
     let
-      writeShellApplicationArgs = builtins.removeAttrs args [ "expected" ];
+      writeShellApplicationArgs = removeAttrs args [ "expected" ];
       script = writeShellApplication writeShellApplicationArgs;
       executable = lib.getExe script;
       expected' = writeTextFile {

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -599,7 +599,7 @@ rec {
       ...
     }@args:
     makeScriptWriter (
-      (builtins.removeAttrs args [
+      (removeAttrs args [
         "babashka"
       ])
       // {
@@ -692,7 +692,7 @@ rec {
     in
     makeScriptWriter
       (
-        (builtins.removeAttrs config [
+        (removeAttrs config [
           "guile"
           "libraries"
           "r6rs"
@@ -728,7 +728,7 @@ rec {
             [ "--no-auto-compile" ]
             ++ lib.optional r6rs "--r6rs"
             ++ lib.optional r7rs "--r7rs"
-            ++ lib.optional (srfi != [ ]) ("--use-srfi=" + concatMapStringsSep "," builtins.toString srfi)
+            ++ lib.optional (srfi != [ ]) ("--use-srfi=" + concatMapStringsSep "," toString srfi)
             ++ [ "-s" ]
           ))
           "!#"
@@ -921,7 +921,7 @@ rec {
       ...
     }@args:
     makeScriptWriter (
-      (builtins.removeAttrs args [ "libraries" ])
+      (removeAttrs args [ "libraries" ])
       // {
         interpreter =
           if libraries == [ ] then "${ruby}/bin/ruby" else "${(ruby.withPackages (ps: libraries))}/bin/ruby";
@@ -963,7 +963,7 @@ rec {
       ...
     }@args:
     makeScriptWriter (
-      (builtins.removeAttrs args [ "libraries" ])
+      (removeAttrs args [ "libraries" ])
       // {
         interpreter = lua.interpreter;
         # if libraries == []
@@ -1134,7 +1134,7 @@ rec {
       ...
     }@args:
     makeScriptWriter (
-      (builtins.removeAttrs args [ "libraries" ])
+      (removeAttrs args [ "libraries" ])
       // {
         interpreter = "${lib.getExe (pkgs.perl.withPackages (p: libraries))}";
       }
@@ -1186,7 +1186,7 @@ rec {
           "--ignore ${concatMapStringsSep "," escapeShellArg flakeIgnore}";
     in
     makeScriptWriter (
-      (builtins.removeAttrs args [
+      (removeAttrs args [
         "libraries"
         "flakeIgnore"
         "doCheck"
@@ -1333,7 +1333,7 @@ rec {
     content:
     makeScriptWriter
       (
-        (builtins.removeAttrs args [
+        (removeAttrs args [
           "dotnet-sdk"
           "fsi-flags"
           "libraries"

--- a/pkgs/by-name/_1/_1password-cli/package.nix
+++ b/pkgs/by-name/_1/_1password-cli/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation {
 
   doInstallCheck = true;
 
-  versionCheckProgram = "${builtins.placeholder "out"}/bin/op";
+  versionCheckProgram = "${placeholder "out"}/bin/op";
   versionCheckProgramArg = "--version";
 
   passthru = {

--- a/pkgs/by-name/ab/aba/package.nix
+++ b/pkgs/by-name/ab/aba/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage {
 
   preBuild = ''
     justFlagsArray+=(
-      PREFIX=${builtins.placeholder "out"}
+      PREFIX=${placeholder "out"}
       MANIFEST_OPTS="--frozen --locked --profile=release"
       INSTALL_OPTS="--no-track"
     )

--- a/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
@@ -24,9 +24,9 @@ runCommand "${alsa-lib.pname}-${alsa-lib.version}"
   }
   (
     (lib.concatMapStringsSep "\n" (output: ''
-      mkdir ${builtins.placeholder output}
+      mkdir ${placeholder output}
       ${lndir}/bin/lndir ${lib.attrByPath [ output ] null alsa-lib} \
-        ${builtins.placeholder output}
+        ${placeholder output}
     '') alsa-lib.outputs)
     + ''
       cp -r ${merged}/lib/alsa-lib $out/lib

--- a/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
+++ b/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  versionCheckProgram = "${builtins.placeholder "out"}/bin/amazon-cloudwatch-agent";
+  versionCheckProgram = "${placeholder "out"}/bin/amazon-cloudwatch-agent";
 
   versionCheckProgramArg = "-version";
 

--- a/pkgs/by-name/ap/apfsprogs/package.nix
+++ b/pkgs/by-name/ap/apfsprogs/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
           version = "v${finalAttrs.version}";
         };
       };
-      versionTestList = builtins.map mkVersionTest tools;
+      versionTestList = map mkVersionTest tools;
 
       versionTests = lib.mergeAttrsList versionTestList;
     in

--- a/pkgs/by-name/ap/aporetic/package.nix
+++ b/pkgs/by-name/ap/aporetic/package.nix
@@ -52,7 +52,7 @@ in
 symlinkJoin {
   inherit pname version;
 
-  paths = (builtins.map makeIosevkaFont sets);
+  paths = (map makeIosevkaFont sets);
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -158,7 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-messages";
     changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-messages/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/bo/bonsai/package.nix
+++ b/pkgs/by-name/bo/bonsai/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     hareThirdParty.hare-json
   ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ca/catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ca/catppuccin-gtk/package.nix
@@ -95,9 +95,9 @@ lib.checkListOfEnum "${pname}: theme accent" validAccents accents lib.checkListO
       mkdir -p $out/share/themes
 
       python3 build.py ${variant} \
-        --accent ${builtins.toString accents} \
+        --accent ${toString accents} \
         ${lib.optionalString (size != [ ]) "--size " + size} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --dest $out/share/themes
 
       runHook postInstall

--- a/pkgs/by-name/co/colloid-gtk-theme/package.nix
+++ b/pkgs/by-name/co/colloid-gtk-theme/package.nix
@@ -87,10 +87,10 @@ lib.checkListOfEnum "colloid-gtk-theme: theme variants"
       runHook preInstall
 
       name= HOME="$TMPDIR" ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (sizeVariants != [ ]) "--size " + builtins.toString sizeVariants} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --dest $out/share/themes
 
       jdupes --quiet --link-soft --recurse $out/share

--- a/pkgs/by-name/co/colloid-icon-theme/package.nix
+++ b/pkgs/by-name/co/colloid-icon-theme/package.nix
@@ -77,8 +77,8 @@ lib.checkListOfEnum "colloid-icon-theme: scheme variants"
       runHook preInstall
 
       name= ./install.sh \
-        ${lib.optionalString (schemeVariants != [ ]) ("--scheme " + builtins.toString schemeVariants)} \
-        ${lib.optionalString (colorVariants != [ ]) ("--theme " + builtins.toString colorVariants)} \
+        ${lib.optionalString (schemeVariants != [ ]) ("--scheme " + toString schemeVariants)} \
+        ${lib.optionalString (colorVariants != [ ]) ("--theme " + toString colorVariants)} \
         --dest $out/share/icons
 
       jdupes --quiet --link-soft --recurse $out/share

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  attrsToSources = attrs: builtins.map ({ repo, version, ... }: "${repo}@${version}") attrs;
+  attrsToSources = attrs: map ({ repo, version, ... }: "${repo}@${version}") attrs;
 in
 buildGoModule (finalAttrs: {
   pname = "coredns";
@@ -75,7 +75,7 @@ buildGoModule (finalAttrs: {
       ) externalPlugins)
     }
     diff -u plugin.cfg.orig plugin.cfg || true
-    for src in ${builtins.toString (attrsToSources externalPlugins)}; do go get $src; done
+    for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
     GOOS= GOARCH= go generate
     go mod vendor
   '';

--- a/pkgs/by-name/cp/cppitertools/package.nix
+++ b/pkgs/by-name/cp/cppitertools/package.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   # files that are also in that repo.
   cmakeBuildDir = "cmake-build";
 
-  includeInstallDir = "${builtins.placeholder "out"}/include/cppitertools";
-  cmakeInstallDir = "${builtins.placeholder "out"}/share/cmake";
+  includeInstallDir = "${placeholder "out"}/include/cppitertools";
+  cmakeInstallDir = "${placeholder "out"}/share/cmake";
 
   # This version of cppitertools considers itself as having used the default value,
   # and issues warning, unless -Dcppitertools_INSTALL_CMAKE_DIR is present as an

--- a/pkgs/by-name/cu/cups-brother-hll2350dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-hll2350dw/package.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
     description = "Brother HL-L2350DW printer driver";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    platforms = builtins.map (arch: "${arch}-linux") arches;
+    platforms = map (arch: "${arch}-linux") arches;
     downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us_ot&lang=en&prod=hll2350dw_us_eu_as&os=128";
     maintainers = [ maintainers.sternenseemann ];
   };

--- a/pkgs/by-name/cu/cups-brother-hll2375dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-hll2375dw/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.brother.com/";
     description = "Brother HLL2375DW printer driver";
     license = licenses.unfree;
-    platforms = builtins.map (arch: "${arch}-linux") arches;
+    platforms = map (arch: "${arch}-linux") arches;
     maintainers = [ maintainers.gador ];
   };
 }

--- a/pkgs/by-name/cu/cups-brother-mfcl2750dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-mfcl2750dw/package.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
     description = "Brother MFC-L2750DW printer driver";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    platforms = builtins.map (arch: "${arch}-linux") arches;
+    platforms = map (arch: "${arch}-linux") arches;
     maintainers = [ maintainers.lovesegfault ];
   };
 }

--- a/pkgs/by-name/cu/cups-brother-mfcl2800dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-mfcl2800dw/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation {
     description = "Brother MFC-L2750DW printer driver";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    platforms = builtins.map (arch: "${arch}-linux") arches;
+    platforms = map (arch: "${arch}-linux") arches;
     maintainers = [ lib.maintainers.luftmensch-luftmensch ];
   };
 }

--- a/pkgs/by-name/cu/curl-impersonate/chrome/update.sh
+++ b/pkgs/by-name/cu/curl-impersonate/chrome/update.sh
@@ -23,7 +23,7 @@ vendorhash() {
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
-    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "fetchGit \"$nixpkgs\"")"
 
     if [ -n "$outpath" ]; then
         path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"

--- a/pkgs/by-name/cu/curl-impersonate/firefox/update.sh
+++ b/pkgs/by-name/cu/curl-impersonate/firefox/update.sh
@@ -23,7 +23,7 @@ vendorhash() {
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
-    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "fetchGit \"$nixpkgs\"")"
 
     if [ -n "$outpath" ]; then
         path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"

--- a/pkgs/by-name/cy/cyrus-imapd/package.nix
+++ b/pkgs/by-name/cy/cyrus-imapd/package.nix
@@ -180,7 +180,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [ cunit ];
   doCheck = true;
 
-  versionCheckProgram = "${builtins.placeholder "out"}/libexec/master";
+  versionCheckProgram = "${placeholder "out"}/libexec/master";
   versionCheckProgramArg = "-V";
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/di/digiham/package.nix
+++ b/pkgs/by-name/di/digiham/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${builtins.placeholder "out"}/bin/dmr_decoder";
+  versionCheckProgram = "${placeholder "out"}/bin/dmr_decoder";
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/dm/dmd/generic.nix
+++ b/pkgs/by-name/dm/dmd/generic.nix
@@ -40,7 +40,7 @@ let
     );
   };
 
-  bits = builtins.toString stdenv.hostPlatform.parsed.cpu.bits;
+  bits = toString stdenv.hostPlatform.parsed.cpu.bits;
   osname = if stdenv.hostPlatform.isDarwin then "osx" else stdenv.hostPlatform.parsed.kernel.name;
 
   pathToDmd = "\${NIX_BUILD_TOP}/dmd/generated/${osname}/release/${bits}/dmd";

--- a/pkgs/by-name/do/docker-credential-helpers/package.nix
+++ b/pkgs/by-name/do/docker-credential-helpers/package.nix
@@ -47,8 +47,8 @@ buildGoModule rec {
           ];
     in
     ''
-      for cmd in ${builtins.toString cmds}; do
-        go build -ldflags "${builtins.toString ldflags}" -trimpath -o bin/docker-credential-$cmd ./$cmd/cmd
+      for cmd in ${toString cmds}; do
+        go build -ldflags "${toString ldflags}" -trimpath -o bin/docker-credential-$cmd ./$cmd/cmd
       done
     '';
 

--- a/pkgs/by-name/dr/dropbear/package.nix
+++ b/pkgs/by-name/dr/dropbear/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   CFLAGS = lib.pipe (lib.attrNames dflags) [
-    (builtins.map (name: "-D${name}=\\\"${dflags.${name}}\\\""))
+    (map (name: "-D${name}=\\\"${dflags.${name}}\\\""))
     (lib.concatStringsSep " ")
   ];
 

--- a/pkgs/by-name/dv/dvdplusrwtools/package.nix
+++ b/pkgs/by-name/dv/dvdplusrwtools/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ]
   # Patches from Gentoo
   ++
-    builtins.map
+    map
       (
         { pfile, sha256 }:
         fetchpatch {

--- a/pkgs/by-name/ej/ejabberd/package.nix
+++ b/pkgs/by-name/ej/ejabberd/package.nix
@@ -127,7 +127,7 @@ let
     };
   };
 
-  beamDeps = builtins.removeAttrs allBeamDeps [
+  beamDeps = removeAttrs allBeamDeps [
     "sqlite3"
     "p1_pgsql"
     "p1_mysql"

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -30,7 +30,7 @@ let
 in
 stdenv.mkDerivation (
   finalAttrs:
-  builtins.removeAttrs pinData [ "hashes" ]
+  removeAttrs pinData [ "hashes" ]
   // {
     pname = "element-desktop";
     name = "${finalAttrs.pname}-${finalAttrs.version}";

--- a/pkgs/by-name/el/element-web-unwrapped/package.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/package.nix
@@ -18,7 +18,7 @@ let
 in
 stdenv.mkDerivation (
   finalAttrs:
-  builtins.removeAttrs pinData [ "hashes" ]
+  removeAttrs pinData [ "hashes" ]
   // {
     pname = "element-web";
 

--- a/pkgs/by-name/en/engage/package.nix
+++ b/pkgs/by-name/en/engage/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
-    ENGAGE_DOCS_LINK = "file://${builtins.placeholder "doc"}/share/doc/${finalAttrs.pname}/index.html";
+    ENGAGE_DOCS_LINK = "file://${placeholder "doc"}/share/doc/${finalAttrs.pname}/index.html";
   };
 
   src = fetchFromGitLab {
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd engage ${
       builtins.concatStringsSep " " (
-        builtins.map (shell: "--${shell} <($out/bin/engage completions ${shell})") [
+        map (shell: "--${shell} <($out/bin/engage completions ${shell})") [
           "bash"
           "zsh"
           "fish"

--- a/pkgs/by-name/ep/epson-escpr2/package.nix
+++ b/pkgs/by-name/ep/epson-escpr2/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation {
   ];
 
   configureFlags = [
-    "--with-cupsfilterdir=${builtins.placeholder "out"}/lib/cups/filter"
-    "--with-cupsppddir=${builtins.placeholder "out"}/share/cups/model"
+    "--with-cupsfilterdir=${placeholder "out"}/lib/cups/filter"
+    "--with-cupsppddir=${placeholder "out"}/share/cups/model"
   ];
 
   meta = {

--- a/pkgs/by-name/eu/eurofurence/package.nix
+++ b/pkgs/by-name/eu/eurofurence/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
       (
         { url, hash }:
         fetchzip {
-          name = builtins.baseNameOf url;
+          name = baseNameOf url;
           stripRoot = false;
           inherit url hash;
         }

--- a/pkgs/by-name/fc/fcft/package.nix
+++ b/pkgs/by-name/fc/fcft/package.nix
@@ -65,9 +65,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     (lib.mesonEnable "system-nanosvg" true)
   ]
-  ++ builtins.map (
-    t: lib.mesonEnable "${t}-shaping" (lib.elem t withShapingTypes)
-  ) availableShapingTypes;
+  ++ map (t: lib.mesonEnable "${t}-shaping" (lib.elem t withShapingTypes)) availableShapingTypes;
 
   doCheck = true;
 

--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -67,7 +67,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
       runtimeEnv = {
         PNAME = finalAttrs.pname;
-        PKG_FILE = builtins.toString ./package.nix;
+        PKG_FILE = toString ./package.nix;
         GITHUB_REPOSITORY = "${finalAttrs.src.owner}/${finalAttrs.src.repo}";
         NNUE_BIG_FILE = nnueBigFile;
         NNUE_BIG_HASH = nnueBigHash;

--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   # We fix this by setting the systemd package's `systemdsystemunitdir` pkg-config variable.
   #
   # https://man.openbsd.org/pkg-config.1#PKG_CONFIG_$PACKAGE_$VARIABLE
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${builtins.placeholder "out"}/lib/systemd/system";
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
 
   outputs = [
     "out"

--- a/pkgs/by-name/fl/fluent-gtk-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-gtk-theme/package.nix
@@ -86,10 +86,10 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook preInstall
 
       name= HOME="$TMPDIR" ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (sizeVariants != [ ]) "--size " + builtins.toString sizeVariants} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --icon nixos \
         --dest $out/share/themes
 

--- a/pkgs/by-name/fl/fluent-icon-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-icon-theme/package.nix
@@ -60,7 +60,7 @@ lib.checkListOfEnum "${pname}: available color variants"
 
       ./install.sh --dest $out/share/icons \
         --name Fluent \
-        ${builtins.toString colorVariants} \
+        ${toString colorVariants} \
         ${lib.optionalString allColorVariants "--all"} \
         ${lib.optionalString roundedIcons "--round"} \
         ${lib.optionalString blackPanelIcons "--black"}

--- a/pkgs/by-name/fr/freecad/freecad-utils.nix
+++ b/pkgs/by-name/fr/freecad/freecad-utils.nix
@@ -31,7 +31,7 @@ let
     in
     lib.optionalString (val != null) "--run ${installer}";
 
-  pythonsProcessed = builtins.map (
+  pythonsProcessed = map (
     pyt:
     if builtins.isString pyt then
       pyt
@@ -57,7 +57,7 @@ let
         let
           modulesStr = wrapPathsStr "--module-path" modules;
           pythonsStr = wrapPathsStr "--python-path" (pythonsProcessed pythons);
-          makeWrapperFlagsStr = builtins.concatStringsSep " " (builtins.map (f: "'${f}'") makeWrapperFlags);
+          makeWrapperFlagsStr = builtins.concatStringsSep " " (map (f: "'${f}'") makeWrapperFlags);
 
           userCfgStr = wrapCfgStr "user" userCfg;
           systemCfgStr = wrapCfgStr "system" systemCfg;

--- a/pkgs/by-name/fr/freeswitch/package.nix
+++ b/pkgs/by-name/fr/freeswitch/package.nix
@@ -100,7 +100,7 @@ let
 
   modulesConf =
     let
-      lst = builtins.map (mod: mod.path) enabledModules;
+      lst = map (mod: mod.path) enabledModules;
       str = lib.strings.concatStringsSep "\n" lst;
     in
     builtins.toFile "modules.conf" str;

--- a/pkgs/by-name/ga/ganttproject-bin/package.nix
+++ b/pkgs/by-name/ga/ganttproject-bin/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       mkdir -pv "$out/bin"
       wrapProgram "$out/share/ganttproject/ganttproject" \
         --set JAVA_HOME "${jre}" \
-        --prefix _JAVA_OPTIONS " " "${builtins.toString javaOptions}"
+        --prefix _JAVA_OPTIONS " " "${toString javaOptions}"
 
       mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
 

--- a/pkgs/by-name/ge/geoserver/package.nix
+++ b/pkgs/by-name/ge/geoserver/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
               (previousAttrs.buildInputs or [ ]) ++ lib.lists.concatMap (drv: drv.buildInputs) selectedExtensions
             );
             postInstall = (previousAttrs.postInstall or "") + ''
-              for extension in ${builtins.toString selectedExtensions} ; do
+              for extension in ${toString selectedExtensions} ; do
                 cp -r $extension/* $out
                 # Some files are the same for all/several extensions. We allow overwriting them again.
                 chmod -R +w $out

--- a/pkgs/by-name/ge/getxbook/package.nix
+++ b/pkgs/by-name/ge/getxbook/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ihwrx4gspj8l7fc8vxch6dpjrw1lvv9z3c19f0wxnmnxhv1cjvs";
   };
 
-  env.NIX_CFLAGS_COMPILE = builtins.toString (
+  env.NIX_CFLAGS_COMPILE = toString (
     [ "-Wno-error=deprecated-declarations" ]
     ++ lib.optionals (!stdenv.cc.isClang) [
       "-Wno-error=format-truncation"

--- a/pkgs/by-name/gi/giflib/package.nix
+++ b/pkgs/by-name/gi/giflib/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [
-    "PREFIX=${builtins.placeholder "out"}"
+    "PREFIX=${placeholder "out"}"
   ];
 
   postPatch = ''

--- a/pkgs/by-name/gi/git-quick-stats/package.nix
+++ b/pkgs/by-name/gi/git-quick-stats/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   installFlags = [
-    "PREFIX=${builtins.placeholder "out"}"
+    "PREFIX=${placeholder "out"}"
   ];
 
   postInstall =

--- a/pkgs/by-name/go/go-ethereum/package.nix
+++ b/pkgs/by-name/go/go-ethereum/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
 
   # Move binaries to separate outputs and symlink them back to $out
   postInstall = lib.concatStringsSep "\n" (
-    builtins.map (
+    map (
       bin:
       "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/"
     ) bins

--- a/pkgs/by-name/go/google-cloud-sdk/components.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/components.nix
@@ -69,7 +69,7 @@ let
     lib.fix (
       self:
       builtins.listToAttrs (
-        builtins.map (component: {
+        map (component: {
           name = component.id;
           value = componentFromSnapshot self {
             inherit
@@ -96,7 +96,7 @@ let
       version,
     }@attrs:
     let
-      baseUrl = builtins.dirOf schema_version.url;
+      baseUrl = dirOf schema_version.url;
       # Architectures supported by this component.  Defaults to all available
       # architectures.
       architectures = builtins.filter (arch: builtins.elem arch (builtins.attrNames arches)) (
@@ -115,12 +115,12 @@ let
         "source"
       ] component) "${baseUrl}/${component.data.source}";
       sha256 = lib.attrByPath [ "data" "checksum" ] "" component;
-      dependencies = builtins.map (dep: builtins.getAttr dep components) component.dependencies;
+      dependencies = map (dep: builtins.getAttr dep components) component.dependencies;
       platforms =
         if component.platform == { } then
           lib.platforms.all
         else
-          builtins.concatMap (arch: builtins.map (os: toNixPlatform arch os) operating_systems) architectures;
+          builtins.concatMap (arch: map (os: toNixPlatform arch os) operating_systems) architectures;
       snapshot = snapshotFromComponent attrs;
     };
 

--- a/pkgs/by-name/go/google-cloud-sdk/withExtraComponents.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/withExtraComponents.nix
@@ -43,11 +43,11 @@ let
 
   installCheck =
     let
-      compNames = builtins.map lib.getName comps_;
+      compNames = map lib.getName comps_;
     in
     ''
       $out/bin/gcloud components list --only-local-state --format 'value(id)' > component_list.txt
-      for comp in ${builtins.toString compNames}; do
+      for comp in ${toString compNames}; do
         snapshot_file="$out/google-cloud-sdk/.install/$comp.snapshot.json"
 
         if ! [ -f "$snapshot_file"  ]; then

--- a/pkgs/by-name/gr/graphhopper/package.nix
+++ b/pkgs/by-name/gr/graphhopper/package.nix
@@ -11,7 +11,7 @@
   ...
 }:
 let
-  version = builtins.fromTOML (builtins.readFile ./version.toml);
+  version = fromTOML (builtins.readFile ./version.toml);
 
   src = fetchFromGitHub {
     owner = "graphhopper";

--- a/pkgs/by-name/gr/graphite-gtk-theme/package.nix
+++ b/pkgs/by-name/gr/graphite-gtk-theme/package.nix
@@ -96,10 +96,10 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook preInstall
 
       name= ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (sizeVariants != [ ]) "--size " + builtins.toString sizeVariants} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --dest $out/share/themes
 
       ${lib.optionalString wallpapers "sh -x wallpaper/install-wallpapers.sh"}
@@ -112,7 +112,7 @@ lib.checkListOfEnum "${pname}: theme variants"
 
         ./install.sh --justcopy --dest $out/share/grub/themes \
           ${lib.optionalString (builtins.elem "nord" tweaks) "--theme nord"} \
-          ${lib.optionalString (grubScreens != [ ]) "--screen " + builtins.toString grubScreens}
+          ${lib.optionalString (grubScreens != [ ]) "--screen " + toString grubScreens}
         )
       ''}
 

--- a/pkgs/by-name/gr/grcov/package.nix
+++ b/pkgs/by-name/gr/grcov/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ];
       skipFlag = test: "--skip " + test;
     in
-    builtins.concatStringsSep " " (builtins.map skipFlag skipList);
+    builtins.concatStringsSep " " (map skipFlag skipList);
 
   meta = {
     description = "Rust tool to collect and aggregate code coverage data for multiple source files";

--- a/pkgs/by-name/gu/guile-gnutls/package.nix
+++ b/pkgs/by-name/gu/guile-gnutls/package.nix
@@ -39,9 +39,9 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-guile-site-dir=${builtins.placeholder "out"}/${guile.siteDir}"
-    "--with-guile-site-ccache-dir=${builtins.placeholder "out"}/${guile.siteCcacheDir}"
-    "--with-guile-extension-dir=${builtins.placeholder "out"}/lib/guile/${guile.effectiveVersion}/extensions"
+    "--with-guile-site-dir=${placeholder "out"}/${guile.siteDir}"
+    "--with-guile-site-ccache-dir=${placeholder "out"}/${guile.siteCcacheDir}"
+    "--with-guile-extension-dir=${placeholder "out"}/lib/guile/${guile.effectiveVersion}/extensions"
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/ha/hare/cross-compilation-tests.nix
+++ b/pkgs/by-name/ha/hare/cross-compilation-tests.nix
@@ -7,9 +7,7 @@
 }:
 let
   archs = lib.concatStringsSep " " (
-    builtins.map (lib.removeSuffix "-linux") (
-      builtins.filter (lib.hasSuffix "-linux") hare.meta.platforms
-    )
+    map (lib.removeSuffix "-linux") (builtins.filter (lib.hasSuffix "-linux") hare.meta.platforms)
   );
   mainDotHare = writeText "main.ha" ''
     export fn main() void = void;

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [
     "HARECACHE=.harecache"
-    "PREFIX=${builtins.placeholder "out"}"
+    "PREFIX=${placeholder "out"}"
     "ARCH=${arch}"
     "VERSION=${finalAttrs.version}-nixpkgs"
     "QBEFLAGS=-t${qbePlatform}"

--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ qbe ];
 
   makeFlags = [
-    "PREFIX=${builtins.placeholder "out"}"
+    "PREFIX=${placeholder "out"}"
     "ARCH=${arch}"
     "VERSION=${finalAttrs.version}-nixpkgs"
     "QBEFLAGS=-t${qbePlatform}"
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = _experimental-update-script-combinators.sequence (
-      builtins.map (item: item.command) [
+      map (item: item.command) [
         (gitUpdater {
           attrPath = "harec";
           ignoredVersions = [ "-rc[0-9]{1,}" ];

--- a/pkgs/by-name/ha/haredo/package.nix
+++ b/pkgs/by-name/ha/haredo/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelChecking = true;
 
-  env.PREFIX = builtins.placeholder "out";
+  env.PREFIX = placeholder "out";
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 

--- a/pkgs/by-name/hi/himitsu/package.nix
+++ b/pkgs/by-name/hi/himitsu/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     scdoc
   ];
 
-  installFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = with lib; {
     homepage = "https://himitsustore.org/";

--- a/pkgs/by-name/hy/hylafaxplus/package.nix
+++ b/pkgs/by-name/hy/hylafaxplus/package.nix
@@ -33,7 +33,7 @@
 let
 
   configSite = replaceVars ./config.site {
-    config_maxgid = lib.optionalString (maxgid != null) ''CONFIG_MAXGID=${builtins.toString maxgid}'';
+    config_maxgid = lib.optionalString (maxgid != null) ''CONFIG_MAXGID=${toString maxgid}'';
     ghostscript_version = ghostscript.version;
     out = null; # "out" will be resolved in post-install.sh
     inherit coreutils ghostscript libtiff;
@@ -41,7 +41,7 @@ let
 
   postPatch = replaceVars ./post-patch.sh {
     inherit configSite;
-    maxuid = lib.optionalString (maxuid != null) (builtins.toString maxuid);
+    maxuid = lib.optionalString (maxuid != null) (toString maxuid);
     faxcover_binpath = lib.makeBinPath [
       stdenv.shellPackage
       coreutils

--- a/pkgs/by-name/ib/ibm-plex/package.nix
+++ b/pkgs/by-name/ib/ibm-plex/package.nix
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation {
   pname = "ibm-plex";
   inherit version;
 
-  srcs = builtins.map (
+  srcs = map (
     family:
     fetchzip {
       url = "https://github.com/IBM/plex/releases/download/%40ibm%2Fplex-${family}%40${version}/ibm-plex-${family}.zip";

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -56,7 +56,7 @@ let
 
   buildLock = {
     sources =
-      builtins.map
+      map
         (p: {
           name = p.pname;
           inherit (p) version;

--- a/pkgs/by-name/im/imv/package.nix
+++ b/pkgs/by-name/im/imv/package.nix
@@ -61,7 +61,7 @@ let
     libjpeg = libjpeg_turbo;
   };
 
-  backendFlags = builtins.map (
+  backendFlags = map (
     b: if builtins.elem b withBackends then "-D${b}=enabled" else "-D${b}=disabled"
   ) (builtins.attrNames backends);
 in
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     inih
   ]
   ++ windowSystems."${withWindowSystem}"
-  ++ builtins.map (b: backends."${b}") withBackends;
+  ++ map (b: backends."${b}") withBackends;
 
   patches = [
     (fetchpatch {

--- a/pkgs/by-name/in/inspircd/package.nix
+++ b/pkgs/by-name/in/inspircd/package.nix
@@ -123,9 +123,7 @@ let
   };
 
   # buildInputs necessary for the enabled extraModules
-  extraInputs = lib.concatMap (
-    m: extras."${m}" or (builtins.throw "Unknown extra module ${m}")
-  ) extraModules;
+  extraInputs = lib.concatMap (m: extras."${m}" or (throw "Unknown extra module ${m}")) extraModules;
 
   # if true, we can't provide a binary version of this
   # package without violating the GPL 2

--- a/pkgs/by-name/in/intel-compute-runtime/package.nix
+++ b/pkgs/by-name/in/intel-compute-runtime/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     (lib.cmakeBool "SKIP_UNIT_TESTS" true)
-    (lib.cmakeFeature "IGC_DIR" (builtins.toString intel-graphics-compiler))
+    (lib.cmakeFeature "IGC_DIR" (toString intel-graphics-compiler))
     (lib.cmakeFeature "OCL_ICD_VENDORDIR" "${placeholder "out"}/etc/OpenCL/vendors")
     # The install script assumes this path is relative to CMAKE_INSTALL_PREFIX
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")

--- a/pkgs/by-name/io/iosevka-bin/package.nix
+++ b/pkgs/by-name/io/iosevka-bin/package.nix
@@ -12,7 +12,7 @@ let
 
   variantHashes = import ./variants.nix;
   validVariants = map (lib.removePrefix "Iosevka") (
-    builtins.attrNames (builtins.removeAttrs variantHashes [ "Iosevka" ])
+    builtins.attrNames (removeAttrs variantHashes [ "Iosevka" ])
   );
 in
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -258,7 +258,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     symlinkJoin {
       name = "isabelle-with-components-${isabelle.version}";
-      paths = [ isabelle ] ++ (builtins.map (c: c.override { inherit isabelle; }) components);
+      paths = [ isabelle ] ++ (map (c: c.override { inherit isabelle; }) components);
 
       postBuild = ''
         rm $out/bin/*

--- a/pkgs/by-name/ja/jasper-gtk-theme/package.nix
+++ b/pkgs/by-name/ja/jasper-gtk-theme/package.nix
@@ -81,10 +81,10 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook preInstall
 
       name= HOME="$TMPDIR" ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (sizeVariants != [ ]) "--size " + builtins.toString sizeVariants} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --dest $out/share/themes
 
       jdupes --quiet --link-soft --recurse $out/share

--- a/pkgs/by-name/ja/jazz2-content/package.nix
+++ b/pkgs/by-name/ja/jazz2-content/package.nix
@@ -8,7 +8,7 @@ runCommandLocal "jazz2-content"
   {
     inherit (jazz2) version src;
 
-    meta = (builtins.removeAttrs jazz2.meta [ "mainProgram" ]) // {
+    meta = (removeAttrs jazz2.meta [ "mainProgram" ]) // {
       description = "Assets needed for jazz2";
       platforms = lib.platforms.all;
     };

--- a/pkgs/by-name/ko/kodelife/update.sh
+++ b/pkgs/by-name/ko/kodelife/update.sh
@@ -24,7 +24,7 @@ nixeval() {
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
-    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "fetchGit \"$nixpkgs\"")"
 
     if [ -n "$outpath" ]; then
         path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"

--- a/pkgs/by-name/ku/kubo-fs-repo-migrations/package.nix
+++ b/pkgs/by-name/ku/kubo-fs-repo-migrations/package.nix
@@ -241,11 +241,11 @@ let
       builder = if x.from >= minRepoVersionValidated then mkMigration else stubBecauseDisabled;
     in
     builder x.from x.to x.release x.hash;
-  migrations = builtins.map mkMigrationOrStub releases;
+  migrations = map mkMigrationOrStub releases;
 
   packageNotBroken = package: !package.meta.broken;
   migrationsBrokenRemoved = builtins.filter packageNotBroken migrations;
-  migrationsBrokenStubbed = builtins.map (
+  migrationsBrokenStubbed = map (
     x: if packageNotBroken x then x else (stubBecauseBroken x.pname)
   ) migrations;
 in
@@ -253,7 +253,7 @@ in
 symlinkJoin {
   name = "kubo-fs-repo-migrations-${version}";
   paths = if stubBrokenMigrations then migrationsBrokenStubbed else migrationsBrokenRemoved;
-  meta = (builtins.removeAttrs kubo-migrator-unwrapped.meta [ "mainProgram" ]) // {
+  meta = (removeAttrs kubo-migrator-unwrapped.meta [ "mainProgram" ]) // {
     description = "Several individual migrations for migrating the filesystem repository of Kubo one version at a time";
     longDescription = ''
       This package contains all the individual migrations in the bin directory.

--- a/pkgs/by-name/ld/ld-audit-search-mod/package.nix
+++ b/pkgs/by-name/ld/ld-audit-search-mod/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    (lib.cmakeFeature "NIX_RTLD_NAME" (builtins.baseNameOf stdenv.cc.bintools.dynamicLinker))
+    (lib.cmakeFeature "NIX_RTLD_NAME" (baseNameOf stdenv.cc.bintools.dynamicLinker))
     (lib.cmakeFeature "NIX_STORE_DIR" storeDir)
   ];
 

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -86,7 +86,7 @@ maven.buildMavenPackage rec {
   passthru = {
     updateScript =
       let
-        pkgFile = builtins.toString ./package.nix;
+        pkgFile = toString ./package.nix;
       in
       lib.getExe (writeShellApplication {
         name = "update-${pname}";

--- a/pkgs/by-name/li/libdynd/package.nix
+++ b/pkgs/by-name/li/libdynd/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     "-DDYND_BUILD_BENCHMARKS=OFF"
   ];
 
-  env.NIX_CFLAGS_COMPILE = builtins.toString [
+  env.NIX_CFLAGS_COMPILE = toString [
     # added to fix build with gcc7+
     "-Wno-error=implicit-fallthrough"
     "-Wno-error=nonnull"

--- a/pkgs/by-name/li/libpsl-with-scripts/package.nix
+++ b/pkgs/by-name/li/libpsl-with-scripts/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
         cd -
       '';
       links = lib.concatMapStrings (
-        output: linkOutput libpsl.${output} (builtins.placeholder output)
+        output: linkOutput libpsl.${output} (placeholder output)
       ) libpsl.outputs;
     in
     ''

--- a/pkgs/by-name/ll/llama-swap/ui.nix
+++ b/pkgs/by-name/ll/llama-swap/ui.nix
@@ -20,7 +20,7 @@ buildNpmPackage (finalAttrs: {
     rm -rf $out/lib
   '';
 
-  meta = (builtins.removeAttrs llama-swap.meta [ "mainProgram" ]) // {
+  meta = (removeAttrs llama-swap.meta [ "mainProgram" ]) // {
     description = "${llama-swap.meta.description} - UI";
   };
 })

--- a/pkgs/by-name/lu/luarocks-packages-updater/package.nix
+++ b/pkgs/by-name/lu/luarocks-packages-updater/package.nix
@@ -25,7 +25,7 @@ let
     luajit
   ];
 
-  attrs = builtins.fromTOML (builtins.readFile ./pyproject.toml);
+  attrs = fromTOML (builtins.readFile ./pyproject.toml);
   pname = attrs.project.name;
   inherit (attrs.project) version;
 in

--- a/pkgs/by-name/ma/magma/package.nix
+++ b/pkgs/by-name/ma/magma/package.nix
@@ -100,7 +100,7 @@ let
   minArch =
     let
       # E.g. [ "80" "86" "90" ]
-      cudaArchitectures = (builtins.map flags.dropDots flags.cudaCapabilities);
+      cudaArchitectures = (map flags.dropDots flags.cudaCapabilities);
       minArch' = builtins.head (builtins.sort strings.versionOlder cudaArchitectures);
     in
     # "75" -> "750"  Cf. https://github.com/icl-utk-edu/magma/blob/v2.9.0/CMakeLists.txt#L200-L201

--- a/pkgs/by-name/ma/matcha-gtk-theme/package.nix
+++ b/pkgs/by-name/ma/matcha-gtk-theme/package.nix
@@ -56,8 +56,8 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "light" "dark" ] col
       mkdir -p $out/share/themes
 
       name= ./install.sh \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
         --dest $out/share/themes
 
       mkdir -p $out/share/doc/matcha-gtk-theme

--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -71,13 +71,13 @@ let
       + lib.optionalString buildOffline ''
         mvn $MAVEN_EXTRA_ARGS de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies -Dmaven.repo.local=$out/.m2 ${mvnDepsParameters}
 
-        for artifactId in ${builtins.toString manualMvnArtifacts}
+        for artifactId in ${toString manualMvnArtifacts}
         do
           echo "downloading manual $artifactId"
           mvn $MAVEN_EXTRA_ARGS dependency:get -Dartifact="$artifactId" -Dmaven.repo.local=$out/.m2
         done
 
-        for artifactId in ${builtins.toString manualMvnSources}
+        for artifactId in ${toString manualMvnSources}
         do
           group=$(echo $artifactId | cut -d':' -f1)
           artifact=$(echo $artifactId | cut -d':' -f2)
@@ -115,7 +115,7 @@ let
   );
 in
 stdenv.mkDerivation (
-  builtins.removeAttrs args [ "mvnFetchExtraArgs" ]
+  removeAttrs args [ "mvnFetchExtraArgs" ]
   // {
     inherit fetchedMavenDeps;
 

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -118,7 +118,7 @@ python3.pkgs.buildPythonApplication rec {
       ''
     ]
     # Remove problematic tests
-    ++ (builtins.map (f: ''rm -vr "${f}";'') (
+    ++ (map (f: ''rm -vr "${f}";'') (
       [
         # requires git, creating cyclic dependency
         ''test cases/common/66 vcstag''

--- a/pkgs/by-name/mf/mfcl5750dw/package.nix
+++ b/pkgs/by-name/mf/mfcl5750dw/package.nix
@@ -113,7 +113,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://www.brother.com/";
     description = "Brother MFCL5750DW CUPS driver";
     license = lib.licenses.unfree;
-    platforms = builtins.map (arch: "${arch}-linux") arches;
+    platforms = map (arch: "${arch}-linux") arches;
     maintainers = with lib.maintainers; [ qdlmcfresh ];
   };
 })

--- a/pkgs/by-name/mi/mission-center/package.nix
+++ b/pkgs/by-name/mi/mission-center/package.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgram = "${builtins.placeholder "out"}/bin/missioncenter";
+  versionCheckProgram = "${placeholder "out"}/bin/missioncenter";
   doInstallCheck = true;
 
   postFixup = ''

--- a/pkgs/by-name/mi/mitm-cache/fetch.nix
+++ b/pkgs/by-name/mi/mitm-cache/fetch.nix
@@ -13,7 +13,7 @@
 }@attrs:
 
 let
-  data' = builtins.removeAttrs (if builtins.isPath data then lib.importJSON data else data) [
+  data' = removeAttrs (if builtins.isPath data then lib.importJSON data else data) [
     "!version"
   ];
 
@@ -59,7 +59,7 @@ let
   );
 in
 runCommand name (
-  builtins.removeAttrs attrs [
+  removeAttrs attrs [
     "name"
     "data"
   ]

--- a/pkgs/by-name/mo/mojave-gtk-theme/package.nix
+++ b/pkgs/by-name/mo/mojave-gtk-theme/package.nix
@@ -137,13 +137,11 @@ lib.checkListOfEnum "${pname}: button size variants" [ "standard" "small" ] butt
       runHook preInstall
 
       name= ./install.sh \
-        ${
-          lib.optionalString (buttonSizeVariants != [ ]) "--small " + builtins.toString buttonSizeVariants
-        } \
-        ${lib.optionalString (buttonVariants != [ ]) "--alt " + builtins.toString buttonVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (opacityVariants != [ ]) "--opacity " + builtins.toString opacityVariants} \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
+        ${lib.optionalString (buttonSizeVariants != [ ]) "--small " + toString buttonSizeVariants} \
+        ${lib.optionalString (buttonVariants != [ ]) "--alt " + toString buttonVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (opacityVariants != [ ]) "--opacity " + toString opacityVariants} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
         --icon nixos \
         --dest $out/share/themes
 

--- a/pkgs/by-name/my/mylvmbackup/package.nix
+++ b/pkgs/by-name/my/mylvmbackup/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs mylvmbackup
     substituteInPlace Makefile \
-      --replace "prefix = /usr/local" "prefix = ${builtins.placeholder "out"}" \
-      --replace "sysconfdir = /etc" "sysconfdir = ${builtins.placeholder "out"}/etc" \
+      --replace "prefix = /usr/local" "prefix = ${placeholder "out"}" \
+      --replace "sysconfdir = /etc" "sysconfdir = ${placeholder "out"}/etc" \
       --replace "/usr/bin/install" "install"
   '';
 

--- a/pkgs/by-name/ne/nemo-with-extensions/package.nix
+++ b/pkgs/by-name/ne/nemo-with-extensions/package.nix
@@ -54,7 +54,7 @@ symlinkJoin {
     done
   '';
 
-  meta = builtins.removeAttrs nemo.meta [
+  meta = removeAttrs nemo.meta [
     "name"
     "outputsToInstall"
     "position"

--- a/pkgs/by-name/ni/nim-unwrapped-1_0/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-1_0/package.nix
@@ -16,7 +16,7 @@ nim-unwrapped-2.overrideAttrs (
     patches =
       builtins.filter (
         p:
-        builtins.elem (builtins.baseNameOf p) [
+        builtins.elem (baseNameOf p) [
           "NIM_CONFIG_DIR.patch"
           "nixbuild.patch"
         ]

--- a/pkgs/by-name/ni/nim-unwrapped-2_0/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_0/package.nix
@@ -15,7 +15,7 @@ nim-unwrapped-2_2.overrideAttrs (
     patches = lib.lists.unique (
       builtins.filter (
         p:
-        builtins.elem (builtins.baseNameOf p) [
+        builtins.elem (baseNameOf p) [
           "NIM_CONFIG_DIR.patch"
           "nixbuild.patch"
           "extra-mangling.patch"

--- a/pkgs/by-name/ni/nix-required-mounts/package.nix
+++ b/pkgs/by-name/ni/nix-required-mounts/package.nix
@@ -28,7 +28,7 @@
 }:
 
 let
-  attrs = builtins.fromTOML (builtins.readFile ./pyproject.toml);
+  attrs = fromTOML (builtins.readFile ./pyproject.toml);
   pname = attrs.project.name;
   inherit (attrs.project) version;
 in

--- a/pkgs/by-name/ni/nixos-init/package.nix
+++ b/pkgs/by-name/ni/nixos-init/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = cargoToml.package.name;

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -179,7 +179,7 @@ goBuild (finalAttrs: {
         in
         if matched == null then str else builtins.head matched;
 
-      cudaArchitectures = builtins.concatStringsSep ";" (builtins.map removeSMPrefix cudaArches);
+      cudaArchitectures = builtins.concatStringsSep ";" (map removeSMPrefix cudaArches);
       rocmTargets = builtins.concatStringsSep ";" rocmGpuTargets;
 
       cmakeFlagsCudaArchitectures = lib.optionalString enableCuda "-DCMAKE_CUDA_ARCHITECTURES='${cudaArchitectures}'";

--- a/pkgs/by-name/op/opa-envoy-plugin/package.nix
+++ b/pkgs/by-name/op/opa-envoy-plugin/package.nix
@@ -10,7 +10,7 @@
 
 assert
   enableWasmEval && stdenv.hostPlatform.isDarwin
-  -> builtins.throw "building with wasm on darwin is failing in nixpkgs";
+  -> throw "building with wasm on darwin is failing in nixpkgs";
 
 buildGoModule rec {
   pname = "opa-envoy-plugin";

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -10,7 +10,7 @@
 
 assert
   enableWasmEval && stdenv.hostPlatform.isDarwin
-  -> builtins.throw "building with wasm on darwin is failing in nixpkgs";
+  -> throw "building with wasm on darwin is failing in nixpkgs";
 
 buildGoModule (finalAttrs: {
   pname = "open-policy-agent";

--- a/pkgs/by-name/op/openutau/update.sh
+++ b/pkgs/by-name/op/openutau/update.sh
@@ -19,7 +19,7 @@ nixbuildscript() {
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
-    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "fetchGit \"$nixpkgs\"")"
 
     if [ -n "$outpath" ]; then
         path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"

--- a/pkgs/by-name/or/orchis-theme/package.nix
+++ b/pkgs/by-name/or/orchis-theme/package.nix
@@ -63,10 +63,8 @@ lib.checkListOfEnum "${pname}: theme tweaks" validTweaks tweaks
     installPhase = ''
       runHook preInstall
       bash install.sh -d $out/share/themes -t all \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
-        ${lib.optionalString (border-radius != null) (
-          "--round " + builtins.toString border-radius + "px"
-        )}
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
+        ${lib.optionalString (border-radius != null) ("--round " + toString border-radius + "px")}
       ${lib.optionalString withWallpapers ''
         mkdir -p $out/share/backgrounds
         cp src/wallpaper/{1080p,2k,4k}.jpg $out/share/backgrounds

--- a/pkgs/by-name/pi/pigpio/package.nix
+++ b/pkgs/by-name/pi/pigpio/package.nix
@@ -7,8 +7,7 @@
 }:
 
 let
-  mkDerivation =
-    if builtins.isNull buildPythonPackage then stdenv.mkDerivation else buildPythonPackage;
+  mkDerivation = if isNull buildPythonPackage then stdenv.mkDerivation else buildPythonPackage;
 in
 mkDerivation rec {
   pname = "pigpio";

--- a/pkgs/by-name/pi/pihole/package.nix
+++ b/pkgs/by-name/pi/pihole/package.nix
@@ -72,7 +72,7 @@
 
   solutions.default =
     let
-      out = builtins.placeholder "out";
+      out = placeholder "out";
       scriptsDir = "${out}/share/pihole/advanced/Scripts";
     in
     {

--- a/pkgs/by-name/pi/pixinsight/package.nix
+++ b/pkgs/by-name/pi/pixinsight/package.nix
@@ -162,7 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   dontWrapQtApps = true;
   postFixup = ''
-    wrapProgram $out/opt/PixInsight/bin/PixInsight ${builtins.toString finalAttrs.qtWrapperArgs}
+    wrapProgram $out/opt/PixInsight/bin/PixInsight ${toString finalAttrs.qtWrapperArgs}
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/pl/plymouth/package.nix
+++ b/pkgs/by-name/pl/plymouth/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
         rm -r "$DESTDIR/''${!o}"
     done
     # Ensure the DESTDIR is removed.
-    rmdir "$DESTDIR/${builtins.storeDir}" "$DESTDIR/${builtins.dirOf builtins.storeDir}" "$DESTDIR"
+    rmdir "$DESTDIR/${builtins.storeDir}" "$DESTDIR/${dirOf builtins.storeDir}" "$DESTDIR"
   '';
 
   # HACK: We want to install configuration files to $out/etc

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
       runtimeEnv = {
         PNAME = "podman-desktop";
-        PKG_FILE = builtins.toString ./package.nix;
+        PKG_FILE = toString ./package.nix;
       };
       text = ''
         new_src="$(nix-build --attr "pkgs.$PNAME.src" --no-out-link)"

--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # some python tests use uv, which in turn needs python
   UV_PYTHON = "${python312}/bin/python";
 
-  checkFlags = builtins.map (t: "--skip ${t}") [
+  checkFlags = map (t: "--skip ${t}") [
     # these tests require internet access
     "check_added_large_files_hook"
     "check_json_hook"

--- a/pkgs/by-name/pr/prowlarr/update.py
+++ b/pkgs/by-name/pr/prowlarr/update.py
@@ -53,7 +53,7 @@ package_attrs = json.loads(subprocess.run(
         "--json",
         "--file", nixpkgs_path,
         "--apply", """p: {
-          dir = builtins.dirOf p.meta.position;
+          dir = dirOf p.meta.position;
           version = p.version;
           sourceHash = p.src.src.outputHash;
           yarnHash = p.yarnOfflineCache.outputHash;

--- a/pkgs/by-name/pu/pulsar/package.nix
+++ b/pkgs/by-name/pu/pulsar/package.nix
@@ -78,7 +78,7 @@ let
   ];
 
   # Hunspell
-  hunspellDirs = builtins.map (lang: "${hunspellDicts.${lang}}/share/hunspell") languages;
+  hunspellDirs = map (lang: "${hunspellDicts.${lang}}/share/hunspell") languages;
   hunspellTargetDirs = "$out/opt/Pulsar/resources/app.asar.unpacked/node_modules/spellchecker/vendor/hunspell_dictionaries";
   hunspellCopyCommands = lib.concatMapStringsSep "\n" (
     lang: "cp -r ${lang}/* ${hunspellTargetDirs};"

--- a/pkgs/by-name/qo/qogir-icon-theme/package.nix
+++ b/pkgs/by-name/qo/qogir-icon-theme/package.nix
@@ -55,8 +55,8 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "dark" "all" ] color
       mkdir -p $out/share/icons
 
       name= ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) ("--theme " + builtins.toString themeVariants)} \
-        ${lib.optionalString (colorVariants != [ ]) ("--color " + builtins.toString colorVariants)} \
+        ${lib.optionalString (themeVariants != [ ]) ("--theme " + toString themeVariants)} \
+        ${lib.optionalString (colorVariants != [ ]) ("--color " + toString colorVariants)} \
         --dest $out/share/icons
 
       jdupes --quiet --link-soft --recurse $out/share

--- a/pkgs/by-name/qo/qogir-theme/package.nix
+++ b/pkgs/by-name/qo/qogir-theme/package.nix
@@ -67,9 +67,9 @@ lib.checkListOfEnum "${pname}: theme variants" [ "default" "manjaro" "ubuntu" "a
       mkdir -p $out/share/themes
 
       name= HOME="$TMPDIR" ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --dest $out/share/themes
 
       mkdir -p $out/share/doc/qogir-theme

--- a/pkgs/by-name/qr/qrq/package.nix
+++ b/pkgs/by-name/qr/qrq/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "BUILD_INFO=nix"
-    "DESTDIR=${builtins.placeholder "out"}"
+    "DESTDIR=${placeholder "out"}"
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ra/racket/minimal.nix
+++ b/pkgs/by-name/ra/racket/minimal.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       }@config:
       assert lib.assertMsg (libraries == [ ]) "library integration for Racket has not been implemented";
       writers.makeScriptWriter (
-        builtins.removeAttrs config [ "libraries" ]
+        removeAttrs config [ "libraries" ]
         // {
           interpreter = "${lib.getExe finalAttrs.finalPackage}";
         }

--- a/pkgs/by-name/ra/racket/tests/get-version-and-variant.nix
+++ b/pkgs/by-name/ra/racket/tests/get-version-and-variant.nix
@@ -10,7 +10,7 @@ runCommandLocal "racket-test-get-version-and-variant"
   }
   (
     lib.concatLines (
-      builtins.map
+      map
         (
           { expectation, output }:
           ''

--- a/pkgs/by-name/ra/radarr/update.py
+++ b/pkgs/by-name/ra/radarr/update.py
@@ -53,7 +53,7 @@ package_attrs = json.loads(subprocess.run(
         "--json",
         "--file", nixpkgs_path,
         "--apply", """p: {
-          dir = builtins.dirOf p.meta.position;
+          dir = dirOf p.meta.position;
           version = p.version;
           sourceHash = p.src.src.outputHash;
           yarnHash = p.yarnOfflineCache.outputHash;

--- a/pkgs/by-name/re/reposilite/package.nix
+++ b/pkgs/by-name/re/reposilite/package.nix
@@ -10,7 +10,7 @@
 }:
 let
   pluginsDir = linkFarm "reposilite-plugins" (
-    builtins.map (p: {
+    map (p: {
       name = (builtins.parseDrvName p.name).name + ".jar";
       path = p.outPath or p;
     }) plugins

--- a/pkgs/by-name/re/reversal-icon-theme/package.nix
+++ b/pkgs/by-name/re/reversal-icon-theme/package.nix
@@ -73,7 +73,7 @@ lib.checkListOfEnum "${pname}: color variants"
       mkdir -p $out/share/icons
 
       name= ./install.sh \
-        ${if allColorVariants then "-a" else builtins.toString colorVariants} \
+        ${if allColorVariants then "-a" else toString colorVariants} \
         -d $out/share/icons
 
       rm $out/share/icons/*/{AUTHORS,COPYING}

--- a/pkgs/by-name/ru/rust-streamdeck/package.nix
+++ b/pkgs/by-name/ru/rust-streamdeck/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${builtins.placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
 
   postInstall = ''
     install -Dm444 40-streamdeck.rules -t $out/lib/udev/rules.d/

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -143,7 +143,7 @@ buildNpmPackage (finalAttrs: {
         ];
         runtimeEnv = {
           PNAME = finalAttrs.pname;
-          PKG_FILE = builtins.toString ./package.nix;
+          PKG_FILE = toString ./package.nix;
         };
         text = ''
           new_src="$(nix-build --attr "pkgs.$PNAME.src" --no-out-link)"

--- a/pkgs/by-name/si/sierra-gtk-theme/package.nix
+++ b/pkgs/by-name/si/sierra-gtk-theme/package.nix
@@ -63,10 +63,10 @@ lib.checkListOfEnum "${pname}: button variants" [ "standard" "alt" ] buttonVaria
 
       mkdir -p $out/share/themes
       name= ./install.sh --dest $out/share/themes \
-        ${lib.optionalString (buttonVariants != [ ]) "--alt " + builtins.toString buttonVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (opacityVariants != [ ]) "--opacity " + builtins.toString opacityVariants} \
-        ${lib.optionalString (sizeVariants != [ ]) "--flat " + builtins.toString sizeVariants}
+        ${lib.optionalString (buttonVariants != [ ]) "--alt " + toString buttonVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (opacityVariants != [ ]) "--opacity " + toString opacityVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--flat " + toString sizeVariants}
 
       # Replace duplicate files with hardlinks to the first file in each
       # set of duplicates, reducing the installed size in about 79%

--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-J7gyR7K1hauV+VrzoNzRrooLuSkjk8U6A3aFn9O2yFY=";
 
   strictDeps = true;
-  cargoBuildFlags = builtins.map (n: "--bin=${n}") solanaPkgs;
+  cargoBuildFlags = map (n: "--bin=${n}") solanaPkgs;
   RUSTFLAGS = "-Amismatched_lifetime_syntaxes -Adead_code";
   LIBCLANG_PATH = "${libclang.lib}/lib";
 

--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -63,7 +63,7 @@ maven.buildMavenPackage rec {
 
   passthru.updateScript =
     let
-      pkgFile = builtins.toString ./package.nix;
+      pkgFile = toString ./package.nix;
     in
     lib.getExe (writeShellApplication {
       name = "update-${pname}";

--- a/pkgs/by-name/so/sonarr/update.py
+++ b/pkgs/by-name/so/sonarr/update.py
@@ -53,7 +53,7 @@ package_attrs = json.loads(subprocess.run(
         "--json",
         "--file", nixpkgs_path,
         "--apply", """p: {
-          dir = builtins.dirOf p.meta.position;
+          dir = dirOf p.meta.position;
           version = p.version;
           sourceHash = p.src.src.outputHash;
           yarnHash = p.yarnOfflineCache.outputHash;

--- a/pkgs/by-name/st/steam/package.nix
+++ b/pkgs/by-name/st/steam/package.nix
@@ -25,7 +25,7 @@ let
       ...
     }@args:
     buildFHSEnv (
-      (builtins.removeAttrs args [
+      (removeAttrs args [
         "extraPkgs"
         "extraLibraries"
         "extraProfile"

--- a/pkgs/by-name/st/stockfish/package.nix
+++ b/pkgs/by-name/st/stockfish/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation rec {
         ];
         runtimeEnv = {
           PNAME = pname;
-          PKG_FILE = builtins.toString ./package.nix;
+          PKG_FILE = toString ./package.nix;
           NNUE_BIG_FILE = nnueBigFile;
           NNUE_BIG_HASH = nnueBigHash;
           NNUE_SMALL_FILE = nnueSmallFile;

--- a/pkgs/by-name/st/streamdeck-ui/package.nix
+++ b/pkgs/by-name/st/streamdeck-ui/package.nix
@@ -103,7 +103,7 @@ python3Packages.buildPythonApplication rec {
         categories = [ "Utility" ];
       };
     in
-    builtins.map makeDesktopItem [
+    map makeDesktopItem [
       common
       (
         common

--- a/pkgs/by-name/st/structurizr-cli/package.nix
+++ b/pkgs/by-name/st/structurizr-cli/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
         }
       ];
     in
-    builtins.map (
+    map (
       entry:
       fetchpatch {
         url = "https://github.com/structurizr/cli/commit/${entry.rev}.patch";

--- a/pkgs/by-name/sw/swi-prolog/package.nix
+++ b/pkgs/by-name/sw/swi-prolog/package.nix
@@ -64,7 +64,7 @@
   #     url = "https://github.com/mndrix/list_util/archive/v0.13.0.zip";
   #     sha256 = "0lx7vffflak0y8l8vg8k0g8qddwwn23ksbz02hi3f8rbarh1n89q";
   #   };
-  #   typedef = builtins.fetchTarball {
+  #   typedef = fetchTarball {
   #     name = "swipl-pack-typedef";
   #     url = "https://raw.githubusercontent.com/samer--/prolog/master/typedef/release/typedef-0.1.9.tgz";
   #     sha256 = "056nqjn01g18fb1b2qivv9s7hb4azk24nx2d4kvkbmm1k91f44p3";
@@ -166,7 +166,7 @@ stdenv.mkDerivation {
     mkdir -p $out/lib/swipl/extra-pack
   '';
 
-  postInstall = builtins.concatStringsSep "\n" (builtins.map (packInstall "$out") extraPacks);
+  postInstall = builtins.concatStringsSep "\n" (map (packInstall "$out") extraPacks);
 
   meta = {
     homepage = "https://www.swi-prolog.org";

--- a/pkgs/by-name/ta/tabby/package.nix
+++ b/pkgs/by-name/ta/tabby/package.nix
@@ -59,7 +59,7 @@ let
   # - metal if (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)
   # !! warn if multiple acceleration methods are enabled and default to the first one in the list
   featureDevice =
-    if (builtins.isNull acceleration) then
+    if (isNull acceleration) then
       (warnIfMultipleAccelerationMethods availableAccelerations)
     else
       acceleration;

--- a/pkgs/by-name/te/tela-circle-icon-theme/package.nix
+++ b/pkgs/by-name/te/tela-circle-icon-theme/package.nix
@@ -72,7 +72,7 @@ lib.checkListOfEnum "tela-circle-icon-theme: color variants"
 
       ./install.sh -d $out/share/icons \
         ${lib.optionalString circularFolder "-c"} \
-        ${if allColorVariants then "-a" else builtins.toString colorVariants}
+        ${if allColorVariants then "-a" else toString colorVariants}
 
       jdupes --quiet --link-soft --recurse $out/share
 

--- a/pkgs/by-name/to/touchosc/update.sh
+++ b/pkgs/by-name/to/touchosc/update.sh
@@ -24,7 +24,7 @@ nixeval() {
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
-    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "fetchGit \"$nixpkgs\"")"
 
     if [ -n "$outpath" ]; then
         path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"

--- a/pkgs/by-name/tr/treecat/package.nix
+++ b/pkgs/by-name/tr/treecat/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     scdoc
   ];
 
-  env.PREFIX = builtins.placeholder "out";
+  env.PREFIX = placeholder "out";
 
   dontConfigure = true;
 

--- a/pkgs/by-name/tr/treefmt/functions-doc.nix
+++ b/pkgs/by-name/tr/treefmt/functions-doc.nix
@@ -24,7 +24,7 @@ in
 {
   locations = lib.pipe attrs [
     builtins.attrNames
-    (builtins.map (
+    (map (
       name:
       let
         pos = builtins.unsafeGetAttrPos name attrs;

--- a/pkgs/by-name/tr/treefmt/options-doc.nix
+++ b/pkgs/by-name/tr/treefmt/options-doc.nix
@@ -26,6 +26,6 @@ let
 in
 nixosOptionsDoc {
   documentType = "none";
-  options = builtins.removeAttrs configuration.options [ "_module" ];
+  options = removeAttrs configuration.options [ "_module" ];
   transformOptions = opt: opt // { declarations = map transformDeclaration opt.declarations; };
 }

--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -44,7 +44,7 @@ let
     "AMDGPU"
     "NVPTX"
   ]
-  ++ builtins.map inferNativeTarget llvmTargetsToBuild;
+  ++ map inferNativeTarget llvmTargetsToBuild;
 
   # This LLVM version can't seem to find pygments/pyyaml,
   # but a later update will likely fix this (triton-2.1.0)

--- a/pkgs/by-name/uc/ucc/package.nix
+++ b/pkgs/by-name/uc/ucc/package.nix
@@ -86,7 +86,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   # NOTE: With `__structuredAttrs` enabled, `LDFLAGS` must be set under `env` so it is assured to be a string;
   # otherwise, we might have forgotten to convert it to a string and Nix would make LDFLAGS a shell variable
   # referring to an array!
-  env.LDFLAGS = builtins.toString (
+  env.LDFLAGS = toString (
     optionals enableCuda [
       # Fake libnvidia-ml.so (the real one is deployed impurely)
       "-L${getLib cuda_nvml_dev}/lib/stubs"

--- a/pkgs/by-name/uw/uwsgi/package.nix
+++ b/pkgs/by-name/uw/uwsgi/package.nix
@@ -76,7 +76,7 @@ let
     else
       throw "Unknown UWSGI plugin ${name}, available : ${all}";
 
-  needed = builtins.map getPlugin plugins;
+  needed = map getPlugin plugins;
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation (finalAttrs: {
               rsync --archive --mkpath --chmod=a+w ${finalAttrs.finalPackage}/ $out/
 
               # Symlink the data derivation to the default data path
-              mkdir -p ${builtins.dirOf Default_Data_Path}
+              mkdir -p ${dirOf Default_Data_Path}
               ln -s ${dataDerivation} ${Default_Data_Path}
 
               # Fix `error: suspicious ownership or permission on '/nix/store/xxx-0.0.0' for output 'out'; rejecting this build output`

--- a/pkgs/by-name/vi/vimix-gtk-themes/package.nix
+++ b/pkgs/by-name/vi/vimix-gtk-themes/package.nix
@@ -76,10 +76,10 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook preInstall
       mkdir -p $out/share/themes
       name= HOME="$TMPDIR" ./install.sh \
-        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
-        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
-        ${lib.optionalString (sizeVariants != [ ]) "--size " + builtins.toString sizeVariants} \
-        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + toString tweaks} \
         --dest $out/share/themes
       rm $out/share/themes/*/{AUTHORS,LICENSE}
       jdupes --quiet --link-soft --recurse $out/share

--- a/pkgs/by-name/vi/vimix-icon-theme/package.nix
+++ b/pkgs/by-name/vi/vimix-icon-theme/package.nix
@@ -61,7 +61,7 @@ lib.checkListOfEnum "${pname}: color variants"
       runHook preInstall
 
       ./install.sh \
-        ${if colorVariants != [ ] then builtins.toString colorVariants else "-a"} \
+        ${if colorVariants != [ ] then toString colorVariants else "-a"} \
         -d $out/share/icons
 
       # replace duplicate files with symlinks

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -33,9 +33,9 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
   '';
 
   preBuild = ''
-    export SYSROOT_LIB=${builtins.placeholder "out"}/lib
-    export SYSROOT_INC=${builtins.placeholder "dev"}/include
-    export SYSROOT_SHARE=${builtins.placeholder "share"}/share
+    export SYSROOT_LIB=${placeholder "out"}/lib
+    export SYSROOT_INC=${placeholder "dev"}/include
+    export SYSROOT_SHARE=${placeholder "share"}/share
     mkdir -p "$SYSROOT_LIB" "$SYSROOT_INC" "$SYSROOT_SHARE"
     makeFlagsArray+=(
       "SYSROOT_LIB:=$SYSROOT_LIB"

--- a/pkgs/by-name/wg/wgpu-native/examples.nix
+++ b/pkgs/by-name/wg/wgpu-native/examples.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeWrapperArgs = lib.optionals (finalAttrs.runtimeInputs != [ ]) [
-    "--prefix LD_LIBRARY_PATH : ${builtins.toString (lib.makeLibraryPath finalAttrs.runtimeInputs)}"
+    "--prefix LD_LIBRARY_PATH : ${toString (lib.makeLibraryPath finalAttrs.runtimeInputs)}"
   ];
 
   installPhase = ''

--- a/pkgs/by-name/wh/whitesur-icon-theme/package.nix
+++ b/pkgs/by-name/wh/whitesur-icon-theme/package.nix
@@ -61,7 +61,7 @@ lib.checkListOfEnum "${pname}: theme variants"
 
       ./install.sh --dest $out/share/icons \
         --name WhiteSur \
-        --theme ${builtins.toString themeVariants} \
+        --theme ${toString themeVariants} \
         ${lib.optionalString alternativeIcons "--alternative"} \
         ${lib.optionalString boldPanelIcons "--bold"} \
 

--- a/pkgs/by-name/xe/xevd/package.nix
+++ b/pkgs/by-name/xe/xevd/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = lib.optionals (!lib.versionOlder "0.5.0" finalAttrs.version) (
-    builtins.map fetchpatch2 [
+    map fetchpatch2 [
       # Upstream accepted patches, should be dropped on next version bump.
       {
         url = "https://github.com/mpeg5/xevd/commit/7eda92a6ebb622189450f7b63cfd4dcd32fd6dff.patch?full_index=1";
@@ -63,8 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     optional isAarch64 (cmakeBool "ARM" true)
     ++ optional isDarwin (cmakeFeature "CMAKE_SYSTEM_NAME" "Darwin");
 
-  env.NIX_CFLAGS_COMPILE = builtins.toString (
-    builtins.map (w: "-Wno-" + w) (
+  env.NIX_CFLAGS_COMPILE = toString (
+    map (w: "-Wno-" + w) (
       [
         # Evaluate on version bump whether still necessary.
         "sometimes-uninitialized"

--- a/pkgs/by-name/xe/xeve/package.nix
+++ b/pkgs/by-name/xe/xeve/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches =
-    builtins.map fetchpatch2 [
+    map fetchpatch2 [
       {
         url = "https://github.com/mpeg5/xeve/commit/954ed6e0494cd2438fd15c717c0146e88e582b33.patch?full_index=1";
         hash = "sha256-//NtOUm1fqPFvOM955N6gF+QgmOdmuVunwx/3s/G/J8=";
@@ -60,8 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     optional isAarch64 (cmakeBool "ARM" true)
     ++ optional isDarwin (cmakeFeature "CMAKE_SYSTEM_NAME" "Darwin");
 
-  env.NIX_CFLAGS_COMPILE = builtins.toString (
-    builtins.map (w: "-Wno-" + w) [
+  env.NIX_CFLAGS_COMPILE = toString (
+    map (w: "-Wno-" + w) [
       # Patch addressing an if without a body was rejected upstream, third
       # line-based comment in this thread, https://github.com/mpeg5/xeve/pull/122#pullrequestreview-2187744305
       # Evaluate on version bump whether still necessary.

--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -30,7 +30,7 @@ let
   # #226165 rewrites cudaStdenv
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else inputs.stdenv;
   # Ensures we don't use the stdenv value by accident.
-  stdenv = builtins.throw "Use effectiveStdenv instead of stdenv in xgboost derivation.";
+  stdenv = throw "Use effectiveStdenv instead of stdenv in xgboost derivation.";
 in
 
 effectiveStdenv.mkDerivation rec {

--- a/pkgs/by-name/ya/yandex-cloud/update.py
+++ b/pkgs/by-name/ya/yandex-cloud/update.py
@@ -38,7 +38,7 @@ package_attrs = json.loads(subprocess.run(
         "--json",
         "--file", nixpkgs_path,
         "--apply", """p: {
-          dir = builtins.dirOf p.meta.position;
+          dir = dirOf p.meta.position;
           version = p.version;
         }""",
         "--",

--- a/pkgs/by-name/zx/zxtune/package.nix
+++ b/pkgs/by-name/zx/zxtune/package.nix
@@ -115,11 +115,11 @@ stdenv.mkDerivation rec {
     in
     ''
       runHook preBuild
-      make ${builtins.toString makeOptsCommon} -C apps/xtractor
-      make ${builtins.toString makeOptsCommon} -C apps/zxtune123
+      make ${toString makeOptsCommon} -C apps/xtractor
+      make ${toString makeOptsCommon} -C apps/zxtune123
     ''
     + lib.optionalString withQt ''
-      make ${builtins.toString (makeOptsCommon ++ makeOptsQt)} -C apps/zxtune-qt
+      make ${toString (makeOptsCommon ++ makeOptsQt)} -C apps/zxtune-qt
     ''
     + ''
       runHook postBuild

--- a/pkgs/common-updater/combinators.nix
+++ b/pkgs/common-updater/combinators.nix
@@ -52,7 +52,7 @@ let
     arg:
     if builtins.isPath arg then
       {
-        args = args ++ [ { __rawShell = "\"\$${builtins.toString maxArgIndex}\""; } ];
+        args = args ++ [ { __rawShell = "\"\$${toString maxArgIndex}\""; } ];
         maxArgIndex = maxArgIndex + 1;
         paths = paths ++ [ arg ];
       }
@@ -144,7 +144,7 @@ rec {
     scripts:
 
     let
-      scriptsNormalized = builtins.map normalize scripts;
+      scriptsNormalized = map normalize scripts;
     in
     let
       scripts = scriptsNormalized;
@@ -174,7 +174,7 @@ rec {
       builtins.length (
         lib.unique (
           builtins.filter (attrPath: attrPath != null) (
-            builtins.map (
+            map (
               {
                 attrPath ? null,
                 ...
@@ -187,7 +187,7 @@ rec {
     ) "Combining update scripts with different attr paths is currently unsupported.";
 
     {
-      command = commandsToShellInvocation (builtins.map ({ command, ... }: command) scripts);
+      command = commandsToShellInvocation (map ({ command, ... }: command) scripts);
       supportedFeatures =
         if hasCommitSupport then
           [ "commit" ]

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -164,7 +164,7 @@ let
 in
 [
   (lib.getExe updateScript)
-  "--url=${builtins.toString url}"
+  "--url=${toString url}"
   "--tag-format=${tagFormat}"
 ]
 ++ lib.optionals (branch != null) [

--- a/pkgs/data/fonts/iosevka/comfy.nix
+++ b/pkgs/data/fonts/iosevka/comfy.nix
@@ -73,7 +73,7 @@ let
     });
 in
 builtins.listToAttrs (
-  builtins.map (set: {
+  map (set: {
     name = set;
     value = makeIosevkaFont set;
   }) sets

--- a/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
+++ b/pkgs/desktops/gnome/extensions/buildGnomeExtension.nix
@@ -27,11 +27,11 @@ let
 
     stdenv.mkDerivation {
       pname = "gnome-shell-extension-${pname}";
-      version = builtins.toString version;
+      version = toString version;
       src = fetchzip {
         url = "https://extensions.gnome.org/extension-data/${
           builtins.replaceStrings [ "@" ] [ "" ] uuid
-        }.v${builtins.toString version}.shell-extension.zip";
+        }.v${toString version}.shell-extension.zip";
         inherit sha256;
         stripRoot = false;
         # The download URL may change content over time. This is because the

--- a/pkgs/desktops/gnome/update.nix
+++ b/pkgs/desktops/gnome/update.nix
@@ -29,7 +29,7 @@ let
       minorAvailable =
         builtins.length versionComponents > 1 && builtins.match "[0-9]+" minorVersion != null;
       nextMinor = builtins.fromJSON minorVersion + 1;
-      upperBound = "${lib.versions.major packageVersion}.${builtins.toString nextMinor}";
+      upperBound = "${lib.versions.major packageVersion}.${toString nextMinor}";
     in
     if builtins.isBool freeze then
       lib.optionals (freeze && minorAvailable) [ upperBound ]

--- a/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Powerful and easy to use calculator for Ubuntu Touch, with calculations history and formula validation";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app";
     changelog = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     mainProgram = "lomiri-calculator-app";

--- a/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "File Manager application for Ubuntu Touch devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app";
     changelog = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     mainProgram = "lomiri-filemanager-app";

--- a/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Photo gallery application for Ubuntu Touch devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app";
     changelog = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = with lib.licenses; [
       gpl3Only

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Media Player application for Ubuntu Touch devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app";
     changelog = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = with lib.licenses; [
       gpl3Only

--- a/pkgs/desktops/lomiri/applications/lomiri-music-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-music-app/default.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Default Music application for Ubuntu devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-music-app";
     changelog = "https://gitlab.com/ubports/development/apps/lomiri-music-app/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = with lib.licenses; [
       gpl3Only

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -198,7 +198,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "System Settings application for Lomiri";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-system-settings";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = licenses.gpl3Only;
     mainProgram = "lomiri-system-settings";

--- a/pkgs/desktops/lomiri/applications/lomiri-terminal-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-terminal-app/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Terminal app for desktop and mobile devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-terminal-app";
     changelog = "https://gitlab.com/ubports/development/apps/lomiri-terminal-app/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     mainProgram = "lomiri-terminal-app";

--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Performs uploads and downloads from a centralized location";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-download-manager";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.lgpl3Only;
     teams = [ lib.teams.lomiri ];

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Ayatana indiator exporting the network settings menu through D-Bus";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-indicator-network";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     teams = [ lib.teams.lomiri ];

--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Policy kit agent for the Lomiri desktop";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-polkit-agent";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     teams = [ lib.teams.lomiri ];

--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gitlab.com/ubports/development/core/lomiri-url-dispatcher";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-url-dispatcher/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = with lib.licenses; [
       lgpl3Only

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Media scanner service & access library";
     homepage = "https://gitlab.com/ubports/development/core/mediascanner2";
     changelog = "https://gitlab.com/ubports/development/core/mediascanner2/-/blob/${
-      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+      if (!isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
     }/ChangeLog";
     license = lib.licenses.gpl3Only;
     teams = [ lib.teams.lomiri ];

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -78,7 +78,7 @@ let
 
   thisSpark =
     spark2014.${gnat_version}
-      or (builtins.throw "GNATprove depends on a specific GNAT version and can't be built using GNAT ${gnat_version}.");
+      or (throw "GNATprove depends on a specific GNAT version and can't be built using GNAT ${gnat_version}.");
 
 in
 stdenv.mkDerivation {

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -86,7 +86,7 @@
 }@attrs:
 let
   # Remove non standard attributes that cannot be coerced to strings
-  overridable = builtins.removeAttrs attrs [
+  overridable = removeAttrs attrs [
     "compileFlags"
     "erlangCompilerOptions"
     "mixNixDeps"

--- a/pkgs/development/compilers/chicken/4/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/4/eggDerivation.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (
     }
     // args.meta or { };
   }
-  // (builtins.removeAttrs args [
+  // (removeAttrs args [
     "name"
     "buildInputs"
     "meta"

--- a/pkgs/development/compilers/chicken/5/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/5/eggDerivation.nix
@@ -78,7 +78,7 @@ in
     }
     // args.meta or { };
   }
-  // builtins.removeAttrs args [
+  // removeAttrs args [
     "name"
     "pname"
     "version"

--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -41,7 +41,7 @@ assert (
   ]
 );
 let
-  mkDerivationArgs = builtins.removeAttrs args [
+  mkDerivationArgs = removeAttrs args [
     "format"
     "installManPages"
     "lockFile"

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -59,12 +59,11 @@ let
       ;
     src = monorepoSrc;
     versionDir =
-      (builtins.toString ../.)
-      + "/${if (gitRelease != null) then "git" else lib.versions.major release_version}";
+      (toString ../.) + "/${if (gitRelease != null) then "git" else lib.versions.major release_version}";
     getVersionFile =
       p:
       builtins.path {
-        name = builtins.baseNameOf p;
+        name = baseNameOf p;
         path =
           let
             patches = args.patchesFn (import ./patches.nix);

--- a/pkgs/development/compilers/gcc/ng/common/libgfortran/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgfortran/default.nix
@@ -165,7 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
     "gcc_cv_target_thread_file=single"
     # $CC cannot link binaries, let alone run then
     "cross_compiling=true"
-    "--with-toolexeclibdir=${builtins.placeholder "dev"}/lib"
+    "--with-toolexeclibdir=${placeholder "dev"}/lib"
   ];
 
   # Set the variable back the way it was, see corresponding code in

--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
@@ -24,7 +24,7 @@
 }@args:
 
 let
-  extraArgs = builtins.removeAttrs args [
+  extraArgs = removeAttrs args [
     "lib"
     "stdenv"
     "alsa-lib"

--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvmProduct.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvmProduct.nix
@@ -14,7 +14,7 @@
 }@args:
 
 let
-  extraArgs = builtins.removeAttrs args [
+  extraArgs = removeAttrs args [
     "lib"
     "stdenv"
     "autoPatchelfHook"

--- a/pkgs/development/compilers/idris2/build-idris.nix
+++ b/pkgs/development/compilers/idris2/build-idris.nix
@@ -50,7 +50,7 @@ let
   libSuffix = "lib/${idrName}";
   libDirs = libs: (lib.makeSearchPath libSuffix libs) + ":${idris2}/${idrName}";
   supportDir = "${idris2}/${idrName}/lib";
-  drvAttrs = builtins.removeAttrs attrs [
+  drvAttrs = removeAttrs attrs [
     "ipkgName"
     "idrisLibraries"
   ];

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -74,12 +74,11 @@ let
       ;
     src = monorepoSrc;
     versionDir =
-      (builtins.toString ../.)
-      + "/${if (gitRelease != null) then "git" else lib.versions.major release_version}";
+      (toString ../.) + "/${if (gitRelease != null) then "git" else lib.versions.major release_version}";
     getVersionFile =
       p:
       builtins.path {
-        name = builtins.baseNameOf p;
+        name = baseNameOf p;
         path =
           let
             patches = args.patchesFn (import ./patches.nix);

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -272,7 +272,7 @@ stdenv.mkDerivation (
           # and thus fails under the sandbox:
           ''
             substituteInPlace unittests/TargetParser/Host.cpp \
-              --replace-fail '/usr/bin/sw_vers' "${(builtins.toString darwin.DarwinTools) + "/bin/sw_vers"}"
+              --replace-fail '/usr/bin/sw_vers' "${(toString darwin.DarwinTools) + "/bin/sw_vers"}"
           ''
         +
           # This test tries to call the intrinsics `@llvm.roundeven.f32` and

--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -197,5 +197,5 @@ if (!config.allowAliases && !(vmsByPlatform ? platform)) then
 else
   vmsByPlatform.${platform} or (throw (
     "Unsupported platform ${platform}: only the following platforms are supported: "
-    + builtins.toString (builtins.attrNames vmsByPlatform)
+    + toString (builtins.attrNames vmsByPlatform)
   ))

--- a/pkgs/development/compilers/rust/1_89.nix
+++ b/pkgs/development/compilers/rust/1_89.nix
@@ -86,7 +86,7 @@ import ./default.nix
   }
 
   (
-    builtins.removeAttrs args [
+    removeAttrs args [
       "llvmPackages_20"
       "llvm_20"
       "wrapCCWith"

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -218,8 +218,8 @@ stdenv.mkDerivation (self: {
     "--prefix=$out"
     "--xc-host=${lib.escapeShellArg bootstrapLisp'}"
   ]
-  ++ builtins.map (x: "--with-${x}") self.enableFeatures
-  ++ builtins.map (x: "--without-${x}") self.disableFeatures
+  ++ map (x: "--with-${x}") self.enableFeatures
+  ++ map (x: "--without-${x}") self.disableFeatures
   ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-darwin") [
     "--arch=arm64"
   ];

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
@@ -83,7 +83,7 @@ let
         binaryBytecode
       ];
       description = "${brand-name}, prebuilt OpenJDK binary";
-      platforms = builtins.map (arch: arch + "-darwin") providedCpuTypes; # some inherit jre.meta.platforms
+      platforms = map (arch: arch + "-darwin") providedCpuTypes; # some inherit jre.meta.platforms
       maintainers = with maintainers; [ taku0 ];
       teams = [ teams.java ];
       inherit knownVulnerabilities;

--- a/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
@@ -139,7 +139,7 @@ let
         binaryBytecode
       ];
       description = "${brand-name}, prebuilt OpenJDK binary";
-      platforms = builtins.map (arch: arch + "-linux") providedCpuTypes; # some inherit jre.meta.platforms
+      platforms = map (arch: arch + "-linux") providedCpuTypes; # some inherit jre.meta.platforms
       maintainers = with maintainers; [ taku0 ];
       teams = [ teams.java ];
       inherit knownVulnerabilities;

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -104,7 +104,7 @@ let
             let
               roundUpToEven = num: num + lib.mod num 2;
             in
-            "vala_${lib.versions.major version}_${builtins.toString (roundUpToEven (lib.toInt (lib.versions.minor version)))}";
+            "vala_${lib.versions.major version}_${toString (roundUpToEven (lib.toInt (lib.versions.minor version)))}";
           packageName = "vala";
           freeze = true;
         };

--- a/pkgs/development/compilers/zulu/11.nix
+++ b/pkgs/development/compilers/zulu/11.nix
@@ -50,5 +50,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/compilers/zulu/17.nix
+++ b/pkgs/development/compilers/zulu/17.nix
@@ -50,5 +50,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/compilers/zulu/21.nix
+++ b/pkgs/development/compilers/zulu/21.nix
@@ -51,5 +51,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/compilers/zulu/23.nix
+++ b/pkgs/development/compilers/zulu/23.nix
@@ -50,5 +50,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/compilers/zulu/24.nix
+++ b/pkgs/development/compilers/zulu/24.nix
@@ -51,5 +51,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/compilers/zulu/25.nix
+++ b/pkgs/development/compilers/zulu/25.nix
@@ -54,5 +54,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -50,5 +50,5 @@ callPackage ./common.nix (
       };
     };
   }
-  // builtins.removeAttrs args [ "callPackage" ]
+  // removeAttrs args [ "callPackage" ]
 )

--- a/pkgs/development/cuda-modules/cuda-library-samples/generic.nix
+++ b/pkgs/development/cuda-modules/cuda-library-samples/generic.nix
@@ -75,7 +75,7 @@ in
       buildInputs = prevAttrs.buildInputs or [ ] ++ [ cutensor ];
 
       cmakeFlags = prevAttrs.cmakeFlags or [ ] ++ [
-        "-DCUTENSOR_EXAMPLE_BINARY_INSTALL_DIR=${builtins.placeholder "out"}/bin"
+        "-DCUTENSOR_EXAMPLE_BINARY_INSTALL_DIR=${placeholder "out"}/bin"
       ];
 
       # CUTENSOR_ROOT is double escaped

--- a/pkgs/development/hare-third-party/hare-compress/default.nix
+++ b/pkgs/development/hare-third-party/hare-compress/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   nativeCheckInputs = [ hareHook ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-json/default.nix
+++ b/pkgs/development/hare-third-party/hare-json/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-png/default.nix
+++ b/pkgs/development/hare-third-party/hare-png/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ hareHook ];
   propagatedBuildInputs = [ hareThirdParty.hare-compress ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     hareHook
   ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   checkTarget = "check_local";
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -392,9 +392,9 @@ let
       # closePropagationFast.
       propagatePlainBuildInputs =
         drvs:
-        builtins.map (i: i.val) (
+        map (i: i.val) (
           builtins.genericClosure {
-            startSet = builtins.map (drv: {
+            startSet = map (drv: {
               key = drv.outPath;
               val = drv;
             }) (builtins.filter propagateValue drvs);
@@ -784,7 +784,7 @@ lib.fix (
         checkFlagsArray+=(
           "--show-details=streaming"
           "--test-wrapper=${testWrapperScript}"
-          ${lib.escapeShellArgs (builtins.map (opt: "--test-option=${opt}") testFlags)}
+          ${lib.escapeShellArgs (map (opt: "--test-option=${opt}") testFlags)}
         )
         export NIX_GHC_PACKAGE_PATH_FOR_TEST="''${NIX_GHC_PACKAGE_PATH_FOR_TEST:-$packageConfDir:}"
         ${setupCommand} test ${testTargetsString} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -87,7 +87,7 @@ buildPackages.stdenv.mkDerivation (finalAttrs: {
       '')
       (
         lib.filter (el: el.haddockDir != null) (
-          builtins.map (p: {
+          map (p: {
             haddockDir = if p ? haddockDir then p.haddockDir p else null;
             name = p.pname;
           }) docPackages

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -662,9 +662,9 @@ rec {
       # closePropagationFast.
       propagatedPlainBuildInputs =
         drvs:
-        builtins.map (i: i.val) (
+        map (i: i.val) (
           builtins.genericClosure {
-            startSet = builtins.map (drv: {
+            startSet = map (drv: {
               key = drv.outPath;
               val = drv;
             }) drvs;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -351,7 +351,7 @@ package-set { inherit pkgs lib callPackage; } self
   developPackage =
     {
       root,
-      name ? lib.optionalString (builtins.typeOf root == "path") (builtins.baseNameOf root),
+      name ? lib.optionalString (builtins.typeOf root == "path") (baseNameOf root),
       source-overrides ? { },
       overrides ? self: super: { },
       modifier ? drv: drv,
@@ -634,7 +634,7 @@ package-set { inherit pkgs lib callPackage; } self
       # pkgWithCombinedDepsDevDrv :: Derivation
       pkgWithCombinedDepsDevDrv = pkgWithCombinedDeps.envFunc { inherit withHoogle; };
 
-      mkDerivationArgs = builtins.removeAttrs args [
+      mkDerivationArgs = removeAttrs args [
         "genericBuilderArgsModifier"
         "packages"
         "withHoogle"

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -63,7 +63,7 @@ let
   docDir = "$out/share/doc/ghc/html";
   packageCfgDir = "${libDir}/package.conf.d";
   paths = lib.concatLists (
-    builtins.map (pkg: [ pkg ] ++ lib.optionals installDocumentation [ (lib.getOutput "doc" pkg) ]) (
+    map (pkg: [ pkg ] ++ lib.optionals installDocumentation [ (lib.getOutput "doc" pkg) ]) (
       lib.filter (x: x ? isHaskellLibrary) (lib.closePropagation packages)
     )
   );

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -26,7 +26,7 @@ let
   allIdrisDeps = idrisDeps ++ lib.optional (!noPrelude) prelude ++ lib.optional (!noBase) base;
   idris-with-packages = with-packages allIdrisDeps;
   newAttrs =
-    builtins.removeAttrs attrs [
+    removeAttrs attrs [
       "idrisDeps"
       "noPrelude"
       "noBase"

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation {
   ++ lib.optional (ffcallAvailable && (libffi != null)) "--with-dynamic-ffi"
   ++ lib.optional ffcallAvailable "--with-ffcall"
   ++ lib.optional (!ffcallAvailable) "--without-ffcall"
-  ++ builtins.map (x: " --with-module=" + x) withModules
+  ++ map (x: " --with-module=" + x) withModules
   ++ lib.optional threadSupport "--with-threads=POSIX_THREADS";
 
   preBuild = ''

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -52,7 +52,7 @@ let
     See https://hexdocs.pm/elixir/${version}/compatibility-and-deprecations.html
   '';
 
-  maxShiftMajor = builtins.toString ((toInt (versions.major maximumOTPVersion)) + 1);
+  maxShiftMajor = toString ((toInt (versions.major maximumOTPVersion)) + 1);
   maxAssert =
     if (maximumOTPVersion == null) then
       true

--- a/pkgs/development/interpreters/octave/build-octave-package.nix
+++ b/pkgs/development/interpreters/octave/build-octave-package.nix
@@ -72,7 +72,7 @@ let
   # This used to mean that if a package defined extra nativeBuildInputs, it
   # would override the ones for building an Octave package (the hook and Octave
   # itself, causing everything to fail.
-  attrs' = builtins.removeAttrs attrs [
+  attrs' = removeAttrs attrs [
     "nativeBuildInputs"
     "passthru"
   ];

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -85,7 +85,7 @@ let
           }@innerArgs:
           let
             allArgs = args // prevArgs // innerArgs;
-            filteredArgs = builtins.removeAttrs allArgs [
+            filteredArgs = removeAttrs allArgs [
               "extensions"
               "extraConfig"
             ];

--- a/pkgs/development/interpreters/python/conda/default.nix
+++ b/pkgs/development/interpreters/python/conda/default.nix
@@ -4,7 +4,7 @@
   # List of libraries that are needed for conda binary packages.
   # When installing a conda binary package, just extend
   # the `buildInputs` with `condaAutopatchLibs`.
-  condaPatchelfLibs = builtins.map (p: p.lib or p) (
+  condaPatchelfLibs = map (p: p.lib or p) (
     [
       pkgs.alsa-lib
       pkgs.cups

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -403,7 +403,7 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-kpXoIHlz53+0FAm/fK99ZBdNUg0u13erOr1XP2FSkQY=";
       };
     in
-    (builtins.map (f: "${mingw-patch}/${f}") [
+    (map (f: "${mingw-patch}/${f}") [
       # The other patches in that repo are already applied to 3.11.10
       "mingw-python3_distutils.patch"
       "mingw-python3_frozenmain.patch"

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -171,12 +171,12 @@ let
       checkDrv = drv: if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch drv else drv;
 
     in
-    inputs: builtins.map (checkDrv) inputs;
+    inputs: map (checkDrv) inputs;
 
   # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
   self = toPythonModule (
     stdenv.mkDerivation (
-      (builtins.removeAttrs attrs [
+      (removeAttrs attrs [
         "disabled"
         "checkPhase"
         "checkInputs"

--- a/pkgs/development/interpreters/ruby/ruby-version.nix
+++ b/pkgs/development/interpreters/ruby/ruby-version.nix
@@ -76,7 +76,7 @@ let
       else
         base;
 
-    # Implements the builtins.toString interface.
+    # Implements the toString interface.
     __toString =
       self:
       self.majMinTiny

--- a/pkgs/development/interpreters/ruby/ruby-version.nix
+++ b/pkgs/development/interpreters/ruby/ruby-version.nix
@@ -76,7 +76,7 @@ let
       else
         base;
 
-    # Implements the toString interface.
+    # Implements the builtins.toString interface.
     __toString =
       self:
       self.majMinTiny

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -41,7 +41,7 @@ let
 
   self = (
     stdenv.mkDerivation (
-      (builtins.removeAttrs attrs [
+      (removeAttrs attrs [
         "addTclConfigureFlags"
         "checkPhase"
         "checkInputs"

--- a/pkgs/development/libraries/astal/buildAstalModule.nix
+++ b/pkgs/development/libraries/astal/buildAstalModule.nix
@@ -15,7 +15,7 @@
   python3,
 }:
 let
-  cleanArgs = lib.flip builtins.removeAttrs [
+  cleanArgs = lib.flip removeAttrs [
     "name"
     "sourceRoot"
     "nativeBuildInputs"

--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -83,7 +83,7 @@
 
       makeFlags = (previousAttrs.makeFlags or [ ]) ++ [
         "localedata/install-locales"
-        "localedir=${builtins.placeholder "out"}/lib/locale"
+        "localedir=${placeholder "out"}/lib/locale"
       ];
 
       installPhase = ''

--- a/pkgs/development/libraries/gobject-introspection/wrapper.nix
+++ b/pkgs/development/libraries/gobject-introspection/wrapper.nix
@@ -16,13 +16,13 @@
 
 let
   # ensure that `.override` works
-  args = builtins.removeAttrs _args [
+  args = removeAttrs _args [
     "buildPackages"
     "targetPackages"
     "gobject-introspection-unwrapped"
   ];
   # passing this stdenv to `targetPackages...` breaks due to splicing not working in `.override``
-  argsForTarget = builtins.removeAttrs args [ "stdenv" ];
+  argsForTarget = removeAttrs args [ "stdenv" ];
 
   overriddenUnwrappedGir = gobject-introspection-unwrapped.override args;
   # if we have targetPackages.gobject-introspection then propagate that

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   # While "out" acts as the bin output, most packages only care about the lib output.
   # We set prefix such that all the pkg-config configuration stays inside the dev and lib outputs.
   # stdenv will take care of overriding bindir, sbindir, etc. such that "out" contains the binaries.
-  prefix = builtins.placeholder "lib";
+  prefix = placeholder "lib";
 
   env = lib.optionalAttrs stdenv.hostPlatform.isStatic {
     NIX_CFLAGS_COMPILE = "-fcommon";

--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -75,29 +75,29 @@ assert (eri3Deriv >= 0 && eri3Deriv <= 4);
 # Ensure valid arguments for generated angular momenta in ERI derivatives are used.
 assert (
   builtins.length eriAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eriAm)
+  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eriAm)
 );
 assert (
   builtins.length eri3Am == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri3Am)
+  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri3Am)
 );
 assert (
   builtins.length eri2Am == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri2Am)
+  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri2Am)
 );
 
 # Ensure valid arguments for generated angular momenta in optimised ERI derivatives are used.
 assert (
   builtins.length eriOptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eriOptAm)
+  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eriOptAm)
 );
 assert (
   builtins.length eri3OptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri3OptAm)
+  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri3OptAm)
 );
 assert (
   builtins.length eri2OptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (builtins.map (a: a <= maxAm && a >= 0) eri2OptAm)
+  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri2OptAm)
 );
 
 # Ensure a valid derivative order for one-electron integrals
@@ -185,26 +185,26 @@ let
     ];
 
     configureFlags = [
-      "--with-max-am=${builtins.toString maxAm}"
-      "--with-eri-max-am=${lib.concatStringsSep "," (builtins.map builtins.toString eriAm)}"
-      "--with-eri3-max-am=${lib.concatStringsSep "," (builtins.map builtins.toString eri3Am)}"
-      "--with-eri2-max-am=${lib.concatStringsSep "," (builtins.map builtins.toString eri2Am)}"
-      "--with-eri-opt-am=${lib.concatStringsSep "," (builtins.map builtins.toString eriOptAm)}"
-      "--with-eri3-opt-am=${lib.concatStringsSep "," (builtins.map builtins.toString eri3OptAm)}"
-      "--with-eri2-opt-am=${lib.concatStringsSep "," (builtins.map builtins.toString eri2OptAm)}"
+      "--with-max-am=${toString maxAm}"
+      "--with-eri-max-am=${lib.concatStringsSep "," (map toString eriAm)}"
+      "--with-eri3-max-am=${lib.concatStringsSep "," (map toString eri3Am)}"
+      "--with-eri2-max-am=${lib.concatStringsSep "," (map toString eri2Am)}"
+      "--with-eri-opt-am=${lib.concatStringsSep "," (map toString eriOptAm)}"
+      "--with-eri3-opt-am=${lib.concatStringsSep "," (map toString eri3OptAm)}"
+      "--with-eri2-opt-am=${lib.concatStringsSep "," (map toString eri2OptAm)}"
       "--with-cartgauss-ordering=${cartGaussOrd}"
       "--with-shgauss-ordering=${shGaussOrd}"
       "--with-shell-set=${shellSet}"
     ]
     ++ lib.optional enableFMA "--enable-fma"
-    ++ lib.optional (eriDeriv > 0) "--enable-eri=${builtins.toString eriDeriv}"
-    ++ lib.optional (eri2Deriv > 0) "--enable-eri2=${builtins.toString eri2Deriv}"
-    ++ lib.optional (eri3Deriv > 0) "--enable-eri3=${builtins.toString eri3Deriv}"
+    ++ lib.optional (eriDeriv > 0) "--enable-eri=${toString eriDeriv}"
+    ++ lib.optional (eri2Deriv > 0) "--enable-eri2=${toString eri2Deriv}"
+    ++ lib.optional (eri3Deriv > 0) "--enable-eri3=${toString eri3Deriv}"
     ++ lib.optionals enableOneBody [
-      "--enable-1body=${builtins.toString oneBodyDerivOrd}"
+      "--enable-1body=${toString oneBodyDerivOrd}"
       "--enable-1body-property-derivs"
     ]
-    ++ lib.optional (multipoleOrd > 0) "--with-multipole-max-order=${builtins.toString multipoleOrd}"
+    ++ lib.optional (multipoleOrd > 0) "--with-multipole-max-order=${toString multipoleOrd}"
     ++ lib.optional enableGeneric "--enable-generic"
     ++ lib.optional enableContracted "--enable-contracted-ints"
     ++ lib.optional eri3PureSh "--enable-eri3-pure-sh"

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -120,8 +120,8 @@ let
   toCommand = dep: "ln -s ${dep} $out/${dep.pname}-${dep.version}.tar.gz";
 
   packageCacheCommand = lib.pipe rustDeps [
-    (builtins.map fetchDep)
-    (builtins.map toCommand)
+    (map fetchDep)
+    (map toCommand)
     (lib.concatStringsSep "\n")
   ];
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -193,9 +193,7 @@ let
       # starting with 3.5 its nice to speed things up for free
       ++ lib.optional stdenv.hostPlatform.isx86_64 "enable-ec_nistp_64_gcc_128"
       # useful to set e.g. 256 bit security level with setting this to 5
-      ++ lib.optional (
-        securityLevel != null
-      ) "-DOPENSSL_TLS_SECURITY_LEVEL=${builtins.toString securityLevel}"
+      ++ lib.optional (securityLevel != null) "-DOPENSSL_TLS_SECURITY_LEVEL=${toString securityLevel}"
       ++ lib.optional enableMD2 "enable-md2"
       ++ lib.optional enableSSL2 "enable-ssl2"
       ++ lib.optional enableSSL3 "enable-ssl3"

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -33,7 +33,7 @@ qtModule {
     # store paths and disallows saving caches of bare qml files in the store.
     (replaceVars ./invalidate-caches-from-mismatched-store-paths.patch {
       nixStore = builtins.storeDir;
-      nixStoreLength = builtins.toString ((builtins.stringLength builtins.storeDir) + 1); # trailing /
+      nixStoreLength = toString ((builtins.stringLength builtins.storeDir) + 1); # trailing /
     })
     # add version specific QML import path
     ./use-versioned-import-path.patch
@@ -41,7 +41,7 @@ qtModule {
 
   preConfigure =
     let
-      storePrefixLen = builtins.toString ((builtins.stringLength builtins.storeDir) + 1);
+      storePrefixLen = toString ((builtins.stringLength builtins.storeDir) + 1);
     in
     ''
       # "NIX:" is reserved for saved qmlc files in patch 0001, "QTDHASH:" takes the place

--- a/pkgs/development/lua-modules/lib.nix
+++ b/pkgs/development/lua-modules/lib.nix
@@ -134,7 +134,7 @@ rec {
       # example externalDeps': [ { name = "CRYPTO"; dep = pkgs.openssl; } ]
       externalDeps' = lib.filter (dep: !lib.isDerivation dep) externalDeps;
 
-      externalDepsDirs = map (x: builtins.toString x) (lib.filter (lib.isDerivation) externalDeps);
+      externalDepsDirs = map (x: toString x) (lib.filter (lib.isDerivation) externalDeps);
 
       generatedConfig = (
         {

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -27,7 +27,7 @@ rec {
   phraseDirective =
     solution: env: name: val:
     if builtins.isInt val then
-      builtins.toString val
+      toString val
     else if builtins.isString val then
       name
     else if true == val then

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -255,16 +255,14 @@ let
   mkLicenseTexts =
     licenseNames:
     lib.lists.flatten (
-      builtins.map (
-        licenseName:
-        builtins.map (licenseText: "--- ${licenseName} ---\n${licenseText}") (mkLicenses licenseName)
+      map (
+        licenseName: map (licenseText: "--- ${licenseName} ---\n${licenseText}") (mkLicenses licenseName)
       ) licenseNames
     );
 
   # Converts a license name to a list of license hashes.
   mkLicenseHashes =
-    licenseName:
-    builtins.map (licenseText: builtins.hashString "sha1" licenseText) (mkLicenses licenseName);
+    licenseName: map (licenseText: builtins.hashString "sha1" licenseText) (mkLicenses licenseName);
 
   # The list of all license names we're accepting. Put android-sdk-license there
   # by default.

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -4,7 +4,7 @@
   # If you copy this example out of nixpkgs, use these lines instead of the next.
   # This example pins nixpkgs: https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.html
   /*
-    nixpkgsSource ? (builtins.fetchTarball {
+    nixpkgsSource ? (fetchTarball {
       name = "nixpkgs-20.09";
       url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
       sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";

--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -4,7 +4,7 @@
   # If you copy this example out of nixpkgs, use these lines instead of the next.
   # This example pins nixpkgs: https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.html
   /*
-    nixpkgsSource ? (builtins.fetchTarball {
+    nixpkgsSource ? (fetchTarball {
       name = "nixpkgs-20.09";
       url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
       sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -2,7 +2,7 @@
   # If you copy this example out of nixpkgs, use these lines instead of the next.
   # This example pins nixpkgs: https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.html
   /*
-    nixpkgsSource ? (builtins.fetchTarball {
+    nixpkgsSource ? (fetchTarball {
       name = "nixpkgs-20.09";
       url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
       sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -168,7 +168,7 @@ final: prev: {
 
   pulp = prev.pulp.override {
     # tries to install purescript
-    npmFlags = builtins.toString [ "--ignore-scripts" ];
+    npmFlags = toString [ "--ignore-scripts" ];
 
     nativeBuildInputs = [ pkgs.buildPackages.makeWrapper ];
     postInstall = ''

--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -31,7 +31,7 @@ buildDunePackage {
     atdgen-codec-runtime
   ];
 
-  meta = (builtins.removeAttrs atd.meta [ "mainProgram" ]) // {
+  meta = (removeAttrs atd.meta [ "mainProgram" ]) // {
     description = "Generates efficient JSON serializers, deserializers and validators";
   };
 }

--- a/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-freestanding/default.nix
@@ -17,7 +17,7 @@ let
 in
 
 if lib.versionOlder ocaml.version "4.08" then
-  builtins.throw "${pname} is not available for OCaml ${ocaml.version}"
+  throw "${pname} is not available for OCaml ${ocaml.version}"
 else
 
   stdenv.mkDerivation rec {
@@ -70,7 +70,7 @@ else
       license = licenses.mit;
       maintainers = [ maintainers.sternenseemann ];
       homepage = "https://github.com/mirage/ocaml-freestanding";
-      platforms = builtins.map ({ arch, os }: "${arch}-${os}") (
+      platforms = map ({ arch, os }: "${arch}-${os}") (
         cartesianProduct {
           arch = [
             "aarch64"

--- a/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
@@ -18,7 +18,7 @@ buildDunePackage {
   doCheck = true;
   checkInputs = [ ounit2 ];
 
-  meta = (builtins.removeAttrs ocaml_gettext.meta [ "mainProgram" ]) // {
+  meta = (removeAttrs ocaml_gettext.meta [ "mainProgram" ]) // {
     description = "Internationalization library using camomile (i18n)";
   };
 

--- a/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
@@ -18,5 +18,5 @@ buildDunePackage {
   doCheck = true;
   checkInputs = [ ounit2 ];
 
-  meta = builtins.removeAttrs ocaml_gettext.meta [ "mainProgram" ];
+  meta = removeAttrs ocaml_gettext.meta [ "mainProgram" ];
 }

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -21,7 +21,7 @@ let
 in
 
 if lib.versionOlder ocaml.version minimalOCamlVersion then
-  builtins.throw "${pname} needs at least OCaml ${minimalOCamlVersion}"
+  throw "${pname} needs at least OCaml ${minimalOCamlVersion}"
 else
 
   stdenv.mkDerivation {

--- a/pkgs/development/php-packages/relay/default.nix
+++ b/pkgs/development/php-packages/relay/default.nix
@@ -90,10 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
       let
         args =
           lib.strings.concatMapStrings
-            (
-              v:
-              " -change ${v.name}" + " ${lib.strings.makeLibraryPath [ v.value ]}/${builtins.baseNameOf v.name}"
-            )
+            (v: " -change ${v.name}" + " ${lib.strings.makeLibraryPath [ v.value ]}/${baseNameOf v.name}")
             (
               with lib.attrsets;
               [

--- a/pkgs/development/python-modules/faiss/default.nix
+++ b/pkgs/development/python-modules/faiss/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage {
   };
 
   meta = lib.pipe (faiss-build.meta or { }) [
-    (lib.flip builtins.removeAttrs [ "mainProgram" ])
+    (lib.flip removeAttrs [ "mainProgram" ])
     (m: m // { description = "Bindings for faiss, the similarity search library"; })
   ];
 }

--- a/pkgs/development/python-modules/fast-histogram/default.nix
+++ b/pkgs/development/python-modules/fast-histogram/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  enabledTestPaths = [ "${builtins.placeholder "out"}/${python.sitePackages}" ];
+  enabledTestPaths = [ "${placeholder "out"}/${python.sitePackages}" ];
 
   pythonImportsCheck = [ "fast_histogram" ];
 

--- a/pkgs/development/python-modules/fontpens/default.nix
+++ b/pkgs/development/python-modules/fontpens/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "fontPens"
   ]
-  ++ (builtins.map (s: "fontPens." + s) [
+  ++ (map (s: "fontPens." + s) [
     "angledMarginPen"
     "digestPointPen"
     "flattenPen"

--- a/pkgs/development/python-modules/hy/default.nix
+++ b/pkgs/development/python-modules/hy/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
       python-packages:
       (python.withPackages (ps: (python-packages ps) ++ [ ps.hy ])).overrideAttrs (old: {
         name = "${hy.name}-env";
-        meta = lib.mergeAttrs (builtins.removeAttrs hy.meta [ "license" ]) { mainProgram = "hy"; };
+        meta = lib.mergeAttrs (removeAttrs hy.meta [ "license" ]) { mainProgram = "hy"; };
       });
   };
 

--- a/pkgs/development/python-modules/invisible-watermark/default.nix
+++ b/pkgs/development/python-modules/invisible-watermark/default.nix
@@ -86,7 +86,7 @@ buildPythonPackage rec {
               ;
           };
         };
-      allTests = builtins.map createTest testCases;
+      allTests = map createTest testCases;
     in
     (lib.attrsets.mergeAttrsList allTests)
     // {

--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -32,7 +32,7 @@
 }:
 
 let
-  installedPackageRoot = "${builtins.placeholder "out"}/${python.sitePackages}";
+  installedPackageRoot = "${placeholder "out"}/${python.sitePackages}";
   self = buildPythonPackage rec {
     pname = "scikit-image";
     version = "0.25.2";

--- a/pkgs/development/python-modules/sentencepiece/default.nix
+++ b/pkgs/development/python-modules/sentencepiece/default.nix
@@ -16,5 +16,5 @@ buildPythonPackage rec {
   sourceRoot = "${src.name}/python";
 
   # sentencepiece installs 'bin' output.
-  meta = builtins.removeAttrs sentencepiece.meta [ "outputsToInstall" ];
+  meta = removeAttrs sentencepiece.meta [ "outputsToInstall" ];
 }

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage {
       substituteInPlace python/uv/_find_uv.py \
         --replace-fail \
         'sysconfig.get_path("scripts", scheme=_user_scheme()),' \
-        'sysconfig.get_path("scripts", scheme=_user_scheme()), "${builtins.baseNameOf (lib.getExe uv)}",'
+        'sysconfig.get_path("scripts", scheme=_user_scheme()), "${baseNameOf (lib.getExe uv)}",'
     ''
     # Sidestep the maturin build system in favour of reusing the binary already built by nixpkgs,
     # to avoid rebuilding the uv binary for every active python package set.

--- a/pkgs/development/python-modules/warp-lang/default.nix
+++ b/pkgs/development/python-modules/warp-lang/default.nix
@@ -35,7 +35,7 @@
 assert libmathdxSupport -> cudaSupport;
 let
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else args.stdenv;
-  stdenv = builtins.throw "Use effectiveStdenv instead of stdenv directly, as it may be replaced by cudaPackages.backendStdenv";
+  stdenv = throw "Use effectiveStdenv instead of stdenv directly, as it may be replaced by cudaPackages.backendStdenv";
 
   version = "1.9.0";
 

--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -478,7 +478,7 @@ let
 in
 outer
 // builtins.listToAttrs (
-  builtins.map (arch: {
+  map (arch: {
     name = arch;
     value = scopeForArches [ arch ];
   }) outer.clr.gpuTargets

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -161,8 +161,8 @@ let
   findClangNostdlibincPatch =
     x:
     (
-      (lib.strings.hasSuffix "add-nostdlibinc-flag.patch" (builtins.baseNameOf x))
-      || (lib.strings.hasSuffix "clang-at-least-16-LLVMgold-path.patch" (builtins.baseNameOf x))
+      (lib.strings.hasSuffix "add-nostdlibinc-flag.patch" (baseNameOf x))
+      || (lib.strings.hasSuffix "clang-at-least-16-LLVMgold-path.patch" (baseNameOf x))
     );
   llvmTargetsFlag = "-DLLVM_TARGETS_TO_BUILD=AMDGPU;${
     {
@@ -251,7 +251,7 @@ rec {
     }).overrideAttrs
       (old: {
         patches = builtins.filter (
-          x: !(lib.strings.hasSuffix "more-openbsd-program-headers.patch" (builtins.baseNameOf x))
+          x: !(lib.strings.hasSuffix "more-openbsd-program-headers.patch" (baseNameOf x))
         ) old.patches;
         dontStrip = profilableStdenv;
         nativeBuildInputs = old.nativeBuildInputs ++ [

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -107,7 +107,7 @@ lib.makeOverridable (
   in
 
   stdenv.mkDerivation (
-    (builtins.removeAttrs attrs [ "source" ])
+    (removeAttrs attrs [ "source" ])
     // {
       inherit ruby;
       inherit dontBuild;

--- a/pkgs/development/tools/analysis/binlore/default.nix
+++ b/pkgs/development/tools/analysis/binlore/default.nix
@@ -136,7 +136,7 @@ rec {
         +
           # append lore from package's $out and drv.binlore.${drv.outputName} (last entry wins)
           ''
-            for lore_type in ${builtins.toString lore.types}; do
+            for lore_type in ${toString lore.types}; do
               if [[ -f "${drv}/nix-support/$lore_type" ]]; then
                 cat "${drv}/nix-support/$lore_type" >> "$out/$lore_type"
               fi

--- a/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
@@ -26,7 +26,7 @@ in
 
 let
   data' =
-    builtins.removeAttrs
+    removeAttrs
       (
         if builtins.isPath data then
           lib.importJSON data
@@ -168,7 +168,7 @@ let
                   sortByVersion = a: b: (builtins.compareVersions a.version b.version) < 0;
                   sortedJarPomList = lib.sort sortByVersion jarPomList;
 
-                  uniqueVersionFiles = builtins.map ({ i, x }: x) (
+                  uniqueVersionFiles = map ({ i, x }: x) (
                     builtins.filter (
                       { i, x }: i == 0 || (builtins.elemAt sortedJarPomList (i - 1)).version != x.version
                     ) (lib.imap0 (i: x: { inherit i x; }) sortedJarPomList)

--- a/pkgs/development/tools/buildah/wrapper.nix
+++ b/pkgs/development/tools/buildah/wrapper.nix
@@ -55,7 +55,7 @@ runCommand buildah-unwrapped.name
 
     preferLocalBuild = true;
 
-    meta = builtins.removeAttrs buildah-unwrapped.meta [ "outputsToInstall" ];
+    meta = removeAttrs buildah-unwrapped.meta [ "outputsToInstall" ];
 
     outputs = [
       "out"

--- a/pkgs/development/tools/haskell/ghc-settings-edit/default.nix
+++ b/pkgs/development/tools/haskell/ghc-settings-edit/default.nix
@@ -11,7 +11,7 @@ mkDerivation {
   src = builtins.path {
     path = ./.;
     name = "source";
-    filter = path: _: (builtins.baseNameOf path) != "default.nix";
+    filter = path: _: (baseNameOf path) != "default.nix";
   };
   isLibrary = false;
   isExecutable = true;

--- a/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/default.nix
@@ -13,5 +13,5 @@ buildDunePackage {
 
   propagatedBuildInputs = [ js_of_ocaml-compiler ];
 
-  meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
+  meta = removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -31,7 +31,7 @@ in
       ...
     }@args:
     let
-      args' = builtins.removeAttrs args [
+      args' = removeAttrs args [
         "hash"
         "pname"
       ];
@@ -56,7 +56,7 @@ in
     ) true;
 
     assert (lib.throwIf (!(builtins.elem fetcherVersion supportedFetcherVersions))
-      "pnpm.fetchDeps `fetcherVersion` is not set to a supported value (${lib.concatStringsSep ", " (builtins.map toString supportedFetcherVersions)}), see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
+      "pnpm.fetchDeps `fetcherVersion` is not set to a supported value (${lib.concatStringsSep ", " (map toString supportedFetcherVersions)}), see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
     ) true;
 
     stdenvNoCC.mkDerivation (

--- a/pkgs/development/tools/yarn2nix-moretea/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/default.nix
@@ -101,7 +101,7 @@ rec {
         builtins.attrNames pkgConfig
       );
 
-      postInstall = builtins.map (
+      postInstall = map (
         key:
         if (pkgConfig.${key} ? postInstall) then
           ''
@@ -285,7 +285,7 @@ rec {
           {
             inherit name;
             value = mkYarnPackage (
-              builtins.removeAttrs attrs [ "packageOverrides" ]
+              removeAttrs attrs [ "packageOverrides" ]
               // {
                 inherit
                   src
@@ -333,8 +333,7 @@ rec {
       baseName = unlessNull name "${safeName}-${version}";
 
       workspaceDependenciesTransitive = lib.unique (
-        (lib.flatten (builtins.map (dep: dep.workspaceDependencies) workspaceDependencies))
-        ++ workspaceDependencies
+        (lib.flatten (map (dep: dep.workspaceDependencies) workspaceDependencies)) ++ workspaceDependencies
       );
 
       deps = mkYarnModules {
@@ -387,7 +386,7 @@ rec {
 
     in
     stdenv.mkDerivation (
-      builtins.removeAttrs attrs [
+      removeAttrs attrs [
         "yarnNix"
         "pkgConfig"
         "workspaceDependencies"

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -12,7 +12,7 @@ const { execFileSync } = require("child_process");
 //
 // to
 //
-// builtins.fetchGit {
+// fetchGit {
 //   url = "https://github.com/srghma/node-shell-quote.git";
 //   ref = "without_unlicenced_jsonify";
 //   rev = "1234commit";
@@ -26,7 +26,7 @@ const { execFileSync } = require("child_process");
 //
 // to
 //
-// builtins.fetchGit {
+// fetchGit {
 //   url = "https://1234user:1234pass@git.graphile.com/git/users/1234user/postgraphile-supporter.git";
 //   ref = "master";
 //   rev = "1234commit";
@@ -47,7 +47,7 @@ function prefetchgit(url, rev) {
 
 function fetchgit(fileName, url, rev, branch, builtinFetchGit) {
   const repo = builtinFetchGit
-    ? `builtins.fetchGit ({
+    ? `fetchGit ({
          url = "${url}";
          ref = "${branch}";
          rev = "${rev}";

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -93,8 +93,8 @@ let
     ''
     + (lib.strings.concatStringsSep "\n" (
       map (dep: ''
-        if ! [[ "${builtins.baseNameOf dep.url}" =~ (PyQt|pyqt) ]]; then
-          ln -vsf ${dep.path} "$out/${builtins.baseNameOf dep.url}"
+        if ! [[ "${baseNameOf dep.url}" =~ (PyQt|pyqt) ]]; then
+          ln -vsf ${dep.path} "$out/${baseNameOf dep.url}"
         fi
       '') pythonDeps
     ));

--- a/pkgs/games/anki/with-addons.nix
+++ b/pkgs/games/anki/with-addons.nix
@@ -99,7 +99,7 @@ symlinkJoin {
       --set ANKI_ADDONS "${anki-utils.buildAnkiAddonsDir (ankiAddons ++ defaultAddons)}"
   '';
 
-  meta = builtins.removeAttrs anki.meta [
+  meta = removeAttrs anki.meta [
     "name"
     "outputsToInstall"
     "position"

--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage rec {
       ];
       skipFlag = test: "--skip " + test;
     in
-    builtins.concatStringsSep " " (builtins.map skipFlag skipList);
+    builtins.concatStringsSep " " (map skipFlag skipList);
 
   meta = with lib; {
     description = "Terminal MUD client written in Rust";

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -20,7 +20,7 @@ let
       base = if stdenv.hostPlatform.is32bit then "linux32" else "linux64";
     in
     prefix + base;
-  inifile = "linux/v0.${builtins.toString dwarf-fortress.baseVersion}.${dwarf-fortress.patchVersion}${platformSlug}.ini";
+  inifile = "linux/v0.${toString dwarf-fortress.baseVersion}.${dwarf-fortress.patchVersion}${platformSlug}.ini";
   unsupportedVersion = lib.versionOlder dwarf-therapist.maxDfVersion dwarf-fortress.dfVersion;
 
   # Used to run dfhack to produce a Therapist ini file for the current memory map.

--- a/pkgs/games/scummvm/games.nix
+++ b/pkgs/games/scummvm/games.nix
@@ -48,7 +48,7 @@ let
       ...
     }@attrs:
     let
-      attrs' = builtins.removeAttrs attrs [
+      attrs' = removeAttrs attrs [
         "plong"
         "pshort"
         "pcode"

--- a/pkgs/games/shattered-pixel-dungeon/generic.nix
+++ b/pkgs/games/shattered-pixel-dungeon/generic.nix
@@ -22,7 +22,7 @@
 }@attrs:
 
 let
-  cleanAttrs = builtins.removeAttrs attrs [
+  cleanAttrs = removeAttrs attrs [
     "lib"
     "stdenv"
     "makeWrapper"

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -161,7 +161,7 @@ let
     env.LANG = "C.UTF-8";
   };
 
-  cleanArgs = builtins.removeAttrs args [
+  cleanArgs = removeAttrs args [
     "extraBuildInputs"
     "extraNativeBuildInputs"
     "extraPropagatedBuildInputs"

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -114,7 +114,7 @@ let
           }
           // extraMeta;
       }
-      // builtins.removeAttrs args [ "extraMeta" ]
+      // removeAttrs args [ "extraMeta" ]
     )
   );
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -137,7 +137,7 @@ let
 
           mkdir -p "$out/nix-support"
           ${lib.concatMapStrings (file: ''
-            echo "file binary-dist ${installDir}/${builtins.baseNameOf file}" >> "$out/nix-support/hydra-build-products"
+            echo "file binary-dist ${installDir}/${baseNameOf file}" >> "$out/nix-support/hydra-build-products"
           '') (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)}
 
           runHook postInstall

--- a/pkgs/os-specific/bsd/freebsd/lib/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/lib/default.nix
@@ -81,7 +81,7 @@
         else if (builtins.isPath patches) then
           (if (isDir patches) then (lib.filesystem.listFilesRecursive patches) else [ patches ])
         else if (builtins.isList patches) then
-          (lib.flatten (builtins.map consolidatePatches patches))
+          (lib.flatten (map consolidatePatches patches))
         else
           throw "Bad patches - must be path or derivation or list thereof";
       consolidated = consolidatePatches patches;
@@ -115,7 +115,7 @@
             );
           filteredLines = builtins.filter filterFunc partitionedPatches;
           derive = patchLines: writeText "freebsd-patch" (lib.concatLines patchLines);
-          derivedPatches = builtins.map derive filteredLines;
+          derivedPatches = map derive filteredLines;
         in
         derivedPatches;
     in

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -40,7 +40,7 @@ mkDerivation rec {
   env = sys.passthru.env;
   SYSDIR = "${sys.src}/sys";
 
-  KMODDIR = "${builtins.placeholder "out"}/kernel";
+  KMODDIR = "${placeholder "out"}/kernel";
 
   meta = {
     description = "GPU firmware for FreeBSD drm-kmod";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -43,7 +43,7 @@ mkDerivation {
   env = sys.passthru.env;
   SYSDIR = "${sys.src}/sys";
 
-  KMODDIR = "${builtins.placeholder "out"}/kernel";
+  KMODDIR = "${placeholder "out"}/kernel";
 
   meta = {
     description = "Linux drm driver, ported to FreeBSD";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
@@ -53,7 +53,7 @@ mkDerivation {
   makeFlags = [
     "STRIP=-s" # flag to install, not command
     "MK_WERROR=no"
-    "TESTSDIR=${builtins.placeholder "test"}"
+    "TESTSDIR=${placeholder "test"}"
   ]
   ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
     "BOOTSTRAPPING=1"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -122,7 +122,7 @@ lib.makeOverridable (
       installPhase = "includesPhase";
       dontBuild = true;
     }
-    // (builtins.removeAttrs attrs [ "env" ])
+    // (removeAttrs attrs [ "env" ])
     // {
       patches =
         (lib.optionals (attrs.autoPickPatches or true) (

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix
@@ -119,11 +119,11 @@ mkDerivation rec {
   inherit env;
   passthru.env = env;
 
-  KODIR = "${builtins.placeholder "out"}/kernel";
-  KMODDIR = "${builtins.placeholder "out"}/kernel";
-  DTBDIR = "${builtins.placeholder "out"}/dbt";
+  KODIR = "${placeholder "out"}/kernel";
+  KMODDIR = "${placeholder "out"}/kernel";
+  DTBDIR = "${placeholder "out"}/dbt";
 
-  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR = "${placeholder "debug"}/lib/debug";
   KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
   KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
 

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libcMinimal/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libcMinimal/package.nix
@@ -57,7 +57,7 @@ mkDerivation {
     csu
   ];
 
-  env.NIX_CFLAGS_COMPILE = builtins.toString [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-B${csu}/lib"
     "-Wno-error"
   ];

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix
@@ -103,6 +103,6 @@ lib.makeOverridable (
       dontBuild = true;
     }
     // lib.optionalAttrs stdenv'.hostPlatform.isStatic { NOLIBSHARED = true; }
-    // (builtins.removeAttrs attrs [ "extraNativeBuildInputs" ])
+    // (removeAttrs attrs [ "extraNativeBuildInputs" ])
   )
 )

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -104,7 +104,7 @@ let
       # and pings all maintainers.
       #
       # For further context, see https://github.com/NixOS/nixpkgs/pull/143113#issuecomment-953319957
-      basicArgs = builtins.removeAttrs args (
+      basicArgs = removeAttrs args (
         lib.filter (
           x:
           !(builtins.elem x [

--- a/pkgs/os-specific/linux/kernel/mainline.nix
+++ b/pkgs/os-specific/linux/kernel/mainline.nix
@@ -29,7 +29,7 @@ let
       };
 
   args' =
-    (builtins.removeAttrs args [ "branch" ])
+    (removeAttrs args [ "branch" ])
     // {
       inherit src version;
       isLTS = thisKernel.lts;

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/2.nix
@@ -115,7 +115,7 @@ kaem.runCommand "${pname}-${version}"
             ]
           );
         }
-        // (builtins.removeAttrs env [ "nativeBuildInputs" ])
+        // (removeAttrs env [ "nativeBuildInputs" ])
       );
 
     passthru.tests.get-version =

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/default.nix
@@ -83,7 +83,7 @@ bootBash.runCommand "${pname}-${version}"
             ]
           );
         }
-        // (builtins.removeAttrs env [ "nativeBuildInputs" ])
+        // (removeAttrs env [ "nativeBuildInputs" ])
       );
 
     passthru.tests.get-version =

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/default.nix
@@ -152,7 +152,7 @@ let
       "src/posixos.c"
     ];
 
-  objects = map (x: lib.replaceStrings [ ".c" ] [ ".o" ] (builtins.baseNameOf x)) sources;
+  objects = map (x: lib.replaceStrings [ ".c" ] [ ".o" ] (baseNameOf x)) sources;
 in
 kaem.runCommand "${pname}-${version}"
   {

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/default.nix
@@ -66,7 +66,7 @@ let
     "error.c"
   ];
 
-  objects = map (x: lib.replaceStrings [ ".c" ] [ ".o" ] (builtins.baseNameOf x)) sources;
+  objects = map (x: lib.replaceStrings [ ".c" ] [ ".o" ] (baseNameOf x)) sources;
 in
 kaem.runCommand "${pname}-${version}"
   {

--- a/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/mes/default.nix
@@ -138,7 +138,7 @@ let
 
   CC = toString ([ cc ] ++ ccArgs);
 
-  stripExt = source: lib.replaceStrings [ ".c" ] [ "" ] (builtins.baseNameOf source);
+  stripExt = source: lib.replaceStrings [ ".c" ] [ "" ] (baseNameOf source);
 
   compile =
     source:

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/bootstrap-sources.nix
@@ -77,7 +77,7 @@ rec {
       #
       # Neither your store nor your substituters seems to have:
       #
-      #  ${builtins.placeholder "out"}
+      #  ${placeholder "out"}
       #
       # You can create this path from an already-bootstrapped nixpkgs
       # using the following command:

--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/kaem/default.nix
@@ -51,7 +51,7 @@ derivationWithMeta {
           ]
         );
       }
-      // (builtins.removeAttrs env [ "nativeBuildInputs" ])
+      // (removeAttrs env [ "nativeBuildInputs" ])
     );
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/utils.nix
@@ -18,7 +18,7 @@ rec {
           inherit (buildPlatform) system;
           inherit (meta) name;
         }
-        // (builtins.removeAttrs attrs [
+        // (removeAttrs attrs [
           "meta"
           "passthru"
         ])
@@ -57,7 +57,7 @@ rec {
           ''
             target=''${out}''${destination}
           ''
-          + lib.optionalString (builtins.dirOf destination == ".") ''
+          + lib.optionalString (dirOf destination == ".") ''
             mkdir -p ''${out}''${destinationDir}
           ''
           + ''
@@ -70,7 +70,7 @@ rec {
       ];
 
       PATH = lib.makeBinPath [ mescc-tools-extra ];
-      destinationDir = builtins.dirOf destination;
+      destinationDir = dirOf destination;
       inherit destination;
     };
 

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -77,7 +77,7 @@ let
   rewritePatch =
     { from, to }:
     patch:
-    runCommandLocal (builtins.baseNameOf patch)
+    runCommandLocal (baseNameOf patch)
       {
         inherit patch;
         nativeBuildInputs = [ patchutils ];
@@ -249,7 +249,7 @@ stdenv.mkDerivation (finalAttrs: {
           ...
         }@args:
         let
-          args' = builtins.removeAttrs args [
+          args' = removeAttrs args [
             "owner"
             "repo"
             "rev"
@@ -276,7 +276,7 @@ stdenv.mkDerivation (finalAttrs: {
           inherit hash;
           nvidia_x11 = finalAttrs.finalPackage;
           patches =
-            (builtins.map (rewritePatch {
+            (map (rewritePatch {
               from = "kernel";
               to = "kernel-open";
             }) patches)

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -891,11 +891,7 @@ stdenv.mkDerivation (finalAttrs: {
   disallowedReferences =
     lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
       # 'or p' is for manually specified buildPackages as they dont have __spliced
-      (
-        builtins.filter (p: p != null) (
-          builtins.map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs
-        )
-      );
+      (builtins.filter (p: p != null) (map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs));
 
   disallowedRequisites = lib.optionals (!withUkify) [
     bash

--- a/pkgs/servers/home-assistant/build-custom-component/default.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/default.nix
@@ -64,7 +64,7 @@ home-assistant.python.pkgs.buildPythonPackage (
     // args.meta or { };
 
   }
-  // builtins.removeAttrs args [
+  // removeAttrs args [
     "meta"
     "nativeCheckInputs"
     "passthru"

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -26,7 +26,7 @@ callPackage ../nginx/generic.nix args rec {
   fixPatch =
     patch:
     let
-      name = patch.name or (builtins.baseNameOf patch);
+      name = patch.name or (baseNameOf patch);
     in
     runCommand "openresty-${name}" { src = patch; } ''
       substitute $src $out \

--- a/pkgs/servers/monitoring/grafana/plugins/grafana-plugin.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-plugin.nix
@@ -64,7 +64,7 @@ stdenvNoCC.mkDerivation (
     }
     // meta;
   }
-  // (builtins.removeAttrs args [
+  // (removeAttrs args [
     "zipHash"
     "pname"
     "versionPrefix"

--- a/pkgs/servers/sql/postgresql/ext/omnigres.nix
+++ b/pkgs/servers/sql/postgresql/ext/omnigres.nix
@@ -59,8 +59,8 @@ postgresqlBuildExtension (finalAttrs: {
   cmakeFlags = [
     "-DOPENSSL_CONFIGURED=1"
     "-DPG_CONFIG=${pgWithExtensions.pg_config}/bin/pg_config"
-    "-DPostgreSQL_TARGET_EXTENSION_DIR=${builtins.placeholder "out"}/share/postgresql/extension/"
-    "-DPostgreSQL_TARGET_PACKAGE_LIBRARY_DIR=${builtins.placeholder "out"}/lib/"
+    "-DPostgreSQL_TARGET_EXTENSION_DIR=${placeholder "out"}/share/postgresql/extension/"
+    "-DPostgreSQL_TARGET_PACKAGE_LIBRARY_DIR=${placeholder "out"}/lib/"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -117,7 +117,7 @@ let
       );
     in
     stdenv.mkDerivation (
-      builtins.removeAttrs args [ "bundlerEnvArgs" ]
+      removeAttrs args [ "bundlerEnvArgs" ]
       // {
         pluginName = if name != null then name else "${pname}-${version}";
         dontConfigure = true;

--- a/pkgs/shells/fish/plugins/build-fish-plugin.nix
+++ b/pkgs/shells/fish/plugins/build-fish-plugin.nix
@@ -31,7 +31,7 @@ attrs@{
 
 let
   # Do not pass attributes that are only relevant to buildFishPlugin to mkDerivation.
-  drvAttrs = builtins.removeAttrs attrs [
+  drvAttrs = removeAttrs attrs [
     "checkPlugins"
     "checkFunctionDirs"
   ];

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -275,7 +275,7 @@ rec {
               drvPath = builtins.unsafeDiscardStringContext pkg.drvPath;
               license = pkg.meta.license or null;
             in
-            builtins.trace "@:drv:${toString drvPath}:${builtins.toString license}:@" val;
+            builtins.trace "@:drv:${toString drvPath}:${toString license}:@" val;
         in
         pkg
         // {

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -108,7 +108,7 @@ let
           args'
         else
           allPackages (
-            (builtins.removeAttrs args' [ "selfBuild" ])
+            (removeAttrs args' [ "selfBuild" ])
             // {
               adjacentPackages =
                 if args.selfBuild or true then

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -16,7 +16,7 @@ let
 
     # Ignore custom stdenvs when cross compiling for compatibility
     # Use replaceCrossStdenv instead.
-    config = builtins.removeAttrs config [ "replaceStdenv" ];
+    config = removeAttrs config [ "replaceStdenv" ];
   };
 
 in

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -18,7 +18,7 @@ let
       overlays
       ;
     # Remove config.replaceStdenv to ensure termination.
-    config = builtins.removeAttrs config [ "replaceStdenv" ];
+    config = removeAttrs config [ "replaceStdenv" ];
   };
 
 in

--- a/pkgs/stdenv/darwin/bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/bootstrap-tools.nix
@@ -5,7 +5,7 @@
   unpack,
 }:
 
-builtins.derivation {
+derivation {
   inherit (stdenv.hostPlatform) system;
 
   name = "bootstrap-tools";
@@ -17,7 +17,7 @@ builtins.derivation {
   ];
 
   PATH = lib.makeBinPath [
-    (builtins.placeholder "out")
+    (placeholder "out")
     unpack
   ];
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -594,8 +594,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
       overrides = self: super: {
         inherit (prevStage) ccWrapperStdenv cctools ld64;
 
-        binutils-unwrapped = builtins.throw "nothing in the Darwin bootstrap should depend on GNU binutils";
-        curl = builtins.throw "nothing in the Darwin bootstrap can depend on curl";
+        binutils-unwrapped = throw "nothing in the Darwin bootstrap should depend on GNU binutils";
+        curl = throw "nothing in the Darwin bootstrap can depend on curl";
 
         # Use this stage’s CF to build CMake. It’s required but can’t be included in the stdenv.
         cmake = self.cmakeMinimal;

--- a/pkgs/stdenv/darwin/test-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/test-bootstrap-tools.nix
@@ -6,7 +6,7 @@
   hello,
 }:
 
-builtins.derivation {
+derivation {
   name = "test-bootstrap-tools";
 
   inherit (stdenv.hostPlatform) system;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -59,7 +59,7 @@ let
       attrs
       // {
         inherit system;
-        name = attrs.name or (builtins.baseNameOf (builtins.elemAt attrs.paths 0));
+        name = attrs.name or (baseNameOf (builtins.elemAt attrs.paths 0));
         src = bootstrapArchive;
         builder = "${bootstrapArchive}/bin/bash";
         # this script will prefer to link files instead of copying them.
@@ -497,7 +497,7 @@ in
           bzip2
           xz
           ;
-        binutils-unwrapped = builtins.removeAttrs bootstrapTools.binutils-unwrapped [ "src" ];
+        binutils-unwrapped = removeAttrs bootstrapTools.binutils-unwrapped [ "src" ];
         fetchurl = import ../../build-support/fetchurl {
           inherit lib;
           inherit (self) stdenvNoCC;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -308,7 +308,7 @@ let
 
       and is missing the following outputs:
 
-      ${concatStrings (builtins.map (output: "  - ${output}\n") missingOutputs)}
+      ${concatStrings (map (output: "  - ${output}\n") missingOutputs)}
     '';
 
   handleEvalIssue =

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -60,7 +60,7 @@ let
     :::{.note}
     This is used as the fundamental building block of most other functions in Nixpkgs for creating derivations.
 
-    Most arguments are also passed through to the underlying call of [`builtins.derivation`](https://nixos.org/manual/nix/stable/language/derivations).
+    Most arguments are also passed through to the underlying call of [`derivation`](https://nixos.org/manual/nix/stable/language/derivations).
     :::
   */
   mkDerivation = fnOrAttrs: makeDerivationExtensible (toFunction fnOrAttrs);
@@ -115,8 +115,8 @@ let
                 ${
                   args.name or "${pname}-${version}"
                 } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
-                  builtins.toString pos.line or "<unknown line>"
-                }:${builtins.toString pos.column or "<unknown column>"}.
+                  toString pos.line or "<unknown line>"
+                }:${toString pos.column or "<unknown column>"}.
 
                 This is most likely not what you want. In order to properly change the version of a package, override
                 both the `version` and `src` attributes:
@@ -130,7 +130,7 @@ let
                 })
 
                 (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
-              '' (prev // (builtins.removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
+              '' (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
             );
         in
         makeDerivationExtensible (extends' (lib.toExtension f0) rattrs);
@@ -866,7 +866,7 @@ let
       # for a fixed-output derivation, the corresponding inputDerivation should
       # *not* be fixed-output. To achieve this we simply delete the attributes that
       # would make it fixed-output.
-      deleteFixedOutputRelatedAttrs = lib.flip builtins.removeAttrs [
+      deleteFixedOutputRelatedAttrs = lib.flip removeAttrs [
         "outputHashAlgo"
         "outputHash"
         "outputHashMode"

--- a/pkgs/stdenv/linux/test-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/test-bootstrap-tools.nix
@@ -7,7 +7,7 @@
   hello,
 }:
 
-builtins.derivation {
+derivation {
   name = "test-bootstrap-tools";
   inherit (stdenv.hostPlatform) system; # We cannot "cross test"
   builder = busybox;
@@ -36,7 +36,7 @@ builtins.derivation {
   ''
   + lib.optionalString (stdenv.hostPlatform.libc == "glibc") ''
     rtld=$(echo ${bootstrapTools}/lib/${builtins.unsafeDiscardStringContext # only basename
-      (builtins.baseNameOf binutils.dynamicLinker)})
+      (baseNameOf binutils.dynamicLinker)})
     libc_includes=${bootstrapTools}/include-glibc
   ''
   + lib.optionalString (stdenv.hostPlatform.libc == "musl") ''

--- a/pkgs/test/auto-patchelf-hook/package.nix
+++ b/pkgs/test/auto-patchelf-hook/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
       readarray -td':' runpathArray < <(echo -n "$runpath")
 
       echo "[auto-patchelf-hook-test]: Check that the runpath has the right number of entries"
-      test "''${#runpathArray[@]}" -eq ${builtins.toString (builtins.length allDeps)}
+      test "''${#runpathArray[@]}" -eq ${toString (builtins.length allDeps)}
 
       echo "[auto-patchelf-hook-test]: Check that the runpath contains the expected runtime deps"
     ''
@@ -89,7 +89,7 @@ stdenv.mkDerivation {
       lib.lists.imap0 (
         i: path:
         let
-          iAsStr = builtins.toString i;
+          iAsStr = toString i;
         in
         ''
           echo "[auto-patchelf-hook-test]: Check that entry ${iAsStr} is ${path}"

--- a/pkgs/test/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/test/make-hardcode-gsettings-patch/default.nix
@@ -38,7 +38,7 @@ let
         cp -r --no-preserve=all "${expected}" src-expected
 
         pushd src
-        for patch in ${lib.escapeShellArgs (builtins.map (p: "${p}") patches)}; do
+        for patch in ${lib.escapeShellArgs (map (p: "${p}") patches)}; do
             patch < "$patch"
         done
         patch < "${patch}"

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -34,7 +34,7 @@ rec {
           nativeBuildInputs = [ texLive ] ++ attrs.nativeBuildInputs or [ ];
           text = builtins.toFile "${name}.tex" text;
         }
-        // builtins.removeAttrs attrs [
+        // removeAttrs attrs [
           "nativeBuildInputs"
           "text"
           "texLive"

--- a/pkgs/tools/misc/bat-extras/buildBatExtrasPkg.nix
+++ b/pkgs/tools/misc/bat-extras/buildBatExtrasPkg.nix
@@ -11,7 +11,7 @@
   zsh,
 }:
 let
-  cleanArgs = lib.flip builtins.removeAttrs [
+  cleanArgs = lib.flip removeAttrs [
     "dependencies"
     "meta"
   ];

--- a/pkgs/tools/networking/maubot/plugins/default.nix
+++ b/pkgs/tools/networking/maubot/plugins/default.nix
@@ -25,7 +25,7 @@ let
       ...
     }:
     stdenvNoCC.mkDerivation (
-      builtins.removeAttrs attrs [ "base_config" ]
+      removeAttrs attrs [ "base_config" ]
       // {
         pluginName = "${pname}-v${version}.mbp";
         nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [

--- a/pkgs/tools/networking/maubot/wrapper.nix
+++ b/pkgs/tools/networking/maubot/wrapper.nix
@@ -46,7 +46,7 @@ let
                 # XXX: would patching maubot be better? See:
                 # https://github.com/maubot/maubot/blob/75879cfb9370aade6fa0e84e1dde47222625139a/maubot/server.py#L106
                 server.override_resource_path =
-                  if builtins.isNull (baseConfig.server.override_resource_path or null) then
+                  if isNull (baseConfig.server.override_resource_path or null) then
                     "${unwrapped}/${python3.sitePackages}/maubot/management/frontend/build"
                   else
                     baseConfig.server.override_resource_path;

--- a/pkgs/tools/package-management/akku/akkuDerivation.nix
+++ b/pkgs/tools/package-management/akku/akkuDerivation.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (
     // args.meta or { };
     setupHook = ./setup-hook.sh;
   }
-  // builtins.removeAttrs args [
+  // removeAttrs args [
     "name"
     "buildInputs"
     "meta"

--- a/pkgs/tools/package-management/akku/default.nix
+++ b/pkgs/tools/package-management/akku/default.nix
@@ -30,9 +30,9 @@ lib.makeScope newScope (self: rec {
           src = fetchurl {
             inherit url sha256;
           };
-          buildInputs = builtins.map (x: akkuself.${x}) dependencies;
+          buildInputs = map (x: akkuself.${x}) dependencies;
           r7rs = source == "snow-fort";
-          nativeBuildInputs = builtins.map (x: akkuself.${x}) dev-dependencies;
+          nativeBuildInputs = map (x: akkuself.${x}) dev-dependencies;
           unpackPhase = "tar xf $src";
 
           meta.homepage = homepage;

--- a/pkgs/tools/package-management/lix/revert-toml11-bump.patch
+++ b/pkgs/tools/package-management/lix/revert-toml11-bump.patch
@@ -16,7 +16,7 @@ index 1522213cb4..0000000000
 -version aligns with the [TOML v1.0.0 specification’s
 -requirement](https://toml.io/en/v1.0.0#integer) to reject integer
 -literals that cannot be losslessly parsed. This means that code like
--`fromTOML "v=0x8000000000000000"` will now produce an error
+-`builtins.fromTOML "v=0x8000000000000000"` will now produce an error
 -rather than silently saturating the integer result.
 diff --git a/lix/libexpr/primops/fromTOML.cc b/lix/libexpr/primops/fromTOML.cc
 index 9d4b5e6abf..3e26773eac 100644
@@ -147,7 +147,7 @@ index 0c90e85edf..0000000000
 -error:
 -       … while calling the 'fromTOML' builtin
 -         at /pwd/in.nix:1:1:
--            1| fromTOML ''attr = 9223372036854775808''
+-            1| builtins.fromTOML ''attr = 9223372036854775808''
 -             | ^
 -            2|
 -
@@ -166,7 +166,7 @@ index a287e18655..0000000000
 -error:
 -       … while calling the 'fromTOML' builtin
 -         at /pwd/in.nix:1:1:
--            1| fromTOML ''attr = -9223372036854775809''
+-            1| builtins.fromTOML ''attr = -9223372036854775809''
 -             | ^
 -            2|
 -

--- a/pkgs/tools/package-management/lix/revert-toml11-bump.patch
+++ b/pkgs/tools/package-management/lix/revert-toml11-bump.patch
@@ -16,7 +16,7 @@ index 1522213cb4..0000000000
 -version aligns with the [TOML v1.0.0 specification’s
 -requirement](https://toml.io/en/v1.0.0#integer) to reject integer
 -literals that cannot be losslessly parsed. This means that code like
--`builtins.fromTOML "v=0x8000000000000000"` will now produce an error
+-`fromTOML "v=0x8000000000000000"` will now produce an error
 -rather than silently saturating the integer result.
 diff --git a/lix/libexpr/primops/fromTOML.cc b/lix/libexpr/primops/fromTOML.cc
 index 9d4b5e6abf..3e26773eac 100644
@@ -147,7 +147,7 @@ index 0c90e85edf..0000000000
 -error:
 -       … while calling the 'fromTOML' builtin
 -         at /pwd/in.nix:1:1:
--            1| builtins.fromTOML ''attr = 9223372036854775808''
+-            1| fromTOML ''attr = 9223372036854775808''
 -             | ^
 -            2|
 -
@@ -166,7 +166,7 @@ index a287e18655..0000000000
 -error:
 -       … while calling the 'fromTOML' builtin
 -         at /pwd/in.nix:1:1:
--            1| builtins.fromTOML ''attr = -9223372036854775809''
+-            1| fromTOML ''attr = -9223372036854775809''
 -             | ^
 -            2|
 -

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -192,9 +192,7 @@ let
 
   buildInputs =
     if enabledPlugins == null then
-      builtins.concatMap pluginBuildInputs (
-        builtins.attrNames (builtins.removeAttrs plugins [ "xencpu" ])
-      )
+      builtins.concatMap pluginBuildInputs (builtins.attrNames (removeAttrs plugins [ "xencpu" ]))
     else
       builtins.concatMap pluginBuildInputs enabledPlugins;
 in

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -20,7 +20,7 @@ let
   ];
   defaultSupport = builtins.listToAttrs (
     # apple can only build on darwin, and it can't build everything else, and vice versa
-    builtins.map (gpu: {
+    map (gpu: {
       name = gpu;
       value =
         (gpu == "apple" && stdenv.buildPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform)
@@ -33,7 +33,7 @@ in
 }
 # additional packages with only one specific GPU family support
 // builtins.listToAttrs (
-  builtins.map (gpu: {
+  map (gpu: {
     name = gpu;
     value = (callPackage ./build-nvtop.nix { "${gpu}" = true; });
   }) defaultGPUFamilies

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -250,7 +250,7 @@ rec {
       "man"
       "info"
     ]
-    ++ (builtins.map (builtins.replaceStrings [ "-" ] [ "_" ]) corePackages);
+    ++ (map (builtins.replaceStrings [ "-" ] [ "_" ]) corePackages);
 
     nativeBuildInputs = [
       pkg-config
@@ -493,7 +493,7 @@ rec {
       "man"
       "info"
     ]
-    ++ (builtins.map (builtins.replaceStrings [ "-" ] [ "_" ]) coreBigPackages)
+    ++ (map (builtins.replaceStrings [ "-" ] [ "_" ]) coreBigPackages)
     # some outputs of metapost, omegaware are for ptex/uptex
     ++ [
       "ptex"

--- a/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
@@ -67,7 +67,7 @@ let
       tlOutputName = tlTypeToOut.${tlType};
     };
   all = lib.filter pkgFilter combined ++ lib.filter (pkg: pkg.tlType == "tlpkg") combined;
-  converted = builtins.map toSpecified all;
+  converted = map toSpecified all;
 in
 buildTeXEnv {
   __extraName = extraName;

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -254,7 +254,7 @@ let
   };
   toSpecifiedNV = p: rec {
     name = value.tlOutputName;
-    value = builtins.removeAttrs p [ "pkgs" ] // {
+    value = removeAttrs p [ "pkgs" ] // {
       outputSpecified = true;
       tlOutputName = tlTypeToOut.${p.tlType};
     };
@@ -262,10 +262,10 @@ let
   toTLPkgSet =
     pname: drvs:
     let
-      set = lib.listToAttrs (builtins.map toSpecifiedNV drvs);
+      set = lib.listToAttrs (map toSpecifiedNV drvs);
       mainDrv = set.out or set.tex or set.tlpkg or set.texdoc or set.texsource;
     in
-    builtins.removeAttrs mainDrv [ "outputSpecified" ];
+    removeAttrs mainDrv [ "outputSpecified" ];
   toTLPkgSets = { pkgs, ... }: lib.mapAttrsToList toTLPkgSet (lib.groupBy (p: p.pname) pkgs);
 
   # export TeX packages as { pkgs = [ ... ]; } in the top attribute set

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8214,7 +8214,7 @@ with pkgs;
         py
       ];
       # Avoid update.nix/tests conflicts with libxml2.
-      passthru = builtins.removeAttrs libxml2.passthru [
+      passthru = removeAttrs libxml2.passthru [
         "updateScript"
         "tests"
       ];

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -20,7 +20,7 @@ let
   mkMassRebuild =
     args:
     mkOption (
-      builtins.removeAttrs args [ "feature" ]
+      removeAttrs args [ "feature" ]
       // {
         type = args.type or (types.uniq types.bool);
         default = args.default or false;

--- a/pkgs/top-level/factor-packages.nix
+++ b/pkgs/top-level/factor-packages.nix
@@ -37,7 +37,7 @@ let
 
     }
     // lib.optionalAttrs pkgs.config.allowAliases {
-      interpreter = builtins.throw "factorPackages now offers various wrapped factor runtimes (see documentation) and the buildFactorApplication helper.";
+      interpreter = throw "factorPackages now offers various wrapped factor runtimes (see documentation) and the buildFactorApplication helper.";
     };
   extensible-self = lib.makeExtensible (lib.extends overrides inside);
 in

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -55,7 +55,7 @@ assert args ? localSystem -> !(args ? system);
 assert args ? system -> !(args ? localSystem);
 
 import ./. (
-  builtins.removeAttrs args [ "system" ]
+  removeAttrs args [ "system" ]
   // {
     inherit config overlays localSystem;
   }

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -116,7 +116,7 @@ lib.makeScope pkgs.newScope (
         ...
       }@args:
       stdenv.mkDerivation (
-        (builtins.removeAttrs args [ "name" ])
+        (removeAttrs args [ "name" ])
         // {
           pname = "php-${name}";
           extensionName = extName;
@@ -845,7 +845,7 @@ lib.makeScope pkgs.newScope (
           # [ { name = <name>; value = <extension drv>; } ... ]
           #
           # which we later use listToAttrs to make all attrs available by name.
-          namedExtensions = builtins.map (drv: {
+          namedExtensions = map (drv: {
             name = drv.name;
             value = mkExtension drv;
           }) extensionData;

--- a/pkgs/top-level/pkg-config/test-defaultPkgConfigPackages.nix
+++ b/pkgs/top-level/pkg-config/test-defaultPkgConfigPackages.nix
@@ -11,7 +11,7 @@ let
   inherit (lib.strings) escapeNixIdentifier;
 
   allTests = lib.mapAttrs (k: v: if v == null then null else makePkgConfigTestMaybe k v) (
-    builtins.removeAttrs defaultPkgConfigPackages [ "recurseForDerivations" ]
+    removeAttrs defaultPkgConfigPackages [ "recurseForDerivations" ]
   );
 
   # nix-build rejects attribute names with periods

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -645,7 +645,7 @@ let
           teams = [ lib.teams.haskell ];
         };
         constituents = accumulateDerivations (
-          builtins.map (name: jobs.haskellPackages."${name}") (maintainedPkgNames pkgs.haskellPackages)
+          map (name: jobs.haskellPackages."${name}") (maintainedPkgNames pkgs.haskellPackages)
         );
       };
 

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -141,7 +141,7 @@ let
 
   splicedPackagesWithXorg =
     splicedPackages
-    // builtins.removeAttrs splicedPackages.xorg [
+    // removeAttrs splicedPackages.xorg [
       "callPackage"
       "newScope"
       "overrideScope"
@@ -150,7 +150,7 @@ let
 
   packagesWithXorg =
     pkgs
-    // builtins.removeAttrs pkgs.xorg [
+    // removeAttrs pkgs.xorg [
       "callPackage"
       "newScope"
       "overrideScope"

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -92,7 +92,7 @@ let
     # The following line guarantees that the output of this function
     # is a well-formed platform with no missing fields.  It will be
     # uncommented in a separate PR, in case it breaks the build.
-    #(x: lib.trivial.pipe x [ (x: builtins.removeAttrs x [ "_type" ]) lib.systems.parse.mkSystem ])
+    #(x: lib.trivial.pipe x [ (x: removeAttrs x [ "_type" ]) lib.systems.parse.mkSystem ])
     (
       parsed
       // {


### PR DESCRIPTION
```
commit c8d4dabc4357a22d1c249a9363998bdb00122544
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-30 08:49:04 +0200

    pkgs: remove optional builtins prefixes from prelude functions

    Remove optional builtins prefixes from prelude functions by running:

        builtins=(
          abort
          baseNameOf
          break
          derivation
          derivationStrict
          dirOf
          false
          fetchGit
          fetchMercurial
          fetchTarball
          fetchTree
          fromTOML
          import
          isNull
          map
          null
          placeholder
          removeAttrs
          scopedImport
          throw
          toString
          true
        )

        fd \
          --type file \
          . \
          pkgs \
          --exec-batch sed --in-place --regexp-extended "
            s/\<builtins\.($(
              printf '%s\n' "${builtins[@]}" |
                paste --delimiter '|' --serial -
            ))\>/\1/g
          "

        nix fmt

 pkgs/applications/audio/mellowplayer/default.nix   |  2 +-
 pkgs/applications/audio/pianoteq/default.nix       |  2 +-
 pkgs/applications/audio/sonic-pi/update.sh         |  2 +-
 .../blockchains/bitcoin-knots/default.nix          |  2 +-
 pkgs/applications/blockchains/bitcoin/default.nix  |  2 +-
 .../emacs-application-framework/package.nix        |  6 ++--
 pkgs/applications/editors/emacs/make-emacs.nix     |  2 +-
 .../editors/jetbrains/plugins/tests.nix            |  2 +-
 .../editors/jetbrains/source/build.nix             |  2 +-
 .../editors/jupyter-kernels/clojupyter/deps.nix    |  2 +-
 .../kakoune/plugins/build-kakoune-plugin.nix       |  2 +-
 pkgs/applications/editors/neovim/utils.nix         |  2 +-
 pkgs/applications/editors/sublime/3/common.nix     |  2 +-
 pkgs/applications/editors/sublime/4/common.nix     |  2 +-
 .../vim/plugins/nvim-treesitter/overrides.nix      |  2 +-
 .../editors/vim/plugins/utils/vim-utils.nix        |  2 +-
 .../editors/vscode/extensions/updateSettings.nix   |  2 +-
 .../editors/vscode/extensions/vscode-utils.nix     |  2 +-
 .../graphics/sane/backends/default.nix             |  2 +-
 pkgs/applications/misc/sweethome3d/linux.nix       |  2 +-
 .../networking/browsers/chromium/common.nix        |  2 +-
 .../networking/browsers/firefox/wrapper.nix        | 10 +++---
 .../networking/cluster/k3s/builder.nix             |  4 +--
 .../networking/cluster/k3s/default.nix             |  2 +-
 .../networking/cluster/kops/default.nix            |  2 +-
 .../networking/cluster/nomad/default.nix           |  2 +-
 .../networking/cluster/rke2/default.nix            |  2 +-
 .../networking/cluster/terraform/default.nix       |  2 +-
 .../instant-messengers/franz/generic.nix           |  2 +-
 .../networking/irc/weechat/wrapper.nix             |  4 +--
 .../networking/mailreaders/mailnag/default.nix     |  2 +-
 .../networking/mailreaders/thunderbird/update.nix  |  2 +-
 .../office/libreoffice/darwin/default.nix          |  4 +--
 pkgs/applications/office/libreoffice/wrapper.nix   |  6 ++--
 pkgs/applications/radio/gnuradio/wrapper.nix       |  8 ++---
 .../science/chemistry/quantum-espresso/default.nix |  2 +-
 .../version-management/sublime-merge/common.nix    |  2 +-
 .../video/obs-studio/plugins/obs-gstreamer.nix     |  2 +-
 .../video/obs-studio/plugins/obs-vaapi/default.nix |  2 +-
 pkgs/applications/virtualization/cri-o/wrapper.nix |  2 +-
 pkgs/build-support/bintools-wrapper/default.nix    |  2 +-
 pkgs/build-support/buildenv/default.nix            |  2 +-
 pkgs/build-support/cc-wrapper/default.nix          |  2 +-
 pkgs/build-support/compress-drv/default.nix        |  2 +-
 pkgs/build-support/coq/meta-fetch/default.nix      |  2 +-
 .../dart/build-dart-application/default.nix        |  2 +-
 pkgs/build-support/docker/default.nix              |  8 ++---
 pkgs/build-support/docker/examples.nix             |  2 +-
 .../dotnet/add-nuget-deps/default.nix              |  2 +-
 .../dotnet/build-dotnet-package/default.nix        |  2 +-
 .../dotnet/make-nuget-deps/default.nix             |  2 +-
 pkgs/build-support/fetchdocker/default.nix         |  4 +--
 pkgs/build-support/fetchmavenartifact/default.nix  |  2 +-
 pkgs/build-support/fetchpatch/default.nix          |  6 ++--
 pkgs/build-support/fetchpypi/default.nix           |  4 +--
 pkgs/build-support/fetchs3/default.nix             |  2 +-
 pkgs/build-support/make-impure-test.nix            |  4 +--
 pkgs/build-support/mkshell/default.nix             |  2 +-
 pkgs/build-support/node/fetch-npm-deps/default.nix |  2 +-
 .../build-support/node/import-npm-lock/default.nix |  2 +-
 pkgs/build-support/ocaml/topkg.nix                 |  2 +-
 pkgs/build-support/release/source-tarball.nix      |  2 +-
 .../replace-vars/replace-vars-with.nix             |  2 +-
 .../rust/build-rust-crate/default.nix              |  2 +-
 .../rust/build-rust-crate/test/default.nix         |  6 ++--
 .../rust/build-rust-crate/test/rcgen-crates.nix    | 16 +++++-----
 pkgs/build-support/rust/fetch-cargo-vendor.nix     |  2 +-
 pkgs/build-support/rust/import-cargo-lock.nix      | 10 +++---
 .../arrayUtilities/isDeclaredArray/tests.nix       |  2 +-
 .../arrayUtilities/isDeclaredMap/tests.nix         |  2 +-
 pkgs/build-support/src-only/default.nix            |  4 +--
 pkgs/build-support/testers/default.nix             |  2 +-
 pkgs/build-support/trivial-builders/default.nix    |  8 ++---
 .../trivial-builders/test-overriding.nix           |  2 +-
 .../trivial-builders/test/concat-test.nix          |  2 +-
 .../test/writeShellApplication.nix                 |  2 +-
 pkgs/build-support/writers/scripts.nix             | 16 +++++-----
 pkgs/by-name/_1/_1password-cli/package.nix         |  2 +-
 pkgs/by-name/ab/aba/package.nix                    |  2 +-
 pkgs/by-name/al/alsa-lib-with-plugins/package.nix  |  4 +--
 .../by-name/am/amazon-cloudwatch-agent/package.nix |  2 +-
 pkgs/by-name/ap/apfsprogs/package.nix              |  2 +-
 pkgs/by-name/ap/aporetic/package.nix               |  2 +-
 .../ay/ayatana-indicator-messages/package.nix      |  2 +-
 pkgs/by-name/bo/bonsai/package.nix                 |  2 +-
 pkgs/by-name/ca/catppuccin-gtk/package.nix         |  4 +--
 pkgs/by-name/co/colloid-gtk-theme/package.nix      |  8 ++---
 pkgs/by-name/co/colloid-icon-theme/package.nix     |  4 +--
 pkgs/by-name/co/coredns/package.nix                |  4 +--
 pkgs/by-name/cp/cppitertools/package.nix           |  4 +--
 pkgs/by-name/cu/cups-brother-hll2350dw/package.nix |  2 +-
 pkgs/by-name/cu/cups-brother-hll2375dw/package.nix |  2 +-
 .../by-name/cu/cups-brother-mfcl2750dw/package.nix |  2 +-
 .../by-name/cu/cups-brother-mfcl2800dw/package.nix |  2 +-
 pkgs/by-name/cu/curl-impersonate/chrome/update.sh  |  2 +-
 pkgs/by-name/cu/curl-impersonate/firefox/update.sh |  2 +-
 pkgs/by-name/cy/cyrus-imapd/package.nix            |  2 +-
 pkgs/by-name/di/digiham/package.nix                |  2 +-
 pkgs/by-name/dm/dmd/generic.nix                    |  2 +-
 .../do/docker-credential-helpers/package.nix       |  4 +--
 pkgs/by-name/dr/dropbear/package.nix               |  2 +-
 pkgs/by-name/dv/dvdplusrwtools/package.nix         |  2 +-
 pkgs/by-name/ej/ejabberd/package.nix               |  2 +-
 pkgs/by-name/el/element-desktop/package.nix        |  2 +-
 pkgs/by-name/el/element-web-unwrapped/package.nix  |  2 +-
 pkgs/by-name/en/engage/package.nix                 |  4 +--
 pkgs/by-name/ep/epson-escpr2/package.nix           |  4 +--
 pkgs/by-name/eu/eurofurence/package.nix            |  2 +-
 pkgs/by-name/fc/fcft/package.nix                   |  4 +--
 pkgs/by-name/fi/fishnet/package.nix                |  2 +-
 pkgs/by-name/fl/fluent-bit/package.nix             |  2 +-
 pkgs/by-name/fl/fluent-gtk-theme/package.nix       |  8 ++---
 pkgs/by-name/fl/fluent-icon-theme/package.nix      |  2 +-
 pkgs/by-name/fr/freecad/freecad-utils.nix          |  4 +--
 pkgs/by-name/fr/freeswitch/package.nix             |  2 +-
 pkgs/by-name/ga/ganttproject-bin/package.nix       |  2 +-
 pkgs/by-name/ge/geoserver/package.nix              |  2 +-
 pkgs/by-name/ge/getxbook/package.nix               |  2 +-
 pkgs/by-name/gi/giflib/package.nix                 |  2 +-
 pkgs/by-name/gi/git-quick-stats/package.nix        |  2 +-
 pkgs/by-name/go/go-ethereum/package.nix            |  2 +-
 pkgs/by-name/go/google-cloud-sdk/components.nix    |  8 ++---
 .../go/google-cloud-sdk/withExtraComponents.nix    |  4 +--
 pkgs/by-name/gr/graphhopper/package.nix            |  2 +-
 pkgs/by-name/gr/graphite-gtk-theme/package.nix     | 10 +++---
 pkgs/by-name/gr/grcov/package.nix                  |  2 +-
 pkgs/by-name/gu/guile-gnutls/package.nix           |  6 ++--
 pkgs/by-name/ha/hare/cross-compilation-tests.nix   |  4 +--
 pkgs/by-name/ha/hare/package.nix                   |  2 +-
 pkgs/by-name/ha/harec/package.nix                  |  4 +--
 pkgs/by-name/ha/haredo/package.nix                 |  2 +-
 pkgs/by-name/hi/himitsu/package.nix                |  2 +-
 pkgs/by-name/hy/hylafaxplus/package.nix            |  4 +--
 pkgs/by-name/ib/ibm-plex/package.nix               |  2 +-
 pkgs/by-name/im/immich/package.nix                 |  2 +-
 pkgs/by-name/im/imv/package.nix                    |  4 +--
 pkgs/by-name/in/inspircd/package.nix               |  4 +--
 pkgs/by-name/in/intel-compute-runtime/package.nix  |  2 +-
 pkgs/by-name/io/iosevka-bin/package.nix            |  2 +-
 pkgs/by-name/is/isabelle/package.nix               |  2 +-
 pkgs/by-name/ja/jasper-gtk-theme/package.nix       |  8 ++---
 pkgs/by-name/ja/jazz2-content/package.nix          |  2 +-
 pkgs/by-name/ko/kodelife/update.sh                 |  2 +-
 .../by-name/ku/kubo-fs-repo-migrations/package.nix |  6 ++--
 pkgs/by-name/ld/ld-audit-search-mod/package.nix    |  2 +-
 pkgs/by-name/le/lemminx/package.nix                |  2 +-
 pkgs/by-name/li/libdynd/package.nix                |  2 +-
 pkgs/by-name/li/libpsl-with-scripts/package.nix    |  2 +-
 pkgs/by-name/ll/llama-swap/ui.nix                  |  2 +-
 .../lu/luarocks-packages-updater/package.nix       |  2 +-
 pkgs/by-name/ma/magma/package.nix                  |  2 +-
 pkgs/by-name/ma/matcha-gtk-theme/package.nix       |  4 +--
 pkgs/by-name/ma/maven/build-maven-package.nix      |  6 ++--
 pkgs/by-name/me/meson/package.nix                  |  2 +-
 pkgs/by-name/mf/mfcl5750dw/package.nix             |  2 +-
 pkgs/by-name/mi/mission-center/package.nix         |  2 +-
 pkgs/by-name/mi/mitm-cache/fetch.nix               |  4 +--
 pkgs/by-name/mo/mojave-gtk-theme/package.nix       | 12 +++-----
 pkgs/by-name/my/mylvmbackup/package.nix            |  4 +--
 pkgs/by-name/ne/nemo-with-extensions/package.nix   |  2 +-
 pkgs/by-name/ni/nim-unwrapped-1_0/package.nix      |  2 +-
 pkgs/by-name/ni/nim-unwrapped-2_0/package.nix      |  2 +-
 pkgs/by-name/ni/nix-required-mounts/package.nix    |  2 +-
 pkgs/by-name/ni/nixos-init/package.nix             |  2 +-
 pkgs/by-name/ol/ollama/package.nix                 |  2 +-
 pkgs/by-name/op/opa-envoy-plugin/package.nix       |  2 +-
 pkgs/by-name/op/open-policy-agent/package.nix      |  2 +-
 pkgs/by-name/op/openutau/update.sh                 |  2 +-
 pkgs/by-name/or/orchis-theme/package.nix           |  6 ++--
 pkgs/by-name/pi/pigpio/package.nix                 |  3 +-
 pkgs/by-name/pi/pihole/package.nix                 |  2 +-
 pkgs/by-name/pi/pixinsight/package.nix             |  2 +-
 pkgs/by-name/pl/plymouth/package.nix               |  2 +-
 pkgs/by-name/po/podman-desktop/package.nix         |  2 +-
 pkgs/by-name/pr/prek/package.nix                   |  2 +-
 pkgs/by-name/pr/prowlarr/update.py                 |  2 +-
 pkgs/by-name/pu/pulsar/package.nix                 |  2 +-
 pkgs/by-name/qo/qogir-icon-theme/package.nix       |  4 +--
 pkgs/by-name/qo/qogir-theme/package.nix            |  6 ++--
 pkgs/by-name/qr/qrq/package.nix                    |  2 +-
 pkgs/by-name/ra/racket/minimal.nix                 |  2 +-
 .../ra/racket/tests/get-version-and-variant.nix    |  2 +-
 pkgs/by-name/ra/radarr/update.py                   |  2 +-
 pkgs/by-name/re/reposilite/package.nix             |  2 +-
 pkgs/by-name/re/reversal-icon-theme/package.nix    |  2 +-
 pkgs/by-name/ru/rust-streamdeck/package.nix        |  2 +-
 pkgs/by-name/sh/shogihome/package.nix              |  2 +-
 pkgs/by-name/si/sierra-gtk-theme/package.nix       |  8 ++---
 pkgs/by-name/so/solana-cli/package.nix             |  2 +-
 pkgs/by-name/so/sonarlint-ls/package.nix           |  2 +-
 pkgs/by-name/so/sonarr/update.py                   |  2 +-
 pkgs/by-name/st/steam/package.nix                  |  2 +-
 pkgs/by-name/st/stockfish/package.nix              |  2 +-
 pkgs/by-name/st/streamdeck-ui/package.nix          |  2 +-
 pkgs/by-name/st/structurizr-cli/package.nix        |  2 +-
 pkgs/by-name/sw/swi-prolog/package.nix             |  4 +--
 pkgs/by-name/ta/tabby/package.nix                  |  2 +-
 pkgs/by-name/te/tela-circle-icon-theme/package.nix |  2 +-
 pkgs/by-name/to/touchosc/update.sh                 |  2 +-
 pkgs/by-name/tr/treecat/package.nix                |  2 +-
 pkgs/by-name/tr/treefmt/functions-doc.nix          |  2 +-
 pkgs/by-name/tr/treefmt/options-doc.nix            |  2 +-
 pkgs/by-name/tr/triton-llvm/package.nix            |  2 +-
 pkgs/by-name/uc/ucc/package.nix                    |  2 +-
 pkgs/by-name/uw/uwsgi/package.nix                  |  2 +-
 pkgs/by-name/va/vanillatd/package.nix              |  2 +-
 pkgs/by-name/vi/vimix-gtk-themes/package.nix       |  8 ++---
 pkgs/by-name/vi/vimix-icon-theme/package.nix       |  2 +-
 pkgs/by-name/wa/wasilibc/package.nix               |  6 ++--
 pkgs/by-name/wg/wgpu-native/examples.nix           |  2 +-
 pkgs/by-name/wh/whitesur-icon-theme/package.nix    |  2 +-
 pkgs/by-name/xe/xevd/package.nix                   |  6 ++--
 pkgs/by-name/xe/xeve/package.nix                   |  6 ++--
 pkgs/by-name/xg/xgboost/package.nix                |  2 +-
 pkgs/by-name/ya/yandex-cloud/update.py             |  2 +-
 pkgs/by-name/zx/zxtune/package.nix                 |  6 ++--
 pkgs/common-updater/combinators.nix                |  8 ++---
 pkgs/common-updater/unstable-updater.nix           |  2 +-
 pkgs/data/fonts/iosevka/comfy.nix                  |  2 +-
 .../gnome/extensions/buildGnomeExtension.nix       |  4 +--
 pkgs/desktops/gnome/update.nix                     |  2 +-
 .../applications/lomiri-calculator-app/default.nix |  2 +-
 .../lomiri-filemanager-app/default.nix             |  2 +-
 .../applications/lomiri-gallery-app/default.nix    |  2 +-
 .../lomiri-mediaplayer-app/default.nix             |  2 +-
 .../applications/lomiri-music-app/default.nix      |  2 +-
 .../lomiri-system-settings/default.nix             |  2 +-
 .../applications/lomiri-terminal-app/default.nix   |  2 +-
 .../services/lomiri-download-manager/default.nix   |  2 +-
 .../services/lomiri-indicator-network/default.nix  |  2 +-
 .../services/lomiri-polkit-agent/default.nix       |  2 +-
 .../services/lomiri-url-dispatcher/default.nix     |  2 +-
 .../lomiri/services/mediascanner2/default.nix      |  2 +-
 pkgs/development/ada-modules/gnatprove/default.nix |  2 +-
 pkgs/development/beam-modules/mix-release.nix      |  2 +-
 .../compilers/chicken/4/eggDerivation.nix          |  2 +-
 .../compilers/chicken/5/eggDerivation.nix          |  2 +-
 .../compilers/crystal/build-package.nix            |  2 +-
 .../compilers/gcc/ng/common/default.nix            |  5 ++-
 .../gcc/ng/common/libgfortran/default.nix          |  2 +-
 .../graalvm/community-edition/buildGraalvm.nix     |  2 +-
 .../community-edition/buildGraalvmProduct.nix      |  2 +-
 pkgs/development/compilers/idris2/build-idris.nix  |  2 +-
 pkgs/development/compilers/llvm/common/default.nix |  5 ++-
 .../compilers/llvm/common/llvm/default.nix         |  2 +-
 .../compilers/opensmalltalk-vm/default.nix         |  2 +-
 pkgs/development/compilers/rust/1_89.nix           |  2 +-
 pkgs/development/compilers/sbcl/default.nix        |  4 +--
 .../compilers/temurin-bin/jdk-darwin-base.nix      |  2 +-
 .../compilers/temurin-bin/jdk-linux-base.nix       |  2 +-
 pkgs/development/compilers/vala/default.nix        |  2 +-
 pkgs/development/compilers/zulu/11.nix             |  2 +-
 pkgs/development/compilers/zulu/17.nix             |  2 +-
 pkgs/development/compilers/zulu/21.nix             |  2 +-
 pkgs/development/compilers/zulu/23.nix             |  2 +-
 pkgs/development/compilers/zulu/24.nix             |  2 +-
 pkgs/development/compilers/zulu/25.nix             |  2 +-
 pkgs/development/compilers/zulu/8.nix              |  2 +-
 .../cuda-modules/cuda-library-samples/generic.nix  |  2 +-
 .../hare-third-party/hare-compress/default.nix     |  2 +-
 .../hare-third-party/hare-ev/default.nix           |  2 +-
 .../hare-third-party/hare-json/default.nix         |  2 +-
 .../hare-third-party/hare-png/default.nix          |  2 +-
 .../hare-third-party/hare-ssh/default.nix          |  2 +-
 .../hare-third-party/hare-toml/default.nix         |  2 +-
 .../haskell-modules/generic-builder.nix            |  6 ++--
 pkgs/development/haskell-modules/hoogle.nix        |  2 +-
 pkgs/development/haskell-modules/lib/compose.nix   |  4 +--
 .../haskell-modules/make-package-set.nix           |  4 +--
 .../haskell-modules/with-packages-wrapper.nix      |  2 +-
 .../idris-modules/build-idris-package.nix          |  2 +-
 pkgs/development/interpreters/clisp/default.nix    |  2 +-
 .../interpreters/elixir/generic-builder.nix        |  2 +-
 .../interpreters/octave/build-octave-package.nix   |  2 +-
 pkgs/development/interpreters/php/generic.nix      |  2 +-
 .../interpreters/python/conda/default.nix          |  2 +-
 .../interpreters/python/cpython/default.nix        |  2 +-
 .../python/python2/mk-python-derivation.nix        |  4 +--
 .../development/interpreters/ruby/ruby-version.nix |  2 +-
 .../interpreters/tcl/mk-tcl-derivation.nix         |  2 +-
 .../libraries/astal/buildAstalModule.nix           |  2 +-
 pkgs/development/libraries/glibc/locales.nix       |  2 +-
 .../libraries/gobject-introspection/wrapper.nix    |  4 +--
 pkgs/development/libraries/kerberos/krb5.nix       |  2 +-
 pkgs/development/libraries/libint/default.nix      | 36 +++++++++++-----------
 pkgs/development/libraries/mesa/default.nix        |  4 +--
 pkgs/development/libraries/openssl/default.nix     |  4 +--
 .../qt-6/modules/qtdeclarative/default.nix         |  4 +--
 pkgs/development/lua-modules/lib.nix               |  2 +-
 pkgs/development/misc/resholve/resholve-utils.nix  |  2 +-
 .../mobile/androidenv/compose-android-packages.nix |  8 ++---
 .../androidenv/examples/shell-with-emulator.nix    |  2 +-
 .../androidenv/examples/shell-without-emulator.nix |  2 +-
 .../mobile/androidenv/examples/shell.nix           |  2 +-
 pkgs/development/node-packages/overrides.nix       |  2 +-
 pkgs/development/ocaml-modules/atdgen/default.nix  |  2 +-
 .../ocaml-modules/ocaml-freestanding/default.nix   |  4 +--
 .../ocaml-modules/ocaml-gettext/camomile.nix       |  2 +-
 .../ocaml-modules/ocaml-gettext/stub.nix           |  2 +-
 pkgs/development/ocaml-modules/uucp/default.nix    |  2 +-
 pkgs/development/php-packages/relay/default.nix    |  5 +--
 pkgs/development/python-modules/faiss/default.nix  |  2 +-
 .../python-modules/fast-histogram/default.nix      |  2 +-
 .../python-modules/fontpens/default.nix            |  2 +-
 pkgs/development/python-modules/hy/default.nix     |  2 +-
 .../python-modules/invisible-watermark/default.nix |  2 +-
 .../python-modules/scikit-image/default.nix        |  2 +-
 .../python-modules/sentencepiece/default.nix       |  2 +-
 pkgs/development/python-modules/uv/default.nix     |  2 +-
 .../python-modules/warp-lang/default.nix           |  2 +-
 pkgs/development/rocm-modules/6/default.nix        |  2 +-
 pkgs/development/rocm-modules/6/llvm/default.nix   |  6 ++--
 pkgs/development/ruby-modules/gem/default.nix      |  2 +-
 .../development/tools/analysis/binlore/default.nix |  2 +-
 .../tools/build-managers/gradle/fetch-deps.nix     |  4 +--
 pkgs/development/tools/buildah/wrapper.nix         |  2 +-
 .../tools/haskell/ghc-settings-edit/default.nix    |  2 +-
 .../tools/ocaml/js_of_ocaml/default.nix            |  2 +-
 pkgs/development/tools/pnpm/fetch-deps/default.nix |  4 +--
 .../development/tools/yarn2nix-moretea/default.nix |  9 +++---
 .../yarn2nix-moretea/yarn2nix/lib/generateNix.js   |  6 ++--
 pkgs/games/anki/default.nix                        |  4 +--
 pkgs/games/anki/with-addons.nix                    |  2 +-
 pkgs/games/blightmud/default.nix                   |  2 +-
 .../dwarf-fortress/dwarf-therapist/wrapper.nix     |  2 +-
 pkgs/games/scummvm/games.nix                       |  2 +-
 pkgs/games/shattered-pixel-dungeon/generic.nix     |  2 +-
 pkgs/kde/lib/mk-kde-derivation.nix                 |  2 +-
 pkgs/misc/arm-trusted-firmware/default.nix         |  2 +-
 pkgs/misc/uboot/default.nix                        |  2 +-
 pkgs/os-specific/bsd/freebsd/lib/default.nix       |  4 +--
 .../bsd/freebsd/pkgs/drm-kmod-firmware.nix         |  2 +-
 .../bsd/freebsd/pkgs/drm-kmod/package.nix          |  2 +-
 pkgs/os-specific/bsd/freebsd/pkgs/install.nix      |  2 +-
 pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix |  2 +-
 pkgs/os-specific/bsd/freebsd/pkgs/sys/package.nix  |  8 ++---
 .../bsd/openbsd/pkgs/libcMinimal/package.nix       |  2 +-
 pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix |  2 +-
 pkgs/os-specific/linux/kernel/generic.nix          |  2 +-
 pkgs/os-specific/linux/kernel/mainline.nix         |  2 +-
 .../os-specific/linux/minimal-bootstrap/bash/2.nix |  2 +-
 .../linux/minimal-bootstrap/bash/default.nix       |  2 +-
 .../linux/minimal-bootstrap/gnumake/default.nix    |  2 +-
 .../linux/minimal-bootstrap/gnupatch/default.nix   |  2 +-
 .../linux/minimal-bootstrap/mes/default.nix        |  2 +-
 .../stage0-posix/bootstrap-sources.nix             |  2 +-
 .../stage0-posix/kaem/default.nix                  |  2 +-
 pkgs/os-specific/linux/minimal-bootstrap/utils.nix |  6 ++--
 pkgs/os-specific/linux/nvidia-x11/generic.nix      |  6 ++--
 pkgs/os-specific/linux/systemd/default.nix         |  6 +---
 .../build-custom-component/default.nix             |  2 +-
 pkgs/servers/http/openresty/default.nix            |  2 +-
 .../monitoring/grafana/plugins/grafana-plugin.nix  |  2 +-
 pkgs/servers/sql/postgresql/ext/omnigres.nix       |  4 +--
 pkgs/servers/web-apps/discourse/default.nix        |  2 +-
 pkgs/shells/fish/plugins/build-fish-plugin.nix     |  2 +-
 pkgs/stdenv/adapters.nix                           |  2 +-
 pkgs/stdenv/booter.nix                             |  2 +-
 pkgs/stdenv/cross/default.nix                      |  2 +-
 pkgs/stdenv/custom/default.nix                     |  2 +-
 pkgs/stdenv/darwin/bootstrap-tools.nix             |  4 +--
 pkgs/stdenv/darwin/default.nix                     |  4 +--
 pkgs/stdenv/darwin/test-bootstrap-tools.nix        |  2 +-
 pkgs/stdenv/freebsd/default.nix                    |  4 +--
 pkgs/stdenv/generic/check-meta.nix                 |  2 +-
 pkgs/stdenv/generic/make-derivation.nix            | 10 +++---
 pkgs/stdenv/linux/test-bootstrap-tools.nix         |  4 +--
 pkgs/test/auto-patchelf-hook/package.nix           |  4 +--
 .../test/make-hardcode-gsettings-patch/default.nix |  2 +-
 pkgs/test/texlive/default.nix                      |  2 +-
 pkgs/tools/misc/bat-extras/buildBatExtrasPkg.nix   |  2 +-
 pkgs/tools/networking/maubot/plugins/default.nix   |  2 +-
 pkgs/tools/networking/maubot/wrapper.nix           |  2 +-
 .../package-management/akku/akkuDerivation.nix     |  2 +-
 pkgs/tools/package-management/akku/default.nix     |  4 +--
 .../lix/revert-toml11-bump.patch                   |  6 ++--
 pkgs/tools/system/collectd/plugins.nix             |  4 +--
 pkgs/tools/system/nvtop/default.nix                |  4 +--
 pkgs/tools/typesetting/tex/texlive/bin.nix         |  4 +--
 .../typesetting/tex/texlive/combine-wrapper.nix    |  2 +-
 pkgs/tools/typesetting/tex/texlive/default.nix     |  6 ++--
 pkgs/top-level/all-packages.nix                    |  2 +-
 pkgs/top-level/config.nix                          |  2 +-
 pkgs/top-level/factor-packages.nix                 |  2 +-
 pkgs/top-level/impure.nix                          |  2 +-
 pkgs/top-level/php-packages.nix                    |  4 +--
 .../pkg-config/test-defaultPkgConfigPackages.nix   |  2 +-
 pkgs/top-level/release-haskell.nix                 |  2 +-
 pkgs/top-level/splice.nix                          |  4 +--
 pkgs/top-level/stage.nix                           |  2 +-
 390 files changed, 568 insertions(+), 597 deletions(-)

commit 3b97761aa798401b34908ed42d8f224ee80a1e84
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-30 20:35:50 +0200

    lixPackageSets.git: revert removal of builtins prefixes in patch

 pkgs/tools/package-management/lix/revert-toml11-bump.patch | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

commit 8052c76154ee922caff2532fe0e7e866be946e67
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-30 08:58:09 +0200

    pkgs: add builtins prefixes for prelude functions to improve clarity

 pkgs/build-support/src-only/default.nix             | 4 ++--
 pkgs/development/interpreters/ruby/ruby-version.nix | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```

Related PRs intentionally split up to simplify review and merging:

1. https://github.com/NixOS/nixpkgs/pull/447401
2. https://github.com/NixOS/nixpkgs/pull/447402
3. https://github.com/NixOS/nixpkgs/pull/447404
4. https://github.com/NixOS/nixpkgs/pull/447403
5. https://github.com/NixOS/nixpkgs/pull/444432

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
