### PR TITLE
glide-browser: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23112,6 +23112,12 @@
     githubId = 31457698;
     name = "Nathanael Robbins";
   };
+  RobertCraigie = {
+    email = "robert@craigie.dev";
+    github = "RobertCraigie";
+    githubId = 23125036;
+    name = "Robert Craigie";
+  };
   roberth = {
     email = "nixpkgs@roberthensing.nl";
     matrix = "@roberthensing:matrix.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23609,6 +23609,12 @@
     githubId = 31457698;
     name = "Nathanael Robbins";
   };
+  RobertCraigie = {
+    email = "robert@craigie.dev";
+    github = "RobertCraigie";
+    githubId = 23125036;
+    name = "Robert Craigie";
+  };
   roberth = {
     email = "nixpkgs@roberthensing.nl";
     matrix = "@roberthensing:matrix.org";

--- a/pkgs/by-name/gl/glide-browser/package.nix
+++ b/pkgs/by-name/gl/glide-browser/package.nix
@@ -1,0 +1,144 @@
+{
+  buildMozillaMach,
+  fetchFromGitHub,
+  lib,
+  fetchurl,
+  git,
+  nodejs,
+  pkg-config,
+  fetchPnpmDeps,
+  pnpm,
+  pnpmConfigHook,
+  python3,
+  stdenv,
+}:
+
+let
+  glideVersion = "0.1.60a";
+  glideRevision = "259da96f5a93";
+  firefoxVersion = "149.0b8";
+
+  firefoxSrc = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.xz";
+    hash = "sha512-kQNOnnx+d9ktBOC9ouThc1sJ3suOeC1K0d5H/j7Yp0rQdRSGTp93eidGsPqB7VbGDAP0majemRCgBhtZEVbZIg==";
+  };
+
+  patchedSrc = stdenv.mkDerivation (finalAttrs: {
+    pname = "firefox-glide-browser-src-patched";
+    version = glideVersion;
+    GLIDE_REVISION = glideRevision;
+
+    src = fetchFromGitHub {
+      owner = "glide-browser";
+      repo = "glide";
+      tag = glideVersion;
+      hash = "sha256-dA1AuioaVligJNSmYSi8KjKYPK5qkRjMvbp2HztPepA=";
+    };
+
+    postUnpack = ''
+      mkdir -p source/engine
+      # note: the firefox tar unpacks to firefox-$version/
+      tar xf ${firefoxSrc} --strip-components=1 -C source/engine
+    '';
+
+    nativeBuildInputs = [
+      git
+      nodejs
+      python3
+      pkg-config
+      pnpm
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      fetcherVersion = 3;
+      hash = "sha256-l4B4t0B6ALDpfzqrQ6WP7GiqmJf7JocBS7QUG6W0BJw=";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+
+      # replace dprint with a no-op script as it's just used for formatting a
+      # generated .d.ts file, which is not worth adding it as a dependency for
+      rm node_modules/.bin/dprint
+      echo '#!/bin/sh' > node_modules/.bin/dprint
+      chmod +x node_modules/.bin/dprint
+
+      patchShebangs scripts/
+
+      pnpm bootstrap --offline
+      # bootstrap includes a default mozconfig but that can mess with options that `buildMozillaMach` sets, so just remove it.
+      rm engine/mozconfig
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r engine $out
+
+      cd $out
+      for i in $(find . -type l); do
+        realpath=$(readlink $i)
+        rm $i
+        cp $realpath $i
+      done
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+  });
+in
+(
+  (buildMozillaMach {
+    pname = "glide-browser";
+    version = firefoxVersion;
+    packageVersion = glideVersion;
+    applicationName = "Glide";
+    binaryName = "glide";
+    branding = "browser/branding/glide";
+
+    requireSigning = false;
+    allowAddonSideload = true;
+
+    src = patchedSrc;
+
+    extraConfigureFlags = [
+      "--disable-lto"
+      "--with-app-basename=Glide"
+    ];
+
+    meta = {
+      description = "Extensible and keyboard-focused web browser built on Firefox";
+      homepage = "https://glide-browser.app/";
+      downloadPage = "https://glide-browser.app/#download";
+      changelog = "https://glide-browser.app/changelog#${glideVersion}";
+      license = lib.licenses.mpl20;
+      maintainers = with lib.maintainers; [
+        RobertCraigie
+        pyrox0
+      ];
+      platforms = lib.platforms.unix;
+      mainProgram = "glide";
+    };
+  }).override
+  {
+    pgoSupport = false;
+    crashreporterSupport = false;
+    enableOfficialBranding = false;
+  }
+).overrideAttrs
+  (
+    prev:
+    {
+      GLIDE_FIREFOX_VERSION = firefoxVersion;
+      MOZ_USER_DIR = "Glide Browser";
+    }
+    // lib.optionalAttrs stdenv.isDarwin {
+      # note: might be redundant
+      MOZ_MACBUNDLE_NAME = "Glide.app";
+    }
+  )

