### PR TITLE
 python3Packages.kicost: init at 1.1.20

### DIFF
--- a/pkgs/development/python-modules/kicost-digikey-api-v3/default.nix
+++ b/pkgs/development/python-modules/kicost-digikey-api-v3/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  inflection,
+  setuptools,
+  requests,
+  urllib3,
+  six,
+  certifi,
+  pyopenssl,
+  tldextract,
+  python-dateutil,
+  distutils,
+}:
+buildPythonPackage rec {
+  pname = "kicost-digikey-api-v3";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "set-soft";
+    repo = "kicost-digikey-api-v3";
+    tag = "v${version}";
+    hash = "sha256-O4bYvf8EnAlcgJ/fqYEuo2+37Q6lTdmlSrmaD2Cl/q8=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "kicost_digikey_api_v3" ];
+
+  dependencies = [
+    inflection
+    requests
+    urllib3
+    six
+    certifi
+    pyopenssl
+    tldextract
+    python-dateutil
+    distutils
+  ];
+
+  meta = {
+    description = "KiCost plugin for the Digikey PartSearch API V3 ";
+    homepage = "https://github.com/set-soft/kicost-digikey-api-v3";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kiranshila ];
+  };
+}

--- a/pkgs/development/python-modules/kicost-digikey-api-v4/default.nix
+++ b/pkgs/development/python-modules/kicost-digikey-api-v4/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  inflection,
+  setuptools,
+  requests,
+  urllib3,
+  six,
+  certifi,
+  pyopenssl,
+  tldextract,
+  python-dateutil,
+  distutils,
+}:
+buildPythonPackage rec {
+  pname = "kicost-digikey-api-v4";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "set-soft";
+    repo = "kicost-digikey-api-v4";
+    tag = "v${version}";
+    hash = "sha256-0IpimgrxguI8Y7mwrHpG42bvbWPR/dukFRicbz3Olow=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "kicost_digikey_api_v4" ];
+
+  dependencies = [
+    inflection
+    requests
+    urllib3
+    six
+    certifi
+    pyopenssl
+    tldextract
+    python-dateutil
+    distutils
+  ];
+
+  meta = {
+    description = "KiCost plugin for the Digikey PartSearch API V4 ";
+    homepage = "https://github.com/set-soft/kicost-digikey-api-v4";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kiranshila ];
+  };
+}

--- a/pkgs/development/python-modules/kicost/default.nix
+++ b/pkgs/development/python-modules/kicost/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  beautifulsoup4,
+  lxml,
+  xlsxwriter,
+  tqdm,
+  requests,
+  validators,
+  wxpython,
+  colorama,
+  pyyaml,
+  setuptools,
+  kicost-digikey-api-v4,
+  kicost-digikey-api-v3,
+  distutils,
+  xlsx2csv,
+  unzip,
+}:
+buildPythonPackage rec {
+  pname = "kicost";
+  version = "1.1.20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hildogjr";
+    repo = "kicost";
+    tag = "v${version}";
+    hash = "sha256-2cJIiF8rZ0mHCO4aCTLTTazLBfGAlcj9u8HvRs5robs=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "kicost" ];
+
+  dependencies = [
+    beautifulsoup4
+    lxml
+    xlsxwriter
+    tqdm
+    requests
+    validators
+    wxpython
+    colorama
+    pyyaml
+    kicost-digikey-api-v4
+    kicost-digikey-api-v3
+    distutils
+  ];
+
+  meta = {
+    description = "Build cost spreadsheets for a KiCAD project";
+    homepage = "https://hildogjr.github.io/KiCost/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiranshila ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14897,6 +14897,8 @@ with pkgs;
 
   kicadAddons = recurseIntoAttrs (callPackage ../applications/science/electronics/kicad/addons { });
 
+  kicost = with python3Packages; toPythonApplication kicost;
+
   librepcb = qt6Packages.callPackage ../applications/science/electronics/librepcb { };
 
   ngspice = libngspice.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7759,6 +7759,8 @@ self: super: with self; {
 
   kicadcliwrapper = callPackage ../development/python-modules/kicadcliwrapper { };
 
+  kicost-digikey-api-v3 = callPackage ../development/python-modules/kicost-digikey-api-v3 { };
+
   kinparse = callPackage ../development/python-modules/kinparse { };
 
   kiss-headers = callPackage ../development/python-modules/kiss-headers { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7759,6 +7759,8 @@ self: super: with self; {
 
   kicadcliwrapper = callPackage ../development/python-modules/kicadcliwrapper { };
 
+  kicost = callPackage ../development/python-modules/kicost { };
+
   kicost-digikey-api-v3 = callPackage ../development/python-modules/kicost-digikey-api-v3 { };
 
   kicost-digikey-api-v4 = callPackage ../development/python-modules/kicost-digikey-api-v4 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7761,6 +7761,8 @@ self: super: with self; {
 
   kicost-digikey-api-v3 = callPackage ../development/python-modules/kicost-digikey-api-v3 { };
 
+  kicost-digikey-api-v4 = callPackage ../development/python-modules/kicost-digikey-api-v4 { };
+
   kinparse = callPackage ../development/python-modules/kinparse { };
 
   kiss-headers = callPackage ../development/python-modules/kiss-headers { };


### PR DESCRIPTION
Adds the python program kicost and associated API libraries used for automatic generation of KiCAD costing spreadsheets.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
