### PR TITLE
[25.05] shogihome: 1.22.1 -> 1.25.0

### DIFF
--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -3,9 +3,8 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
-  fetchpatch,
   makeWrapper,
-  electron_35,
+  electron_36,
   vulkan-loader,
   makeDesktopItem,
   copyDesktopItems,
@@ -14,30 +13,20 @@
 }:
 
 let
-  electron = electron_35;
+  electron = electron_36;
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.22.1";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vVKdaFKOx4xm4BK+AjVr4cEDOHpOjOe58k2wUAhB9XA=";
+    hash = "sha256-uJ3cCwGp2cZ/6uCi0YmRZ+0Q9X7KuPfJRDbIUZqmdmU=";
   };
 
-  npmDepsHash = "sha256-OS5DR+24F98ICgQ6zL4VD231Rd5JB/gJKl+qNfnP3PE=";
-
-  patches = [
-    # Make it possible to load the electron-builder config without sideeffects.
-    # PR at https://github.com/sunfish-shogi/shogihome/pull/1184
-    # Should be removed next 1.22.X ShogiHome update or possibly 1.23.X.
-    (fetchpatch {
-      url = "https://github.com/sunfish-shogi/shogihome/commit/a075571a3bf4f536487e1212a2e7a13802dc7ec7.patch";
-      sha256 = "sha256-dJyaoWOC+fEufzpYenmfnblgd2C9Ymv4Cl8Y/hljY6c=";
-    })
-  ];
+  npmDepsHash = "sha256-QYTnOZ9eSE6H3iXbWCQG6FUlNR6LLQdsmsfayawolBQ=";
 
   postPatch = ''
     substituteInPlace package.json \
