### PR TITLE
pidgin-msn-pecan-crosstalk: init at 0.1.4-unstable-2025-08-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20296,6 +20296,13 @@
     name = "Pablo Ovelleiro Corral";
     keys = [ { fingerprint = "D03B 218C AE77 1F77 D7F9  20D9 823A 6154 4264 08D3"; } ];
   };
+  pionaiki = {
+    email = "marta+git@pionaiki.com";
+    github = "pionaiki";
+    githubId = 51377752;
+    name = "Marta";
+    keys = [ { fingerprint = "1D6D E31F 298A 239C 49CE  63AE 61B6 6525 11C9 A28C"; } ];
+  };
   piotrkwiecinski = {
     email = "piokwiecinski+nixpkgs@gmail.com";
     github = "piotrkwiecinski";

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/default.nix
@@ -38,6 +38,8 @@ lib.makeScope newScope (
 
     pidgin-window-merge = callPackage ./window-merge { };
 
+    pidgin-msn-pecan-crosstalk = callPackage ./pidgin-msn-pecan-crosstalk { };
+
     purple-discord = callPackage ./purple-discord { };
 
     purple-googlechat = callPackage ./purple-googlechat { };

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/pidgin-msn-pecan-crosstalk/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/pidgin-msn-pecan-crosstalk/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  pidgin,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pidgin-msn-pecan-crosstalk";
+  version = "0.1.4-unstable-2025-08-11";
+  src = fetchgit {
+    url = "https://git.hiden.cc/CrossTalk/msn-pecan";
+    rev = "4d064f7665d41bee757a41f3d0c44a1ba2d3ce03";
+    hash = "sha256-Qh73CQVydS/sx5dHuH3onzjDFq/EwKlWbpsYGhKUkfs=";
+  };
+
+  meta = with lib; {
+    description = "A modified version of the pidgin-msn-pecan libpurple plugin, updated to connect to the CrossTalk service.";
+    license = licenses.gpl2Plus;
+    homepage = "https://git.hiden.cc/CrossTalk/msn-pecan";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pionaiki ];
+  };
+
+  makeFlags = [
+    "PURPLE_LIBDIR=${placeholder "out"}/lib/purple-2"
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/lib/purple-2"
+    install -D -m 755 "./libmsn-pecan.so" "$out/lib/purple-2/libmsn-pecan.so"
+  '';
+
+  buildInputs = [ pidgin ];
+}


### PR DESCRIPTION
Added a package pidgin-msn-pecan-crosstalk, a modified version of the [pidgin-msn-pecan](https://github.com/felipec/msn-pecan) libpurple plugin, updated to connect to the [CrossTalk](https://crosstalk.im/) service. [Homepage](https://git.hiden.cc/CrossTalk/msn-pecan). (+ added myself to the maintainers list)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
