### PR TITLE
home-assistant-custom-components.pirate-weather: init at 1.8.3

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/pirate-weather/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/pirate-weather/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  nix-update-script,
+  # Test dependencies
+  pytestCheckHook,
+  pytest-homeassistant-custom-component,
+  pytest-asyncio,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "Pirate-Weather";
+  domain = "pirateweather";
+  version = "1.8.3";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "pirate-weather-ha";
+    tag = "v${version}";
+    hash = "sha256-0IEuMuzTj6puUXYr815ZOn5pqu11R+uhKKsSVtxMvHM=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-homeassistant-custom-component
+    pytest-asyncio
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/Pirate-Weather/pirate-weather-ha/releases/tag/${src.tag}";
+    description = "Replacement for the default Dark Sky Home Assistant integration using Pirate Weather";
+    homepage = "https://github.com/Pirate-Weather/pirate-weather-ha";
+    maintainers = with lib.maintainers; [ CodedNil ];
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
Adds the home assistant custom component pirate weather. https://github.com/Pirate-Weather/pirate-weather-ha

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
