### PR TITLE
Add an Agda team

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -333,6 +333,13 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /pkgs/development/dhall-modules      @Gabriella439 @Profpatsch
 /pkgs/development/interpreters/dhall @Gabriella439 @Profpatsch
 
+# Agda
+/pkgs/build-support/agda                  @NixOS/agda
+/pkgs/top-level/agda-packages.nix         @NixOS/agda
+/pkgs/development/libraries/agda          @NixOS/agda
+/doc/languages-frameworks/agda.section.md @NixOS/agda
+/nixos/tests/agda.nix                     @NixOS/agda
+
 # Idris
 /pkgs/development/idris-modules @Infinisil
 /pkgs/development/compilers/idris2 @mattpolzin

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -45,6 +45,17 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  agda = {
+    members = [
+      alexarice
+      ncfavier
+      phijor
+      turion
+    ];
+    scope = "Maintain Agda-related packages and modules.";
+    shortName = "Agda";
+  };
+
   android = {
     members = [
       adrian-gierakowski

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -364,6 +364,7 @@ package-maintainers:
     - amazonka
   ncfavier:
     - Agda
+    - agda2hs
     - irc-client
     - lambdabot
     - shake


### PR DESCRIPTION
Adding myself as a code owner for Agda-related paths. Currently @philiptaron gets pinged by default as owner of `pkgs/build-support`, as in https://github.com/NixOS/nixpkgs/pull/447924.

**Does anyone else want to be added?** cc @iblech @turion @alexarice @phijor @mudri

EDIT: Also adding myself as a maintainer for the orphaned `agda2hs` package.