### PR TITLE
opentofu: fix `withPlugins` to properly propagate package

### DIFF
--- a/pkgs/by-name/op/opentofu/package.nix
+++ b/pkgs/by-name/op/opentofu/package.nix
@@ -42,7 +42,7 @@ let
     patches = [ ./provider-path-0_15.patch ];
 
     passthru = {
-      inherit full plugins withPlugins;
+      inherit plugins;
       tests = {
         inherit opentofu_plugins_test;
       };
@@ -73,8 +73,6 @@ let
     };
   };
 
-  full = withPlugins (p: lib.filter lib.isDerivation (lib.attrValues p.actualProviders));
-
   opentofu_plugins_test =
     let
       mainTf = writeText "main.tf" ''
@@ -88,7 +86,7 @@ let
 
         resource "random_id" "test" {}
       '';
-      opentofu = package.withPlugins (p: [ p.random ]);
+      opentofu = (pluggable package).withPlugins (p: [ p.random ]);
       test = runCommand "opentofu-plugin-test" { buildInputs = [ opentofu ]; } ''
         # make it fail outside of sandbox
         export HTTP_PROXY=http://127.0.0.1:0 HTTPS_PROXY=https://127.0.0.1:0
@@ -105,89 +103,95 @@ let
     "recurseForDerivations"
   ];
 
-  withPlugins =
-    plugins:
+  pluggable =
+    opentofu:
     let
-      actualPlugins = plugins package.plugins;
+      withPlugins =
+        plugins:
+        let
+          actualPlugins = plugins opentofu.plugins;
 
-      # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
-      wrapperInputs = lib.unique (
-        lib.flatten (lib.catAttrs "propagatedBuildInputs" (builtins.filter (x: x != null) actualPlugins))
-      );
+          # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
+          wrapperInputs = lib.unique (
+            lib.flatten (lib.catAttrs "propagatedBuildInputs" (builtins.filter (x: x != null) actualPlugins))
+          );
 
-      passthru = {
-        withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);
+          passthru = {
+            withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);
+            full = withPlugins (p: lib.filter lib.isDerivation (lib.attrValues p.actualProviders));
 
