### PR TITLE
haskell: fix missing cabal file after prePatch for various packages

### DIFF
--- a/pkgs/by-name/ec/echidna/package.nix
+++ b/pkgs/by-name/ec/echidna/package.nix
@@ -96,7 +96,7 @@ haskellPackages.mkDerivation rec {
     makeWrapper
   ];
 
-  preConfigure = ''
+  prePatch = ''
     hpack
   '';
 

--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -46,6 +46,7 @@ mkDerivation rec {
   prePatch = ''
     substituteInPlace package.yaml \
         --replace -Werror ""
+    hpack
   '';
 
   isLibrary = false;
@@ -82,7 +83,6 @@ mkDerivation rec {
     hspec-expectations
     quickcheck-instances
   ];
-  preConfigure = "hpack";
   homepage = "https://github.com/channable/vaultenv#readme";
   description = "Runs processes with secrets from HashiCorp Vault";
   license = lib.licenses.bsd3;

--- a/pkgs/tools/misc/fffuu/default.nix
+++ b/pkgs/tools/misc/fffuu/default.nix
@@ -16,15 +16,15 @@ mkDerivation {
     sha256 = "1qc7p44dqja6qrjbjdc2xn7n9v41j5v59sgjnxjj5k0mxp58y1ch";
   };
 
+  postUnpack = ''
+    sourceRoot="$sourceRoot/haskell_tool"
+  '';
+
   postPatch = ''
-    substituteInPlace haskell_tool/fffuu.cabal \
+    substituteInPlace fffuu.cabal \
       --replace "containers >=0.5 && <0.6" "containers >= 0.6" \
       --replace "optparse-generic >= 1.2.3 && < 1.3" "optparse-generic >= 1.2.3" \
       --replace "split >= 0.2.3 && <= 0.2.4" "split >= 0.2.3"
-  '';
-
-  preCompileBuildDriver = ''
-    cd haskell_tool
   '';
 
   isLibrary = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
