### PR TITLE
lfortran: init at 0.65.0

### DIFF
--- a/pkgs/by-name/lf/lfortran/package.nix
+++ b/pkgs/by-name/lf/lfortran/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  python3,
+  llvmPackages_19,
+  pkg-config,
+  wrapCCWith,
+  wrapBintoolsWith,
+  overrideCC,
+  targetPackages,
+  re2c,
+  bison,
+  bash,
+  zlib,
+  ccache,
+  zstd,
+  pandoc,
+  ninja,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lfortran";
+  version = "0.63.0";
+
+  src = fetchFromGitHub {
+    owner = "lfortran";
+    repo = "lfortran";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Yj4OZ6LYXPk4JdjjUA3jop8/YWePmO/ioezh+Vi51Fc=";
+  };
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+    re2c
+    bison
+    bash
+    ccache
+    pandoc
+    ninja
+  ];
+
+  buildInputs = with llvmPackages_19; [
+    llvm
+    libclang
+    lld
+    (zstd.override { enableStatic = true; })
+    libunwind
+  ];
+
+  propagatedBuildInputs = [
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DLFORTRAN_BUILD_ALL=ON"
+    "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
+    "-DWITH_ZLIB=no"
+    "-DWITH_LLVM=yes"
+    "-DWITH_LSP=yes"
+    "-DWITH_STACKTRACE=no"
+    "-DWITH_RUNTIME_STACKTRACE=yes"
+    "-DCMAKE_INSTALL_LIBDIR=share/lfortran/lib"
+    "-DCMAKE_EXPORT_COMPILE_COMMANDS=yes"
+    "-G Ninja"
+  ];
+
+  # LFortran needs LLVM libraries
+  NIX_LDFLAGS = "-L${llvmPackages_19.llvm}/lib";
+  NIX_CXXFLAGS = "-Wall -Wextra -O3 -funroll-loops -DNDEBUG";
+
+  postPatch = ''
+    # Fix shebang lines to use env from nix
+    patchShebangs ci/version.sh build0.sh src/libasr/dwarf_convert.py
+
+    # Skip version.sh and use fixed version directly
+    substituteInPlace build0.sh --replace-fail "ci/version.sh" "echo ${finalAttrs.version} > version"
+
+    # Use fixed version instead of calling git
+    echo "${finalAttrs.version}" > version
+  '';
+
+  doCheck = true;
+
+  passthru = {
+    # Add compiler wrapper support
+    bintools-unwrapped = finalAttrs.finalPackage;
+    bintools = wrapBintoolsWith { bintools = finalAttrs.passthru.bintools-unwrapped; };
+
+    cc-unwrapped = finalAttrs.finalPackage;
+    cc = wrapCCWith {
+      cc = finalAttrs.passthru.cc-unwrapped;
+      bintools = finalAttrs.passthru.bintools;
+      extraPackages = [ ];
+      nixSupport.cc-cflags = [
+        "-target"
+        "${stdenv.targetPlatform.system}-${stdenv.targetPlatform.parsed.abi.name}"
+      ]
+      ++ lib.optional (
+        stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.isStatic or false)
+      ) "-Wl,-dynamic-linker=${targetPackages.stdenv.cc.bintools.dynamicLinker}";
+    };
+
+    stdenv = overrideCC stdenv finalAttrs.passthru.cc;
+  };
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Modern interactive LLVM-based Fortran compiler";
+    homepage = "https://lfortran.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ taranarmo ];
+    mainProgram = "lfortran";
+    # https://github.com/lfortran/lfortran/issues/8643
+    broken = stdenv.hostPlatform.system == "aarch64-linux";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/lf/lfortran/package.nix
+++ b/pkgs/by-name/lf/lfortran/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  python3,
+  llvmPackages_19,
+  pkg-config,
+  wrapCCWith,
+  wrapBintoolsWith,
+  overrideCC,
+  targetPackages,
+  re2c,
+  bison,
+  bash,
+  zlib,
+  zstd,
+  pandoc,
+  ninja,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lfortran";
+  version = "0.65.0";
+
+  src = fetchFromGitHub {
+    owner = "lfortran";
+    repo = "lfortran";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-hm+i4z9LW6CKbbu+ymvrMORhp79WDS3lKVe3XzxrU3g=";
+  };
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+    re2c
+    bison
+    bash
+    pandoc
+    ninja
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.toml
+  ];
+
+  buildInputs = with llvmPackages_19; [
+    llvm
+    libclang
+    lld
+    (zstd.override { enableStatic = true; })
+    libunwind
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "LFORTRAN_BUILD_ALL" true)
+    "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
+    (lib.cmakeBool "WITH_ZLIB" false)
+    (lib.cmakeBool "WITH_LLVM" true)
+    (lib.cmakeBool "WITH_LSP" true)
+    (lib.cmakeBool "WITH_STACKTRACE" false)
+    (lib.cmakeBool "WITH_RUNTIME_STACKTRACE" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "share/lfortran/lib")
+    (lib.cmakeBool "CMAKE_EXPORT_COMPILE_COMMANDS" true)
+  ];
+
+  # LFortran needs LLVM libraries
+  NIX_LDFLAGS = "-L${llvmPackages_19.llvm}/lib";
+  NIX_CXXFLAGS = "-Wall -Wextra -O3 -funroll-loops -DNDEBUG";
+
+  postPatch = ''
+    # Fix shebang lines to use env from nix
+    patchShebangs ci/version.sh build0.sh src/libasr/dwarf_convert.py
+
+    # Skip version.sh and use fixed version directly
+    substituteInPlace build0.sh --replace-fail "ci/version.sh" "echo ${finalAttrs.version} > version"
+
+    # Use fixed version instead of calling git
+    echo "${finalAttrs.version}" > version
+  '';
+
+  preCheck = ''
+    export LFORTRAN_LINKER=cc
+  '';
+
+  doCheck = true;
+
+  passthru = {
+    # Add compiler wrapper support
+    bintools-unwrapped = finalAttrs.finalPackage;
+    bintools = wrapBintoolsWith { bintools = finalAttrs.passthru.bintools-unwrapped; };
+
+    cc-unwrapped = finalAttrs.finalPackage;
+    cc = wrapCCWith {
+      cc = finalAttrs.passthru.cc-unwrapped;
+      bintools = finalAttrs.passthru.bintools;
+      extraPackages = [ ];
+      nixSupport.cc-cflags = [
+        "-target"
+        "${stdenv.targetPlatform.system}-${stdenv.targetPlatform.parsed.abi.name}"
+      ]
+      ++ lib.optional (
+        stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.isStatic or false)
+      ) "-Wl,-dynamic-linker=${targetPackages.stdenv.cc.bintools.dynamicLinker}";
+    };
+
+    stdenv = overrideCC stdenv finalAttrs.passthru.cc;
+
+    updateScript = nix-update-script { };
+
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
+
+  meta = {
+    description = "Modern interactive LLVM-based Fortran compiler";
+    homepage = "https://lfortran.org/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ taranarmo ];
+    mainProgram = "lfortran";
+    # https://github.com/lfortran/lfortran/issues/8643
+    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Modern interactive LLVM-based Fortran compiler
https://lfortran.org/
https://github.com/lfortran/lfortran
https://github.com/lfortran/lfortran/tree/v0.65.0
resolves #305403

This is my first experience in packaging compilers, errors and flaws are expected

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
