### PR TITLE
python3Packages.imageio: fetch patch to fix failing tests

### DIFF
--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   isPyPy,
+  fetchpatch2,
 
   # build-system
   setuptools,
@@ -24,9 +25,10 @@
   tifffile,
 
   # tests
-  pytestCheckHook,
-  gitMinimal,
   fsspec,
+  gitMinimal,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -51,6 +53,19 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-/nxJxZrTYX7F2grafIWwx9SyfR47ZXyaUwPHMEOdKkI=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      # https://github.com/imageio/imageio/issues/1139
+      # https://github.com/imageio/imageio/pull/1144
+      name = "fix-pyav-13-1-compat";
+      url = "https://github.com/imageio/imageio/commit/eadfc5906f5c2c3731f56a582536dbc763c3a7a9.patch";
+      excludes = [
+        "setup.py"
+      ];
+      hash = "sha256-xBYdhK6XmJJuChqXOIdRVf8X6/GpWLG+21+cPVZ4bVg=";
+    })
+  ];
 
   postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     substituteInPlace tests/test_core.py \
@@ -90,15 +105,16 @@ buildPythonPackage rec {
     gitMinimal
     psutil
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ]
   ++ fsspec.optional-dependencies.github
   ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pytestFlags = [ "--test-images=file://${test_images}" ];
 
-  # These should have had `needs_internet` mark applied but don't so far.
-  # See https://github.com/imageio/imageio/pull/1142
   disabledTests = [
+    # These should have had `needs_internet` mark applied but don't so far.
+    # See https://github.com/imageio/imageio/pull/1142
     "test_read_stream"
     "test_uri_reading"
     "test_trim_filter"
@@ -111,7 +127,6 @@ buildPythonPackage rec {
 
   preCheck = ''
     export IMAGEIO_USERDIR=$(mktemp -d)
-    export HOME=$(mktemp -d)
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
_____________________________ test_write_float_fps _____________________________

test_images = PosixPath('/build/source/.test_images')

    def test_write_float_fps(test_images):
        fps = 3.5
        frames = iio.imread(test_images / "cockatoo.mp4", plugin="pyav")
>       buffer = iio.imwrite(
            "<bytes>", frames, extension=".mp4", codec="h264", plugin="pyav", fps=fps
        )

tests/test_pyav.py:540:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
imageio/v3.py:147: in imwrite
    encoded = img_file.write(image, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
imageio/plugins/pyav.py:679: in write
    self.write_frame(img, pixel_format=in_pixel_format)
imageio/plugins/pyav.py:964: in write_frame
    av_frame.time_base = stream.codec_context.time_base
    ^^^^^^^^^^^^^^^^^^
av/frame.py:144: in av.frame.Frame.time_base.__set__
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   AttributeError: 'NoneType' object has no attribute 'numerator'

av/utils.pyx:51: AttributeError
```

cc @Luflosi

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
