### PR TITLE
veloren: fix assets path search

### DIFF
--- a/pkgs/by-name/ve/veloren/fix-assets-path.patch
+++ b/pkgs/by-name/ve/veloren/fix-assets-path.patch
@@ -1,23 +1,19 @@
-commit 3048885aa749774b5677ab8df8f1a3eeff125d7a
+commit 0a258effd3492d7e4c11b4d175538c619699fbd6
 Author: rnhmjoj <rnhmjoj@inventati.org>
-Date:   Tue Aug 6 08:36:38 2024 +0200
+Date:   Wed Oct 1 09:43:45 2025 +0200
 
     Fix assets path on NixOS
 
 diff --git a/common/assets/src/lib.rs b/common/assets/src/lib.rs
-index 03746dc4..c69d607b 100644
+index 13102e8..898b23b 100644
 --- a/common/assets/src/lib.rs
 +++ b/common/assets/src/lib.rs
-@@ -400,6 +400,13 @@ lazy_static! {
+@@ -381,6 +381,9 @@ lazy_static! {
              }
          }
  
 +        // 5. NixOS path
-+        if let Some(executable) = std::env::args().nth(0).map(PathBuf::from) {
-+            if let Some(package) = executable.ancestors().nth(2) {
-+                paths.push(package.join("share/veloren"));
-+            }
-+        }
++        paths.push("@out@/share/veloren/".into());
 +
          tracing::trace!("Possible asset locations paths={:?}", paths);
  

--- a/pkgs/by-name/ve/veloren/package.nix
+++ b/pkgs/by-name/ve/veloren/package.nix
@@ -52,6 +52,8 @@ rustPlatform.buildRustPackage {
       println!("cargo:rustc-cfg=nightly");
     }
     EOF
+    # Fix assets path
+    substituteAllInPlace common/assets/src/lib.rs
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fix #446235

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
