### PR TITLE
kanagawa-gtk-theme: 0-unstable-2023-07-03 -> 0-unstable-2025-09-10

### DIFF
--- a/pkgs/by-name/ka/kanagawa-gtk-theme/package.nix
+++ b/pkgs/by-name/ka/kanagawa-gtk-theme/package.nix
@@ -4,20 +4,25 @@
   fetchFromGitHub,
   gtk3,
   gtk-engine-murrine,
+  sassc,
+  tweaks ? [ ],
+  variant ? "default",
+  size ? "standard",
 }:
 stdenvNoCC.mkDerivation {
   pname = "kanagawa-gtk-theme";
-  version = "0-unstable-2023-07-03";
+  version = "0-unstable-2025-09-10";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Kanagawa-GKT-Theme";
-    rev = "35936a1e3bbd329339991b29725fc1f67f192c1e";
-    hash = "sha256-BZRmjVas8q6zsYbXFk4bCk5Ec/3liy9PQ8fqFGHAXe0=";
+    rev = "36ce4c341dca01e497109f62e3ca26c9614ebefc";
+    hash = "sha256-iQbvKmHeyrNIFbuoqmX5jgmXWFjc0ZjAw4IxCOxic4k=";
   };
 
   nativeBuildInputs = [
     gtk3
+    sassc
   ];
 
   propagatedUserEnvPkgs = [
@@ -27,8 +32,13 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/themes
-    cp -a themes/* $out/share/themes
+    patchShebangs ./themes/install.sh
+    ./themes/install.sh \
+      --name Kanagawa \
+      --tweaks ${lib.concatStringsSep " " tweaks} \
+      --theme ${variant} \
+      --size ${size} \
+      --dest $out/share/themes
 
     runHook postInstall
   '';


### PR DESCRIPTION
needed a few changes due to upstream now using an install script


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
