### PR TITLE
nixos/tests/bird-lg: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -273,6 +273,7 @@ in
     _module.args.compression = "xz";
   };
   bind = runTest ./bind.nix;
+  bird-lg = runTest ./bird-lg.nix;
   bird2 = import ./bird.nix {
     inherit runTest;
     package = pkgs.bird2;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -280,6 +280,7 @@ in
     _module.args.compression = "xz";
   };
   bind = runTest ./bind.nix;
+  bird-lg = runTest ./bird-lg.nix;
   bird2 = import ./bird.nix {
     inherit runTest;
     package = pkgs.bird2;

--- a/nixos/tests/bird-lg.nix
+++ b/nixos/tests/bird-lg.nix
@@ -1,0 +1,83 @@
+{ pkgs, ... }:
+
+let
+  format = pkgs.formats.json { };
+  apiCalls = {
+    serverList = format.generate "serverList.json" {
+      servers = [ ];
+      type = "server_list";
+      args = "";
+    };
+    listProtocols = format.generate "listProtocols.json" {
+      servers = [ "localhost" ];
+      type = "summary";
+      args = "";
+    };
+    tracerouteLocalhost = format.generate "tracerouteLocalhost.json" {
+      servers = [ "localhost" ];
+      type = "traceroute";
+      args = "127.0.0.1";
+    };
+  };
+in
+{
+  name = "bird-lg";
+  meta = {
+    maintainers = [
+      pkgs.lib.maintainers.e1mo
+    ];
+  };
+
+  nodes.machine = {
+    environment.systemPackages = with pkgs; [ jq ];
+    services.bird-lg = {
+      proxy = {
+        enable = true;
+        birdSocket = "/var/run/bird/bird.ctl";
+        listenAddresses = [
+          "127.0.0.1:8000"
+          "127.0.0.1:8001"
+        ];
+      };
+      frontend = {
+        enable = true;
+        servers = [
+          "localhost"
+          "does-not-exist"
+        ];
+        domain = "localhost";
+        listenAddresses = [
+          "127.0.0.1:5000"
+          "127.0.0.1:5001"
+        ];
+      };
+    };
+    services.bird = {
+      enable = true;
+      config = ''
+        router id 10.0.0.1;
+
+        protocol ospf v3 ospf4 {
+          area 0 {};
+        }
+        protocol ospf v3 ospf6 {
+          area 0 {};
+        }
+      '';
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("bird-lg-frontend.service")
+    machine.wait_for_unit("bird-lg-proxy.service")
+
+    machine.succeed("curl -f http://localhost:8000/bird?q=show+status")
+    machine.succeed("curl -f http://localhost:8001/bird?q=show+status")
+    machine.succeed("curl -f --json @${apiCalls.tracerouteLocalhost} http://localhost:5000/api/ | jq -e '.result[0].data' | grep 'traceroute to'")
+    machine.succeed("curl -f --json @${apiCalls.tracerouteLocalhost} http://localhost:5001/api/ | jq -e '.result[0].data' | grep 'traceroute to'")
+    machine.succeed("curl -f --json @${apiCalls.serverList} http://localhost:5000/api/ | grep localhost | grep 'does-not-exist' ")
+    machine.succeed("curl -f --json @${apiCalls.listProtocols} http://localhost:5000/api/ | grep 'ospf4' | grep 'ospf6'")
+  '';
+}

--- a/nixos/tests/bird-lg.nix
+++ b/nixos/tests/bird-lg.nix
@@ -1,0 +1,85 @@
+{ pkgs, lib, ... }:
+
+let
+  format = pkgs.formats.json { };
+  apiCalls = {
+    serverList = format.generate "serverList.json" {
+      servers = [ ];
+      type = "server_list";
+      args = "";
+    };
+    listProtocols = format.generate "listProtocols.json" {
+      servers = [ "localhost" ];
+      type = "summary";
+      args = "";
+    };
+    tracerouteLocalhost = format.generate "tracerouteLocalhost.json" {
+      servers = [ "localhost" ];
+      type = "traceroute";
+      args = "127.0.0.1";
+    };
+  };
+in
+{
+  name = "bird-lg";
+  meta = {
+    maintainers = [
+      lib.maintainers.e1mo
+    ];
+  };
+
+  containers.machine = {
+    environment.systemPackages = with pkgs; [ jq ];
+    services.bird-lg = {
+      proxy = {
+        enable = true;
+        birdSocket = "/var/run/bird/bird.ctl";
+        listenAddresses = [
+          "127.0.0.1:8000"
+          "127.0.0.1:8001"
+        ];
+      };
+      frontend = {
+        enable = true;
+        servers = [
+          "localhost"
+          "does-not-exist"
+        ];
+        domain = "localhost";
+        listenAddresses = [
+          "127.0.0.1:5000"
+          "127.0.0.1:5001"
+        ];
+      };
+    };
+    services.bird = {
+      enable = true;
+      config = ''
+        router id 10.0.0.1;
+
+        protocol ospf v3 ospf4 {
+          area 0 {};
+        }
+        protocol ospf v3 ospf6 {
+          area 0 {};
+        }
+      '';
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("bird-lg-frontend.service")
+    machine.wait_for_unit("bird-lg-proxy.service")
+    machine.wait_for_open_port(8000)
+    machine.wait_for_open_port(8001)
+
+    machine.succeed("curl -f http://localhost:8000/bird?q=show+protocols")
+    machine.succeed("curl -f http://localhost:8001/bird?q=show+protocols")
+    machine.succeed("curl -f --json @${apiCalls.tracerouteLocalhost} http://localhost:5000/api/ | jq -e '.result[0].data' | grep 'traceroute to'")
+    machine.succeed("curl -f --json @${apiCalls.tracerouteLocalhost} http://localhost:5001/api/ | jq -e '.result[0].data' | grep 'traceroute to'")
+    machine.succeed("curl -f --json @${apiCalls.serverList} http://localhost:5000/api/ | grep localhost | grep 'does-not-exist' ")
+    machine.succeed("curl -f --json @${apiCalls.listProtocols} http://localhost:5000/api/ | grep 'ospf4' | grep 'ospf6'")
+  '';
+}

--- a/pkgs/by-name/bi/bird-lg/package.nix
+++ b/pkgs/by-name/bi/bird-lg/package.nix
@@ -2,6 +2,7 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
+  nixosTests,
   symlinkJoin,
 }:
 let
@@ -58,4 +59,8 @@ symlinkJoin {
 }
 // {
   inherit (bird-lg-frontend) version meta;
+
+  passthru.tests = {
+    basic-functionality = nixosTests.bird-lg;
+  };
 }

--- a/pkgs/by-name/bi/bird-lg/package.nix
+++ b/pkgs/by-name/bi/bird-lg/package.nix
@@ -4,6 +4,7 @@
   lib,
   nix-update-script,
   symlinkJoin,
+  nixosTests,
 }:
 let
   generic =
@@ -59,6 +60,9 @@ symlinkJoin {
   ];
   passthru = {
     inherit bird-lg-frontend bird-lg-proxy;
+    tests = {
+      basic-functionality = nixosTests.bird-lg;
+    };
     updateScript = nix-update-script {
       extraArgs = [
         "--subpackage"


### PR DESCRIPTION
Just a few very simple tests as an additional sanity check for updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
