### PR TITLE
lib.types.mkOptionType: add support for extensibility

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -496,6 +496,9 @@ checkConfigOutput '^"extendedSimple \(extended simple\)"$' options.extendedSimpl
 checkConfigOutput '^"description-based-extendedDescription"$' options.extendedDescriptionOption.type.name ./option-type-extending.nix
 checkConfigOutput '^"description-based-extendedDescription"$' options.extendedDescriptionOption.type.description ./option-type-extending.nix
 
+# Check option type merging with extended types
+checkConfigError 'A definition for option .foo. is not of type .string.. Definition values:\n\s*- In .*: "wrong start"' config.foo ./option-type-merging-with-extended.nix
+
 # Test type.functor.wrapped deprecation warning
 # should emit the warning on:
 # - merged types

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -469,6 +469,33 @@ checkConfigError 'infinite recursion encountered' config.nonLazyResult ./lazy-at
 checkConfigOutput '^"mergedName.<id>.nested"$' config.result ./name-merge-attrsWith-1.nix
 checkConfigError 'The option .mergedName. in .*\.nix. is already declared in .*\.nix' config.mergedName ./name-merge-attrsWith-2.nix
 
+# Check option type extending
+checkConfigOutput '^"simple"$' options.simpleOption.type.name ./option-type-extending.nix
+
+checkConfigOutput '^"description-based"$' options.descriptionBasedOption.type.name ./option-type-extending.nix
+checkConfigOutput '^"description-based"$' options.descriptionBasedOption.type.description ./option-type-extending.nix
+
+checkConfigOutput '^"parametric-name-suffix"$' options.parametricOption.type.name ./option-type-extending.nix
+checkConfigOutput '^"parametric"$' options.parametricOption.type.description ./option-type-extending.nix
+
+checkConfigOutput '^"parametricUncall-too-name-suffix"$' options.parametricUncallOption.type.name ./option-type-extending.nix
+checkConfigOutput '^"parametricUncall"$' options.parametricUncallOption.type.description ./option-type-extending.nix
+
+checkConfigOutput '^"extendedParametric"$' options.extendedParametricOption.type.name ./option-type-extending.nix
+checkConfigOutput '^"extendedParametric-description-suffix"$' options.extendedParametricOption.type.description ./option-type-extending.nix
+
+checkConfigOutput '^"extendedParametricUncall"$' options.extendedParametricUncallOption.type.name ./option-type-extending.nix
+checkConfigOutput '^"extendedParametricUncall-description-suffix"$' options.extendedParametricUncallOption.type.description ./option-type-extending.nix
+
+checkConfigOutput '^"simple"$' options.simpleUncallOption.type.name ./option-type-extending.nix
+
+checkConfigOutput '^"description-based"$' options.descriptionBasedUncallOption.type.name ./option-type-extending.nix
+
+checkConfigOutput '^"extendedSimple \(extended simple\)"$' options.extendedSimpleOption.type.name ./option-type-extending.nix
+
+checkConfigOutput '^"description-based-extendedDescription"$' options.extendedDescriptionOption.type.name ./option-type-extending.nix
+checkConfigOutput '^"description-based-extendedDescription"$' options.extendedDescriptionOption.type.description ./option-type-extending.nix
+
 # Test type.functor.wrapped deprecation warning
 # should emit the warning on:
 # - merged types

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -496,6 +496,9 @@ checkConfigOutput '^"extendedSimple \(extended simple\)"$' options.extendedSimpl
 checkConfigOutput '^"description-based-extendedDescription"$' options.extendedDescriptionOption.type.name ./option-type-extending.nix
 checkConfigOutput '^"description-based-extendedDescription"$' options.extendedDescriptionOption.type.description ./option-type-extending.nix
 
+# Check option type merging with addCheck types
+checkConfigError 'Always fails. No value allowed.' config.foo ./option-type-merging-with-add-check.nix
+
 # Check option type merging with extended types
 checkConfigError 'A definition for option .foo. is not of type .string.. Definition values:\n\s*- In .*: "wrong start"' config.foo ./option-type-merging-with-extended.nix
 

--- a/lib/tests/modules/declare-lazyAttrsOf.nix
+++ b/lib/tests/modules/declare-lazyAttrsOf.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   options.value = lib.mkOption {
-    type = lib.types.lazyAttrsOf (lib.types.str // { emptyValue.value = "empty"; });
+    type = lib.types.lazyAttrsOf (lib.types.str.extend (final: prev: { emptyValue.value = "empty"; }));
     default = { };
   };
 }

--- a/lib/tests/modules/default-type-merge-both.nix
+++ b/lib/tests/modules/default-type-merge-both.nix
@@ -1,12 +1,12 @@
 { lib, options, ... }:
 let
