### PR TITLE
hyprlax: init at 1.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19206,6 +19206,12 @@
     githubId = 1538622;
     name = "Michael Reilly";
   };
+  oncaged = {
+    name = "oncaged";
+    email = "oncaged@gmail.com";
+    github = "oncaged";
+    githubId = 219910401;
+  };
   ondt = {
     name = "Ondrej Telka";
     email = "nix@ondt.dev";

--- a/pkgs/by-name/hy/hyprlax/package.nix
+++ b/pkgs/by-name/hy/hyprlax/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  pkg-config,
+  fetchFromGitHub,
+  hyprland,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  mesa,
+  libGL,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hyprlax";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "sandwichfarm";
+    repo = "hyprlax";
+    tag = "v${version}";
+    hash = "sha256-NoXoYxrQREL8eTN7vdEDzkoUwJxw3c+ujmDAA4dXgiM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    mesa
+    libGL
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Smooth parallax wallpaper animations for Hyprland";
+    homepage = "https://github.com/sandwichfarm/hyprlax";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.oncaged ];
+
+    inherit (hyprland.meta) platforms;
+  };
+}


### PR DESCRIPTION
This PR adds the hyprlax package, a tool for smooth parallax wallpaper animations on Hyprland, and adds myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
