### PR TITLE
python3Packages.bcrypt: 4.3.0 -> 5.0.0, adopt

### DIFF
--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage rec {
     description = "Modern password hashing for your software and your servers";
     homepage = "https://github.com/pyca/bcrypt/";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -5,12 +5,9 @@
   rustPlatform,
   rustc,
   setuptools,
-  setuptoolsRustBuildHook,
-  fetchPypi,
-  pythonOlder,
+  setuptools-rust,
+  fetchFromGitHub,
   pytestCheckHook,
-  libiconv,
-  stdenv,
   # for passthru.tests
   asyncssh,
   django_4,
@@ -21,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "bcrypt";
-  version = "4.3.0";
-  format = "pyproject";
+  version = "5.0.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Oj/SIEF4ttKtzwnLT2Qm/+9UdiV3p8m1TBWQCMsojBg=";
+  src = fetchFromGitHub {
+    owner = "pyca";
+    repo = "bcrypt";
+    tag = version;
+    hash = "sha256-7Dp07xoq6h+fiP7d7/TRRoYszWsyQF1c4vuFUpZ7u6U=";
   };
 
   cargoRoot = "src/_bcrypt";
@@ -39,19 +36,19 @@ buildPythonPackage rec {
       src
       cargoRoot
       ;
-    hash = "sha256-HgHvfMBspPsSYhllnKBg5XZB6zxFIqJj+4//xKG8HwA=";
+    hash = "sha256-hYMJlwxnXA0ZOJiyZ8rDp9govVcc1SGkDfqUVngnUPQ=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
-    setuptoolsRustBuildHook
+    setuptools-rust
+  ];
+
+  nativeBuildInputs = [
     rustPlatform.cargoSetupHook
     cargo
     rustc
   ];
-
-  # Remove when https://github.com/NixOS/nixpkgs/pull/190093 lands.
-  buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -67,10 +64,11 @@ buildPythonPackage rec {
       ;
   };
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/pyca/bcrypt/blob/${src.tag}/CHANGELOG.rst";
     description = "Modern password hashing for your software and your servers";
     homepage = "https://github.com/pyca/bcrypt/";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/libpass/default.nix
+++ b/pkgs/development/python-modules/libpass/default.nix
@@ -41,6 +41,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "passlib" ];
 
+  disabledTestPaths = [
+    # https://github.com/notypecheck/passlib/issues/18
+    "tests/test_handlers_bcrypt.py::bcrypt_bcrypt_test::test_70_hashes"
+    "tests/test_handlers_bcrypt.py::bcrypt_bcrypt_test::test_77_fuzz_input"
+    "tests/test_handlers_django.py::django_bcrypt_test::test_77_fuzz_input"
+    "tests/test_handlers_bcrypt.py::bcrypt_bcrypt_test::test_secret_w_truncate_size"
+    "tests/test_handlers_django.py::django_bcrypt_test::test_secret_w_truncate_size"
+  ];
+
   disabledTests = [
     # timming sensitive
     "test_dummy_verify"


### PR DESCRIPTION
Diff: https://github.com/pyca/bcrypt/compare/4.3.0...5.0.0

Changelog: https://github.com/pyca/bcrypt/blob/5.0.0/README.rst#changelog

This breaks at least

- [x] python3Packages.libpass https://github.com/notypecheck/passlib/issues/18
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
