### PR TITLE
structorizer: using freedesktop files from src

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1731,7 +1731,7 @@
   };
   annaaurora = {
     email = "anna@annaaurora.eu";
-    matrix = "@papojari:artemislena.eu";
+    matrix = "@anna:annaaurora.eu";
     github = "auroraanna";
     githubId = 81317317;
     name = "Anna Aurora";

--- a/pkgs/by-name/st/structorizer/package.nix
+++ b/pkgs/by-name/st/structorizer/package.nix
@@ -14,31 +14,6 @@ stdenv.mkDerivation rec {
   pname = "structorizer";
   version = "3.32-32";
 
-  desktopItems = [
-    (makeDesktopItem {
-      type = "Application";
-      name = "Structorizer";
-      desktopName = "Structorizer";
-      genericName = "Diagram creator";
-      comment = meta.description;
-      icon = pname;
-      exec = pname;
-      terminal = false;
-      mimeTypes = [ "application/nsd" ];
-      categories = [
-        "Development"
-        "Graphics"
-        "VectorGraphics"
-        "RasterGraphics"
-        "ComputerScience"
-      ];
-      keywords = [
-        "nsd"
-        "diagrams"
-      ];
-    })
-  ];
-
   src = fetchFromGitHub {
     owner = "fesch";
     repo = "Structorizer.Desktop";
@@ -57,7 +32,6 @@ stdenv.mkDerivation rec {
     jdk11
     makeWrapper
     wrapGAppsHook3
-    copyDesktopItems
   ];
 
   buildInputs = [ jdk11 ];
@@ -82,7 +56,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -d $out/bin $out/share/mime/packages
+    install -d $out/bin $out/share/mime/packages $out/share/applications
 
     install -D ${pname}.jar -t $out/share/java/
       makeWrapper ${jdk11}/bin/java $out/bin/${pname} \
@@ -90,16 +64,8 @@ stdenv.mkDerivation rec {
       --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
       ''${gappsWrapperArgs[@]}
 
-    cat << EOF > $out/share/mime/packages/structorizer.xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-      <mime-type type="application/nsd">
-             <comment xml:lang="en">Nassi-Shneiderman diagram</comment>
-             <comment xml:lang="de">Nassi-Shneiderman-Diagramm</comment>
-             <glob pattern="*.nsd"/>
-      </mime-type>
-    </mime-info>
-    EOF
+    cp freedesktop/mime/packages/structorizer.xml $out/share/mime/packages/
+    cp freedesktop/applications/structorizer.desktop $out/share/applications/
 
     cd src/lu/fisch/${pname}/gui
     install -vD icons/000_${pname}.png $out/share/icons/hicolor/16x16/apps/${pname}.png

--- a/pkgs/by-name/st/structorizer/package.nix
+++ b/pkgs/by-name/st/structorizer/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "structorizer";
-  version = "3.32-32";
+  version = "3.32-33";
 
   src = fetchFromGitHub {
     owner = "fesch";
     repo = "Structorizer.Desktop";
     rev = version;
-    hash = "sha256-ZA+DGys4vR8W+nX8JyWiD1GPOLjYAKaqJTel8wWooHA=";
+    hash = "sha256-7cvh1h4IFYD/5UMs6g76LmjJoDpkLLdvX2ED5oLtD5o=";
   };
 
   patches = [


### PR DESCRIPTION
- changed structorizer to use the freedesktop desktop file and mime type file from upstream.
- updates annaaurora's matrix id
- updated structorizer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