-  foo = lib.mkOptionType {
+  foo = lib.mkOptionType (self: {
     name = "foo";
-    functor = lib.types.defaultFunctor "foo" // {
+    functor = lib.types.defaultFunctor self // {
       wrapped = lib.types.int;
       payload = 10;
     };
-  };
+  });
 in
 {
   imports = [

--- a/lib/tests/modules/option-type-extending.nix
+++ b/lib/tests/modules/option-type-extending.nix
@@ -1,0 +1,69 @@
+{ lib, ... }:
+{
+  options =
+    let
+      # simple option type with no arguments
+      simpleType = lib.mkOptionType {
+        name = "simple";
+      };
+
+      # option type that depends on `self`
+      descriptionBasedType = lib.mkOptionType (self: {
+        name = self.description;
+        description = "description-based";
+      });
+
+      # option type that accepts additional arguments
+      parametricType =
+        (lib.mkOptionType (
+          self: namePart: suffix: {
+            name = self.description + suffix;
+            description = namePart;
+          }
+        ))
+          "parametric"
+          "-name-suffix";
+
+      # `__constructor__` testing for different types
+      simpleUncall = simpleType.__constructor__;
+      descriptionBasedUncall = descriptionBasedType.__constructor__;
+      parametricUncall = parametricType.__constructor__ "parametricUncall" "-too-name-suffix";
+
+      # extend testing on `__constructor__`'ed parametric type
+      extendedParametricType = (parametricType.__constructor__ "extendedParametric" "fake").extend (
+        final: prev: {
+          name = prev.description;
+          description = prev.description + "-description-suffix";
+        }
+      );
+
+      # Testing `__constructor__` after extend
+      extendedParametricUncall = extendedParametricType.__constructor__ "extendedParametricUncall" "fake";
+
+      # extend on simple and description-based types
+      extendedSimpleType = simpleType.extend (
+        final: prev: {
+          name = "extendedSimple (extended ${prev.name})";
+        }
+      );
+
+      extendedDescriptionType = descriptionBasedType.extend (
+        final: prev: {
+          description = prev.description + "-extendedDescription";
+        }
+      );
+
+    in
+    {
+      simpleOption = lib.mkOption { type = simpleType; };
+      descriptionBasedOption = lib.mkOption { type = descriptionBasedType; };
+      parametricOption = lib.mkOption { type = parametricType; };
+      parametricUncallOption = lib.mkOption { type = parametricUncall; };
+      extendedParametricOption = lib.mkOption { type = extendedParametricType; };
+      extendedParametricUncallOption = lib.mkOption { type = extendedParametricUncall; };
+      simpleUncallOption = lib.mkOption { type = simpleUncall; };
+      descriptionBasedUncallOption = lib.mkOption { type = descriptionBasedUncall; };
+      extendedSimpleOption = lib.mkOption { type = extendedSimpleType; };
+      extendedDescriptionOption = lib.mkOption { type = extendedDescriptionType; };
+    };
+}

--- a/lib/tests/modules/option-type-merging-with-add-check.nix
+++ b/lib/tests/modules/option-type-merging-with-add-check.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+let
+  stringWithCheck = lib.types.addCheck lib.types.str (v: throw "Always fails. No value allowed.");
+in
+{
+  imports = [
+    {
+      options.foo = lib.mkOption {
+        type = stringWithCheck;
+        default = "foo";
+      };
+    }
+    {
+      options.foo = lib.mkOption {
+        type = stringWithCheck;
+      };
+    }
+  ];
+}

--- a/lib/tests/modules/option-type-merging-with-extended.nix
+++ b/lib/tests/modules/option-type-merging-with-extended.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+{
+  imports = [
+    {
+      options.foo = lib.mkOption {
+        type = lib.types.str;
+      };
+    }
+    {
+      options.foo = lib.mkOption {
+        type = lib.types.str.extend (
+          final: prev: {
+            check = x: prev.check x && lib.strings.hasPrefix "start" x;
+          }
+        );
+      };
+    }
+  ];
+
+  config.foo = "wrong start";
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -657,10 +657,11 @@ let
         lib.warn
           "The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types."
           (
-            separatedString ""
-            // {
-              name = "string";
-            }
+            (separatedString "").extend (
+              final: prev: {
+                name = "string";
+              }
+            )
           );
 
       passwdEntry =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1422,8 +1422,8 @@ let
       );
 
       # A value from a set of allowed ones.
-      enum =
-        values:
+      enum = mkOptionType (
+        self: values:
         let
           inherit (lib.lists) unique;
           show =
@@ -1437,7 +1437,7 @@ let
             else
               ''<${builtins.typeOf v}>'';
         in
-        mkOptionType rec {
+        {
           name = "enum";
           description =
             # Length 0 or 1 enums may occur in a design pattern with type merging
@@ -1453,12 +1453,13 @@ let
           descriptionClass = if builtins.length values < 2 then "noun" else "conjunction";
           check = flip elem values;
           merge = mergeEqualOption;
-          functor = (defaultFunctor name) // {
+          functor = defaultFunctor self // {
+            type = payload: self.__constructor__ payload.values;
             payload = { inherit values; };
-            type = payload: types.enum payload.values;
             binOp = a: b: { values = unique (a.values ++ b.values); };
           };
-        };
+        }
+      );
 
       # Either value of type `t1` or `t2`.
       either =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1239,7 +1239,8 @@ let
             mergedOption.type;
       };
 
-      submoduleWith =
+      submoduleWith = mkOptionType (
+        self:
         {
           modules,
           specialArgs ? { },
@@ -1297,7 +1298,7 @@ let
 
           check = x: isAttrs x || isFunction x || path.check x;
         in
-        mkOptionType {
+        {
           inherit name;
           description =
             if description != null then
@@ -1339,12 +1340,10 @@ let
           getSubOptions =
             prefix:
             let
-              docsEval = (
-                base.extendModules {
-                  inherit prefix;
-                  modules = [ noCheckForDocsModule ];
-                }
-              );
+              docsEval = base.extendModules {
+                inherit prefix;
+                modules = [ noCheckForDocsModule ];
+              };
               # Intentionally shadow the freeformType from the possibly *checked*
               # configuration. See `noCheckForDocsModule` comment.
               inherit (docsEval._module) freeformType;
@@ -1359,7 +1358,7 @@ let
           getSubModules = modules;
           substSubModules =
             m:
-            submoduleWith (
+            self.__constructor__ (
               attrs
               // {
                 modules = m;
@@ -1368,8 +1367,7 @@ let
           nestedTypes = lib.optionalAttrs (freeformType != null) {
             freeformType = freeformType;
           };
-          functor = defaultFunctor name // {
-            type = types.submoduleWith;
+          functor = defaultFunctor self // {
             payload = {
               inherit
                 modules
@@ -1420,7 +1418,8 @@ let
                   throw "A submoduleWith option is declared multiple times with conflicting descriptions";
             };
           };
-        };
+        }
+      );
 
       # A value from a set of allowed ones.
       enum =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -473,11 +473,12 @@ let
             );
           ign =
             lowest: highest: name: docStart:
-            between lowest highest
-            // {
-              inherit name;
-              description = docStart + "; between ${betweenDesc lowest highest}";
-            };
+            (between lowest highest).extend (
+              final: prev: {
+                inherit name;
+                description = docStart + "; between ${betweenDesc lowest highest}";
+              }
+            );
           unsign =
             bit: range: ign 0 (range - 1) "unsignedInt${toString bit}" "${toString bit} bit unsigned integer";
           sign =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -379,7 +379,7 @@ let
         merge = mergeOneOption;
       };
 
