### PR TITLE
unixtools: ensure packages have pname and version

### DIFF
--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -17,7 +17,9 @@ in
 
 lib.makeOverridable (
   {
-    name,
+    name ? "${pname}-${version}",
+    pname ? null,
+    version ? null,
 
     # The manifest file (if any).  A symlink $out/manifest will be
     # created to it.
@@ -60,8 +62,6 @@ lib.makeOverridable (
 
     passthru ? { },
     meta ? { },
-    pname ? null,
-    version ? null,
   }:
   let
     chosenOutputs = map (drv: {


### PR DESCRIPTION
> [!IMPORTANT]
>
> Depends on
>
> - #447526

Adds `pname` and `version` attributes to the derivations in `unixtools`.

Certain packages are missing `pname` or `version` attributes, the latter of which is problematic given we do:

https://github.com/NixOS/nixpkgs/blob/249c11a05037a4d0312daec87231201a5e482972/pkgs/top-level/unixtools.nix#L47

Example failure:

```console
nix-repl> legacyPackages.aarch64-darwin.unixtools.more.version
error:
       … while evaluating the attribute 'aarch64-darwin.unixtools.more.version'
         at /nix/store/nb3xkg0x8gf3hwajaszm37dzjikcahpc-source/pkgs/top-level/unixtools.nix:47:30:
           46|           inherit provider;
           47|           inherit (provider) version;
             |                              ^
           48|         }

       error: attribute 'version' missing
       at /nix/store/nb3xkg0x8gf3hwajaszm37dzjikcahpc-source/pkgs/top-level/unixtools.nix:47:30:
           46|           inherit provider;
           47|           inherit (provider) version;
             |                              ^
           48|         }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
