### PR TITLE
python313Packages.hatch-regex-commit: 0.0.3 -> 0.0.4

### DIFF
--- a/pkgs/development/python-modules/hatch-regex-commit/default.nix
+++ b/pkgs/development/python-modules/hatch-regex-commit/default.nix
@@ -3,33 +3,31 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  pythonOlder,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
   pname = "hatch-regex-commit";
-  version = "0.0.3";
+  version = "0.0.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "frankie567";
     repo = "hatch-regex-commit";
     tag = "v${version}";
-    hash = "sha256-E0DIBBaDmTCsZQ41NcjcbzgJ16BwhdexlrGWBdf77oA=";
+    hash = "sha256-xdt3qszigdCudt2+EpUZPkJzL+XQ6TnVEAMm0sV3zwY=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'dynamic = ["version"]' 'version = "${version}"' \
-      --replace-fail ', "hatch-regex-commit"' "" \
-      --replace-fail " --cov-report=term-missing --cov-config=pyproject.toml --cov=hatch_regex_commit --cov=tests" ""
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
   build-system = [ hatchling ];
 
   dependencies = [ hatchling ];
+
+  nativeCheckInputs = [ pytest-cov-stub ];
 
   # Module has no tests
   doCheck = false;
@@ -39,6 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Hatch plugin to create a commit and tag when bumping version";
     homepage = "https://github.com/frankie567/hatch-regex-commit";
+    changelog = "https://github.com/frankie567/hatch-regex-commit/releases/tag/${src.tag}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/frankie567/hatch-regex-commit/releases/tag/v0.0.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
