### PR TITLE
etlegacy: remove symlinks

### DIFF
--- a/pkgs/by-name/et/etlegacy/package.nix
+++ b/pkgs/by-name/et/etlegacy/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   symlinkJoin,
   etlegacy-assets,
   etlegacy-unwrapped,
@@ -9,6 +10,7 @@
 symlinkJoin {
   name = "etlegacy";
   version = "2.83.2";
+
   paths = [
     etlegacy-assets
     etlegacy-unwrapped
@@ -23,8 +25,6 @@ symlinkJoin {
       --add-flags "+set fs_basepath ${placeholder "out"}/lib/etlegacy"
     wrapProgram $out/bin/etlded.* \
       --add-flags "+set fs_basepath ${placeholder "out"}/lib/etlegacy"
-    makeWrapper $out/bin/etl.* $out/bin/etl
-    makeWrapper $out/bin/etlded.* $out/bin/etlded
   '';
 
   meta = {
@@ -39,7 +39,7 @@ symlinkJoin {
       for the popular online FPS game Wolfenstein: Enemy Territory - whose
       gameplay is still considered unmatched by many, despite its great age.
     '';
-    mainProgram = "etl";
+    mainProgram = "etl." + (if stdenv.hostPlatform.isi686 then "i386" else "x86_64");
     maintainers = with lib.maintainers; [
       ashleyghooper
     ];


### PR DESCRIPTION
This will facilitate the installation of both 32 and 64bits version of the game by avoiding file collisions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
