### PR TITLE
1c enterprise client: init at (8.3.27.1606)

### DIFF
--- a/pkgs/by-name/_1/_1c-enterprise-client/package.nix
+++ b/pkgs/by-name/_1/_1c-enterprise-client/package.nix
@@ -1,0 +1,184 @@
+#TODO LIST:
+#1. Split to _1c-enterprise-common/_1c-enterprise-client/_1c-enterprise-server and symlink _1c-enterprise-server and _1c-enterprise-common to _1c-enterprise-client
+#2. Add systemd and 1cv8usr:1cv8grp for _1c-enterprise-server
+{ stdenv
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, glib
+, glibc
+, gtk3
+, pango
+, atk
+, cairo
+, gdk-pixbuf
+, freetype
+, fontconfig
+, dbus
+, nss
+, nspr
+, alsa-lib
+, cups
+, expat
+, lib
+, libdrm
+, xorg
+, openssl
+, libxml2
+, zlib
+, requireFile # or use fetchurl
+, openal
+, libssh
+, libGLU
+, webkitgtk_4_0
+, webkitgtk_4_1
+, libsoup_2_4
+, libGL
+, e2fsprogs
+, patchelf
+, gsettings-desktop-schemas
+, copyDesktopItems
+, ...
+}:
+
+let
+  pkgName = "_1c-enterprise-client";
+  pkgVersion = "8.3.27.1606";
+  Version =  lib.versions.splitVersion pkgVersion;
+  pkgVersion3 =  builtins.concatStringsSep "." (lib.take 3 Version);
+  pkgVersionBuild = builtins.elemAt Version 3;
+  pkgVersionStr = "${pkgVersion3}-${pkgVersionBuild}";
+  # Define the deb files
+  clientDeb = requireFile {
+    name = "1c-enterprise-${pkgVersion}-client_${pkgVersionStr}_amd64.deb";
+    url = "https://releases.1c.ru/project/Platform83";
+    sha256 = "sha256-gTylZZNYM7mSxqwKGDQktF8swBl1cSkHIC0K833cnhQ=";
+  };
+  commonDeb = requireFile {
+    name = "1c-enterprise-${pkgVersion}-common_${pkgVersionStr}_amd64.deb";
+    url = "https://releases.1c.ru/project/Platform83";
+    sha256 = "sha256-PGjttk+GIum/4yp9rwG5iRXhIkUkP35bNP2hVUpDB5s=";
+  };
+  serverDeb = requireFile {
+    name = "1c-enterprise-${pkgVersion}-server_${pkgVersionStr}_amd64.deb";
+    url = "https://releases.1c.ru/project/Platform83";
+    sha256 = "sha256-l4vibq5/V78CgDwoIFJnS4PC2chXfPEyvOrcVnq+KNg=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = pkgName;
+  version = pkgVersion;
+  pkgversion = pkgVersionStr;
+  src = ./.;
+
+  nativeBuildInputs = [ dpkg patchelf autoPatchelfHook makeWrapper ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    glibc
+    e2fsprogs
+    glib
+    gtk3
+    pango
+    atk
+    cairo
+    gdk-pixbuf
+    freetype
+    fontconfig
+    dbus
+    nss
+    nspr
+    alsa-lib
+    cups
+    expat
+    libdrm
+    xorg.libX11
+    xorg.libXext
+    xorg.libXrender
+    xorg.libXrandr
+    xorg.libXinerama
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXfixes
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXxf86vm
+    openssl
+    libxml2
+    zlib
+    openal
+    libssh
+    libGLU
+    webkitgtk_4_0
+    webkitgtk_4_1
+    libsoup_2_4
+    libGL
+    gsettings-desktop-schemas
+    copyDesktopItems
+  ];
+
+  unpackPhase = ''
+   dpkg-deb -x ${clientDeb} .
+   dpkg-deb -x ${commonDeb} .
+   dpkg-deb -x ${serverDeb} .
+  '';
+
+  preInstall = ''
+    mkdir -p $out/{bin,opt/1cv8/{conf,common},share/applications,sbin}
+    cat > $out/sbin/ldconfig <<EOF
+    #!${stdenv.shell}
+    echo "ldconfig dummy"
+    EOF
+    chmod +x $out/sbin/ldconfig
+    export PATH="/sbin:$PATH"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r ./opt $out
+    cp -r ./usr/share $out
+    find $out/opt/1cv8 -name 'libstdc++.so.6' -delete
+    find $out/opt/1cv8 -name 'libcairo-v8.so' -delete
+    mv $out/opt/1cv8/x86_64/${finalAttrs.version}/1cestart-${finalAttrs.pkgversion}.desktop $out/share/applications/1cestart-${finalAttrs.pkgversion}.desktop
+
+    runHook postInstall
+  '';
+
+
+  postInstall = ''
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/1cestart $out/opt/1cv8/common/1cestart
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/1cestart $out/bin/1cestart
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/1cv8 $out/bin/1cv8
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/1cv8c $out/bin/1cv8c
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/1cv8s $out/bin/1cv8s
+    substituteInPlace $out/share/applications/1cestart-${finalAttrs.pkgversion}.desktop \
+      --replace "/opt/1cv8/common/1cestart" "1cestart"
+    substituteInPlace $out/share/applications/1cv8-${finalAttrs.pkgversion}.desktop \
+      --replace "/opt/1cv8/x86_64/${finalAttrs.version}/1cv8" "1cv8"
+    substituteInPlace $out/share/applications/1cv8c-${finalAttrs.pkgversion}.desktop \
+      --replace "/opt/1cv8/x86_64/${finalAttrs.version}/1cv8c" "1cv8c"
+    substituteInPlace $out/share/applications/1cv8s-${finalAttrs.pkgversion}.desktop \
+      --replace "/opt/1cv8/x86_64/${finalAttrs.version}/1cv8s" "1cv8s"
+  '';
+
+  preFixup = ''
+  '';
+
+  postFixup = ''
+    if [ -d $out/opt/1cv8 ]; then
+      addAutoPatchelfSearchPath $out/opt/1cv8/x86_64/${finalAttrs.version}/
+    fi
+  '';
+
+  meta = with lib; {
+    description = "1C Enterprise Client Full";
+    homepage = "https://1c.ru";
+    license = {
+      fullName = "License agreement for 1C:Enterprise 8.3";
+      url = "file://${out}/opt/1cv8/x86_64/${finalAttrs.version}/licenses/1CEnterprise_en.htm ";
+      free = false;
+    };
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/_1/_1c-enterprise-common/default.nix
+++ b/pkgs/by-name/_1/_1c-enterprise-common/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, glibc
+, glib
+, lib
+, requireFile
+, libxml2
+, versions ? ""
+, callPackage
+, ...
+}:
+
+let
+  v = callPackage ../_1c-enterprise {};
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "_1c-enterprise-common";
+  version = v.pkgVersion;
+  pkgversion = v.pkgVersionStr;
+  src = requireFile v.commonDebInfo;
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook makeWrapper ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    glibc
+    glib
+    libxml2
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt}
+    find ./opt/1cv8 -name 'libstdc++.so.6' -delete
+    find ./opt/1cv8 -name 'libstdc++.so.6.0.28' -delete
+    cp -r ./opt $out
+    cp -r ./usr/share $out
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/addnhost64 $out/bin/addnhost64
+  '';
+
+  meta = with lib; {
+    description = "1C:Enterprise ${finalAttrs.version} common components";
+    homepage = "https://1c.ru";
+    license = {
+      fullName = "License agreement for 1C:Enterprise 8.3";
+      url = "file://${out}/opt/1cv8/x86_64/${finalAttrs.version}/licenses/1CEnterprise_en.htm";
+      free = false;
+    };
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/_1/_1c-enterprise-server/default.nix
+++ b/pkgs/by-name/_1/_1c-enterprise-server/default.nix
@@ -1,0 +1,93 @@
+#TODO LIST:
+#1. Add systemd and 1cv8usr:1cv8grp for _1c-enterprise-server
+{ stdenv
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, _1c-enterprise-common
+, requireFile
+, glib
+, glibc
+, lib
+, e2fsprogs
+, krb5
+, libssh
+, unixODBC
+, patchelf
+, versions ? ""
+, callPackage
+, ...
+}:
+
+let
+  v = callPackage ../_1c-enterprise {};
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "_1c-enterprise-server";
+  version = v.pkgVersion;
+  pkgversion = v.pkgVersionStr;
+  src = requireFile v.serverDebInfo;
+
+  nativeBuildInputs = [ dpkg patchelf autoPatchelfHook makeWrapper ];
+
+  buildInputs = [
+    _1c-enterprise-common
+    stdenv.cc.cc.lib
+    glibc
+    e2fsprogs
+    krb5
+    glib
+    libssh
+    unixODBC
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+#    ln -sf ${_1c-enterprise-common}/opt/1cv8/x86_64/${finalAttrs.version}/*.so       $out/opt/1cv8/x86_64/${finalAttrs.version}/
+#    ln -sf ${_1c-enterprise-common}/opt/1cv8/x86_64/${finalAttrs.version}/lib*       $out/opt/1cv8/x86_64/${finalAttrs.version}/
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt,share/applications}
+    find ./opt/1cv8 -name 'libcairo-v8.so' -delete
+    cp -r ./opt $out
+    cp -r ./usr/share $out
+
+    ln -s ${_1c-enterprise-common}/opt/1cv8/x86_64/${finalAttrs.version}/* $out/opt/1cv8/x86_64/${finalAttrs.version}/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/ci     $out/bin/ci
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/dbda   $out/bin/dbda
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/dbgs   $out/bin/dbgs
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/ibcmd  $out/bin/ibcmd
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/ibsrv  $out/bin/ibsrv
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/rac    $out/bin/rac
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/ragent $out/bin/ragent
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/ras    $out/bin/ras
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/rmngr  $out/bin/rmngr
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/rmstt  $out/bin/rmstt
+    ln -s $out/opt/1cv8/x86_64/${finalAttrs.version}/rphost $out/bin/rphost
+  '';
+
+  preFixup = ''
+    addAutoPatchelfSearchPath "$out/opt/1cv8/x86_64/${finalAttrs.version}"
+    autoPatchelf $out
+  '';
+
+  meta = with lib; {
+    description = "1C:Enterprise ${finalAttrs.version} server";
+    homepage = "https://1c.ru";
+    license = {
+      fullName = "License agreement for 1C:Enterprise 8.3";
+      url = "file://${out}/opt/1cv8/x86_64/${finalAttrs.version}/licenses/1CEnterprise_en.htm";
+      free = false;
+    };
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/_1/_1c-enterprise/default.nix
+++ b/pkgs/by-name/_1/_1c-enterprise/default.nix
@@ -1,0 +1,29 @@
+{ lib }:
+
+let
+  pkgVersion = "8.3.27.1606";
+  versionParts = lib.versions.splitVersion pkgVersion;
+  versionShort = builtins.concatStringsSep "." (lib.take 3 versionParts);
+  versionBuild = builtins.elemAt versionParts 3;
+  pkgVersionStr = "${versionShort}-${versionBuild}";
+in {
+  inherit pkgVersion versionShort versionBuild pkgVersionStr;
+
+  commonDebInfo = {
+    name = "1c-enterprise-${pkgVersion}-common_${pkgVersionStr}_amd64.deb";
+    url = "https://releases.1c.ru/project/Platform83";
+    sha256 = "sha256-PGjttk+GIum/4yp9rwG5iRXhIkUkP35bNP2hVUpDB5s=";
+  };
+
+  clientDebInfo = {
+    name = "1c-enterprise-${pkgVersion}-client_${pkgVersionStr}_amd64.deb";
+    url = "https://releases.1c.ru/project/Platform83";
+    sha256 = "sha256-gTylZZNYM7mSxqwKGDQktF8swBl1cSkHIC0K833cnhQ=";
+  };
+
+  serverDebInfo = {
+    name = "1c-enterprise-${pkgVersion}-server_${pkgVersionStr}_amd64.deb";
+    url = "https://releases.1c.ru/project/Platform83";
+    sha256 = "sha256-l4vibq5/V78CgDwoIFJnS4PC2chXfPEyvOrcVnq+KNg=";
+  };
+}


### PR DESCRIPTION
<!--
Add 1c enterprise client

1C:Enterprise is a full-stack, low-code platform that provides infrastructure and tools for the development of business applications.
[1C:ENTERPRISE](https://1c-dn.com/)
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [*] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [*] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