@@ -46,6 +35,10 @@ buildNpmPackage (finalAttrs: {
 
     substituteInPlace .electron-builder.config.mjs \
       --replace-fail 'AppImage' 'dir'
+
+    # Workaround for https://github.com/electron/electron/issues/31121
+    substituteInPlace src/background/window/path.ts \
+      --replace-fail 'process.resourcesPath' "'$out/share/lib/shogihome/resources'"
   '';
 
   env = {

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -66,12 +66,15 @@ buildNpmPackage (finalAttrs: {
     rm electron-dist/libvulkan.so.1
     cp '${lib.getLib vulkan-loader}/lib/libvulkan.so.1' electron-dist
   ''
+  # Explicitly set identity to null to avoid signing on arm64 macs with newer electron-builder.
+  # See: https://github.com/electron-userland/electron-builder/pull/9007
   + ''
     npm run electron:pack
 
     ./node_modules/.bin/electron-builder \
         --dir \
         --config .electron-builder.config.mjs \
+        -c.mac.identity=null \
         -c.electronDist=electron-dist \
         -c.electronVersion=${electron.version}
 

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -17,16 +17,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.24.0";
+  version = "1.24.1";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8tHKU/6jEyt3o7kbYyhYfQY7luLbX01U7EtK4eEHh+M=";
+    hash = "sha256-BVc/aQ9q+VfWWOJQgNEBNYpvYLsX6eiIwiKRhVkxmZ8=";
   };
 
-  npmDepsHash = "sha256-QARCfpeC19iCpnllHlzAS3Ey9Sj35QQCsPA+/JdzLjM=";
+  npmDepsHash = "sha256-9BsEEcdFYs9SSgL749Zhau34uieyOQry/g3wo/oW0DA=";
 
   postPatch = ''
     substituteInPlace package.json \

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -17,16 +17,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.24.3";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q0d+SKCLtT/gv9mrx0o8qIdWYVwNM2x8/LfRsG4J4rw=";
+    hash = "sha256-Qa8ykN514Moc/PpBhD/X+mzfclQPp3yiriwTJCtmMA8=";
   };
 
-  npmDepsHash = "sha256-mCECqh2iRVD4lsCWYdf15VMuaH8dqpDfWWs/6q4H6Lo=";
+  npmDepsHash = "sha256-rcrj3dG96oNbmp3cXw1qRJPi1SZdBcG9paAShSfb/0E=";
 
   postPatch = ''
     substituteInPlace package.json \

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -17,16 +17,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.23.0";
+  version = "1.23.2";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uJ3cCwGp2cZ/6uCi0YmRZ+0Q9X7KuPfJRDbIUZqmdmU=";
+    hash = "sha256-tZw9iEhZ5ss+mv/WUFaj+xQ6GP4GAHq+PvBOv6F5tgM=";
   };
 
-  npmDepsHash = "sha256-QYTnOZ9eSE6H3iXbWCQG6FUlNR6LLQdsmsfayawolBQ=";
+  npmDepsHash = "sha256-dx66k82o+TWrrK9xBHPbnudDn0CG8mM7c1xeoSAM4Fs=";
 
   postPatch = ''
     substituteInPlace package.json \

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -35,8 +35,9 @@ buildNpmPackage (finalAttrs: {
 
     substituteInPlace .electron-builder.config.mjs \
       --replace-fail 'AppImage' 'dir'
-
-    # Workaround for https://github.com/electron/electron/issues/31121
+  ''
+  # Workaround for https://github.com/electron/electron/issues/31121
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace src/background/window/path.ts \
       --replace-fail 'process.resourcesPath' "'$out/share/lib/shogihome/resources'"
   '';

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -110,7 +110,11 @@ buildNpmPackage (finalAttrs: {
       genericName = "Shogi Frontend";
       comment = finalAttrs.meta.description;
       categories = [ "Game" ];
-      startupWMClass = "ShogiHome";
+
+      # The project was renamed "shogihome" from "electron-shogi."
+      # Some references to "electron-shogi" remain for compatibility.
+      # ref: https://github.com/sunfish-shogi/shogihome/commit/e5bbc4d43d231df23ac31c655adb64e11890993e
+      startupWMClass = "electron-shogi";
     })
   ];
 

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -17,16 +17,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.24.2";
+  version = "1.24.3";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nQ7BqFTLzGSq65nd8zGD2Y1wF4Qjt6iLkEYCA5SL4TY=";
+    hash = "sha256-q0d+SKCLtT/gv9mrx0o8qIdWYVwNM2x8/LfRsG4J4rw=";
   };
 
-  npmDepsHash = "sha256-Qe9g0bOSLQBV8pVyi3WlG7qoAyJeR1sTOLLwW78Hark=";
+  npmDepsHash = "sha256-mCECqh2iRVD4lsCWYdf15VMuaH8dqpDfWWs/6q4H6Lo=";
 
   postPatch = ''
     substituteInPlace package.json \

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -4,7 +4,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   makeWrapper,
-  electron_36,
+  electron_37,
   vulkan-loader,
   makeDesktopItem,
   copyDesktopItems,
@@ -13,20 +13,20 @@
 }:
 
 let
-  electron = electron_36;
+  electron = electron_37;
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.23.2";
+  version = "1.24.0";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tZw9iEhZ5ss+mv/WUFaj+xQ6GP4GAHq+PvBOv6F5tgM=";
+    hash = "sha256-8tHKU/6jEyt3o7kbYyhYfQY7luLbX01U7EtK4eEHh+M=";
   };
 
-  npmDepsHash = "sha256-dx66k82o+TWrrK9xBHPbnudDn0CG8mM7c1xeoSAM4Fs=";
+  npmDepsHash = "sha256-QARCfpeC19iCpnllHlzAS3Ey9Sj35QQCsPA+/JdzLjM=";
 
   postPatch = ''
     substituteInPlace package.json \

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -17,16 +17,16 @@ let
 in
 buildNpmPackage (finalAttrs: {
   pname = "shogihome";
-  version = "1.24.1";
+  version = "1.24.2";
 
   src = fetchFromGitHub {
     owner = "sunfish-shogi";
     repo = "shogihome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BVc/aQ9q+VfWWOJQgNEBNYpvYLsX6eiIwiKRhVkxmZ8=";
+    hash = "sha256-nQ7BqFTLzGSq65nd8zGD2Y1wF4Qjt6iLkEYCA5SL4TY=";
   };
 
-  npmDepsHash = "sha256-9BsEEcdFYs9SSgL749Zhau34uieyOQry/g3wo/oW0DA=";
+  npmDepsHash = "sha256-Qe9g0bOSLQBV8pVyi3WlG7qoAyJeR1sTOLLwW78Hark=";
 
   postPatch = ''
     substituteInPlace package.json \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backports of `shogihome` updates, to bump the electron version, because `electron_35` is EOL. See: https://github.com/NixOS/nixpkgs/pull/445467

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