-      anything = mkOptionType {
+      anything = mkOptionType (self: {
         name = "anything";
         description = "anything";
         descriptionClass = "noun";
@@ -403,12 +403,12 @@ let
             mergeFunction =
               {
                 # Recursively merge attribute sets
-                set = (attrsOf anything).merge;
+                set = (attrsOf self).merge;
                 # This is the type of packages, only accept a single definition
                 stringCoercibleSet = mergeOneOption;
                 lambda =
                   loc: defs: arg:
-                  anything.merge (loc ++ [ "<function body>" ]) (
+                  self.merge (loc ++ [ "<function body>" ]) (
                     map (def: {
                       file = def.file;
                       value = def.value arg;
@@ -419,7 +419,7 @@ let
               .${commonType} or mergeEqualOption;
           in
           mergeFunction loc defs;
-      };
+      });
 
       unspecified = mkOptionType {
         name = "unspecified";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -717,12 +717,14 @@ let
       );
 
       pkgs = addCheck (
-        unique { message = "A Nixpkgs pkgs set can not be merged with another pkgs set."; } attrs
-        // {
-          name = "pkgs";
-          descriptionClass = "noun";
-          description = "Nixpkgs package set";
-        }
+        (unique { message = "A Nixpkgs pkgs set can not be merged with another pkgs set."; } attrs).extend
+        (
+          final: prev: {
+            name = "pkgs";
+            descriptionClass = "noun";
+            description = "Nixpkgs package set";
+          }
+        )
       ) (x: (x._type or null) == "pkgs");
 
       path = pathWith {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1073,10 +1073,10 @@ let
 
       uniq = unique { message = ""; };
 
-      unique =
+      unique = mkOptionType (
+        self:
         { message }:
-        type:
-        mkOptionType rec {
+        type: {
           name = "unique";
           inherit (type) description descriptionClass check;
           merge = mergeUniqueOption {
@@ -1087,11 +1087,12 @@ let
           getSubOptions = type.getSubOptions;
           getSubModules = type.getSubModules;
           substSubModules = m: uniq (type.substSubModules m);
-          functor = elemTypeFunctor name { elemType = type; } // {
-            type = payload: types.unique { inherit message; } payload.elemType;
+          functor = elemTypeFunctor self.name { elemType = type; } // {
+            type = payload: self.__constructor__ { inherit message; } payload.elemType;
           };
           nestedTypes.elemType = type;
-        };
+        }
+      );
 
       # Null or value of ...
       nullOr =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -763,9 +763,8 @@ let
           }
       );
 
-      listOf =
-        elemType:
-        mkOptionType rec {
+      listOf = mkOptionType (
+        self: elemType: {
           name = "listOf";
           description = "list of ${
             optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType
@@ -797,7 +796,7 @@ let
                 );
               in
               {
-                headError = checkDefsForError check loc defs;
+                headError = checkDefsForError self.check loc defs;
                 value = map (x: x.optionalValue.value or x.mergedValue) evals;
                 valueMeta.list = map (v: v.checkedAndMerged.valueMeta) evals;
               };
@@ -807,12 +806,13 @@ let
           };
           getSubOptions = prefix: elemType.getSubOptions (prefix ++ [ "*" ]);
           getSubModules = elemType.getSubModules;
-          substSubModules = m: listOf (elemType.substSubModules m);
-          functor = (elemTypeFunctor name { inherit elemType; }) // {
-            type = payload: types.listOf payload.elemType;
+          substSubModules = m: self.__constructor__ (elemType.substSubModules m);
+          functor = (elemTypeFunctor self.name { inherit elemType; }) // {
+            type = payload: self.__constructor__ payload.elemType;
           };
           nestedTypes.elemType = elemType;
-        };
+        }
+      );
 
       nonEmptyListOf =
         elemType:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -599,20 +599,20 @@ let
           merge = loc: defs: lib.removeSuffix "\n" (merge loc defs);
         };
 
-      strMatching =
-        pattern:
-        mkOptionType {
+      strMatching = mkOptionType (
+        self: pattern: {
           name = "strMatching ${escapeNixString pattern}";
           description = "string matching the pattern ${pattern}";
           descriptionClass = "noun";
           check = x: str.check x && builtins.match pattern x != null;
           inherit (str) merge;
-          functor = defaultFunctor "strMatching" // {
-            type = payload: strMatching payload.pattern;
+          functor = defaultFunctor self // {
+            type = payload: self.__constructor__ payload.pattern;
             payload = { inherit pattern; };
             binOp = lhs: rhs: if lhs == rhs then lhs else null;
           };
-        };
+        }
+      );
 
       # Merge multiple definitions by concatenating them (with the given
       # separator between the values).

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -616,9 +616,8 @@ let
 
       # Merge multiple definitions by concatenating them (with the given
       # separator between the values).
