### PR TITLE
rust/hooks: Fix linking for thumb targets

### DIFF
--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -92,6 +92,7 @@
               [
                 ''"-Ctarget-feature=${if stdenv.targetPlatform.isStatic then "+" else "-"}crt-static"''
               ]
+              ++ lib.optional (lib.strings.hasPrefix "thumbv" stdenv.targetPlatform.rust.rustcTarget) ''"-Clinker-flavor=gcc"''
               ++ lib.optional (!stdenv.targetPlatform.isx86_32) ''"-Cforce-frame-pointers=yes"''
             )
           } ]


### PR DESCRIPTION
For some reason rustc expect lld linker instead of cc (https://github.com/rust-lang/rust/blob/4da69dfff1929cc79872b3d05ab7112d84753dba/compiler/rustc_target/src/spec/base/thumb.rs#L35) for thumbv* targets unlike other targets. Therefore cross compilation for these targets are broken: gcc do not understand linker args without -Wl prefix:

    $ nix build
    ...
           > error: linking with `/nix/store/bp791a3wh7b4zqrf4h3vampxpydak7qa-armv7m-unknown-none-eabihf-gcc-wrapper-14.3.0/bin/armv7m-unknown-none-eabihf-cc` failed: exit status: 1
           >   |
           ...
           >   = note: armv7m-unknown-none-eabihf-gcc: error: unrecognized command-line option '-flavor'
           >           armv7m-unknown-none-eabihf-gcc: error: unrecognized command-line option '--as-needed'
           >           armv7m-unknown-none-eabihf-gcc: error: unrecognized command-line option '--eh-frame-hdr'
           >           armv7m-unknown-none-eabihf-gcc: error: unrecognized command-line option '--gc-sections'; did you mean '--data-sections'?

This can be fixed by giving rustc hint that the linker binary is in fact gcc using linker-flavor codegen CLI argument.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
