### PR TITLE
cups-filters: fix build with gcc15

### DIFF
--- a/pkgs/by-name/cu/cups-filters/package.nix
+++ b/pkgs/by-name/cu/cups-filters/package.nix
@@ -6,6 +6,7 @@
   dbus,
   dejavu_fonts,
   fetchFromGitHub,
+  fetchpatch,
   fontconfig,
   gawk,
   ghostscript,
@@ -61,6 +62,16 @@
         rev = version;
         hash = "sha256-bLOl64bdeZ10JLcQ7GbU+VffJu3Lzo0ves7O7GQIOWY=";
       };
+
+      patches = [
+        # Fix build with gcc15
+        # https://github.com/OpenPrinting/cups-filters/pull/618
+        (fetchpatch {
+          name = "cups-filters-fix-build-with-gcc15-c23.patch";
+          url = "https://github.com/OpenPrinting/cups-filters/commit/9871a50b5c1f9c2caa2754aac1f5db70c886021b.patch";
+          hash = "sha256-Hu3nCHzX6K4tD7T5XIt0dh6GPQxmgfuHqbBXWfdXxoA=";
+        })
+      ];
 
       strictDeps = true;
 


### PR DESCRIPTION
- add patch from merged upstream PR:
https://www.github.com/OpenPrinting/cups-filters/pull/618
https://github.com/OpenPrinting/cups-filters/commit/9871a50b5c1f9c2caa2754aac1f5db70c886021b

Fixes build failure with gcc15:
```
filter/foomatic-rip/renderer.c: In function 'exec_kid3':
filter/foomatic-rip/renderer.c:456:32: error: passing argument 2 of
'start_process' from incompatible pointer type [-Wincompatible-pointer-types]
  456 |   kid4 = start_process("kid4", exec_kid4, NULL, &kid4in, NULL);
      |                                ^~~~~~~~~
      |                                |
      |                                int (*)(FILE *, FILE *, void *)
In file included from filter/foomatic-rip/renderer.c:21:
filter/foomatic-rip/process.h:21:45: note: expected 'int (*)(void)' but
argument is of type 'int (*)(FILE *, FILE *, void *)'
   21 | pid_t start_process(const char *name, int (*proc_func)(), void *user_arg,
      |                                       ~~~~~~^~~~~~~~~~~~
filter/foomatic-rip/renderer.c:384:1: note: 'exec_kid4' declared here
  384 | exec_kid4(FILE *in,
      | ^~~~~~~~~
filter/foomatic-rip/process.c:231:1: error: conflicting types for 'start_process';
have 'pid_t(const char *, int (*)(FILE *, FILE *, void *), void *, FILE **, FILE **)'
{aka 'int(const char *, int (*)(FILE *, FILE *, void *), void *, FILE **, FILE **)'}
  231 | start_process(const char *name,
      | ^~~~~~~~~~~~~
In file included from filter/foomatic-rip/process.c:14:
filter/foomatic-rip/process.h:21:7: note: previous declaration of 'start_process'
with type 'pid_t(const char *, int (*)(void), void *, FILE **, FILE **)'
{aka 'int(const char *, int (*)(void), void *, FILE **, FILE **)'}
   21 | pid_t start_process(const char *name, int (*proc_func)(), void *user_arg,
      |       ^~~~~~~~~~~~~
```
---

Tested build with:
```bash
nix-build --expr 'with import ./. {}; cups-filters.override { stdenv = gcc15Stdenv; }'
```

Part of fixes for gcc15 update:
https://github.com/NixOS/nixpkgs/pull/440456

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