--- a/pkgs/by-name/gl/glide-browser/package.nix
+++ b/pkgs/by-name/gl/glide-browser/package.nix
@@ -1,0 +1,156 @@
+{
+  buildMozillaMach,
+  fetchFromGitHub,
+  lib,
+  fetchurl,
+  git,
+  nodejs,
+  pkg-config,
+  fetchPnpmDeps,
+  pnpm,
+  pnpmConfigHook,
+  python3,
+  stdenv,
+}:
+
+let
+  glideVersion = "0.1.62a";
+  glideRevision = "e89e9a621993";
+  firefoxVersion = "152.0b2";
+
+  firefoxSrc = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.xz";
+    hash = "sha512-DoHR3+TI+nSCZpo+EEV16qzzxnHWelGNoSrJCZiQiK8etxaAFQQsSWfAQsHVpxXtVbjgxUmcPAU/5MQ6O0Z16A==";
+  };
+
+  patchedSrc = stdenv.mkDerivation (finalAttrs: {
+    pname = "firefox-glide-browser-src-patched";
+    version = glideVersion;
+    GLIDE_REVISION = glideRevision;
+
+    src = fetchFromGitHub {
+      owner = "glide-browser";
+      repo = "glide";
+      tag = glideVersion;
+      hash = "sha256-g5QzxF6v7NzwqfZC0oOkebjQjsvwTGgaitXQjK1Yqs4=";
+    };
+
+    postUnpack = ''
+      mkdir -p source/engine
+      # note: the firefox tar unpacks to firefox-$version/
+      tar xf ${firefoxSrc} --strip-components=1 -C source/engine
+    '';
+
+    nativeBuildInputs = [
+      git
+      nodejs
+      python3
+      pkg-config
+      pnpm
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      fetcherVersion = 3;
+      hash = "sha256-P1ROOZC4F00WqAfkN2hcvcHfJ2l+2rfWVUdJOQ9+wIg=";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+
+      # replace dprint with a no-op script as it's just used for formatting a
+      # generated .d.ts file, which is not worth adding it as a dependency for
+      rm node_modules/.bin/dprint
+      echo '#!/bin/sh' > node_modules/.bin/dprint
+      chmod +x node_modules/.bin/dprint
+
+      patchShebangs scripts/
+
+      pnpm bootstrap --offline
+      # bootstrap includes a default mozconfig but that can mess with options that `buildMozillaMach` sets, so just remove it.
+      rm engine/mozconfig
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r engine $out
+
+      cd $out
+      for i in $(find . -type l); do
+        realpath=$(readlink $i)
+        rm $i
+        cp $realpath $i
+      done
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+  });
+in
+(
+  (buildMozillaMach {
+    pname = "glide-browser";
+    version = firefoxVersion;
+    packageVersion = glideVersion;
+    applicationName = "Glide";
+    binaryName = "glide";
+    branding = "browser/branding/glide";
+
+    requireSigning = false;
+    allowAddonSideload = true;
+
+    src = patchedSrc;
+
+    extraConfigureFlags = [
+      "--disable-lto"
+      "--with-app-basename=Glide"
+    ];
+
+    meta = {
+      description = "Extensible and keyboard-focused web browser built on Firefox";
+      homepage = "https://glide-browser.app/";
+      downloadPage = "https://glide-browser.app/#download";
+      changelog = "https://glide-browser.app/changelog#${glideVersion}";
+      license = lib.licenses.mpl20;
+      maintainers = with lib.maintainers; [
+        RobertCraigie
+        pyrox0
+      ];
+      platforms = lib.platforms.unix;
+      mainProgram = "glide";
+    };
+  }).override
+  {
+    pgoSupport = false;
+    crashreporterSupport = false;
+    enableOfficialBranding = false;
+  }
+).overrideAttrs
+  (
+    prev:
+    {
+      strictDeps = true;
+      __structuredAttrs = true;
+
+      GLIDE_FIREFOX_VERSION = firefoxVersion;
+      MOZ_USER_DIR = "Glide Browser";
+
+      # these revert patches don't apply.
+      patches = lib.filter (
+        p:
+        !lib.elem (p.name or (builtins.baseNameOf p)) [
+          "73cbb9ff0fdbf8b13f38d078ce01ef6ec0794f9c.patch"
+          "c1cd0d56e047a40afb2a59a56e1fd8043e448e05.patch"
+        ]
+      ) prev.patches;
+    }
+    // lib.optionalAttrs stdenv.isDarwin {
+      # note: might be redundant
+      MOZ_MACBUNDLE_NAME = "Glide.app";
+    }
+  )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Glide Browser](https://glide-browser.app/), a firefox fork of which I'm the maintainer.

Glide is *very* new, I only publicly [announced](https://blog.craigie.dev/introducing-glide/) it today - but I have personally been using it for ~6 months. That said, I want to make it clear that I have no expectations of this getting merged quickly.

Glide is currently based of off the Firefox beta channel, because the frequent small bumps are easier to maintain.

I'm also quite new to Nix so please let me know if I did anything silly :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
