### PR TITLE
immich: 1.143.1 -> 1.144.1

### DIFF
--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.92";
+  version = "2.2.94";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -34,7 +34,7 @@
 }:
 let
   pnpm = pnpm_10;
-  version = "1.143.1";
+  version = "1.144.1";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,14 +108,14 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-lP/IrKV2B1Gq43jqVa1hIpx4HOJoiYBDUOvyTJB0t7k=";
+    hash = "sha256-lSe50nbVWNWej137JgfJawIOPhtMVoolHahfrd1ENJc=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     pname = "immich";
     inherit version src;
     fetcherVersion = 2;
-    hash = "sha256-ShKgfsYc9n+B+NnSaJOSyLb4ev43ZsympYhRgPZtlxs=";
+    hash = "sha256-+CwwTqjI+xOGCAb66lZplNMBwR2xJZBs6E0OyGHbSAE=";
   };
 
   web = stdenv.mkDerivation {


### PR DESCRIPTION
Updated unstable immich 1.143.1 to 1.144.1

https://github.com/immich-app/immich/releases

Changelog of Immich:
What's Changed
🚀 Features
feat: show motion photo icon on mobile timeline tile by @bwees in https://github.com/immich-app/immich/pull/22454
🐛 Bug fixes
fix(server): update libmimalloc path by @mertalev in https://github.com/immich-app/immich/pull/22345
fix: ios export sqlite db by @shenlong-tanwen in https://github.com/immich-app/immich/pull/22369
fix: map attribution and other styling by @bwees in https://github.com/immich-app/immich/pull/22303
fix: delete temp file on iOS after upload by @shenlong-tanwen in https://github.com/immich-app/immich/pull/22364
fix(mobile): load local thumbnails in album timeline by @mertalev in https://github.com/immich-app/immich/pull/22329
fix(mobile): scrubbing mode on scroll to date event by @mertalev in https://github.com/immich-app/immich/pull/22390
fix: local assets should not be added to album by @bwees in https://github.com/immich-app/immich/pull/22304
feat(mobile): add unstack button by @shenlong-tanwen in https://github.com/immich-app/immich/pull/21869
fix: prefer remote images in new timeline by @shenlong-tanwen in https://github.com/immich-app/immich/pull/22452
fix: merged timeline orderby localtime by @shenlong-tanwen in https://github.com/immich-app/immich/pull/22371
fix: process upload only after successful remote sync by @shenlong-tanwen in https://github.com/immich-app/immich/pull/22360
📚 Documentation
feat: docs.immich.app by @zackpollard in https://github.com/immich-app/immich/pull/21819
🌐 Translations
chore(web): update translations by @weblate in https://github.com/immich-app/immich/pull/22343
Full Changelog: https://github.com/immich-app/immich/compare/v1.143.1...v1.144.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
