### PR TITLE
nixos/power-management: add bootCommands and pre-shutdown hooks

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -83,42 +83,57 @@ in
       unitConfig.StopWhenUnneeded = true;
     };
 
-    # Service executed before suspending/hibernating.
-    systemd.services.pre-sleep = {
-      description = "Pre-Sleep Actions";
-      wantedBy = [ "sleep.target" ];
-      before = [ "sleep.target" ];
-      script = ''
-        ${cfg.powerDownCommands}
-      '';
-      serviceConfig.Type = "oneshot";
-    };
-
-    systemd.services.post-boot = {
-      description = "Post-boot Actions";
-      # It's not well defined at what point in the bootup sequence this should run
-      # we should eventually just remove this.
-      wantedBy = [ "multi-user.target" ];
-      restartIfChanged = false;
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
+    systemd.services = {
+      # Service executed before suspending/hibernating.
+      pre-sleep = {
+        description = "Pre-Sleep Actions";
+        wantedBy = [ "sleep.target" ];
+        before = [ "sleep.target" ];
+        script = cfg.powerDownCommands;
+        serviceConfig.Type = "oneshot";
       };
-      script = ''
-        ${cfg.powerUpCommands}
-      '';
-    };
 
-    systemd.services.post-resume = {
-      description = "Post-Resume Actions";
-      # Pulled in by post-resume.service above
-      after = [ "sleep.target" ];
-      script = ''
-        /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
-        ${cfg.resumeCommands}
-        ${cfg.powerUpCommands}
-      '';
-      serviceConfig.Type = "oneshot";
+      # Service executed after resuming from suspend/hibernate
+      post-resume = {
+        description = "Post-Resume Actions";
+        # Pulled in by post-resume.service above
+        after = [ "sleep.target" ];
+        script = ''
+          /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
+          ${cfg.resumeCommands}
+          ${cfg.powerUpCommands}
+        '';
+        serviceConfig.Type = "oneshot";
+      };
+
+      # Service executed before shutdown
+      pre-shutdown = {
+        description = "Pre-Shutdown Actions";
+        wantedBy = [
+          "shutdown.target"
+        ];
+        before = [
+          "shutdown.target"
+        ];
+        script = cfg.powerDownCommands;
+        serviceConfig.Type = "oneshot";
+        unitConfig.DefaultDependencies = false;
+      };
+
+      post-boot = {
+        description = "Post-boot Actions";
+        # It's not well defined at what point in the bootup sequence this should run
+        # we should eventually just remove this.
+        wantedBy = [ "multi-user.target" ];
+        restartIfChanged = false;
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          ${cfg.powerUpCommands}
+        '';
+      };
     };
 
   };

--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -25,6 +25,9 @@ in
       resumeCommands = lib.mkOption {
         type = lib.types.lines;
         default = "";
+        example = lib.literalExpression ''
+          "''${pkgs.util-linux}/bin/rfkill unblock all"
+        '';
         description = "Commands executed after the system resumes from suspend-to-RAM.";
       };
 
@@ -32,7 +35,7 @@ in
         type = lib.types.lines;
         default = "";
         example = lib.literalExpression ''
-          "''${pkgs.hdparm}/sbin/hdparm -B 255 /dev/sda"
+          "''${pkgs.powertop}/bin/powertop --auto-tune"
         '';
         description = ''
           Commands executed when the machine powers up.  That is,
@@ -51,6 +54,18 @@ in
           Commands executed when the machine powers down.  That is,
           they're executed both when the system shuts down and when
           it goes to suspend or hibernation.
+        '';
+      };
+
+      bootCommands = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = lib.literalExpression ''
+          "''${pkgs.networkmanager}/bin/nmcli radio wifi on"
+        '';
+        description = ''
+          Commands executed only once after initial boot.
+          These commands are executed before `powerUpCommands`.
         '';
       };
 
@@ -120,19 +135,21 @@ in
         unitConfig.DefaultDependencies = false;
       };
 
+      # Service executed after boot
       post-boot = {
-        description = "Post-boot Actions";
+        description = "Post-Boot Actions";
         # It's not well defined at what point in the bootup sequence this should run
         # we should eventually just remove this.
         wantedBy = [ "multi-user.target" ];
         restartIfChanged = false;
+        script = ''
+          ${cfg.bootCommands}
+          ${cfg.powerUpCommands}
+        '';
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
         };
-        script = ''
-          ${cfg.powerUpCommands}
-        '';
       };
     };
 


### PR DESCRIPTION
1. Fixed `powerDownCommands` to also run before shutdown, as the option implies.
2. Added new `bootCommands` option:
   - Runs the specified commands once after boot
   - Runs after `powerUpCommands`
3. Adjusted the provided examples to avoid duplicates.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