-      separatedString =
-        sep:
-        mkOptionType rec {
+      separatedString = mkOptionType (
+        self: sep: {
           name = "separatedString";
           description =
             if sep == "" then
@@ -628,12 +627,13 @@ let
           descriptionClass = "noun";
           check = isString;
           merge = loc: defs: concatStringsSep sep (getValues defs);
-          functor = (defaultFunctor name) // {
+          functor = defaultFunctor self // {
+            type = payload: self.__constructor__ payload.sep;
             payload = { inherit sep; };
-            type = payload: types.separatedString payload.sep;
             binOp = lhs: rhs: if lhs.sep == rhs.sep then { inherit (lhs) sep; } else null;
           };
-        };
+        }
+      );
 
       lines = separatedString "\n";
       commas = separatedString ",";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1468,9 +1468,8 @@ let
       );
 
       # Either value of type `t1` or `t2`.
-      either =
-        t1: t2:
-        mkOptionType rec {
+      either = mkOptionType (
+        self: t1: t2: {
           name = "either";
           description =
             if t1.descriptionClass or null == "nonRestrictiveClause" then
@@ -1541,16 +1540,24 @@ let
               mt1 = t1.typeMerge (elemAt f'.payload.elemType 0).functor;
               mt2 = t2.typeMerge (elemAt f'.payload.elemType 1).functor;
             in
-            if (name == f'.name) && (mt1 != null) && (mt2 != null) then functor.type mt1 mt2 else null;
-          functor = elemTypeFunctor name {
-            elemType = [
-              t1
-              t2
-            ];
-          };
+            if (self.name == f'.name) && (mt1 != null) && (mt2 != null) then
+              self.functor.type mt1 mt2
+            else
+              null;
+          functor =
+            elemTypeFunctor self.name {
+              elemType = [
+                t1
+                t2
+              ];
+            }
+            // {
+              type = self.__constructor__;
+            };
           nestedTypes.left = t1;
           nestedTypes.right = t2;
-        };
+        }
+      );
 
       # Any of the types in the given list
       oneOf =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -666,14 +666,16 @@ let
 
       passwdEntry =
         entryType:
-        addCheck entryType (str: !(hasInfix ":" str || hasInfix "\n" str))
-        // {
-          name = "passwdEntry ${entryType.name}";
-          description = "${
-            optionDescriptionPhrase (class: class == "noun") entryType
-          }, not containing newlines or colons";
-          descriptionClass = "nonRestrictiveClause";
-        };
+        (addCheck entryType (str: !(hasInfix ":" str || hasInfix "\n" str))).extend (
+          final: prev: {
+            name = "passwdEntry ${entryType.name}";
+            description = "${
+              optionDescriptionPhrase (class: class == "noun") entryType
+            }, not containing newlines or colons";
+            descriptionClass = "nonRestrictiveClause";
+            __constructor__ = passwdEntry;
+          }
+        );
 
       attrs = mkOptionType {
         name = "attrs";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -710,9 +710,11 @@ let
             res;
       };
 
-      shellPackage = package // {
-        check = x: isDerivation x && hasAttr "shellPath" x;
-      };
+      shellPackage = package.extend (
+        final: prev: {
+          check = x: isDerivation x && hasAttr "shellPath" x;
+        }
+      );
 
       pkgs = addCheck (
         unique { message = "A Nixpkgs pkgs set can not be merged with another pkgs set."; } attrs

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1167,11 +1167,12 @@ let
       # A module to be imported in some other part of the configuration.
       # `staticModules`' options will be added to the documentation, unlike
       # options declared via `config`.
-      deferredModuleWith =
+      deferredModuleWith = mkOptionType (
+        self:
         attrs@{
           staticModules ? [ ],
         }:
-        mkOptionType {
+        {
           name = "deferredModule";
           description = "module";
           descriptionClass = "noun";
@@ -1189,14 +1190,13 @@ let
             ;
           substSubModules =
             m:
-            deferredModuleWith (
+            self.__constructor__ (
               attrs
               // {
                 staticModules = m;
               }
             );
-          functor = defaultFunctor "deferredModuleWith" // {
-            type = types.deferredModuleWith;
+          functor = defaultFunctor self // {
             payload = {
               inherit staticModules;
             };
@@ -1204,7 +1204,8 @@ let
               staticModules = lhs.staticModules ++ rhs.staticModules;
             };
           };
-        };
+        }
+      );
 
       # The type of a type!
       optionType = mkOptionType {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -944,15 +944,16 @@ let
       # TODO: deprecate this in the future:
       loaOf =
         elemType:
-        types.attrsOf elemType
-        // {
-          name = "loaOf";
-          deprecationMessage =
-            "Mixing lists with attribute values is no longer"
-            + " possible; please use `types.attrsOf` instead. See"
-            + " https://github.com/NixOS/nixpkgs/issues/1800 for the motivation.";
-          nestedTypes.elemType = elemType;
-        };
+        (types.attrsOf elemType).extend (
+          final: prev: {
+            name = "loaOf";
+            deprecationMessage =
+              "Mixing lists with attribute values is no longer"
+              + " possible; please use `types.attrsOf` instead. See"
+              + " https://github.com/NixOS/nixpkgs/issues/1800 for the motivation.";
+            nestedTypes.elemType = elemType;
+          }
+        );
 
       attrTag = mkOptionType (
         self: tags':

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -565,16 +565,18 @@ let
               }
             );
 
-          nonnegative = addCheck number (x: x >= 0) // {
-            name = "numberNonnegative";
-            description = "nonnegative integer or floating point number, meaning >=0";
-            descriptionClass = "nonRestrictiveClause";
-          };
           positive = addCheck number (x: x > 0) // {
             name = "numberPositive";
             description = "positive integer or floating point number, meaning >0";
             descriptionClass = "nonRestrictiveClause";
           };
