### PR TITLE
python3Packages.tree-sitter-zeek: init at 0.2.9; zeekscript: update, unbreak, modernize

### DIFF
--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -1,31 +1,35 @@
 {
   lib,
   python3,
-  fetchPypi,
+  fetchFromGitHub,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "zeekscript";
-  version = "1.2.8";
+  version = "1.3.2-unstable-2025-09-29";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-v0PJY0Ahxa4k011AwtWSIAWBXvt3Aybrd382j1SIT6M=";
+  src = fetchFromGitHub {
+    owner = "zeek";
+    repo = "zeekscript";
+    rev = "f0fa5746633a709759a94695fcc81b43feb8e2d9";
+    hash = "sha256-g4Iv9xw6Owuqi+UudRzWatK09mjNDWdp0cBvH7iuV+U=";
   };
 
-  postPatch = ''
-    sed -i '/name = "zeekscript"/a version = "${version}"' pyproject.toml
-  '';
+  build-system = with python3.pkgs; [ setuptools ];
 
-  nativeBuildInputs = with python3.pkgs; [
-    setuptools
-    wheel
-  ];
-
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
+    argcomplete
     tree-sitter
+    tree-sitter-zeek
   ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  checkInputs = with python3.pkgs; [ syrupy ];
 
   pythonImportsCheck = [
     "zeekscript"
@@ -34,13 +38,12 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "Zeek script formatter and analyzer";
     homepage = "https://github.com/zeek/zeekscript";
-    changelog = "https://github.com/zeek/zeekscript/blob/v${version}/CHANGES";
+    changelog = "https://github.com/zeek/zeekscript/blob/${src.rev}/CHANGES";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       fab
       tobim
+      mdaniels5757
     ];
-    # Incompatible with tree-sitter > 0.21.
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/tree-sitter-zeek/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-zeek/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  tree-sitter,
+}:
+
+buildPythonPackage rec {
+  pname = "tree-sitter-zeek";
+  version = "0.2.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "zeek";
+    repo = "tree-sitter-zeek";
+    tag = "v${version}";
+    hash = "sha256-0ixZAJ940mYIPD//RJVJ3PAVdY/jtYNJ5+WIlq+zfnY=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    core = [ tree-sitter ];
+  };
+
+  pythonImportsCheck = [ "tree_sitter_zeek" ];
+
+  meta = {
+    description = "Tree-sitter grammar for the Zeek scripting language";
+    homepage = "https://github.com/zeek/tree-sitter-zeek";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      mdaniels5757
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18715,6 +18715,8 @@ self: super: with self; {
 
   tree-sitter-yaml = callPackage ../development/python-modules/tree-sitter-yaml { };
 
+  tree-sitter-zeek = callPackage ../development/python-modules/tree-sitter-zeek { };
+
   treelib = callPackage ../development/python-modules/treelib { };
 
   treelog = callPackage ../development/python-modules/treelog { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
