### PR TITLE
mbmd: init at 0.13-unstable-2025-08-08

### DIFF
--- a/pkgs/by-name/mb/mbmd/package.nix
+++ b/pkgs/by-name/mb/mbmd/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+let
+  version = "0.13-unstable-2025-08-08";
+  rev = "499ae856f44e511b236660d9dce0021f758fc64e";
+  modulePath = "github.com/volkszaehler/mbmd";
+in
+buildGoModule {
+  pname = "mbmd";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "volkszaehler";
+    repo = "mbmd";
+    hash = "sha256-HdldLF9+QgaIvGG8lAENvUiPonMwrdHUphGRSmaeRj8=";
+  };
+
+  tags = [ "release" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X ${modulePath}/server.Version=${version}"
+    "-X ${modulePath}/server.Commit=${rev}"
+  ];
+
+  vendorHash = "sha256-L816AQmyL6ZctKgImbU/cAYSQkQhxuhvtr4SyjPKMFs=";
+
+  env.CGO_ENABLED = 0; # NOTE: Pure Go
+
+  meta = with lib; {
+    description = "ModBus Measurement Daemon - simple reading of data from ModBus meters and grid inverters";
+    homepage = "https://github.com/volkszaehler/mbmd";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tsandrini ];
+    mainProgram = "mbmd";
+  };
+}


### PR DESCRIPTION
Initializes package for https://github.com/volkszaehler/mbmd - the modbus measurement daemon for data from various meters and grid inverters, useful for various PLCs, rpis running NixOS -> mbmd enables quick prototyping and support in these scenarios.

I also have a NixOS module for mbmd in progress, which I will try to push later after this package is accepted hopefully :heart: 

**Note**: The project is actively developed and well supported, but doesn't seem to be doing releases (last from 5 years ago), so I decided to use the unstable versioning convention instead.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
