### PR TITLE
runapp: init at 0.4.1

### DIFF
--- a/pkgs/by-name/ru/runapp/package.nix
+++ b/pkgs/by-name/ru/runapp/package.nix
@@ -1,0 +1,45 @@
+{
+  fetchFromGitHub,
+  gcc15Stdenv,
+  lib,
+  nix-update-script,
+  pkg-config,
+  systemd,
+}:
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "runapp";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "c4rlo";
+    repo = "runapp";
+    tag = finalAttrs.version;
+    hash = "sha256-+dIawnBTf8QU0dv93NQUCgW60BrlUXljaoNnRQjfJZQ=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ systemd ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "-march=native" ""
+  '';
+
+  buildFlags = [ "release" ];
+
+  installFlags = [
+    "prefix=$(out)"
+    "install_runner="
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Application runner for Linux desktop environments that integrate with systemd";
+    homepage = "https://github.com/c4rlo/runapp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ clementpoiret ];
+    mainProgram = "runapp";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This MR adds [runapp](https://github.com/c4rlo/runapp), a native executable which can replace `uwsm-app` to run a given application in an appropriate systemd user unit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
