### PR TITLE
amd-blis: add patch to make output reproducible, cleanup

### DIFF
--- a/pkgs/by-name/am/amd-blis/build-date.patch
+++ b/pkgs/by-name/am/amd-blis/build-date.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index d96114619..119040151 100755
+--- a/configure
++++ b/configure
+@@ -1913,7 +1913,7 @@ set_default_version()
+ 	echo "${script_name}: determining default version string."
+
+ 	# Use what's in the version file as-is.
+-	version="AOCL-BLAS $(cat "${version_file}") Build $(date +%Y%m%d)"
++	version="AOCL-BLAS $(cat "${version_file}") Build $(date -d "@$SOURCE_DATE_EPOCH" +%Y%m%d)"
+ }
+
+

--- a/pkgs/by-name/am/amd-blis/package.nix
+++ b/pkgs/by-name/am/amd-blis/package.nix
@@ -33,6 +33,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-hqb/Q1CBqtC4AXqHNd7voewGUD675hJ9IwvP3Mn9b+M=";
   };
 
+  patches = [
+    # Set the date stamp to $SOURCE_DATE_EPOCH
+    ./build-date.patch
+  ];
+
   inherit blas64;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/am/amd-blis/package.nix
+++ b/pkgs/by-name/am/amd-blis/package.nix
@@ -10,7 +10,7 @@
 
   # Target architecture. "amdzen" compiles kernels for all Zen
   # generations. To build kernels for specific Zen generations,
-  # use "zen", "zen2", "zen3", or "zen4".
+  # use "zen", "zen2", "zen3", "zen4", or "zen5".
   withArchitecture ? "amdzen",
 
   # Enable OpenMP-based threading.
@@ -22,14 +22,14 @@ let
   blasIntSize = if blas64 then "64" else "32";
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amd-blis";
   version = "5.1";
 
   src = fetchFromGitHub {
     owner = "amd";
     repo = "blis";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-hqb/Q1CBqtC4AXqHNd7voewGUD675hJ9IwvP3Mn9b+M=";
   };
 
@@ -66,11 +66,11 @@ stdenv.mkDerivation rec {
     ln -s $out/lib/libcblas.so.3 $out/lib/libcblas.so
   '';
 
-  meta = with lib; {
+  meta = {
     description = "BLAS-compatible library optimized for AMD CPUs";
     homepage = "https://developer.amd.com/amd-aocl/blas-library/";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.markuskowa ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.markuskowa ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/447615

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
