### PR TITLE
python3Packages.momongo: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/momonga/default.nix
+++ b/pkgs/development/python-modules/momonga/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pyserial,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "momonga";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nbtk";
+    repo = "momonga";
+    tag = "v${version}";
+    hash = "sha256-sc81L71DJq+XiIYUSMH6knfaPfV7cng/Sp0ZTY6N7ZI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "momonga" ];
+
+  # tests require access to the API
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/nbtk/momonga/releases/tag/${src.tag}";
+    description = "Python Route B Library: A Communicator for Low-voltage Smart Electric Energy Meters";
+    homepage = "https://github.com/nbtk/momonga";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9602,6 +9602,8 @@ self: super: with self; {
 
   momepy = callPackage ../development/python-modules/momepy { };
 
+  momonga = callPackage ../development/python-modules/momonga { };
+
   monai = callPackage ../development/python-modules/monai { };
 
   monai-deploy = callPackage ../development/python-modules/monai-deploy { };


### PR DESCRIPTION
needed for https://rc.home-assistant.io/integrations/route_b_smart_meter
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