+          nonnegative = (addCheck number (x: x >= 0)).extend (
+            final: prev: {
+              name = "numberNonnegative";
+              description = "nonnegative integer or floating point number, meaning >=0";
+              descriptionClass = "nonRestrictiveClause";
+            }
+          );
         };
 
       str = mkOptionType {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -112,10 +112,12 @@ let
 
     setType =
       typeName: value:
-      value
-      // {
-        _type = typeName;
-      };
+      let
+        ext = {
+          _type = typeName;
+        };
+      in
+      if value ? extend then value.extend (final: prev: ext) else value // ext;
 
     # Default type merging function
     # takes two type functors and return the merged type

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -465,11 +465,12 @@ let
           between =
             lowest: highest:
             assert lib.assertMsg (lowest <= highest) "ints.between: lowest must be smaller than highest";
-            addCheck int (x: x >= lowest && x <= highest)
-            // {
-              name = "intBetween";
-              description = "integer between ${betweenDesc lowest highest}";
-            };
+            (addCheck int (x: x >= lowest && x <= highest)).extend (
+              final: prev: {
+                name = "intBetween";
+                description = "integer between ${betweenDesc lowest highest}";
+              }
+            );
           ign =
             lowest: highest: name: docStart:
             between lowest highest

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -510,15 +510,17 @@ let
           */
           inherit between;
 
-          positive = addCheck types.int (x: x > 0) // {
-            name = "positiveInt";
-            description = "positive integer, meaning >0";
-            descriptionClass = "nonRestrictiveClause";
-          };
           unsigned = (addCheck types.int (x: x >= 0)).extend (
             final: prev: {
               name = "unsignedInt";
               description = "unsigned integer, meaning >=0";
+              descriptionClass = "nonRestrictiveClause";
+            }
+          );
+          positive = (addCheck types.int (x: x > 0)).extend (
+            final: prev: {
+              name = "positiveInt";
+              description = "positive integer, meaning >0";
               descriptionClass = "nonRestrictiveClause";
             }
           );

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -717,28 +717,26 @@ let
         inStore = true;
       };
 
-      pathWith =
+      pathWith = mkOptionType (
+        self:
         {
           inStore ? null,
           absolute ? null,
         }:
         throwIf (inStore != null && absolute != null && inStore && !absolute)
           "In pathWith, inStore means the path must be absolute"
-          mkOptionType
           {
             name = "path";
-            description = (
+            description =
               (if absolute == null then "" else (if absolute then "absolute " else "relative "))
               + "path"
               + (
                 if inStore == null then "" else (if inStore then " in the Nix store" else " not in the Nix store")
-              )
-            );
+              );
             descriptionClass = "noun";
 
             merge = mergeEqualOption;
-            functor = defaultFunctor "path" // {
-              type = pathWith;
+            functor = defaultFunctor self // {
               payload = { inherit inStore absolute; };
               binOp = lhs: rhs: if lhs == rhs then lhs else null;
             };
@@ -755,14 +753,15 @@ let
                     /. + builtins.unsafeDiscardStringContext x
                 );
                 isAbsolute = builtins.substring 0 1 (toString x) == "/";
-                isExpectedType = (
+                isExpectedType =
                   if inStore == null || inStore then isStringLike x else isString x # Do not allow a true path, which could be copied to the store later on.
-                );
+                ;
               in
               isExpectedType
               && (inStore == null || inStore == isInStore)
               && (absolute == null || absolute == isAbsolute);
-          };
+          }
+      );
 
       listOf =
         elemType:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1127,9 +1127,8 @@ let
         }
       );
 
-      functionTo =
-        elemType:
-        mkOptionType {
+      functionTo = mkOptionType (
+        self: elemType: {
           name = "functionTo";
           description = "function that evaluates to a(n) ${
             optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType
@@ -1152,12 +1151,13 @@ let
           };
           getSubOptions = prefix: elemType.getSubOptions (prefix ++ [ "<function body>" ]);
           getSubModules = elemType.getSubModules;
-          substSubModules = m: functionTo (elemType.substSubModules m);
-          functor = (elemTypeFunctor "functionTo" { inherit elemType; }) // {
-            type = payload: types.functionTo payload.elemType;
+          substSubModules = m: self.__constructor__ (elemType.substSubModules m);
+          functor = (elemTypeFunctor self.name { inherit elemType; }) // {
+            type = payload: self.__constructor__ payload.elemType;
           };
           nestedTypes.elemType = elemType;
-        };
+        }
+      );
 
       # A submodule (like typed attribute set). See NixOS manual.
       submodule =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -558,11 +558,12 @@ let
           between =
             lowest: highest:
             assert lib.assertMsg (lowest <= highest) "numbers.between: lowest must be smaller than highest";
-            addCheck number (x: x >= lowest && x <= highest)
-            // {
-              name = "numberBetween";
-              description = "integer or floating point number between ${betweenDesc lowest highest}";
-            };
+            (addCheck number (x: x >= lowest && x <= highest)).extend (
+              final: prev: {
+                name = "numberBetween";
+                description = "integer or floating point number between ${betweenDesc lowest highest}";
+              }
+            );
 
           nonnegative = addCheck number (x: x >= 0) // {
             name = "numberNonnegative";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -161,13 +161,27 @@ let
         f.type;
 
     # Default type functor
-    defaultFunctor = name: {
-      inherit name;
-      type = types.${name} or null;
-      wrapped = null;
-      payload = null;
-      binOp = a: b: null;
-    };
+    defaultFunctor =
+      self:
+      lib.warnIfNot (isAttrs self)
+        ''
+          Passing name to `types.defaultFunctor` is deprecated.
+          You should pass `self` of the function instead:
+          ```nix
+            lib.types.mkOptionType (self: {
+              name = "${lib.escape [ "\"" ] self}";
+              functor = lib.types.defaultFunctor self;
+              # ...
+            })
+          ```
+        ''
+        {
+          name = if isAttrs self then self.name else self;
+          type = if isAttrs self then self.__constructor__ else types.${self} or null;
+          wrapped = null;
+          payload = null;
+          binOp = a: b: null;
+        };
 
     isOptionType = isType "option-type";
     mkOptionType =

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -950,16 +950,13 @@ let
           nestedTypes.elemType = elemType;
         };
 
