### PR TITLE
lib/systems/platforms: Add ppc64; linux: Add 64-bit POWER settings, strip vmlinux kernels

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -33,16 +33,6 @@ rec {
       baseConfig = "powernv_defconfig";
       target = "vmlinux";
       autoModules = true;
-      # avoid driver/FS trouble arising from unusual page size
-      extraConfig = ''
-        PPC_64K_PAGES n
-        PPC_4K_PAGES y
-        IPV6 y
-
-        ATA_BMDMA y
-        ATA_SFF y
-        VIRTIO_MENU y
-      '';
     };
   };
 

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -22,6 +22,10 @@ rec {
     linux-kernel.autoModules = false;
   };
 
+  ##
+  ## POWER
+  ##
+
   powernv = {
     linux-kernel = {
       name = "PowerNV";
@@ -39,6 +43,16 @@ rec {
         ATA_SFF y
         VIRTIO_MENU y
       '';
+    };
+  };
+
+  ppc64 = {
+    linux-kernel = {
+      name = "powerpc64";
+
+      baseConfig = "ppc64_defconfig";
+      target = "vmlinux";
+      autoModules = true;
     };
   };
 
@@ -628,8 +642,8 @@ rec {
     else if platform.parsed.cpu == lib.systems.parse.cpuTypes.mipsel then
       (import ./examples.nix { inherit lib; }).mipsel-linux-gnu
 
-    else if platform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le then
-      powernv
+    else if platform.isPower64 then
+      if platform.isLittleEndian then powernv else ppc64
 
     else if platform.isLoongArch64 then
       loongarch64-multiplatform

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -504,6 +504,12 @@ lib.makeOverridable (
         export HOME=${installkernel}
       '';
 
+    preFixup = ''
+      if [ -z "''${dontStrip-}" -a -e $out/vmlinux ]; then
+        strip -v -S -p $out/vmlinux
+      fi
+    '';
+
     requiredSystemFeatures = [ "big-parallel" ];
 
     passthru = rec {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -986,6 +986,9 @@ let
       XEN_PVHVM = option yes;
       XEN_SAVE_RESTORE = option yes;
 
+      # Disabled by default on POWER
+      VIRTIO_MENU = yes;
+
       # Enable device detection on virtio-mmio hypervisors
       VIRTIO_MMIO_CMDLINE_DEVICES = yes;
 
@@ -1433,6 +1436,10 @@ let
         # Enable coreboot firmware drivers.
         # While these are called CONFIG_GOOGLE_*, they apply to coreboot systems in general.
         GOOGLE_FIRMWARE = yes;
+
+        # Disabled by default on POWER
+        ATA_BMDMA = yes;
+        ATA_SFF = yes;
       }
       //
         lib.optionalAttrs
@@ -1548,6 +1555,11 @@ let
 
         # Enable Intel Turbo Boost Max 3.0
         INTEL_TURBO_MAX_3 = yes;
+      }
+      // lib.optionalAttrs (stdenv.hostPlatform.isPower64) {
+        # avoid driver/FS trouble arising from unusual page size
+        PPC_64K_PAGES = no;
+        PPC_4K_PAGES = yes;
       };
 
     accel = {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1560,6 +1560,15 @@ let
         # avoid driver/FS trouble arising from unusual page size
         PPC_64K_PAGES = no;
         PPC_4K_PAGES = yes;
+
+        # Does not get auto-loaded on relevant systems, makes fans stuck at max speed.
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=713943 (2014 :<)
+        # > This module ought to be auto-loaded where it's needed, but somehow that
+        # > has broken.  I asked Benjamin Herrenschmidt (upstream powerpc maintainer
+        # > and the last person to touch it) and he was aware of this but hadn't got
+        # > round to working out why.  The workaround is to build it in[…].
+        # > (It won't do any harm on non-Mac systems.)
+        I2C_POWERMAC = yes;
       };
 
     accel = {


### PR DESCRIPTION
Testing this via VM tests won't happen (#447751), but I did boot this once on hardware: https://tech.lgbt/@Puna/115323957077318335

The `vmlinux` stripping part could be moved into a separate PR, but a 340+ MiB kernel makes using this without the stripping abit annoying, and I don't think there are any `vmlinux` configs that we support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
