### PR TITLE
home-assistant-custom-components.dreo: init at 1.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4987,6 +4987,12 @@
     githubId = 118829;
     name = "codec";
   };
+  CodedNil = {
+    github = "CodedNil";
+    githubId = 5075747;
+    email = "codenil@proton.me";
+    name = "Dan Lock";
+  };
   CodeLongAndProsper90 = {
     github = "CodeLongAndProsper90";
     githubId = 50145141;

--- a/pkgs/servers/home-assistant/custom-components/dreo/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/dreo/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  nix-update-script,
+  websockets,
+  # Test dependencies
+  pytestCheckHook,
+  pytest-homeassistant-custom-component,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "JeffSteinbok";
+  domain = "dreo";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "hass-dreo";
+    tag = "v${version}";
+    hash = "sha256-eAgqjAXNAY8kr7+49q+tikW3bDBJ0N0Rh5WJwzLYr8I=";
+  };
+
+  dependencies = [ websockets ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/JeffSteinbok/hass-dreo/releases/tag/${src.tag}";
+    description = "Dreo Smart Device Integration for Home Assistant";
+    homepage = "https://github.com/JeffSteinbok/hass-dreo";
+    maintainers = with lib.maintainers; [ CodedNil ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Adds home assistant custom component for Dreo fans. https://github.com/JeffSteinbok/hass-dreo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
