### PR TITLE
Reapply "linux: default stdenv.hostPlatform.linux-kernel"

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -65,7 +65,7 @@ let
       # optionally be compressed with gzip or bzip2.
       kernelPatches ? [ ],
       ignoreConfigErrors ?
-        !lib.elem stdenv.hostPlatform.linux-kernel.name [
+        !lib.elem stdenv.hostPlatform.linux-kernel.name or "" [
           "aarch64-multiplatform"
           "pc"
         ],
@@ -78,7 +78,7 @@ let
       isHardened ? false,
 
       # easy overrides to stdenv.hostPlatform.linux-kernel members
-      autoModules ? stdenv.hostPlatform.linux-kernel.autoModules,
+      autoModules ? stdenv.hostPlatform.linux-kernel.autoModules or true,
       preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false,
       kernelArch ? stdenv.hostPlatform.linuxArch,
       kernelTests ? { },
@@ -205,10 +205,9 @@ let
 
         RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
 
-        platformName = stdenv.hostPlatform.linux-kernel.name;
         # e.g. "defconfig"
         kernelBaseConfig =
-          if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig;
+          if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig or "defconfig";
 
         makeFlags = import ./common-flags.nix {
           inherit

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -160,6 +160,8 @@ lib.makeOverridable (
         isModular = config.isYes "MODULES";
         withRust = config.isYes "RUST";
 
+        target = kernelConf.target or "vmlinux";
+
         buildDTBs = kernelConf.DTB or false;
 
         # Dependencies that are required to build kernel modules
@@ -332,7 +334,7 @@ lib.makeOverridable (
 
         buildFlags = [
           "KBUILD_BUILD_VERSION=1-NixOS"
-          kernelConf.target
+          target
           "vmlinux" # for "perf" and things like that
           "scripts_gdb"
         ]
@@ -413,14 +415,10 @@ lib.makeOverridable (
         # Some image types need special install targets (e.g. uImage is installed with make uinstall on arm)
         installTargets = [
           (kernelConf.installTarget or (
-            if kernelConf.target == "uImage" && stdenv.hostPlatform.linuxArch == "arm" then
+            if target == "uImage" && stdenv.hostPlatform.linuxArch == "arm" then
               "uinstall"
             else if
-              (
-                kernelConf.target == "zImage"
-                || kernelConf.target == "Image.gz"
-                || kernelConf.target == "vmlinuz.efi"
-              )
+              (target == "zImage" || target == "Image.gz" || target == "vmlinuz.efi")
               && builtins.elem stdenv.hostPlatform.linuxArch [
                 "arm"
                 "arm64"


### PR DESCRIPTION
This reverts commit ddaa949afe18949396a1de532df60ffaea5bf2a3.

This was reverted as part of a bulk revert of all kernel changes in a certain time period — as far as I know there was no actual justification for reverting this change in particular.  The original rationale for making this change stands: it's nice for new platforms not to have to copy the defaults over and over in
lib/systems/platforms.nix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
