### PR TITLE
openspeedrun: init at 0.3.3

### DIFF
--- a/pkgs/by-name/op/openspeedrun/package.nix
+++ b/pkgs/by-name/op/openspeedrun/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  wayland,
+  libxkbcommon,
+  libGL,
+  autoPatchelfHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "openspeedrun";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "SrWither";
+    repo = "OpenSpeedRun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EZPApXUVhsaOYa6CnpR8IWeEoHEl89KJGGoBOYFqBV0=";
+  };
+
+  cargoHash = "sha256-WzsLEfDZpjpUrbyPOr5QUkTMrlAJoC9Rej5BMOKF7OM=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  runtimeDependencies = [
+    wayland
+    libxkbcommon
+    libGL
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libgcc_s.so.1"
+  ];
+
+  meta = {
+    changelog = "https://github.com/SrWither/OpenSpeedRun/releases/tag/v${finalAttrs.version}";
+    description = "Modern and minimalistic open-source speedrun timer";
+    homepage = "https://github.com/SrWither/OpenSpeedRun";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.pyrox0 ];
+    mainProgram = "openspeedrun";
+  };
+})


### PR DESCRIPTION
https://github.com/SrWither/OpenSpeedRun

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
