### PR TITLE
mesa: fix build with llvm 21 on exotic platforms

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -144,6 +144,8 @@ stdenv.mkDerivation {
 
   patches = [
     ./opencl.patch
+    # https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37027
+    ./gallivm-llvm-21.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/mesa/gallivm-llvm-21.patch
+++ b/pkgs/development/libraries/mesa/gallivm-llvm-21.patch
@@ -1,0 +1,53 @@
+From eca19331d94005485de5246cfa87a21621486cd8 Mon Sep 17 00:00:00 2001
+From: no92 <no92.mail@gmail.com>
+Date: Wed, 27 Aug 2025 16:02:31 +0200
+Subject: [PATCH] gallivm: support LLVM 21
+
+LLVM PR#146819 changed the signature of `setObjectLinkingLayerCreator`,
+dropping the Triple argument. The PR was first included in the LLVM 21
+series, and the new signature is gated behind a version check for that.
+
+`LLVMOrcThreadSafeContextGetContext` was removed in LLVM commit b18e5b6,
+and the ORC examples in the LLVM tree seem to just create a context
+instead, which we replicate here.
+
+With this commit, mesa successfully builds the llvmpipe gallium driver
+on riscv64 with LLVM 21.1.0.
+
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13785
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13852
+
+Reviewed-by: David Heidelberg <david@ixit.cz>
+---
+ src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
+index 3d2b8cf81bc0c..0be69b02b6eef 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
++++ b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
+@@ -340,7 +340,12 @@ LPJit::LPJit() :jit_dylib_count(0) {
+          .setJITTargetMachineBuilder(std::move(JTMB))
+ #ifdef USE_JITLINK
+          .setObjectLinkingLayerCreator(
++#if LLVM_VERSION_MAJOR >= 21
++            /* LLVM 21 removed the Triple argument */
++            [&](ExecutionSession &ES) {
++#else
+             [&](ExecutionSession &ES, const llvm::Triple &TT) {
++#endif
+                return std::make_unique<ObjectLinkingLayer>(
+                   ES, ExitOnErr(llvm::jitlink::InProcessMemoryManager::Create()));
+             })
+@@ -552,7 +557,7 @@ init_gallivm_state(struct gallivm_state *gallivm, const char *name,
+    gallivm->cache = cache;
+ 
+    gallivm->_ts_context = context->ref;
+-   gallivm->context = LLVMOrcThreadSafeContextGetContext(context->ref);
++   gallivm->context = LLVMContextCreate();
+ 
+    gallivm->module_name = LPJit::get_unique_name(name);
+    gallivm->module = LLVMModuleCreateWithNameInContext(gallivm->module_name,
+-- 
+GitLab
+


### PR DESCRIPTION
Closes #447936.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
