### PR TITLE
scotch: 7.0.9 -> 7.0.10, add musl to tests

### DIFF
--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -12,6 +12,7 @@
   mpi,
   withPtScotch ? false,
   testers,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -58,15 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     mpi
   ];
 
-  passthru = {
-    tests = {
-      cmake-config = testers.hasCmakeConfigModules {
-        moduleNames = [ "SCOTCH" ];
-        package = finalAttrs.finalPackage;
-      };
-    };
-  };
-
   # SCOTCH provide compatibility with Metis/Parmetis interface.
   # We install the metis compatible headers to subdirectory to
   # avoid conflict with metis/parmetis.
@@ -74,6 +66,17 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $dev/include/scotch
     mv $dev/include/{*metis,metisf}.h $dev/include/scotch
   '';
+
+  passthru = {
+    tests = {
+      cmake-config = testers.hasCmakeConfigModules {
+        moduleNames = [ "SCOTCH" ];
+        package = finalAttrs.finalPackage;
+      };
+    };
+
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering";

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -12,19 +12,20 @@
   mpi,
   withPtScotch ? false,
   testers,
+  pkgsMusl ? { }, # default to empty set to avoid CI fails with allowVariants = false
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scotch";
-  version = "7.0.9";
+  version = "7.0.10";
 
   src = fetchFromGitLab {
     domain = "gitlab.inria.fr";
     owner = "scotch";
     repo = "scotch";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-dbf18XdmDP0KgS4H4L7Wnam7kGF88yBcCvehYRRpHvA=";
+    hash = "sha256-qeMgTkoM/RDsZa0T6hmrDLbLuSeR8WNxllyHSlkMVzA=";
   };
 
   outputs = [
@@ -73,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
         moduleNames = [ "SCOTCH" ];
         package = finalAttrs.finalPackage;
       };
+      musl = pkgsMusl.scotch or null;
     };
 
     updateScript = nix-update-script { };


### PR DESCRIPTION
Release notes: https://gitlab.inria.fr/scotch/scotch/-/tags/v7.0.10

Fixes the musl build, so add that to passthru tests to spot later regressions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] x86_64-linux (musl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
