### PR TITLE
symengine: modernize; fix downstream build with cmake v4

### DIFF
--- a/pkgs/by-name/sy/symengine/package.nix
+++ b/pkgs/by-name/sy/symengine/package.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-WriVcYt3fkObR2U4J6a4KGGc2HgyyFyFpdrwxBD+AHA=";
   };
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [

--- a/pkgs/by-name/sy/symengine/package.nix
+++ b/pkgs/by-name/sy/symengine/package.nix
@@ -40,8 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_SHARED_LIBS" withShared)
   ];
 
-  # error: unrecognized instruction mnemonic, did you mean: bit, cnt, hint, ins, not?
-  doCheck = !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64);
+  doCheck = true;
 
   meta = {
     description = "Fast symbolic manipulation library";

--- a/pkgs/by-name/sy/symengine/package.nix
+++ b/pkgs/by-name/sy/symengine/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   gmp,
   flint,
@@ -24,6 +25,18 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+  ];
+
+  # upgrade supported cmake version in SymEngineConfig.cmake
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/symengine/symengine/commit/c149b874b8ff947e51e8e58670a0d37daf588f86.patch?full_index=1";
+      hash = "sha256-LqkJRPdsbE8OE8G6AkpWX9B+GqnOQjUNPHpKKIcCL3Q=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/symengine/symengine/commit/186f72e208220efd12362c336a49378076f63f30.patch?full_index=1";
+      hash = "sha256-CuQra9K3MTxm8M0bt3LooJz9HgW0/Jy6ydRBCvEgkO4=";
+    })
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/symengine/default.nix
+++ b/pkgs/development/python-modules/symengine/default.nix
@@ -3,19 +3,17 @@
   buildPythonPackage,
   fetchFromGitHub,
   cython,
+  setuptools,
   cmake,
   symengine,
   pytest,
   sympy,
   python,
-  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "symengine";
   version = "0.14.1";
-
-  build-system = [ setuptools ];
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -25,19 +23,24 @@ buildPythonPackage rec {
     hash = "sha256-adzODm7gAqwAf7qzfRQ1AG8mC3auiXM4OsV/0h+ZmUg=";
   };
 
-  env = {
-    SymEngine_DIR = "${symengine}";
-  };
-
   postPatch = ''
     substituteInPlace setup.py \
       --replace-fail "'cython>=0.29.24'" "'cython'"
   '';
 
+  build-system = [
+    cython
+    setuptools
+  ];
+
   dontUseCmakeConfigure = true;
+
   nativeBuildInputs = [
     cmake
-    cython
+  ];
+
+  buildInputs = [
+    symengine
   ];
 
   nativeCheckInputs = [
@@ -47,15 +50,17 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
+
     mkdir empty && cd empty
     ${python.interpreter} ../bin/test_python.py
+
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Python library providing wrappers to SymEngine";
     homepage = "https://github.com/symengine/symengine.py";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
SymEngineConfig.cmake declare cmake_minimum_required(VERSION 2.8.12).
This block downstream build with Cmake v4 .e.g python3Packages.symengine.
We apply patches from upstream to upgrade it's supported cmake version range.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
