### PR TITLE
reel: init at 0.7.5

### DIFF
--- a/pkgs/by-name/re/reel/package.nix
+++ b/pkgs/by-name/re/reel/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  desktop-file-utils,
+  wrapGAppsHook4,
+  gtk4,
+  libadwaita,
+  adwaita-icon-theme,
+  hicolor-icon-theme,
+  libepoxy,
+  gst_all_1,
+  glib,
+  cairo,
+  pango,
+  gdk-pixbuf,
+  graphene,
+  sqlite,
+  openssl,
+  curl,
+  glib-networking,
+  libsecret,
+  dbus,
+  gettext,
+  librsvg,
+  mold,
+  mpv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "reel";
+  version = "0.7.5";
+
+  src = fetchFromGitHub {
+    owner = "arsfeld";
+    repo = "reel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-o4DgocqWBEjfOZaTOyKAFjSvyF00VQ3EBhODPfJE75c=";
+  };
+
+  cargoHash = "sha256-zHZ+BsyOdMPvoJJRd+S4f6lJ2WR8/whrbcgI5Cw2VQI=";
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    mold
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    adwaita-icon-theme
+    cairo
+    curl
+    dbus
+    dbus.dev
+    gdk-pixbuf
+    gettext
+    glib
+    glib-networking
+    graphene
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-rs
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gstreamer
+    gtk4
+    hicolor-icon-theme
+    libadwaita
+    libepoxy
+    librsvg
+    libsecret
+    mpv
+    openssl
+    pango
+    sqlite
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/reel \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath ( finalAttrs.buildInputs )
+      }
+  '';
+
+  # Running tests fail:
+  #   Running unittests src/lib.rs (target/x86_64-unknown-linux-gnu/release/deps/reel-4f2ffc60f7acb19a)
+  #   /build/source/target/x86_64-unknown-linux-gnu/release/deps/reel-4f2ffc60f7acb19a: error while loading shared libraries: libdbus-1.so.3: cannot open shared object file: No such file or directory
+  #   error: test failed, to rerun pass `--lib`
+  #   Caused by:
+  #   process didn't exit successfully: `/build/source/target/x86_64-unknown-linux-gnu/release/deps/reel-4f2ffc60f7acb19a` (exit status: 127)
+  #   note: test exited abnormally; to see the full output pass --nocapture to the harness.
+  doCheck = false;
+
+  meta = {
+    description = "Reel - A modern, native media player for the GNOME desktop";
+    homepage = "https://github.com/arsfeld/reel";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.onny ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adding [reel](https://github.com/arsfeld/reel) a native GTK4 Jellyfin and Plex client for movies and music

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
