### PR TITLE
agdaPackages.agda2hs: init at 1.3-unstable-2025-07-25

### DIFF
--- a/pkgs/development/libraries/agda/agda2hs-base/default.nix
+++ b/pkgs/development/libraries/agda/agda2hs-base/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  mkDerivation,
+  haskellPackages,
+}:
+
+mkDerivation {
+  pname = "agda2hs-base";
+
+  inherit (haskellPackages.agda2hs) src version;
+
+  sourceRoot = "source/lib/base";
+
+  libraryFile = "base.agda-lib";
+
+  meta = with lib; {
+    homepage = "https://github.com/agda/agda2hs";
+    description = "Standard library for compiling Agda code to readable Haskell";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with maintainers; [
+      wrvsrx
+    ];
+  };
+}

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -36,6 +36,8 @@ let
 
       agda-categories = callPackage ../development/libraries/agda/agda-categories { };
 
+      agda2hs-base = callPackage ../development/libraries/agda/agda2hs-base { };
+
       cubical = callPackage ../development/libraries/agda/cubical { };
 
       cubical-mini = callPackage ../development/libraries/agda/cubical-mini { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
