### PR TITLE
renovate: 41.81.0 -> 41.132.4, fix nixos test

### DIFF
--- a/nixos/tests/renovate.nix
+++ b/nixos/tests/renovate.nix
@@ -12,7 +12,7 @@
       services.renovate = {
         enable = true;
         settings = {
-          platform = "gitea";
+          platform = "forgejo";
           endpoint = "http://localhost:3000";
           autodiscover = true;
           gitAuthor = "Renovate <renovate@example.com>";
@@ -34,24 +34,24 @@
     };
 
   testScript = ''
-    def gitea(command):
-      return machine.succeed(f"cd /var/lib/forgejo && sudo --user=forgejo GITEA_WORK_DIR=/var/lib/forgejo GITEA_CUSTOM=/var/lib/forgejo/custom gitea {command}")
+    def forgejo(command):
+      return machine.succeed(f"cd /var/lib/forgejo && sudo --user=forgejo FORGEJO_WORK_DIR=/var/lib/forgejo FORGEJO_CUSTOM=/var/lib/forgejo/custom forgejo {command}")
 
     machine.wait_for_unit("forgejo.service")
     machine.wait_for_open_port(3000)
 
     machine.systemctl("stop forgejo.service")
 
-    gitea("admin user create --username meow --email meow@example.com --password meow")
+    forgejo("admin user create --username meow --email meow@example.com --password meow")
 
     machine.systemctl("start forgejo.service")
     machine.wait_for_unit("forgejo.service")
     machine.wait_for_open_port(3000)
 
-    accessToken = gitea("admin user generate-access-token --raw --username meow --scopes all | tr -d '\n'")
+    accessToken = forgejo("admin user generate-access-token --raw --username meow --scopes all | tr -d '\n'")
 
     machine.succeed(f"tea login add --name default --user meow --token '{accessToken}' --password meow --url http://localhost:3000")
-    machine.succeed("tea repo create --name kitty --init")
+    machine.succeed("tea repo create --login default --name kitty --init")
     machine.succeed("git config --global user.name Meow")
     machine.succeed("git config --global user.email meow@example.com")
     machine.succeed(f"git clone http://meow:{accessToken}@localhost:3000/meow/kitty.git /tmp/kitty")
@@ -63,8 +63,8 @@
     machine.succeed(f"echo '{accessToken}' > /etc/renovate-token")
     machine.systemctl("start --wait renovate.service")
 
-    machine.succeed("tea pulls list --repo meow/kitty | grep 'Configure Renovate'")
-    machine.succeed("tea pulls merge --repo meow/kitty 1")
+    machine.succeed("tea pulls list --login default --repo meow/kitty | grep 'Configure Renovate'")
+    machine.succeed("tea pulls merge --login default --repo meow/kitty 1")
 
     machine.systemctl("start --wait renovate.service")
   '';

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "renovate";
-  version = "41.81.0";
+  version = "41.132.4";
 
   src = fetchFromGitHub {
     owner = "renovatebot";
     repo = "renovate";
     tag = finalAttrs.version;
-    hash = "sha256-iFcq8TbUXcEf0q/ifAC4dXJkG7pYvTM78FHPZucky8g=";
+    hash = "sha256-Sgs2WL/rZ4zLYWqw7wXTpHQz2j5NhDMUpzFNte+3h/E=";
   };
 
   postPatch = ''
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 2;
-    hash = "sha256-HQEN+gBvI9s5WEXrH/3WTMSCg0ERykeKit8z8BBUe6w=";
+    hash = "sha256-r2/BTBsBvks1M0oPn4mYjdUYkYRvZDmlZgSxUd7WbEM=";
   };
 
   env.COREPACK_ENABLE_STRICT = 0;


### PR DESCRIPTION
NixOS test needed fixing because the `gitea` executable in the forgejo package was renamed to `forgejo` and the `tea` commands were asking to select a login.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
