### PR TITLE
electron-mail: 5.3.0 -> 5.3.3

### DIFF
--- a/pkgs/by-name/el/electron-mail/package.nix
+++ b/pkgs/by-name/el/electron-mail/package.nix
@@ -34,7 +34,7 @@ appimageTools.wrapType2 {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Unofficial Election-based ProtonMail desktop client";
+    description = "Unofficial Electron-based ProtonMail desktop client";
     mainProgram = "electron-mail";
     homepage = "https://github.com/vladimiry/ElectronMail";
     license = lib.licenses.gpl3;


### PR DESCRIPTION
Updates `electron-mail` to the upstream v5.3.3 release (latest AppImage).

- use `--replace-fail` so the desktop entry patch fails if upstream changes
- fix the meta description typo

Upstream release notes: https://github.com/vladimiry/ElectronMail/releases/tag/v5.3.3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in `nixos/tests`
  - [ ] Package tests (`passthru.tests`)
  - [ ] Tests in `lib/tests` or `pkgs/test`
- [x] Ran `nixpkgs-review` on this PR (optional)
- [ ] Tested basic functionality of all binary files
- Nixpkgs Release Notes
  - [ ] Package update (major/breaking)
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md`

Tested via `nix build .#electron-mail` on x86_64-linux.
