### PR TITLE
mtkclient: Init at 2.0.1/HEAD

### DIFF
--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchFromGitHub,
+  fuse,
+  lib,
+  libusb1,
+  python3Packages,
+  ...
+}:
+python3Packages.buildPythonApplication {
+  name = "mtkclient";
+  version = "2.0.1";
+  pyproject = true;
+
+  build-system = with python3Packages; [ hatchling ];
+
+  src = fetchFromGitHub {
+    owner = "bkerler";
+    repo = "mtkclient";
+    rev = "399b3a1c25e73ddf4951f12efd20f7254ee04a39";
+    hash = "sha256-XNPYeVhp5P+zQdumS9IzlUd5+WebL56qcgs10WS2/LY=";
+  };
+
+  buildInputs = [
+    libusb1
+    fuse
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    wheel
+    setuptools
+    pyusb
+    pycryptodome
+    pycryptodomex
+    colorama
+    shiboken6
+    pyside6
+    mock
+    pyserial
+    flake8
+    keystone-engine
+    capstone
+    unicorn
+    keystone-engine
+    fusepy
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    cp $src/mtkclient/Setup/Linux/*.rules $out/lib/udev/rules.d
+    ln -s $out/bin/mtk $out/bin/mtkclient
+  '';
+
+  meta = {
+    description = "MTK reverse engineering and flash tool.";
+    homepage = "https://github.com/bkerler/mtkclient";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "mtk";
+    maintainers = with lib.maintainers; [ shymega ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds `mtkclient` at v2.0.1, but the `src` is at the latest Git HEAD, due to needing a release after v2.0.1 to fix `pyproject.toml`.

It's not ideal, but once a new release is made, I'll push a PR to bump the version and src tag/hash.

`mtkclient` is a set of Python tools to work with the preloader/boot ROM on certain Mediatek devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
