### PR TITLE
llvmPackages.compiler-rt: clean up libxcrypt fix

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -15,7 +15,6 @@
   libcxx,
   linuxHeaders,
   freebsd,
-  libxcrypt,
 
   # Some platforms have switched to using compiler-rt, but still want a
   # libgcc.a for ABI compat purposes. The use case would be old code that
@@ -122,9 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "COMPILER_RT_DEFAULT_TARGET_ONLY" true)
     (lib.cmakeFeature "CMAKE_C_COMPILER_TARGET" stdenv.hostPlatform.config)
     (lib.cmakeFeature "CMAKE_ASM_COMPILER_TARGET" stdenv.hostPlatform.config)
-  ]
-  ++ lib.optionals (haveLibc && stdenv.hostPlatform.libc == "glibc") [
-    (lib.cmakeFeature "SANITIZER_COMMON_CFLAGS" "-I${libxcrypt}/include")
   ]
   ++ lib.optionals (useLLVM && haveLibc && stdenv.cc.libcxx == libcxx) [
     (lib.cmakeFeature "SANITIZER_CXX_ABI" "libcxxabi")

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -425,11 +425,6 @@ let
           {
             inherit stdenv;
           }
-          // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
-            libxcrypt = (libxcrypt.override { inherit stdenv; }).overrideAttrs (old: {
-              configureFlags = old.configureFlags ++ [ "--disable-symvers" ];
-            });
-          }
         );
 
         compiler-rt-no-libc = callPackage ./compiler-rt {


### PR DESCRIPTION
This is unnecessary since LLVM commit d7bead833631 ("[sanitizer] Remove crypt and crypt_r interceptors"), included in LLVM 18, the oldest version we still have in Nixpkgs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
