### PR TITLE
python3Packages.vllm: 0.10.1.1 -> 0.10.2

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   python,
   buildPythonPackage,
-  pythonAtLeast,
+  pythonOlder,
   fetchFromGitHub,
   fetchpatch,
   symlinkJoin,
@@ -115,8 +115,8 @@ let
     src = fetchFromGitHub {
       owner = "vllm-project";
       repo = "FlashMLA";
-      rev = "0e43e774597682284358ff2c54530757b654b8d1";
-      hash = "sha256-wxL/jtq/lsLg1o+4392KNgfw5TYlW6lqEVbmR3Jl4/Q=";
+      rev = "a757314c04eedd166e329e846c820eb1bdd702de";
+      hash = "sha256-KT9R6ju7XzgqKHPGQwzw0yNiKL3DNW6qJrEBvmLn4hY=";
     };
 
     dontConfigure = true;
@@ -135,15 +135,15 @@ let
   vllm-flash-attn' = lib.defaultTo (stdenv.mkDerivation {
     pname = "vllm-flash-attn";
     # https://github.com/vllm-project/flash-attention/blob/${src.rev}/vllm_flash_attn/__init__.py
-    version = "2.7.4.post1";
+    version = "2.7.2.post1";
 
     # grep for GIT_TAG in the following file
     # https://github.com/vllm-project/vllm/blob/v${version}/cmake/external_projects/vllm_flash_attn.cmake
     src = fetchFromGitHub {
       owner = "vllm-project";
       repo = "flash-attention";
-      rev = "57b4e68b9f9d94750b46de8f8dbd2bfcc86edd4f";
-      hash = "sha256-c7L7WZVVEnXMOTPBoSp7jhkl9d4TA4sj11QvOSWTDIE=";
+      rev = "ee4d25bd84e0cbc7e0b9b9685085fd5db2dcb62a";
+      hash = "sha256-2r0Habd/kBpvM4/aQFIYyj+uQAa3M9gjk3DcBZHFNfA=";
     };
 
     patches = [
@@ -179,7 +179,7 @@ let
 
   cpuSupport = !cudaSupport && !rocmSupport;
 
-  # https://github.com/pytorch/pytorch/blob/v2.7.1/torch/utils/cpp_extension.py#L2343-L2345
+  # https://github.com/pytorch/pytorch/blob/v2.8.0/torch/utils/cpp_extension.py#L2411-L2414
   supportedTorchCudaCapabilities =
     let
       real = [
@@ -204,8 +204,12 @@ let
         "10.0a"
         "10.1"
         "10.1a"
+        "10.3"
+        "10.3a"
         "12.0"
         "12.0a"
+        "12.1"
+        "12.1a"
       ];
       ptx = lists.map (x: "${x}+PTX") real;
     in
@@ -245,6 +249,7 @@ let
   mergedCudaLibraries = with cudaPackages; [
     cuda_cudart # cuda_runtime.h, -lcudart
     cuda_cccl
+    libcurand # curand_kernel.h
     libcusparse # cusparse.h
     libcusolver # cusolverDn.h
     cuda_nvtx
@@ -266,11 +271,8 @@ in
 
 buildPythonPackage rec {
   pname = "vllm";
-  version = "0.10.1.1";
+  version = "0.10.2";
   pyproject = true;
-
-  # https://github.com/vllm-project/vllm/issues/12083
-  disabled = pythonAtLeast "3.13";
 
   stdenv = torch.stdenv;
 
@@ -278,7 +280,7 @@ buildPythonPackage rec {
     owner = "vllm-project";
     repo = "vllm";
     tag = "v${version}";
-    hash = "sha256-lLNjBv5baER0AArX3IV4HWjDZ2jTGXyGIvnHupR8MGM=";
+    hash = "sha256-m9P4cxxdAToGKKIyTQdFupG3vZ3sEueMMxjugYfjKbo=";
   };
 
   patches = [
@@ -483,6 +485,10 @@ buildPythonPackage rec {
       lach
       daniel-fahey
     ];
+    # Python 3.12 vLLM v0.10.2+CPU blake3 1.0.7 incompatibility
+    # discovered during https://github.com/NixOS/nixpkgs/pull/447722
+    # reported upstream in https://github.com/vllm-project/vllm/issues/26229
+    broken = (cpuSupport && pythonOlder "3.13");
     badPlatforms = [
       # CMake Error at cmake/cpu_extension.cmake:78 (find_isa):
       # find_isa Function invoked with incorrect arguments for function named:

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -481,6 +481,7 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [
       happysalada
       lach
+      daniel-fahey
     ];
     badPlatforms = [
       # CMake Error at cmake/cpu_extension.cmake:78 (find_isa):


### PR DESCRIPTION
Notably adds Python 3.13 support (see https://github.com/vllm-project/vllm/pull/13164) among many other things (https://github.com/vllm-project/vllm/releases/tag/v0.10.2).

Supersedes existing PR #442802 from @r-ryantm.

Python 3.13 support is also needed for vLLM to appear in the builds on the new (and fantastic initiative, btw) [nixos-cuda](https://github.com/nixos-cuda) [Hydra](https://hydra.nixos-cuda.org/), configured by @GaetanLepage.

<details>

<summary>For reference I share part of my engineer's log re: the nixos-cuda builder herein:</summary>

The new [hydra.nixos-cuda.org](https://hydra.nixos-cuda.org/) instance is building the [cuda-packages jobset](https://hydra.nixos-cuda.org/jobset/cuda/cuda-packages/evals), which is defined by [`release-cuda.nix`](https://github.com/NixOS/nixpkgs/blob/db8556be0060cd2f57e58010f95b710b0f4021c7/pkgs/top-level/release-cuda.nix#L168). While `python3Packages.vllm` is explicitly listed in that file, it doesn't appear in any evaluation results.

This is because vLLM is being filtered out during the evaluation phase:
1. The nixpkgs revision being evaluated defaults to Python 3.13 (as of writing, [eval 53](https://hydra.nixos-cuda.org/eval/53) uses [`b6f6c61`](https://github.com/NixOS/nixpkgs/commit/b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0), see below)
2. Our Nixpkgs derivation currently has vLLM 0.10.1.1 with [`disabled = pythonAtLeast "3.13";`](https://github.com/NixOS/nixpkgs/blob/a77b87719ff11d3d7ea2439c406361b6b0c4c56a/pkgs/development/python-modules/vllm/default.nix#L273) in its package definition
3. This causes evaluation to fail with: `error: vllm-0.10.1.1 not supported for interpreter python3.13`

To check which nixpkgs revision the new nixos-cuda Hydra is currently using:
```console
[daniel@laptop:~]$ # Get the nixpkgs revision used in the latest evaluation (53; as above)
curl -sH "Accept: application/json" https://hydra.nixos-cuda.org/eval/53 | \
  jq -r '.jobsetevalinputs.nixpkgs.revision'
b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0
```

To reproduce the evaluation failure:
```console
[daniel@laptop:~]$ # This will fail with the Python 3.13 error
nix-instantiate --eval --expr '
  let
    pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b6f6c613838dd776620c34e8f15fe4d8a9cdf9c0.tar.gz") {
      config = {
        allowUnfree = true;
        cudaSupport = true;
        inHydra = true;
        allowAliases = false;
      };
    };
  in
    pkgs.python3Packages.vllm.drvPath
'
error:
       … while evaluating the attribute 'python3Packages.vllm.drvPath'
         at /nix/store/w2l3qlg0bvkhiy34dkgdmhwq68qk1y8f-source/lib/customisation.nix:429:7:
          428|     // {
          429|       drvPath =
             |       ^
          430|         assert condition;

       … while evaluating the attribute 'drvPath'
         at /nix/store/w2l3qlg0bvkhiy34dkgdmhwq68qk1y8f-source/lib/customisation.nix:429:7:
          428|     // {
          429|       drvPath =
             |       ^
          430|         assert condition;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: vllm-0.10.1.1 not supported for interpreter python3.13
```

And to verify vLLM is missing from the evaluation:
```console
[daniel@laptop:~]$ # Check which python3Packages are actually in the latest evaluation
curl -sH "Accept: application/json" https://hydra.nixos-cuda.org/eval/53/builds | \
  jq -r 'to_entries[] | .value.job' | grep python3Packages | sort
python3Packages.cupy.x86_64-linux
python3Packages.faiss.x86_64-linux
python3Packages.faster-whisper.x86_64-linux
python3Packages.flashinfer.x86_64-linux
python3Packages.flax.x86_64-linux
python3Packages.gpt-2-simple.x86_64-linux
python3Packages.grad-cam.x86_64-linux
python3Packages.jaxlib.x86_64-linux
python3Packages.jax.x86_64-linux
python3Packages.keras.x86_64-linux
python3Packages.kornia.x86_64-linux
python3Packages.mmcv.x86_64-linux
python3Packages.mxnet.x86_64-linux
python3Packages.numpy.x86_64-linux
python3Packages.onnx.x86_64-linux
python3Packages.openai-whisper.x86_64-linux
python3Packages.opencv4.x86_64-linux
python3Packages.opensfm.x86_64-linux
python3Packages.pycuda.x86_64-linux
python3Packages.pyrealsense2WithCuda.x86_64-linux
python3Packages.pytorch-lightning.x86_64-linux
python3Packages.scikit-image.x86_64-linux
python3Packages.scikit-learn.x86_64-linux
python3Packages.scipy.x86_64-linux
python3Packages.spacy-transformers.x86_64-linux
python3Packages.tensorflow.x86_64-linux
python3Packages.tesserocr.x86_64-linux
python3Packages.tiny-cuda-nn.x86_64-linux
python3Packages.torchaudio.x86_64-linux
python3Packages.torchvision.x86_64-linux
python3Packages.torch.x86_64-linux
python3Packages.transformers.x86_64-linux
python3Packages.triton.x86_64-linux
python3Packages.ttstokenizer.x86_64-linux
python3Packages.vidstab.x86_64-linux
```
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
