### PR TITLE
home-assistant-custom-components.hildebrand_glow_ihd: init at 1.8.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/hildebrand_glow_ihd/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/hildebrand_glow_ihd/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "megakid";
+  domain = "hildebrand_glow_ihd";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "ha_hildebrand_glow_ihd_mqtt";
+    tag = "v${version}";
+    hash = "sha256-13NmNHaCYDZkWK5uqKeTZlB84UuThNLOAYaPS4QfTKY=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/megakid/ha_hildebrand_glow_ihd_mqtt/releases/tag/${src.tag}";
+    description = "Home Assistant integration for local MQTT Hildebrand Glow IHD";
+    homepage = "https://github.com/megakid/ha_hildebrand_glow_ihd_mqtt";
+    maintainers = with lib.maintainers; [ CodedNil ];
+  };
+}


### PR DESCRIPTION
Adds homeassistant custom component for hildrebrant glow MQTT, for smart meter monitoring. https://github.com/megakid/ha_hildebrand_glow_ihd_mqtt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
