### PR TITLE
cyrus_sasl: fix build with gcc15

### DIFF
--- a/pkgs/by-name/cy/cyrus_sasl/package.nix
+++ b/pkgs/by-name/cy/cyrus_sasl/package.nix
@@ -39,6 +39,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/cyrusimap/cyrus-sasl/compare/cb549ef71c5bb646fe583697ebdcaba93267a237...dfaa62392e7caecc6ecf0097b4d73738ec4fc0a8.patch";
       hash = "sha256-pc0cZqj1QoxDqgd/j/5q3vWONEPrTm4Pr6MzHlfjRCc=";
     })
+    # Fix build with gcc15
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/cyrus-sasl/raw/388b80c6a8f93667587b4ac2e7992d0aa1c431f9/f/cyrus-sasl-2.1.28-gcc15.patch";
+      hash = "sha256-AfSQXFtVh0IHG8Uw9nWMWlkQnyaX3ZMsdZLd7hTru7Q=";
+    })
   ];
 
   outputs = [


### PR DESCRIPTION
- add patch from fedora that combines merged upstream PR:
https://www.github.com/cyrusimap/cyrus-sasl/pull/869
with extra fixes for md5 that was removed upstream on master:
https://www.github.com/cyrusimap/cyrus-sasl/pull/789

Fixes build failure with gcc15:
```
md5.c:139:8: error: too many arguments to function 'MD5_memcpy'; expected 0, have 3
  139 |        MD5_memcpy
      |        ^~~~~~~~~~
  140 |        ((POINTER)&context->buffer[index], (POINTER)input, partLen); MD5Transform
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
md5.c:62:13: note: declared here
   62 | static void MD5_memcpy PROTO_LIST ((POINTER, POINTER, unsigned int));
      |             ^~~~~~~~~~
md5.c:140:69: error: too many arguments to function 'MD5Transform'; expected 0, have 2
  140 |        ((POINTER)&context->buffer[index], (POINTER)input, partLen); MD5Transform
      |                                                                     ^~~~~~~~~~~~
  141 |        (context->state, context->buffer);
      |         ~~~~~~~~~~~~~~
md5.c:57:13: note: declared here
   57 | static void MD5Transform PROTO_LIST ((UINT4 [4], const unsigned char [64]));
      |             ^~~~~~~~~~~~
```

---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; cyrus_sasl.override { stdenv = gcc15Stdenv; buildPackages = buildPackages // { stdenv = gcc15Stdenv; }; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
