### PR TITLE
pmacct: add optional apache-kafka dependency

### DIFF
--- a/pkgs/by-name/pm/pmacct/package.nix
+++ b/pkgs/by-name/pm/pmacct/package.nix
@@ -8,6 +8,8 @@
   libpcap,
   libcdada,
   # Optional Dependencies
+  withKafka ? true,
+  rdkafka,
   withJansson ? true,
   jansson,
   withNflog ? true,
@@ -45,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     libcdada
     libpcap
   ]
+  ++ lib.optional withKafka rdkafka
   ++ lib.optional withJansson jansson
   ++ lib.optional withNflog libnetfilter_log
   ++ lib.optional withSQLite sqlite
@@ -61,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-pcap-includes=${libpcap}/include"
   ]
+  ++ lib.optional withKafka "--enable-kafka"
   ++ lib.optional withJansson "--enable-jansson"
   ++ lib.optional withNflog "--enable-nflog"
   ++ lib.optional withSQLite "--enable-sqlite3"


### PR DESCRIPTION
To get netflow data into apache-kafka pmacct needs rdkafka (https://github.com/pmacct/pmacct/blob/3a37aa67704983e54ebcf2fc5cbfe44805ec518e/QUICKSTART#L996) 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
