### PR TITLE
nixos/podman: Create user 'containers'

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -315,6 +315,15 @@ in
 
       users.groups.podman = { };
 
+      # User 'containers' is required by podman when running in rootful mode with --userns=auto
+      users.users.containers = {
+        isSystemUser = true;
+        autoSubUidGidRange = true;
+        description = "User required by podman to get subuids from.";
+        group = "containers";
+      };
+      users.groups.containers = { };
+
       assertions = [
         {
           assertion = cfg.dockerCompat -> !config.virtualisation.docker.enable;

--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -119,6 +119,15 @@ import ../make-test-python.nix (
           rootful.succeed("podman stop sleeping")
           rootful.succeed("podman rm sleeping")
 
+      with subtest("Run container with --userns=auto"):
+          rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
+          rootful.succeed(
+              "podman run -d --userns=auto --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+          )
+          rootful.succeed("podman ps | grep sleeping")
+          rootful.succeed("podman stop sleeping")
+          rootful.succeed("podman rm sleeping")
+
       # now without installed runc
       with subtest("Run runc-less container as root with runc"):
           rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")


### PR DESCRIPTION
This user is required by podman for running containers with `--userns=auto`: It uses it acquire the necessary subuid ranges from.

See https://docs.podman.io/en/latest/markdown/podman-run.1.html#userns-mode

Without it, running a rootful `--userns=auto` results in:
`ERRO[0002] Cannot find mappings for user "containers": no subuid ranges found for user "containers" in /etc/subuid`

Fixes https://github.com/NixOS/nixpkgs/issues/444449.

Formally, we only need to add the subuid range. But this is, afaik, only supported via a user on NixOS.

The user is put into the same-named group. This may confuse people into thinking `containers` is a meaningful group. I'm open to other suggestions regarding naming.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
