### PR TITLE
python3Packages.certifi: fix build on Python 3.10

### DIFF
--- a/pkgs/development/python-modules/certifi/env.patch
+++ b/pkgs/development/python-modules/certifi/env.patch
@@ -1,5 +1,5 @@
 diff --git a/certifi/core.py b/certifi/core.py
-index 1c9661c..7039be3 100644
+index 1c9661c..d904382 100644
 --- a/certifi/core.py
 +++ b/certifi/core.py
 @@ -4,6 +4,7 @@ certifi.py
@@ -51,3 +51,11 @@ index 1c9661c..7039be3 100644
  
      def where() -> str:
          # This is slightly terrible, but we want to delay extracting the
+@@ -80,4 +92,6 @@ else:
+         return _CACERT_PATH
+ 
+     def contents() -> str:
+-        return read_text("certifi", "cacert.pem", encoding="ascii")
++        if _CACERT_PATH is not None:
++            return open(_CACERT_PATH, encoding="utf-8").read()
++        return read_text("certifi", "cacert.pem", encoding="utf-8")


### PR DESCRIPTION
The previous commit #420216 to the patch removed too much when adjusting to upstream deprecating 3.7; in particular it removed the patch to the `contents` function on Python <3.11. Nixpkgs gives `certifi` its own `cacert`, which isn't preprocessed to be ASCII, which upstream expects, so the patch previously changed the encoding to `utf-8`.


## Things done

The associated pytests run, and I checked that the package works as expected in the repo where it's a nested dependency (https://github.com/UniMath/agda-unimath)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
