### PR TITLE
vscode-extensions.jetpack-io.devbox: init at 0.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14040,6 +14040,12 @@
     githubId = 15742918;
     name = "Sergey Kuznetsov";
   };
+  kuzushicat = {
+    email = "kuzushicat-nixpkgs.postwar333@passmail.net";
+    github = "kuzushicat";
+    githubId = 235389611;
+    name = "KuzushiCat";
+  };
   kvendingoldo = {
     email = "kvendingoldo@gmail.com";
     github = "kvendingoldo";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2540,6 +2540,8 @@ let
         };
       };
 
+      jetpack-io.devbox = callPackage ./jetpack-io.devbox { };
+
       jkillian.custom-local-formatters = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "jkillian";

--- a/pkgs/applications/editors/vscode/extensions/jetpack-io.devbox/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jetpack-io.devbox/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "devbox";
+    publisher = "jetpack-io";
+    version = "0.1.6";
+    hash = "sha256-cPlMZzF3UNVJCz16TNPoiGknukEWXNNXnjZVMyp/Dz8=";
+  };
+
+  meta = {
+    description = "Official VSCode extension for devbox open source project by jetify.com";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=jetpack-io.devbox";
+    homepage = "https://github.com/jetify-com/devbox#readme";
+    changelog = "https://marketplace.visualstudio.com/items/jetpack-io.devbox/changelog";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kuzushicat ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Things done
I have added the [jetify-io.devbox vscode extension](https://github.com/jetify-com/devbox/blob/main/vscode-extension/README.md) as a new package. It allows integration of the devbox shell into vscode/codium among other features. I've also assigned kuzushicat as maintainer of the package/extension.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
