### PR TITLE
libtorrent-rasterbar: fix pkgconfig file

### DIFF
--- a/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
@@ -55,6 +55,11 @@ stdenv.mkDerivation {
       --replace-fail 'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")' \
                      'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
                       set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")'
+  ''
+  # a: libdir=''${prefix}//nix/store/...
+  # b: libdir=/nix/store/...
+  # https://github.com/NixOS/nixpkgs/issues/144170
+  + ''
     substituteInPlace cmake/Modules/GeneratePkgConfig/pkg-config.cmake.in \
       --replace-fail '$'{prefix}/@_INSTALL_LIBDIR@ @_INSTALL_FULL_LIBDIR@
   '';
@@ -67,6 +72,12 @@ stdenv.mkDerivation {
   postFixup = ''
     substituteInPlace "$dev/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets-release.cmake" \
       --replace-fail "\''${_IMPORT_PREFIX}/lib" "$out/lib"
+  ''
+  # a: Cflags: ... -I/nix/store/x//nix/store/x-dev/include ...
+  # b: Cflags: ... -I/nix/store/x-dev/include ...
+  + ''
+    substituteInPlace $dev/lib/pkgconfig/libtorrent-rasterbar.pc \
+      --replace-fail "$out/$dev" "$dev"
   '';
 
   outputs = [

--- a/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
@@ -1,35 +1,30 @@
 {
   lib,
   stdenv,
+  boost,
   fetchFromGitHub,
   cmake,
-  zlib,
-  boost,
   openssl,
   python3,
-  ncurses,
 }:
 
 let
-  version = "2.0.11";
-
   # Make sure we override python, so the correct version is chosen
   boostPython = boost.override {
     enablePython = true;
     python = python3;
   };
-
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtorrent-rasterbar";
-  inherit version;
+  version = "2.0.11";
 
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
-    tag = "v${version}";
-    hash = "sha256-iph42iFEwP+lCWNPiOJJOejISFF6iwkGLY9Qg8J4tyo=";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
+    hash = "sha256-iph42iFEwP+lCWNPiOJJOejISFF6iwkGLY9Qg8J4tyo=";
   };
 
   nativeBuildInputs = [
@@ -52,9 +47,10 @@ stdenv.mkDerivation {
   # https://github.com/arvidn/libtorrent/issues/6865
   postPatch = ''
     substituteInPlace cmake/Modules/GeneratePkgConfig/target-compile-settings.cmake.in \
-      --replace-fail 'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")' \
-                     'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
-                      set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")'
+      --replace-fail \
+        'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")' \
+        'set(_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@")
+         set(_INSTALL_FULL_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@")'
   ''
   # a: libdir=''${prefix}//nix/store/...
   # b: libdir=/nix/store/...
@@ -87,14 +83,15 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-Dpython-bindings=on"
+    (lib.cmakeBool "python-bindings" true)
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://libtorrent.org/";
-    description = "C++ BitTorrent implementation focusing on efficiency and scalability";
-    license = licenses.bsd3;
+    description = "Efficient feature complete C++ bittorrent implementation";
+    changelog = "https://github.com/arvidn/libtorrent/blob/${finalAttrs.src.tag}/ChangeLog";
+    license = lib.licenses.bsd3;
     maintainers = [ ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Things done

Fix `libtorrent-rasterbar.pc` generation, allowing for proper import via pkg-config.

Fixes https://github.com/milahu/nixpkgs/issues/93

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
