### PR TITLE
tests.stdenv: use system from stdenv.{build,host}Platform

### DIFF
--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -279,7 +279,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           dep2 = derivation {
             name = "dep2";
@@ -288,7 +288,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           passAsFile = [ "dep2" ];
         })
@@ -319,7 +319,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           dep2 = derivation {
             name = "dep2";
@@ -328,7 +328,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           name = "meow";
           outputHash = "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
@@ -386,7 +386,7 @@ in
   ensure-no-execve-in-setup-sh =
     derivation {
       name = "ensure-no-execve-in-setup-sh";
-      system = stdenv.system;
+      inherit (stdenv.hostPlatform) system;
       builder = "${stdenv.bootstrapTools}/bin/bash";
       PATH = "${pkgs.strace}/bin:${stdenv.bootstrapTools}/bin";
       initialPath = [


### PR DESCRIPTION
Removes use of `builtins.currentSystem` and `stdenv.system` in favor of `stdenv.buildPlatform.system` and `stdenv.hostPlatform.system`, respectively. This allows pure evaluation.

Command:

```console
nix eval --json .#legacyPackages.x86_64-linux.tests.stdenv --apply 'tests: builtins.removeAttrs tests ["override" "overrideDerivation"]'
```

Before:

```console
error (ignored): attribute 'currentSystem' missing
error:
       … while evaluating attribute 'test-inputDerivation'
         at /Users/connorbaker/Packages/nixpkgs/pkgs/test/stdenv/default.nix:271:3:
          270|
          271|   test-inputDerivation =
             |   ^
          272|     let

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'currentSystem' missing
       at /Users/connorbaker/Packages/nixpkgs/pkgs/test/stdenv/default.nix:282:22:
          281|             ];
          282|             system = builtins.currentSystem;
             |                      ^
          283|           };
```

After:

```json
{
  "ensure-no-execve-in-setup-sh": "/nix/store/67ln49wq8a571fczfcnpcqkw12il4bhg-ensure-no-execve-in-setup-sh",
  "hooks": {
    "compress-man-pages": "/nix/store/7qrapb17zsvzwigk82yzrd05bhvvb7jg-test-compress-man-pages",
    "make-symlinks-relative": "/nix/store/1sidm3vppi7r8iswgr0206dwg3v00rjf-test-make-symlinks-relative",
    "move-docs": "/nix/store/i60la2h30nqnny0yfg7k9m2551qvd5z3-test-move-docs",
    "move-lib64": "/nix/store/az9l66yi7dk5x6y6lhsgh4kg68z0qmx8-test-move-lib64",
    "move-sbin": "/nix/store/2xl7gnf26phjn9wcpyj75y70iagf5fgd-test-move-sbin",
    "no-broken-symlinks": {
      "fail-broken-symlinks-absolute": "/nix/store/5s9xjraw0qlm2p6q7hjfq766mkacy9an-fail-broken-symlinks-absolute",
      "fail-broken-symlinks-relative": "/nix/store/fcr11qq65xhwwhnhcvz5i740wrgknr8b-fail-broken-symlinks-relative",
      "fail-dangling-symlink-absolute": "/nix/store/dyyamhj7p61j0n8h1y6gadcda3fr6dai-fail-dangling-symlink-absolute",
      "fail-dangling-symlink-relative": "/nix/store/gxh5wjn6kwh7qaj6m5syql7k4lcwg5x7-fail-dangling-symlink-relative",
      "fail-reflexive-symlink-absolute": "/nix/store/cdpmgchbw53bnpxkzkhqsnnsy5rgb7xa-fail-reflexive-symlink-absolute",
      "fail-reflexive-symlink-relative": "/nix/store/mar3h8p271g43zn28wyknxpcy64syp2l-fail-reflexive-symlink-relative",
      "pass-all-broken-symlinks-absolute-allowed": "/nix/store/0gc2hf61jllnzdvr07bqk074xsdwxnix-pass-all-broken-symlinks-absolute-allowed",
      "pass-all-broken-symlinks-relative-allowed": "/nix/store/7ryxbhb15mjxn6shgrxn2xy9iyiv7fvs-pass-all-broken-symlinks-relative-allowed",
      "pass-broken-symlinks-absolute-allowed": "/nix/store/9mgyzl9lkxsgl50cdylbghbwjqk5xv47-pass-broken-symlinks-absolute-allowed",
      "pass-broken-symlinks-relative-allowed": "/nix/store/3axxipcwcj16m2spgx9bas20iqj3pzgf-pass-broken-symlinks-relative-allowed",
      "pass-dangling-symlink-absolute-allowed": "/nix/store/37blgsi7w5ijks39qzgmiw3xrrz7kvd3-pass-dangling-symlink-absolute-allowed",
      "pass-dangling-symlink-relative-allowed": "/nix/store/0q7wfq2lml8fw1790yb8skpk3lhbryww-pass-dangling-symlink-relative-allowed",
      "pass-reflexive-symlink-absolute-allowed": "/nix/store/dy6g550bl3sg54j60rh9c9v1gbg64ps8-pass-reflexive-symlink-absolute-allowed",
      "pass-reflexive-symlink-relative-allowed": "/nix/store/kw2cq6rk4q494hvcq0zvpmbcylkzq7mz-pass-reflexive-symlink-relative-allowed",
      "pass-unreadable-symlink-absolute-allowed": "/nix/store/fbrva55nzbavv2ghb3j5rvnfcmz7j6cg-pass-unreadable-symlink-absolute-allowed",
      "pass-unreadable-symlink-relative-allowed": "/nix/store/ybzfifmzwcgk9jf0mnsazc2ns6sva20r-pass-unreadable-symlink-relative-allowed",
      "pass-valid-symlink-absolute": "/nix/store/znwhx4cam3b7kvh9hgskxr8k2fvqg7xw-pass-valid-symlink-absolute",
      "pass-valid-symlink-outside-nix-store-absolute": "/nix/store/jwbr5qwgqzkd7ivl44x4aqmjz0jmj5nz-pass-valid-symlink-outside-nix-store-absolute",
      "pass-valid-symlink-outside-nix-store-relative": "/nix/store/8l6pkf8lyqm3x9cgakfjr59n3af5gkj7-pass-valid-symlink-outside-nix-store-relative",
      "pass-valid-symlink-relative": "/nix/store/dq0m0ks7yaj5pm97niksp8apn1nlk6jd-pass-valid-symlink-relative",
      "recurseForDerivations": true
    },
    "patch-shebangs": "/nix/store/fvk5ppkvmnji8b16zn3vvniy0pxb2m63-test-patch-shebangs",
    "prune-libtool-files": "/nix/store/d02l09zv0w3zm6rsngkfggvgrv51p12y-test-prune-libtool-files",
    "recurseForDerivations": true,
    "reproducible-builds": "/nix/store/mh2h8yhk5l6nxqmkwpgw02rbb9291k4p-test-reproducible-builds",
    "set-source-date-epoch-to-latest": "/nix/store/g8ri3k1h1g8s9747fk5575ghq2w6ll2f-test-set-source-date-epoch-to-latest"
  },
  "outputs-no-out": "/nix/store/hz9zlikgvn017771fzd8vg8i1nsc27n3-outputs-no-out-assert",
  "recurseForDerivations": true,
  "rejectedHashes": {
    "md5": {},
    "recurseForDerivations": true
  },
  "structuredAttrsByDefault": {
    "hooks": {
      "compress-man-pages": "/nix/store/zv1n0iyrjm1drvajfbkh8f4xdizw3bwy-test-compress-man-pages",
      "make-symlinks-relative": "/nix/store/1dn6n4nm57x01h1k0p5qfrz04d9cz6zz-test-make-symlinks-relative",
      "move-docs": "/nix/store/dvinq4iv8261inr8g0wmss42vqwkdj39-test-move-docs",
      "move-lib64": "/nix/store/y1q069mym8wkq11skxi5wy66w3h60j8a-test-move-lib64",
      "move-sbin": "/nix/store/pfkdsya14jisks5v988mlc1a81yrxlf7-test-move-sbin",
      "no-broken-symlinks": {
        "fail-broken-symlinks-absolute": "/nix/store/ai4axsl1i7kiygka94xjw8pwyin659np-fail-broken-symlinks-absolute",
        "fail-broken-symlinks-relative": "/nix/store/w0jgfvd7r079y0y5b19w9fwfri08j6xv-fail-broken-symlinks-relative",
        "fail-dangling-symlink-absolute": "/nix/store/4qmiqnlbzx93bv05pyczz85mdri5y4d8-fail-dangling-symlink-absolute",
        "fail-dangling-symlink-relative": "/nix/store/p0f9gpcpvqhn27win55sfv60dl6qfpqd-fail-dangling-symlink-relative",
        "fail-reflexive-symlink-absolute": "/nix/store/l9np46wb2dd9cbq0g25dy9cwzjsfipf8-fail-reflexive-symlink-absolute",
        "fail-reflexive-symlink-relative": "/nix/store/16wcn5dinc5j7g0l2m5vba368csznwsz-fail-reflexive-symlink-relative",
        "pass-all-broken-symlinks-absolute-allowed": "/nix/store/n69glphhsnmw87p46r19rfvmvba138h7-pass-all-broken-symlinks-absolute-allowed",
        "pass-all-broken-symlinks-relative-allowed": "/nix/store/jnm9khscbpxsx7dj1syj5352k3628f1p-pass-all-broken-symlinks-relative-allowed",
        "pass-broken-symlinks-absolute-allowed": "/nix/store/5k80mp50ya1cbr34w72c1hhix7smnip5-pass-broken-symlinks-absolute-allowed",
        "pass-broken-symlinks-relative-allowed": "/nix/store/9i316zwhbmslk14f30vpb9kjvyldkiaf-pass-broken-symlinks-relative-allowed",
        "pass-dangling-symlink-absolute-allowed": "/nix/store/c0dkrh0x6ymriwiqsn4g59q71zjhlixp-pass-dangling-symlink-absolute-allowed",
        "pass-dangling-symlink-relative-allowed": "/nix/store/rqhcq7ia0aaiypbppwd7nlyp09ylnhml-pass-dangling-symlink-relative-allowed",
        "pass-reflexive-symlink-absolute-allowed": "/nix/store/1yvh6zg8mw4mk8va5i2ll6rlcvprj62i-pass-reflexive-symlink-absolute-allowed",
        "pass-reflexive-symlink-relative-allowed": "/nix/store/g8lx7ciwlhv4f88lvn4144qygp6szf61-pass-reflexive-symlink-relative-allowed",
        "pass-unreadable-symlink-absolute-allowed": "/nix/store/q1wfqf54j4c9h5nddqmcsk06xzf5kfrr-pass-unreadable-symlink-absolute-allowed",
        "pass-unreadable-symlink-relative-allowed": "/nix/store/q1bs1xpnqymqrjqdcanlcazzdr20hjcl-pass-unreadable-symlink-relative-allowed",
        "pass-valid-symlink-absolute": "/nix/store/v0z9z0bgl9z02wzsvpci114byai8y85q-pass-valid-symlink-absolute",
        "pass-valid-symlink-outside-nix-store-absolute": "/nix/store/4z3rjdgwzsai8d8zg85hnq8jha1a66m1-pass-valid-symlink-outside-nix-store-absolute",
        "pass-valid-symlink-outside-nix-store-relative": "/nix/store/djba3lb1bl52rls1y7ml31gyf2v0aiy5-pass-valid-symlink-outside-nix-store-relative",
        "pass-valid-symlink-relative": "/nix/store/z1cwsv2llq41h4i7mjyaakb5mgr36ddx-pass-valid-symlink-relative",
        "recurseForDerivations": true
      },
      "patch-shebangs": "/nix/store/mbxrxncyhh8dnvfq7r5cylk7kqy092kb-test-patch-shebangs",
      "prune-libtool-files": "/nix/store/ilz29q3l5j0r8aa0pc2jilyqldqcrrv2-test-prune-libtool-files",
      "recurseForDerivations": true,
      "reproducible-builds": "/nix/store/m93p1681lqq64c24alp8n3c3ini3nxwa-test-reproducible-builds",
      "set-source-date-epoch-to-latest": "/nix/store/zcp89bdya4d61xqrc855sp6aihk1jl9w-test-set-source-date-epoch-to-latest"
    },
    "recurseForDerivations": true,
    "test-cc-wrapper-substitutions": "/nix/store/dka1if0ia85vnifikgb6lh05y9b9x32b-test-cc-wrapper-substitutions-structuredAttrsByDefault",
    "test-concat-strings-sep": "/nix/store/a56fs96x26ax1dp3wcrgryw26dbbpxsq-test-concat-strings-sep-structuredAttrsByDefault",
    "test-concat-to": "/nix/store/6m4xk71vxfdak1rysnjs7kvyv7fj6xym-test-concat-to-structuredAttrsByDefault",
    "test-golden-example-structuredAttrs": "/nix/store/pawnaw5cawfswsx52jyf7mqy7v9ww6sm-test-golden-example-structuredAttrsByDefault",
    "test-prepend-append-to-var": "/nix/store/nyvpwbqi2p82kdwy84v6a03lhzdvc215-test-prepend-append-to-var-structuredAttrsByDefault",
    "test-structured-env-attrset": "/nix/store/5480di6capiwxpzhn9kry8dyy8z7jcyl-test-structured-env-attrset-structuredAttrsByDefault"
  },
  "test-cc-wrapper-substitutions": "/nix/store/m50l3ahh0si6a0614czd4f6bbysxcvzh-test-cc-wrapper-substitutions",
  "test-concat-strings-sep": "/nix/store/hpxvlqmj8nrw4nif6a9xlyis41cid4zn-test-concat-strings-sep",
  "test-concat-to": "/nix/store/x14hm2dpb50i40sprm1qqn5ryk32k7k0-test-concat-to",
  "test-env-attrset": "/nix/store/nfypd8lx6dfpiqnhg9gvzgmvlrjbs8d4-test-env-attrset",
  "test-inputDerivation": "/nix/store/cc7bbgv2hdhka0l1p04gwlgh87pqa2nr-test-inputDerivation",
  "test-inputDerivation-fixed-output": "/nix/store/cwrw3s12dayygpk1jph1310m7c7a8j7b-test-inputDerivation",
  "test-prepend-append-to-var": "/nix/store/0di2cqznh0gsca2kjj55v8krksndd3pd-test-prepend-append-to-var",
  "test-structured-env-attrset": "/nix/store/1v9wjyk4k9r0pyczw0c73779y76bi45y-test-structured-env-attrset"
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
