### PR TITLE
bird-lg: 1.3.8 -> 1.3.11

### DIFF
--- a/nixos/modules/services/networking/bird-lg.nix
+++ b/nixos/modules/services/networking/bird-lg.nix
@@ -16,7 +16,7 @@ let
     {
       "--servers" = lib.concatStringsSep "," fe.servers;
       "--domain" = fe.domain;
-      "--listen" = fe.listenAddress;
+      "--listen" = stringOrConcat "," fe.listenAddresses;
       "--proxy-port" = fe.proxyPort;
       "--whois" = fe.whois;
       "--dns-interface" = fe.dnsInterface;
@@ -37,7 +37,7 @@ let
     {
       "--allowed" = lib.concatStringsSep "," px.allowedIPs;
       "--bird" = px.birdSocket;
-      "--listen" = px.listenAddress;
+      "--listen" = stringOrConcat "," px.listenAddresses;
       "--traceroute_bin" = px.traceroute.binary;
       "--traceroute_flags" = lib.concatStringsSep " " px.traceroute.flags;
       "--traceroute_raw" = px.traceroute.rawOutput;
@@ -58,6 +58,17 @@ let
     args: lib.mapAttrsToList (name: value: "${name} " + mkArgValue value) (filterNull args);
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "bird-lg" "frontend" "listenAddress" ]
+      [ "services" "bird-lg" "frontend" "listenAddresses" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "bird-lg" "proxy" "listenAddress" ]
+      [ "services" "bird-lg" "proxy" "listenAddresses" ]
+    )
+  ];
+
   options = {
     services.bird-lg = {
       package = lib.mkPackageOption pkgs "bird-lg" { };
@@ -77,8 +88,8 @@ in
       frontend = {
         enable = lib.mkEnableOption "Bird Looking Glass Frontend Webserver";
 
-        listenAddress = lib.mkOption {
-          type = lib.types.str;
+        listenAddresses = lib.mkOption {
+          type = with lib.types; either str (listOf str);
           default = "127.0.0.1:5000";
           description = "Address to listen on.";
         };
@@ -202,8 +213,8 @@ in
       proxy = {
         enable = lib.mkEnableOption "Bird Looking Glass Proxy";
 
-        listenAddress = lib.mkOption {
-          type = lib.types.str;
+        listenAddresses = lib.mkOption {
+          type = with lib.types; either str (listOf str);
           default = "127.0.0.1:8000";
           description = "Address to listen on.";
         };

--- a/pkgs/by-name/bi/bird-lg/package.nix
+++ b/pkgs/by-name/bi/bird-lg/package.nix
@@ -9,13 +9,13 @@ let
     { modRoot, vendorHash }:
     buildGoModule rec {
       pname = "bird-lg-${modRoot}";
-      version = "1.3.8";
+      version = "1.3.11";
 
       src = fetchFromGitHub {
         owner = "xddxdd";
         repo = "bird-lg-go";
         rev = "v${version}";
-        hash = "sha256-j81cfHqXNsTM93ofxXz+smkjN8OdJXxtm9z5LdzC+r8=";
+        hash = "sha256-C0JC8vLLEk+d6vlrtuW7tHj06K7A3HBjKXZ5Nt+2i4I=";
       };
 
       doDist = false;
@@ -41,12 +41,12 @@ let
 
   bird-lg-frontend = generic {
     modRoot = "frontend";
-    vendorHash = "sha256-luJuIZ0xN8mdtWwTlfEDnAwMgt+Tzxlk2ZIDPIwHpcY=";
+    vendorHash = "sha256-kNysGHtOUtYGHDFDlYNzdkCXGUll105Triy4UR7UP0M=";
   };
 
   bird-lg-proxy = generic {
     modRoot = "proxy";
-    vendorHash = "sha256-OVyfPmLTHV5RFdLgRHEH/GqxuG5MnGt9Koz0DxpSg+4=";
+    vendorHash = "sha256-iosWHHeJyqMPF+Y01+mj70HDKWw0FAZKDpEESAwS/i4=";
   };
 in
 symlinkJoin {


### PR DESCRIPTION
Changes:
- Return data from available services even if one backend fails ()
- Correctly handle protocol names with dash and/or numbers
- Add multi listen support

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
