### PR TITLE
papermc: 1.21.8 -> 1.21.9

### DIFF
--- a/pkgs/games/papermc/update.py
+++ b/pkgs/games/papermc/update.py
@@ -47,7 +47,7 @@ class VersionManager:
 
         # we only want versions that are no pre-releases
         release_versions = filter(
-            lambda v_name: 'pre' not in v_name, response.json()["versions"])
+            lambda v_name: all(s not in v_name for s in ["pre", "rc"]), response.json()["versions"])
 
         for version_name in release_versions:
 

--- a/pkgs/games/papermc/versions.json
+++ b/pkgs/games/papermc/versions.json
@@ -86,5 +86,9 @@
     "1.21.8": {
         "hash": "sha256-jefFLDsCQDUD0W+sWAA/Hv733XoCVnhoQ5J/qS7lfx4=",
         "version": "1.21.8-60"
+    },
+    "1.21.9": {
+        "hash": "sha256-YXZVx7iTC3EViKM8r4SKBLgArd0JcZ9jziZuBtWBYOc=",
+        "version": "1.21.9-41"
     }
 }


### PR DESCRIPTION
Hey all, first time contributing to a nixpkg so let me know if I've missed or am doing something dumb. Also feel free to tell me I've jumped the gun on doing this update since 1.21.9 paper is still new :) 

Changes:
- Patched update.py to skip release-candidates (https://api.papermc.io/v2/projects/paper has a "1.21.9-rc1" version that wasnt handled gracefully)
- Fetched new 1.21.9 jar using update.py


## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Note I also manually used the built jar in my paper server config, and everything worked as expected

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
