### PR TITLE
Include all usr/ paths when assembling paths for buildFHSEnv.

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/rootfs-builder/src/main.rs
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/rootfs-builder/src/main.rs
@@ -213,7 +213,15 @@ fn remap_multilib_path(root: &Path, p: &Path) -> Option<PathBuf> {
         return Some(PathBuf::from("usr/").join(libdir).join(no_lib));
     }
 
-    if p.starts_with("etc/") || p.starts_with("opt/") {
+    if p.starts_with("etc/") {
+        return Some(p.into());
+    }
+
+    if p.starts_with("usr/")  || p.starts_with("opt/") {
+        // Useful when proprietary code has a hardcoded path dependency.
+        // They are often put in places like
+        // /opt/FOO  /usr/local/ /usr/FOO etc
+        // Should really make these paths configurable through ATTRS file.
         return Some(p.into());
     }
 


### PR DESCRIPTION
Include all paths under usr/ in the same clause as opt/ to cover more proprietary applications ( e.g. depending on stuff in /usr/local/ or /usr/FOO/ )


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
