### PR TITLE
tfctl: init at 0.16.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15420,6 +15420,13 @@
       }
     ];
   };
+  lunkentuss = {
+    email = "peter.hansson17@gmail.com";
+    matrix = "@lunkentuss:matrix.org";
+    github = "lunkentuss";
+    githubId = 9850798;
+    name = "Peter Hansson";
+  };
   LunNova = {
     email = "nixpkgs-maintainer@lunnova.dev";
     github = "LunNova";

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -5,7 +5,12 @@
   fetchFromGitHub,
   installShellFiles,
   kubectl,
+  writeScript,
 }:
+let
+  commitHash = "a53488094851773978301511922c2ced1397cdf9"; # matches tag release
+  shortCommitHash = builtins.substring 0 8 commitHash;
+in
 buildGoModule (finalAttrs: {
   pname = "tfctl";
   version = "0.15.1";
@@ -19,7 +24,7 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/tfctl" ];
   ldflags = [
-    "-X main.BuildSHA=${finalAttrs.src.rev}"
+    "-X main.BuildSHA=${shortCommitHash}"
     "-X main.BuildVersion=${finalAttrs.version}"
   ];
 
@@ -36,6 +41,22 @@ buildGoModule (finalAttrs: {
     done
 
     installShellCompletion tfctl.{bash,zsh,fish}
+  '';
+
+  passthru.updateScript = writeScript "update-tfctl" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq nix-update
+
+    set -eu -o pipefail
+
+    gh_metadata="$(curl -LsS https://api.github.com/repos/flux-iac/tofu-controller/tags)"
+    version="$(echo "$gh_metadata" | jq -r '.[] | .name' | sort --version-sort | tail -1)"
+    commit_hash="$(echo "$gh_metadata" | jq -r --arg ver "$version" '.[] | select(.name == $ver).commit.sha')"
+
+    filename="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" tfctl).file" | tr -d '"')"
+    sed -i "s/commitHash = \"[^\"]*\"/commitHash = \"$commit_hash\"/" $filename
+
+    nix-update tfctl
   '';
 
   meta = {

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -25,7 +25,7 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace tfctl/break_glass.go \
       --replace-fail 'exec.Command("kubectl"' 'exec.Command("${lib.getExe kubectl}"'
   '';

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  kubectl,
+}:
+buildGoModule (finalAttrs: {
+  name = "tfctl";
+  version = "0.15.1";
+  src = fetchFromGitHub {
+    owner = "flux-iac";
+    repo = "tofu-controller";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rA3HLO4sD8UmcebGGFxyg0zFpDHCzFHjHwMxPw8MiRU=";
+  };
+  vendorHash = "sha256-NhXgWuxSuurP46DBWOviFzCINJKaTb1mINRYeYcnnH8=";
+
+  subPackages = [ "cmd/tfctl" ];
+  ldflags = [
+    "-X main.BuildSHA=${finalAttrs.src.rev}"
+    "-X main.BuildVersion=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = [ kubectl ];
+
+  patchPhase = ''
+    substituteInPlace tfctl/break_glass.go \
+      --replace-fail 'exec.Command("kubectl"' 'exec.Command("${lib.getExe kubectl}"'
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    for shell in bash zsh fish ; do
+      $out/bin/tfctl completion "$shell" > "tfctl.$shell"
+    done
+
+    installShellCompletion tfctl.{bash,zsh,fish}
+  '';
+
+  meta = {
+    homepage = "https://github.com/flux-iac/tofu-controller";
+    description = "Cli for managing tofu-controller";
+    mainProgram = "tfctl";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lunkentuss
+    ];
+  };
+})

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -7,7 +7,7 @@
   kubectl,
 }:
 buildGoModule (finalAttrs: {
-  name = "tfctl";
+  pname = "tfctl";
   version = "0.15.1";
   src = fetchFromGitHub {
     owner = "flux-iac";

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
     set -eu -o pipefail
 
     gh_metadata="$(curl -LsS https://api.github.com/repos/flux-iac/tofu-controller/tags)"
-    version="$(echo "$gh_metadata" | jq -r '.[] | .name' | sort --version-sort | tail -1)"
+    version="$(echo "$gh_metadata" | jq -r '.[] | select(.name | test("rc") | not) | .name' | sort --version-sort | tail -1)"
     commit_hash="$(echo "$gh_metadata" | jq -r --arg ver "$version" '.[] | select(.name == $ver).commit.sha')"
 
     filename="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" tfctl).file" | tr -d '"')"

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -24,7 +24,6 @@ buildGoModule (finalAttrs: {
   ];
 
   nativeBuildInputs = [ installShellFiles ];
-  buildInputs = [ kubectl ];
 
   patchPhase = ''
     substituteInPlace tfctl/break_glass.go \

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -5,12 +5,7 @@
   fetchFromGitHub,
   installShellFiles,
   kubectl,
-  writeScript,
 }:
-let
-  commitHash = "a53488094851773978301511922c2ced1397cdf9"; # matches tag release
-  shortCommitHash = builtins.substring 0 8 commitHash;
-in
 buildGoModule (finalAttrs: {
   pname = "tfctl";
   version = "0.15.1";
@@ -24,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/tfctl" ];
   ldflags = [
-    "-X main.BuildSHA=${shortCommitHash}"
+    "-X main.BuildSHA=${finalAttrs.src.tag}"
     "-X main.BuildVersion=${finalAttrs.version}"
   ];
 
@@ -41,22 +36,6 @@ buildGoModule (finalAttrs: {
     done
 
     installShellCompletion tfctl.{bash,zsh,fish}
-  '';
-
-  passthru.updateScript = writeScript "update-tfctl" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl jq nix-update
-
-    set -eu -o pipefail
-
-    gh_metadata="$(curl -LsS https://api.github.com/repos/flux-iac/tofu-controller/tags)"
-    version="$(echo "$gh_metadata" | jq -r '.[] | select(.name | test("rc") | not) | .name' | sort --version-sort | tail -1)"
-    commit_hash="$(echo "$gh_metadata" | jq -r --arg ver "$version" '.[] | select(.name == $ver).commit.sha')"
-
-    filename="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" tfctl).file" | tr -d '"')"
-    sed -i "s/commitHash = \"[^\"]*\"/commitHash = \"$commit_hash\"/" $filename
-
-    nix-update tfctl
   '';
 
   meta = {

--- a/pkgs/by-name/tf/tfctl/package.nix
+++ b/pkgs/by-name/tf/tfctl/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  kubectl,
+}:
+buildGoModule (finalAttrs: {
+  pname = "tfctl";
+  version = "0.16.5";
+  src = fetchFromGitHub {
+    owner = "flux-iac";
+    repo = "tofu-controller";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-I2gWdTJHmPXvuqomsoD2ufWdPGG95+8NNf6DOVw/W9c=";
+  };
+  vendorHash = "sha256-6gwkIbvddIwKwvq7y6Oj90oMTeKgI0jDghLSQ1cVEe0=";
+
+  subPackages = [ "cmd/tfctl" ];
+  ldflags = [
+    "-X main.BuildSHA=${finalAttrs.src.tag}"
+    "-X main.BuildVersion=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  # Wrap with kubectl since tfctl/break_glass.go executes kubectl
+  postInstall = ''
+    wrapProgram $out/bin/tfctl \
+      --prefix PATH : ${lib.makeBinPath [ kubectl ]}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    for shell in bash zsh fish ; do
+      $out/bin/tfctl completion "$shell" > "tfctl.$shell"
+    done
+
+    installShellCompletion tfctl.{bash,zsh,fish}
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/flux-iac/tofu-controller";
+    description = "Cli for managing tofu-controller";
+    mainProgram = "tfctl";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lunkentuss
+    ];
+  };
+})


### PR DESCRIPTION
Adds the CLI utiliy `tfctl` used to to control [tofu controller](https://github.com/flux-iac/tofu-controller).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

edit: Added the pull request template since the new package `tfctl` was included in the PR.