### PR TITLE
linux/common-config: disable Bcachefs configs for version >= 6.18

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -708,8 +708,8 @@ let
 
       BTRFS_FS_POSIX_ACL = yes;
 
-      BCACHEFS_QUOTA = whenAtLeast "6.7" (option yes);
-      BCACHEFS_POSIX_ACL = whenAtLeast "6.7" (option yes);
+      BCACHEFS_QUOTA = whenBetween "6.7" "6.18" (option yes);
+      BCACHEFS_POSIX_ACL = whenBetween "6.7" "6.18" (option yes);
 
       UBIFS_FS_ADVANCED_COMPR = option yes;
 


### PR DESCRIPTION
Bcachefs core code has been removed from upstream linux for 6.18.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f2c61db29f277b9c80de92102fc532cc247495cd