### PR TITLE
nodePackages.coc-docker: migrate to pkgs/by-name

### DIFF
--- a/pkgs/applications/editors/vim/plugins/cocPlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/cocPlugins.nix
@@ -4,6 +4,7 @@
   coc-clangd,
   coc-css,
   coc-diagnostic,
+  coc-docker,
   coc-pyright,
   coc-toml,
 }:
@@ -26,6 +27,11 @@ final: prev: {
   coc-diagnostic = buildVimPlugin {
     inherit (coc-diagnostic) pname version meta;
     src = "${coc-diagnostic}/lib/node_modules/coc-diagnostic";
+  };
+
+  coc-docker = buildVimPlugin {
+    inherit (coc-docker) pname version meta;
+    src = "${coc-docker}/lib/node_modules/coc-docker";
   };
 
   coc-pyright = buildVimPlugin {

--- a/pkgs/applications/editors/vim/plugins/nodePackagePlugins.nix
+++ b/pkgs/applications/editors/vim/plugins/nodePackagePlugins.nix
@@ -7,7 +7,6 @@ final: prev:
 let
   nodePackageNames = [
     "coc-cmake"
-    "coc-docker"
     "coc-emmet"
     "coc-eslint"
     "coc-explorer"

--- a/pkgs/by-name/co/coc-docker/package.nix
+++ b/pkgs/by-name/co/coc-docker/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "coc-docker";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "josa42";
+    repo = "coc-docker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-orSwQys+w2TKLau0gROyKh54vq7AwlVLsoU1EzALIDQ=";
+  };
+
+  npmDepsHash = "sha256-ow9viEFfyBUM2yDa63+pQCg6R5cAmznanqfI131fRxc=";
+
+  meta = {
+    description = "Docker language server extension using dockerfile-language-server-nodejs for coc.nvim";
+    homepage = "https://github.com/josa42/coc-docker";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pyrox0 ];
+  };
+})

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -73,6 +73,7 @@ mapAliases {
   inherit (pkgs) coc-clangd; # added 2024-06-29
   inherit (pkgs) coc-css; # added 2024-06-29
   inherit (pkgs) coc-diagnostic; # added 2024-06-29
+  inherit (pkgs) coc-docker; # added 2025-10-01
   coc-imselect = throw "coc-imselect was removed because it was broken"; # added 2023-08-21
   inherit (pkgs) coc-pyright; # added 2024-07-14
   coc-metals = throw "coc-metals was removed because it was deprecated upstream. vimPlugins.nvim-metals is its official replacement."; # Added 2024-10-16

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -24,7 +24,6 @@
 , "cdktf-cli"
 , "clipboard-cli"
 , "coc-cmake"
-, "coc-docker"
 , "coc-emmet"
 , "coc-eslint"
 , "coc-explorer"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -15666,24 +15666,6 @@ let
         sha512 = "ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==";
       };
     };
-    "dockerfile-ast-0.4.2" = {
-      name = "dockerfile-ast";
-      packageName = "dockerfile-ast";
-      version = "0.4.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.4.2.tgz";
-        sha512 = "k770mVWaCm3KbyOSPFizP6WB2ucZjfAv8aun4UsKl+IivowK7ItwBixNbziBjN05yNpvCL1/IxBdZiSz6KQIvA==";
-      };
-    };
-    "dockerfile-language-server-nodejs-0.9.0" = {
-      name = "dockerfile-language-server-nodejs";
-      packageName = "dockerfile-language-server-nodejs";
-      version = "0.9.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.9.0.tgz";
-        sha512 = "QPWcUxbbNTaWaRQrJKUBmCXI6iE8l7f81bCVaZizCIkVg4py/4o2mho+AKlLUsZcCml5ss8MkJ257SFV2BZWCg==";
-      };
-    };
     "dockerfile-language-service-0.9.0" = {
       name = "dockerfile-language-service";
       packageName = "dockerfile-language-service";
@@ -15691,15 +15673,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.9.0.tgz";
         sha512 = "sDUkTR4LUimEAWXDIbUTEx2CytCBlx+XlJkg4B2Ptvak9HkwPD4JpXesaWxXPpp6YHCzxqwsTDY7Gf79ic340g==";
-      };
-    };
-    "dockerfile-utils-0.10.0" = {
-      name = "dockerfile-utils";
-      packageName = "dockerfile-utils";
-      version = "0.10.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.10.0.tgz";
-        sha512 = "gnEhxITHpOXNXdlwJgJEq3xnJokm0IZOmrmHlJv8zCB2EDsgZWwdYWuktMMslIywK2YT22gxgZEoFjtEaJqzhQ==";
       };
     };
     "dockerode-4.0.4" = {
@@ -41282,15 +41255,6 @@ let
         sha512 = "tZFUSbyjUcrh+qQf13ALX4QDdOfDX0cVaBFgy7ktJ0VwS7AW/yRKgGPSxVqqP9OCMNPdqP57O5q47w2pEwfaUg==";
       };
     };
-    "vscode-languageserver-types-3.17.0-next.3" = {
-      name = "vscode-languageserver-types";
-      packageName = "vscode-languageserver-types";
-      version = "3.17.0-next.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.3.tgz";
-        sha512 = "VQcXnhKYxUW6OiRMhG++SzmZYMJwusXknJGd+FfdOnS1yHAo734OHyR0e2eEHDlv0/oWc8RZPgx/VKSKyondVg==";
-      };
-    };
     "vscode-languageserver-types-3.17.2" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
@@ -48203,50 +48167,6 @@ in
     meta = {
       description = "coc.nvim extension for cmake language";
       homepage = "https://github.com/voldikss/coc-cmake#readme";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
-  coc-docker = nodeEnv.buildNodePackage {
-    name = "coc-docker";
-    packageName = "coc-docker";
-    version = "1.0.2";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/coc-docker/-/coc-docker-1.0.2.tgz";
-      sha512 = "6As7Y7yhU0aI5UwI/QOuJzmAluoDMUcOcNg0yJZOMsnpjw9ezrPdNMIo+vRImXp1V/STU0j27CztwnH8vofOQQ==";
-    };
-    dependencies = [
-      sources."dockerfile-ast-0.4.2"
-      sources."dockerfile-language-server-nodejs-0.9.0"
-      (
-        sources."dockerfile-language-service-0.9.0"
-        // {
-          dependencies = [
-            sources."vscode-languageserver-types-3.17.0-next.3"
-          ];
-        }
-      )
-      sources."dockerfile-utils-0.10.0"
-      sources."tslib-2.8.1"
-      sources."vscode-jsonrpc-8.1.0"
-      sources."vscode-languageserver-8.1.0"
-      (
-        sources."vscode-languageserver-protocol-3.17.3"
-        // {
-          dependencies = [
-            sources."vscode-languageserver-types-3.17.3"
-          ];
-        }
-      )
-      sources."vscode-languageserver-textdocument-1.0.12"
-      sources."vscode-languageserver-types-3.17.5"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "docker extension for coc";
-      homepage = "https://github.com/josa42/coc-docker#readme";
       license = "MIT";
     };
     production = true;


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
