### PR TITLE
[25.05] koodo-reader: 1.7.4 -> 2.0.9

### DIFF
--- a/pkgs/by-name/ko/koodo-reader/bump-node-abi.patch
+++ b/pkgs/by-name/ko/koodo-reader/bump-node-abi.patch
@@ -1,0 +1,17 @@
+diff --git a/yarn.lock b/yarn.lock
+index 83cf080..8bee81e 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -10914,9 +10914,9 @@ node-abi@^3.0.0, node-abi@^3.3.0:
+     semver "^7.3.5"
+ 
+ node-abi@^3.45.0:
+-  version "3.74.0"
+-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.74.0.tgz#5bfb4424264eaeb91432d2adb9da23c63a301ed0"
+-  integrity sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==
++  version "3.77.0"
++  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.77.0.tgz#3ad90d5c9d45663420e5aa4ff58dbf4e3625419a"
++  integrity sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==
+   dependencies:
+     semver "^7.3.5"
+ 

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -14,11 +14,11 @@
   wrapGAppsHook3,
   xcbuild,
 
-  electron_35,
+  electron_37,
 }:
 
 let
-  electron = electron_35; # don't use latest electron to avoid going over the supported abi numbers
+  electron = electron_37; # don't use latest electron to avoid going over the supported abi numbers
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "koodo-reader";
@@ -31,9 +31,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-t93yRd9TrtGZogjpSy0Bse0cM5BFyMaSxFYQFZZyvPM=";
   };
 
+  patches = [
+    ./bump-node-abi.patch
+  ];
+
   offlineCache = fetchYarnDeps {
-    inherit (finalAttrs) src;
-    hash = "sha256-NCnIayneTJqkNHHO98iS4bp7mlV3WHXF9Z7F5zKpD8I=";
+    inherit (finalAttrs) src patches;
+    hash = "sha256-gRaHVWSTBwjVcswy6DVk5yLympudbDcKkvWDry4rsvI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -54,9 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  # disable code signing on Darwin
-  env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
-
   postBuild = ''
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
@@ -68,7 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
     export npm_config_nodedir=${electron.headers}
     npm run postinstall
 
+    # Explicitly set identity to null to avoid signing on darwin
     yarn --offline run electron-builder --dir \
+      -c.mac.identity=null \
       -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version}
   '';

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -3,44 +3,54 @@
   stdenv,
   fetchFromGitHub,
   fetchYarnDeps,
+  makeDesktopItem,
+
+  copyDesktopItems,
+  cctools,
+  makeWrapper,
+  nodejs,
   yarnConfigHook,
   yarnBuildHook,
-  nodejs,
-  makeDesktopItem,
-  copyDesktopItems,
-  makeWrapper,
   wrapGAppsHook3,
-  electron,
+  xcbuild,
+
+  electron_35,
 }:
 
+let
+  electron = electron_35; # don't use latest electron to avoid going over the supported abi numbers
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "koodo-reader";
-  version = "1.7.4";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "troyeguo";
     repo = "koodo-reader";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rLW5FS8xM7Z49AaLq0KzBCoRgAVxwTDCHQFdIaEyygA=";
+    hash = "sha256-t93yRd9TrtGZogjpSy0Bse0cM5BFyMaSxFYQFZZyvPM=";
   };
 
   offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-58mxYt2wD6SGzhvo9c44CPmdX+/tLnbJCMPafo4txbY=";
+    inherit (finalAttrs) src;
+    hash = "sha256-NCnIayneTJqkNHHO98iS4bp7mlV3WHXF9Z7F5zKpD8I=";
   };
 
   nativeBuildInputs = [
     makeWrapper
+    nodejs
+    (nodejs.python.withPackages (ps: [ ps.setuptools ]))
     yarnConfigHook
     yarnBuildHook
-    nodejs
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems
     wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+    xcbuild
   ];
-
-  dontWrapGApps = true;
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -50,6 +60,14 @@ stdenv.mkDerivation (finalAttrs: {
   postBuild = ''
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
+
+    # we need to build cpu-features with the non-electron headers first
+    export npm_config_nodedir=${nodejs}
+    npm rebuild --verbose cpu-features
+
+    export npm_config_nodedir=${electron.headers}
+    npm run postinstall
+
     yarn --offline run electron-builder --dir \
       -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version}
@@ -74,6 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  dontWrapGApps = true;
 
   # we use makeShellWrapper instead of the makeBinaryWrapper provided by wrapGAppsHook for proper shell variable expansion
   postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backports of https://github.com/NixOS/nixpkgs/pull/395560, https://github.com/NixOS/nixpkgs/pull/432381, https://github.com/NixOS/nixpkgs/pull/443886

The reason for the backport is that `electron_35` is EOL. See: https://github.com/NixOS/nixpkgs/pull/445467

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