-      attrTag =
-        tags:
-        let
-          tags_ = tags;
-        in
+      attrTag = mkOptionType (
+        self: tags':
         let
           tags = mapAttrs (
             n: opt:
             builtins.addErrorContext
-              "while checking that attrTag tag ${lib.strings.escapeNixIdentifier n} is an option with a type${inAttrPosSuffix tags_ n}"
+              "while checking that attrTag tag ${lib.strings.escapeNixIdentifier n} is an option with a type${inAttrPosSuffix tags' n}"
               (
                 throwIf (opt._type or null != "option")
                   "In attrTag, each tag value must be an option, but tag ${lib.strings.escapeNixIdentifier n} ${
@@ -976,23 +973,23 @@ let
                   declarations =
                     opt.declarations or (
                       let
-                        pos = builtins.unsafeGetAttrPos n tags_;
+                        pos = builtins.unsafeGetAttrPos n tags';
                       in
                       if pos == null then [ ] else [ pos.file ]
                     );
                   declarationPositions =
                     opt.declarationPositions or (
                       let
-                        pos = builtins.unsafeGetAttrPos n tags_;
+                        pos = builtins.unsafeGetAttrPos n tags';
                       in
                       if pos == null then [ ] else [ pos ]
                     );
                 }
               )
-          ) tags_;
+          ) tags';
           choicesStr = concatMapStringsSep ", " lib.strings.escapeNixIdentifier (attrNames tags);
         in
-        mkOptionType {
+        {
           name = "attrTag";
           description = "attribute-tagged union";
           descriptionClass = "noun";
@@ -1022,8 +1019,8 @@ let
             else
               throw "The option `${showOption loc}` is defined as ${lib.strings.escapeNixIdentifier choice}, but ${lib.strings.escapeNixIdentifier choice} is not among the valid choices (${choicesStr}). Value ${choice} was defined in ${showFiles (getFiles defs)}.";
           nestedTypes = tags;
-          functor = defaultFunctor "attrTag" // {
-            type = { tags, ... }: types.attrTag tags;
+          functor = defaultFunctor self // {
+            type = { tags, ... }: self.__constructor__ tags;
             payload = { inherit tags; };
             binOp =
               let
@@ -1057,7 +1054,8 @@ let
                   ) (builtins.intersectAttrs a.tags b.tags);
               };
           };
-        };
+        }
+      );
 
       # A value produced by `lib.mkLuaInline`
       luaInline = mkOptionType {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -510,16 +510,18 @@ let
           */
           inherit between;
 
-          unsigned = addCheck types.int (x: x >= 0) // {
-            name = "unsignedInt";
-            description = "unsigned integer, meaning >=0";
-            descriptionClass = "nonRestrictiveClause";
-          };
           positive = addCheck types.int (x: x > 0) // {
             name = "positiveInt";
             description = "positive integer, meaning >0";
             descriptionClass = "nonRestrictiveClause";
           };
+          unsigned = (addCheck types.int (x: x >= 0)).extend (
+            final: prev: {
+              name = "unsignedInt";
+              description = "unsigned integer, meaning >=0";
+              descriptionClass = "nonRestrictiveClause";
+            }
+          );
           u8 = unsign 8 256;
           u16 = unsign 16 65536;
           # the biggest int Nix accepts is 2^63 - 1 (9223372036854775808)

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1095,9 +1095,8 @@ let
       );
 
       # Null or value of ...
-      nullOr =
-        elemType:
-        mkOptionType rec {
+      nullOr = mkOptionType (
+        self: elemType: {
           name = "nullOr";
           description = "null or ${
             optionDescriptionPhrase (class: class == "noun" || class == "conjunction") elemType
@@ -1120,12 +1119,13 @@ let
           };
           getSubOptions = elemType.getSubOptions;
           getSubModules = elemType.getSubModules;
-          substSubModules = m: nullOr (elemType.substSubModules m);
-          functor = (elemTypeFunctor name { inherit elemType; }) // {
-            type = payload: types.nullOr payload.elemType;
+          substSubModules = m: self.__constructor__ (elemType.substSubModules m);
+          functor = (elemTypeFunctor self.name { inherit elemType; }) // {
+            type = payload: self.__constructor__ payload.elemType;
           };
           nestedTypes.elemType = elemType;
-        };
+        }
+      );
 
       functionTo =
         elemType:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -565,15 +565,17 @@ let
               }
             );
 
-          positive = addCheck number (x: x > 0) // {
-            name = "numberPositive";
-            description = "positive integer or floating point number, meaning >0";
-            descriptionClass = "nonRestrictiveClause";
-          };
           nonnegative = (addCheck number (x: x >= 0)).extend (
             final: prev: {
               name = "numberNonnegative";
               description = "nonnegative integer or floating point number, meaning >=0";
+              descriptionClass = "nonRestrictiveClause";
+            }
+          );
+          positive = (addCheck number (x: x > 0)).extend (
+            final: prev: {
+              name = "numberPositive";
+              description = "positive integer or floating point number, meaning >0";
               descriptionClass = "nonRestrictiveClause";
             }
           );

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -819,12 +819,12 @@ let
         let
           list = addCheck (types.listOf elemType) (l: l != [ ]);
         in
