### PR TITLE
vscode-extensions.docker.docker: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13827,6 +13827,13 @@
     githubId = 1903418;
     name = "Kovacsics Robert";
   };
+  kozm9000 = {
+    email = "ubermailbox@protonmail.ch";
+    github = "kozm9000";
+    githubId = 80588292;
+    name = "Roman Balashov";
+    keys = [ { fingerprint = "E5A5 700D 96ED 42F2 13D4  D16B 2E79 1278 5DDB 96B5"; } ];
+  };
   kpbaks = {
     email = "kristoffer.pbs@gmail.com";
     github = "kpbaks";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1366,6 +1366,8 @@ let
         };
       };
 
+      docker.docker = callPackage ./docker.docker { };
+
       donjayamanne.githistory = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "githistory";

--- a/pkgs/applications/editors/vscode/extensions/docker.docker/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/docker.docker/default.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  vscode-utils,
+}:
+
+let
+  supported = {
+    x86_64-linux = {
+      hash = "sha256-2m1hVQ497zQs2pmk+F+5thO4cz7dP4dDEPznPBqKfX0=";
+      arch = "linux-x64";
+    };
+    x86_64-darwin = {
+      hash = "sha256-U2BcDUiper4chL8rF4ZUSos7erfXaq1LNqYYsRe2GDk=";
+      arch = "darwin-x64";
+    };
+    aarch64-linux = {
+      hash = "sha256-qYdYmPZPlf++cJWLbhvqeO0uePbAJE4hL2bVYlKbk0c=";
+      arch = "linux-arm64";
+    };
+    aarch64-darwin = {
+      hash = "sha256-oN3CWc/OLbeuyKfdPoh26yUQzH3d6YfpxacByWM43qk=";
+      arch = "darwin-arm64";
+    };
+  };
+
+  base =
+    supported.${stdenv.hostPlatform.system}
+      or (throw "unsupported platform ${stdenv.hostPlatform.system}");
+
+in
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = base // {
+    publisher = "docker";
+    name = "docker";
+    version = "0.17.0";
+  };
+
+  meta = {
+    description = "Official Docker DX (Developer Experience) extension. Edit smarter, ship faster with an enhanced Docker-development experience.";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=docker.docker";
+    homepage = "https://github.com/docker/vscode-extension#readme";
+    changelog = "https://marketplace.visualstudio.com/items/docker.docker/changelog";
+    license = lib.licenses.asl20;
+    platforms = builtins.attrNames supported;
+    maintainers = [ lib.maintainers.kozm9000 ];
+  };
+}


### PR DESCRIPTION
New [official](https://www.docker.com/blog/docker-dx-extension-for-vs-code/) Docker extension. 
When downloaded via `pkgs.vscode-utils.extensionsFromVscodeMarketplace` without specifying `arch` defaults to `aarch64-linux`  ( `?targetPlatform=` in `mktplcExtRefToFetchArgs.nix` is empty ).  This determines which version of [Docker Language Server](https://github.com/docker/docker-language-server) binary is bundled with the extension. Without it, the extension does not work properly. See https://github.com/docker/vscode-extension/issues/110#issuecomment-3350215471
## Things done
Since I only have `x86_64-linux`, I could not test it for other platforms within VSCode. However, when built with `nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'` for each platform ( specifying sha256 and arch manually ), build succeeds without errors and correct binary is stored in `/nix/store/hash-vscode-extension-docker-docker-0.17.0/share/vscode/extensions/docker.docker/bin/`
`docker-language-server-linux-amd64`
`docker-language-server-linux-arm64`
`docker-language-server-darwin-amd64`
`docker-language-server-darwin-arm64`

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
