### PR TITLE
arch-install-scripts: 29 -> 31

### DIFF
--- a/pkgs/by-name/ar/arch-install-scripts/package.nix
+++ b/pkgs/by-name/ar/arch-install-scripts/package.nix
@@ -19,18 +19,19 @@
     "/usr/bin/vendor_perl"
     "/usr/bin/core_perl"
   ],
+  chrootSetprivPath ? "/usr/bin/setpriv",
 }:
 
 resholve.mkDerivation rec {
   pname = "arch-install-scripts";
-  version = "29";
+  version = "31";
 
   src = fetchFromGitLab {
     domain = "gitlab.archlinux.org";
     owner = "archlinux";
     repo = "arch-install-scripts";
     tag = "v${version}";
-    hash = "sha256-XWcZZ+ET3J4dB6M9CdXESf0iQh+2vYxlxoJ6TZ3vFUk=";
+    hash = "sha256-Oh1nC/gPJDDy8cXiZPbEfpwOuO+RFRcxVCZuTtB2MV8=";
   };
 
   nativeBuildInputs = [
@@ -40,12 +41,16 @@ resholve.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./Makefile \
-      --replace "PREFIX = /usr/local" "PREFIX ?= /usr/local"
+      --replace-fail "PREFIX = /usr/local" "PREFIX ?= /usr/local"
+
     substituteInPlace ./pacstrap.in \
-      --replace "cp -a" "cp -LR --no-preserve=mode" \
-      --replace "unshare pacman" "unshare ${pacman}/bin/pacman" \
-      --replace 'gnupg "$newroot/etc/pacman.d/"' 'gnupg "$newroot/etc/pacman.d/" && chmod 700 "$newroot/etc/pacman.d/gnupg"'
+      --replace-fail "cp -a" "cp -LR --no-preserve=mode" \
+      --replace-fail "unshare pacman" "unshare ${pacman}/bin/pacman" \
+      --replace-fail '"$gpg_dir" "$newroot/$gpg_dir"' '"$gpg_dir" "$newroot/$gpg_dir" && chmod 700 "$newroot/etc/pacman.d/gnupg"'
+
     echo "export PATH=${lib.strings.makeSearchPath "" chrootPath}:\$PATH" >> ./common
+    substituteInPlace ./arch-chroot.in \
+      --replace-fail "sd_args+=(setpriv" "sd_args+=(${chrootSetprivPath}"
   '';
 
   installFlags = [ "PREFIX=$(out)" ];
@@ -80,10 +85,17 @@ resholve.mkDerivation rec {
         util-linux
       ];
 
-      execer = [ "cannot:${pacman}/bin/pacman-key" ];
+      execer = [
+        "cannot:${pacman}/bin/pacman-conf"
+        "cannot:${pacman}/bin/pacman-key"
+      ];
 
-      # TODO: no good way to resolve mount/umount in Nix builds for now
-      # see https://github.com/abathur/resholve/issues/29
+      fake.external = [
+        "systemd-escape"
+        "systemd-run"
+      ];
+
+      # Avoid using setuid wrappers
       fix = {
         mount = true;
         umount = true;
@@ -93,6 +105,7 @@ resholve.mkDerivation rec {
         "$setup"
         "$pid_unshare"
         "$mount_unshare"
+        "$sd_args"
         "${pacman}/bin/pacman"
       ];
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/releases/v30
https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/tags/v31

Notably, `arch-chroot` now has a new flag, `-S`, which uses `systemd-run` under the hood.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