-        list
-        // {
-          description = "non-empty ${optionDescriptionPhrase (class: class == "noun") list}";
-          emptyValue = { }; # no .value attr, meaning unset
-          substSubModules = m: nonEmptyListOf (elemType.substSubModules m);
-        };
+        list.extend (
+          final: prev: {
+            description = "non-empty ${optionDescriptionPhrase (class: class == "noun") list}";
+            emptyValue = { }; # no .value attr, meaning unset
+          }
+        );
 
       attrsOf = elemType: attrsWith { inherit elemType; };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -643,9 +643,9 @@ Types are mainly characterized by their `check` and `merge` functions.
     {
       nixThings = mkOption {
         description = "words that start with 'nix'";
-        type = types.str // {
-          check = (x: lib.hasPrefix "nix" x);
-        };
+        type = types.str.extend (final: prev: {
+          check = x: prev.check x && lib.hasPrefix "nix" x;
+        });
       };
     }
     ```
@@ -661,9 +661,14 @@ Types are mainly characterized by their `check` and `merge` functions.
 ## Custom types {#sec-option-types-custom}
 
 Custom types can be created with the `mkOptionType` function. As type
-creation includes some more complex topics such as submodule handling,
+creation includes some advanced topics such as submodule handling,
 it is recommended to get familiar with `types.nix` code before creating
-a new type.
+a new type. If a type needs access to its own resolved attributes,
+accept `self` as the first parameter and place any additional parameters
+after it. For parameterised types, the unapplied form is available as
+`.__constructor__`, ensuring consistent behaviour for argument application
+and `.extend`.
+
 
 The only required parameter is `name`.
 
@@ -749,7 +754,7 @@ The only required parameter is `name`.
 
     `type`
 
-    :   The type function.
+    :   Function to initialize the type with passed values.
 
     `wrapped`
 

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -1,10 +1,12 @@
 { lib, ... }:
 let
-  docFile = lib.types.path // {
-    # Returns tuples of
-    #   { file = "module location"; value = <path/to/doc.xml>; }
-    merge = loc: defs: defs;
-  };
+  docFile = lib.types.path.extend (
+    final: prev: {
+      # Returns tuples of
+      #   { file = "module location"; value = <path/to/doc.xml>; }
+      merge = loc: defs: defs;
+    }
+  );
 in
 
 {
@@ -24,9 +26,11 @@ in
       };
 
       buildDocsInSandbox = lib.mkOption {
-        type = lib.types.bool // {
-          merge = loc: defs: defs;
-        };
+        type = lib.types.bool.extend (
+          final: prev: {
+            merge = loc: defs: defs;
+          }
+        );
         internal = true;
         default = true;
         description = ''

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -51,11 +51,13 @@ let
     merge = lib.mergeOneOption;
   };
 
-  pkgsType = lib.types.pkgs // {
-    # This type is only used by itself, so let's elaborate the description a bit
-    # for the purpose of documentation.
-    description = "An evaluation of Nixpkgs; the top level attribute set of packages";
-  };
+  pkgsType = lib.types.pkgs.extend (
+    final: prev: {
+      # This type is only used by itself, so let's elaborate the description a bit
+      # for the purpose of documentation.
+      description = "An evaluation of Nixpkgs; the top level attribute set of packages";
+    }
+  );
 
   hasBuildPlatform = opt.buildPlatform.highestPrio < (lib.mkOptionDefault { }).priority;
   hasHostPlatform = opt.hostPlatform.isDefined;

--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -30,10 +30,12 @@ let
   planExample = "1h=>10min,1d=>1h,1w=>1d,1m=>1w,1y=>1m";
 
   # A type for a string of the form number{b|k|M|G}
-  mbufferSizeType = lib.types.str // {
-    check = x: lib.types.str.check x && builtins.isList (builtins.match "^[0-9]+[bkMG]$" x);
-    description = "string of the form number{b|k|M|G}";
-  };
+  mbufferSizeType = lib.types.str.extend (
+    final: prev: {
+      check = x: prev.check x && builtins.isList (builtins.match "^[0-9]+[bkMG]$" x);
+      description = "string of the form number{b|k|M|G}";
+    }
+  );
 
   enabledFeatures = lib.concatLists (
     lib.mapAttrsToList (name: enabled: lib.optional enabled name) cfg.features

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -12,7 +12,7 @@ let
   ldapValueType =
     let
       # Can't do types.either with multiple non-overlapping submodules, so define our own
-      singleLdapValueType = lib.mkOptionType rec {
+      singleLdapValueType = lib.mkOptionType {
         name = "LDAP";
         # TODO: It would be nice to define a { secret = ...; } option, using
         # systemd's LoadCredentials for secrets. That would remove the last

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -120,16 +120,20 @@ in
       };
 
       defaultSession = lib.mkOption {
-        type = lib.types.nullOr lib.types.str // {
-          description = "session name";
-          check =
-            d:
-            lib.assertMsg (d != null -> (lib.types.str.check d && lib.elem d cfg.sessionData.sessionNames)) ''
-              Default graphical session, '${d}', not found.
-              Valid names for 'services.displayManager.defaultSession' are:
-                ${lib.concatStringsSep "\n  " cfg.sessionData.sessionNames}
-            '';
-        };
+        type = lib.types.nullOr (
+          lib.types.str.extend (
+            final: prev: {
+              description = "session name";
+              check =
+                d:
+                lib.assertMsg (d != null -> (prev.check d && lib.elem d cfg.sessionData.sessionNames)) ''
+                  Default graphical session, '${d}', not found.
+                  Valid names for 'services.displayManager.defaultSession' are:
+                    ${lib.concatStringsSep "\n  " cfg.sessionData.sessionNames}
+                '';
+            }
+          )
+        );
         default = null;
         example = "gnome";
         description = ''

--- a/nixos/modules/services/misc/autorandr.nix
+++ b/nixos/modules/services/misc/autorandr.nix
@@ -11,7 +11,7 @@ let
 
   matrixOf =
     n: m: elemType:
-    lib.mkOptionType rec {
+    lib.mkOptionType (self: {
       name = "matrixOf";
       description = "${toString n}×${toString m} matrix of ${elemType.description}s";
       check =
@@ -31,11 +31,11 @@ let
           ]
         );
       getSubModules = elemType.getSubModules;
-      substSubModules = mod: matrixOf n m (elemType.substSubModules mod);
-      functor = (lib.defaultFunctor name) // {
+      substSubModules = mod: self.__constructor__ n m (elemType.substSubModules mod);
+      functor = lib.defaultFunctor self // {
         wrapped = elemType;
       };
-    };
+    });
 
   profileModule = lib.types.submodule {
     options = {

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -225,17 +225,17 @@ in
       plugins = mkOption {
         type =
           let
-            networkManagerPluginPackage = types.package // {
-              description = "NetworkManager plugin package";
-              check =
-                p:
-                lib.assertMsg
-                  (types.package.check p && p ? networkManagerPlugin && lib.isString p.networkManagerPlugin)
-                  ''
+            networkManagerPluginPackage = types.package.extend (
+              final: prev: {
+                description = "NetworkManager plugin package";
+                check =
+                  p:
+                  lib.assertMsg (prev.check p && p ? networkManagerPlugin && lib.isString p.networkManagerPlugin) ''
                     Package ‘${p.name}’, is not a NetworkManager plugin.
                     Those need to have a ‘networkManagerPlugin’ attribute.
                   '';
-            };
+              }
+            );
           in
           types.listOf networkManagerPluginPackage;
         default = [ ];

--- a/nixos/modules/services/networking/privoxy.nix
+++ b/nixos/modules/services/networking/privoxy.nix
@@ -39,10 +39,12 @@ let
       '';
     };
 
-  ageType = types.str // {
-    check = x: isString x && (builtins.match "([0-9]+([smhdw]|min|ms|us)*)+" x != null);
-    description = "tmpfiles.d(5) age format";
-  };
+  ageType = types.str.extend (
+    final: prev: {
+      check = x: isString x && (builtins.match "([0-9]+([smhdw]|min|ms|us)*)+" x != null);
+      description = "tmpfiles.d(5) age format";
+    }
+  );
 
   configFile = pkgs.writeText "privoxy.conf" (
     concatStrings (

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -473,10 +473,12 @@ in
                       path = mkOption {
                         # TODO for release 23.05: allow relative paths again and set
                         # working directory to cfg.dataDir
-                        type = types.str // {
-                          check = x: types.str.check x && (substring 0 1 x == "/" || substring 0 2 x == "~/");
-                          description = types.str.description + " starting with / or ~/";
-                        };
+                        type = types.str.extend (
+                          final: prev: {
+                            check = x: prev.check x && (substring 0 1 x == "/" || substring 0 2 x == "~/");
+                            description = prev.description + " starting with / or ~/";
+                          }
+                        );
                         default = name;
                         description = ''
                           The path to the folder which should be shared.

--- a/nixos/modules/system/boot/kernel_config.nix
+++ b/nixos/modules/system/boot/kernel_config.nix
@@ -29,9 +29,13 @@ let
       };
 
       freeform = mkOption {
-        type = types.nullOr types.str // {
-          merge = mergeEqualOption;
-        };
+        type = types.nullOr (
+          types.str.extend (
+            final: prev: {
+              merge = mergeEqualOption;
+            }
+          )
+        );
         default = null;
         example = ''MMC_BLOCK_MINORS.freeform = "32";'';
         description = ''
@@ -40,9 +44,11 @@ let
       };
 
       optional = mkOption {
-        type = types.bool // {
-          merge = mergeFalseByDefault;
-        };
+        type = types.bool.extend (
+          final: prev: {
+            merge = mergeFalseByDefault;
+          }
+        );
         default = false;
         description = ''
           Whether option should generate a failure when unused.


### PR DESCRIPTION
Added extensibility to option types created with `mkOptionType`. This is implemented by adding an optional argument `self` to the type function, which is used like this:

```nix
mkOptionType (self: {
  name = "test";
  description = self.name;
})
```

Additionally, `__constructor__` and `extend` were added, working the same way as elsewhere (`lib.makeExtensible`).

Moreover, `functor.type` was improved: a new argument `__constructor__` was added to `mkOptionType`, which preserves the original function with all arguments after `self` unapplied (so if you want to add arguments to the type, **the first argument must always be `self`**). For example:

```nix
# fooType == fooType.__constructor__
fooType = mkOptionType (self: {
  name = "foo";
  description = self.name;
})

