### PR TITLE
nixos/modules/netbird/server: make 'stateDir' configurable

### DIFF
--- a/nixos/modules/services/networking/netbird/management.nix
+++ b/nixos/modules/services/networking/netbird/management.nix
@@ -30,8 +30,6 @@ let
 
   inherit (utils) escapeSystemdExecArgs genJqSecretsReplacementSnippet;
 
-  stateDir = "/var/lib/netbird-mgmt";
-
   settingsFormat = pkgs.formats.json { };
 
   defaultSettings = {
@@ -72,7 +70,7 @@ let
       TrustedPeers = [ "0.0.0.0/0" ];
     };
 
-    Datadir = "${stateDir}/data";
+    Datadir = "${cfg.stateDir}/data";
     DataStoreEncryptionKey = "very-insecure-key";
     StoreConfig = {
       Engine = "sqlite";
@@ -140,6 +138,12 @@ in
     enable = mkEnableOption "Netbird Management Service";
 
     package = mkPackageOption pkgs "netbird-management" { };
+
+    stateDir = mkOption {
+      type = str;
+      description = "Toplevel directory containing management server persistent state";
+      default = "/var/lib/netbird-mgmt";
+    };
 
     domain = mkOption {
       type = str;
@@ -258,7 +262,7 @@ in
             TrustedPeers = [ "0.0.0.0/0" ];
           };
 
-          Datadir = "''${stateDir}/data";
+          Datadir = "''${cfg.stateDir}/data";
           DataStoreEncryptionKey = "genEVP6j/Yp2EeVujm0zgqXrRos29dQkpvX0hHdEUlQ=";
           StoreConfig = { Engine = "sqlite"; };
 
@@ -381,7 +385,7 @@ in
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ managementFile ];
 
-      preStart = genJqSecretsReplacementSnippet managementConfig "${stateDir}/management.json";
+      preStart = genJqSecretsReplacementSnippet managementConfig "${cfg.stateDir}/management.json";
 
       serviceConfig = {
         ExecStart = escapeSystemdExecArgs (
@@ -390,10 +394,10 @@ in
             "management"
             # Config file
             "--config"
-            "${stateDir}/management.json"
+            "${cfg.stateDir}/management.json"
             # Data directory
             "--datadir"
-            "${stateDir}/data"
+            "${cfg.stateDir}/data"
             # DNS domain
             "--dns-domain"
             cfg.dnsDomain
@@ -427,7 +431,7 @@ in
         ];
         StateDirectoryMode = "0750";
         RuntimeDirectoryMode = "0750";
-        WorkingDirectory = stateDir;
+        WorkingDirectory = cfg.stateDir;
 
         # hardening
         LockPersonality = true;


### PR DESCRIPTION
Expose 'stateDir' in module options instead of an unreachable 'let' block; with the same default as the previously unconfigurable value.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [N/A] [Package tests] at `passthru.tests`.
  - [N/A] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [N/A] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [N/A] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [N/A] Module addition: when adding a new NixOS module.
  - [N/A] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
