### PR TITLE
rimsort: 1.0.30 -> 1.0.47, fix desktop item

### DIFF
--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -15,13 +15,13 @@
 }:
 let
   pname = "rimsort";
-  version = "1.0.30";
+  version = "1.0.47";
 
   src = fetchFromGitHub {
     owner = "RimSort";
     repo = "RimSort";
     rev = "v${version}";
-    hash = "sha256-f1wYoBC0EbkvYNJHkVuoMukJZMY7eNjCIzJra7/hpLs=";
+    hash = "sha256-1wn3WIflrhH3IMBeGFwcHi0zOREakuk/5gqwPY720eA=";
     fetchSubmodules = true;
   };
   steamworksSrc = fetchzip {
@@ -100,6 +100,7 @@ stdenv.mkDerivation {
       toposort
       watchdog
       xmltodict
+      zstandard
       steamworkspy
       ;
   };

--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -7,6 +7,7 @@
   makeBinaryWrapper,
 
   makeDesktopItem,
+  copyDesktopItems,
   replaceVars,
 
   todds,
@@ -24,6 +25,7 @@ let
     hash = "sha256-1wn3WIflrhH3IMBeGFwcHi0zOREakuk/5gqwPY720eA=";
     fetchSubmodules = true;
   };
+
   steamworksSrc = fetchzip {
     url = "https://web.archive.org/web/20250527013243/https://partner.steamgames.com/downloads/steamworks_sdk_162.zip"; # Steam sometimes requires auth to download.
     hash = "sha256-yDA92nGj3AKTNI4vnoLaa+7mDqupQv0E4YKRRUWqyZw=";
@@ -70,6 +72,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     makeBinaryWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -134,7 +137,7 @@ stdenv.mkDerivation {
       name = "RimSort";
       desktopName = "RimSort";
       exec = "rimsort";
-      icon = "io.github.rimsort.rimsort";
+      icon = "rimsort.png";
       comment = "RimWorld Mod Manager";
       categories = [ "Game" ];
     })
@@ -156,7 +159,7 @@ stdenv.mkDerivation {
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --set RIMSORT_DISABLE_UPDATER 1
 
-    install -D ./themes/default-icons/AppIcon_a.png $out/share/icons/hicolor/512x512/apps/io.github.rimsort.rimsort
+    install -D ./themes/default-icons/AppIcon_a.png $out/share/icons/hicolor/512x512/apps/rimsort.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation {
       name = "RimSort";
       desktopName = "RimSort";
       exec = "rimsort";
-      icon = "rimsort.png";
+      icon = "rimsort";
       comment = "RimWorld Mod Manager";
       categories = [ "Game" ];
     })

--- a/pkgs/by-name/ri/rimsort/steam-run.patch
+++ b/pkgs/by-name/ri/rimsort/steam-run.patch
@@ -1,19 +1,23 @@
 diff --git a/app/utils/generic.py b/app/utils/generic.py
+index f23aa5c..9ff4a04 100644
 --- a/app/utils/generic.py
 +++ b/app/utils/generic.py
-@@ -255,7 +255,7 @@
-                 popen_args.extend(args)
-                 p = subprocess.Popen(popen_args)
-             else:
--                popen_args = [executable_path]
-+                popen_args = ["@steam-run@/bin/steam-run", executable_path]
-                 popen_args.extend(args)
- 
-                 if sys.platform == "win32":
+@@ -260,6 +260,10 @@ def launch_game_process(game_install_path: Path, args: list[str]) -> None:
+                 + str(args)
+                 + "`"
+             )
++
++            args = [executable_path, *args]
++            executable_path = "@steam-run@/bin/steam-run"
++
+             pid, popen_args = launch_process(
+                 executable_path, args, str(game_install_path)
+             )
 diff --git a/app/utils/steam/steamcmd/wrapper.py b/app/utils/steam/steamcmd/wrapper.py
+index 398e0fd..79bb162 100644
 --- a/app/utils/steam/steamcmd/wrapper.py
 +++ b/app/utils/steam/steamcmd/wrapper.py
-@@ -316,8 +316,8 @@
+@@ -317,8 +317,8 @@ class SteamcmdInterface:
                  script_output.write("\n".join(script))
              runner.message(f"Compiled & using script: {script_path}")
              runner.execute(


### PR DESCRIPTION
Update rimsort to 1.0.47
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