# barType types.str "" == (barType types.str "").__constructor__ types.str ""
barType = mkOptionType (self: forExampleElemType: blabla: {
  name = "bar";
  description = self.name;
})
```

All extensions in `__constructor__` are preserved, see https://github.com/yunfachi/nixpkgs/blob/393b9e8196fd9285c206da5e4bd29ea4b312238e/lib/types.nix#L309-L313 :

```nix
extendedBarType = ((barType types.str "").extend (final: prev: { name = "extendedBar"; })).__constructor__
```

## Key points to note

* Arguments for initializing a type should now be specified **inside** `mkOptionType`, not outside (**Not a breaking change!** `extend` simply doesn't apply to arguments outside).
* If `mkOptionType` has arguments, the first must always be `self` (**Still not a breaking change**, because before this PR, `mkOptionType` couldn't accept functions at all - it only accepted attrsets).
* `__constructor__` can be passed as an argument to `mkOptionType` and can also be overridden in `.extend`.
* `__constructor__` tracks type extensions. For a type with one argument (excluding `self`) (pseudocode): `__constructor__ = x: (prev.__constructor__ x).extend ext`.
* `defaultFunctor` now accepts `self` from `mkOptionType` (With full backward compatibility, of course. Once most types have been refactored to the new system, we can deprecate passing a string to `defaultFunctor`) and uses `__constructor__` for `functor.type`.

## Things to be done

* [x] improve naming
* [x] documentation
* [x] refactor all uses of `mkOptionType`
* [x] tests

I think this fixes #396021, let me know if it doesn't.
