### PR TITLE
ocamlPackages.ocp-browser: init at 1.4.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocp-browser/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-browser/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  cppo,
+  ocp-index,
+  cmdliner,
+  re,
+  lambda-term,
+  zed,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "ocp-browser";
+  version = "1.4.0";
+
+  minimalOCamlVersion = "4.08";
+
+  src = fetchFromGitHub {
+    owner = "OCamlPro";
+    repo = "ocp-index";
+    tag = finalAttrs.version;
+    hash = "sha256-pv6aBJjRkibISpZEnlfyn72smcYEbZoPQoQH2p/JwH0=";
+  };
+
+  nativeBuildInputs = [ cppo ];
+  propagatedBuildInputs = [
+    cmdliner
+    lambda-term
+    ocp-index
+    re
+    zed
+  ];
+
+  meta = {
+    homepage = "https://github.com/OCamlPro/ocp-index";
+    description = "Console browser for the documentation of installed OCaml libraries";
+    changelog = "https://github.com/OCamlPro/ocp-index/raw/${finalAttrs.version}/CHANGES.md";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ redianthus ];
+    mainProgram = "ocp-browser";
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1499,6 +1499,8 @@ let
 
         ocolor = callPackage ../development/ocaml-modules/ocolor { };
 
+        ocp-browser = callPackage ../development/tools/ocaml/ocp-browser { };
+
         ocp-build = callPackage ../development/tools/ocaml/ocp-build { };
 
         ocp-indent = callPackage ../development/tools/ocaml/ocp-indent { };


### PR DESCRIPTION
Hi,

This is adding the `ocp-browser` tool. I built the tool and locally checked that I could launch and use it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