-        # Expose wrappers around the override* functions of the terraform
-        # derivation.
-        #
-        # Note that this does not behave as anyone would expect if plugins
-        # are specified. The overrides are not on the user-visible wrapper
-        # derivation but instead on the function application that eventually
-        # generates the wrapper. This means:
-        #
-        # 1. When using overrideAttrs, only `passthru` attributes will
-        #    become visible on the wrapper derivation. Other overrides that
-        #    modify the derivation *may* still have an effect, but it can be
-        #    difficult to follow.
-        #
-        # 2. Other overrides may work if they modify the terraform
-        #    derivation, or they may have no effect, depending on what
-        #    exactly is being changed.
-        #
-        # 3. Specifying overrides on the wrapper is unsupported.
-        #
-        # See nixpkgs#158620 for details.
-        overrideDerivation = f: (package.overrideDerivation f).withPlugins plugins;
-        overrideAttrs = f: (package.overrideAttrs f).withPlugins plugins;
-        override = x: (package.override x).withPlugins plugins;
-      };
+            # Expose wrappers around the override* functions of the terraform
+            # derivation.
+            #
+            # Note that this does not behave as anyone would expect if plugins
+            # are specified. The overrides are not on the user-visible wrapper
+            # derivation but instead on the function application that eventually
+            # generates the wrapper. This means:
+            #
+            # 1. When using overrideAttrs, only `passthru` attributes will
+            #    become visible on the wrapper derivation. Other overrides that
+            #    modify the derivation *may* still have an effect, but it can be
+            #    difficult to follow.
+            #
+            # 2. Other overrides may work if they modify the terraform
+            #    derivation, or they may have no effect, depending on what
+            #    exactly is being changed.
+            #
+            # 3. Specifying overrides on the wrapper is unsupported.
+            #
+            # See nixpkgs#158620 for details.
+            overrideDerivation = f: (pluggable (opentofu.overrideDerivation f)).withPlugins plugins;
+            overrideAttrs = f: (pluggable (opentofu.overrideAttrs f)).withPlugins plugins;
+            override = x: (pluggable (opentofu.override x)).withPlugins plugins;
+          };
+        in
+        # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
+        # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
+        if actualPlugins == [ ] then
+          opentofu.overrideAttrs (orig: {
+            passthru = orig.passthru // passthru;
+          })
+        else
+          lib.appendToName "with-plugins" (
+            stdenv.mkDerivation {
+              inherit (opentofu) meta pname version;
+              nativeBuildInputs = [ makeWrapper ];
+
+              # Expose the passthru set with the override functions
+              # defined above, as well as any passthru values already
+              # set on `terraform` at this point (relevant in case a
+              # user overrides attributes).
+              passthru = opentofu.passthru // passthru;
+
+              buildCommand = ''
+                # Create wrappers for terraform plugins because OpenTofu only
+                # walks inside of a tree of files.
+                # Also replace registry.terraform.io dir with registry.opentofu.org,
+                # so OpenTofu can find the plugins.
+                for providerDir in ${toString actualPlugins}
+                do
+                  for file in $(find $providerDir/libexec/terraform-providers -type f)
+                  do
+                    relFile=''${file#$providerDir/}
+                    relFile=''${relFile/registry.terraform.io/registry.opentofu.org}
+                    mkdir -p $out/$(dirname $relFile)
+                    cat <<WRAPPER > $out/$relFile
+                #!${runtimeShell}
+                exec "$file" "$@"
+                WRAPPER
+                    chmod +x $out/$relFile
+                  done
+                done
+
+                # Create a wrapper for opentofu to point it to the plugins dir.
+                mkdir -p $out/bin/
+                makeWrapper "${opentofu}/bin/tofu" "$out/bin/tofu" \
+                  --set NIX_TERRAFORM_PLUGIN_DIR $out/libexec/terraform-providers \
+                  --prefix PATH : "${lib.makeBinPath wrapperInputs}"
+              '';
+            }
+          );
     in
-    # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
-    # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
-    if actualPlugins == [ ] then
-      package.overrideAttrs (orig: {
-        passthru = orig.passthru // passthru;
-      })
-    else
-      lib.appendToName "with-plugins" (
-        stdenv.mkDerivation {
-          inherit (package) meta pname version;
-          nativeBuildInputs = [ makeWrapper ];
-
-          # Expose the passthru set with the override functions
-          # defined above, as well as any passthru values already
-          # set on `terraform` at this point (relevant in case a
-          # user overrides attributes).
-          passthru = package.passthru // passthru;
-
-          buildCommand = ''
-            # Create wrappers for terraform plugins because OpenTofu only
-            # walks inside of a tree of files.
-            # Also replace registry.terraform.io dir with registry.opentofu.org,
-            # so OpenTofu can find the plugins.
-            for providerDir in ${toString actualPlugins}
-            do
-              for file in $(find $providerDir/libexec/terraform-providers -type f)
-              do
-                relFile=''${file#$providerDir/}
-                relFile=''${relFile/registry.terraform.io/registry.opentofu.org}
-                mkdir -p $out/$(dirname $relFile)
-                cat <<WRAPPER > $out/$relFile
-            #!${runtimeShell}
-            exec "$file" "$@"
-            WRAPPER
-                chmod +x $out/$relFile
-              done
-            done
-
-            # Create a wrapper for opentofu to point it to the plugins dir.
-            mkdir -p $out/bin/
-            makeWrapper "${package}/bin/tofu" "$out/bin/tofu" \
-              --set NIX_TERRAFORM_PLUGIN_DIR $out/libexec/terraform-providers \
-              --prefix PATH : "${lib.makeBinPath wrapperInputs}"
-          '';
-        }
-      );
+    withPlugins (_: [ ]);
 in
-package
+pluggable package


### PR DESCRIPTION
Adjusts the OpenTofu package in line with the [`pluggable` construct](https://github.com/NixOS/nixpkgs/commit/80319c123876064df40235eb21ab9ddd2d5a241a#diff-e5f49304a8a3dd119d91adf831640baa940ef883d4fc414d1623f31fe01fa2d5) used over at the Terraform package.

This resolves a bug preventing package overrides from properly getting propagated.
This triggered particularly in constructs invoking `overrideAttrs` after `withPlugins`, e.g.:

- `(pkgs.opentofu.overrideAttrs { ... }).withPlugins (p: with p; [ ... ])`
- `(pkgs.opentofu.withPlugins (p: with p; [ ... ])).overrideAttrs { ... }`

Prior to this fix, in such an invocation the `overrideAttrs` part would not take effect, given the original `package` would simply be used in `${package}/bin/tofu`.

/cc @zowoq @NickCao

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
