### PR TITLE
arduino-language-server: fix arduino-cli and clangd dependencies

### DIFF
--- a/pkgs/by-name/ar/arduino-language-server/package.nix
+++ b/pkgs/by-name/ar/arduino-language-server/package.nix
@@ -3,6 +3,9 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  makeWrapper,
+  arduino-cli,
+  clang-tools,
 }:
 
 buildGoModule rec {
@@ -15,6 +18,8 @@ buildGoModule rec {
     tag = version;
     hash = "sha256-twTbJ5SFbL4AIX+ffB0LdOYXUxh4SzmZguJSRdEo1lQ=";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
 
   subPackages = [ "." ];
 
@@ -31,6 +36,15 @@ buildGoModule rec {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "-extldflags '-static'"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/arduino-language-server --prefix PATH : ${
+      lib.makeBinPath [
+        arduino-cli
+        clang-tools
+      ]
+    }
+  '';
 
   meta = {
     description = "Arduino Language Server based on Clangd to Arduino code autocompletion";


### PR DESCRIPTION
`arduino-language-server` depends on `arduino-cli` and `clangd`, hence this PR adds these tools to its environment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
