### PR TITLE
jetbrains: 2025.2.1.1 -> 2025.2.4

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -19,10 +19,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "7cac5ce1fc16ee3e7500a675ebf235e3285d6e87c0d61e8370e847f3a48528a7",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3.tar.gz",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "37d0af4ec30b94c71d3507fe35b3b0bdd389903db7e2f1a8ed73353b22718476",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4.tar.gz",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -84,26 +84,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "3397ebebc3531eca4c6b866e8223a5d53c04794dd847f2bbd7218c2b5d1b9a24",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "1c8977152a96132145b7ca2c3ba99e56f24690659bca14850c29a084b3ee761f",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.2.tar.gz",
+      "build_number": "252.26199.168"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "280da5efe11f17d86e5173fe0cf05af4704b9c858f1c9c2fea6de6b2071ada83",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "6ffd11bc2ab84f57e90683ce5a9c73ff6ec47e5746e7e4d7ce5f2dc335af6481",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.2.tar.gz",
+      "build_number": "252.26199.168"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "1ebffac91d70f8ce64567955de35738bb52d5e81b45d8c67dd494ff3fa0301df",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.tar.gz",
-      "build_number": "252.26199.154"
+      "version": "2025.2.2.1",
+      "sha256": "3b2550f438cc82ad31df42aa639d9c763d7f530942f85571438061c808dfefbb",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.1.tar.gz",
+      "build_number": "252.26199.190"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -158,10 +158,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "33caa8e0fb4c76e2704bc2457d0b87209f53861517bb43a1c675811b0703a773",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3-aarch64.tar.gz",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "7df40778500a599d565ba985d1583f3334903fbb731f53add526b19557208d97",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4-aarch64.tar.gz",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -223,26 +223,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "f501a424c1554fb529bc3de3ce7ce49587ef419ebfd85d8ec12ddb5eaf291022",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1-aarch64.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "81058e1fa8cc4e9f075d286a8016a345724e2f454a18f641f3ab0b73ade972a5",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.2-aarch64.tar.gz",
+      "build_number": "252.26199.168"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "97a359d900e4010a1d1ca57a9ae9f496f16bb377798d8fe0ffbfb071bbbc191c",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1-aarch64.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "feb9b98c64739d39ecc9a8a67aeab1249448026f2f21f7d147953c66a99f5fe2",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.2-aarch64.tar.gz",
+      "build_number": "252.26199.168"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "36523ab3b94d1ee1b92794476870727faa1ca29fbd365b7c3239f199399f6dbe",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.154"
+      "version": "2025.2.2.1",
+      "sha256": "9e5cb3f78c985af7b1d9267786265dd7bf5bd918bb98dcd12e66d4b9ad8ded40",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.1-aarch64.tar.gz",
+      "build_number": "252.26199.190"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -297,10 +297,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2025.2.3",
-      "sha256": "3b14fce3bef29338a4d369e0236f0972cec18cfa1e32563d37cb10bafa782226",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3.dmg",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "9267cd82c2589f6f2f52f71960a8ba201bd9f02b8c10dede99323b845360de7b",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4.dmg",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -362,26 +362,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "651d1c0a264e9a4fc8c7e134d42ece4a15fd444cd74424a9ed054659e5346db7",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "a0954335ed7e09346849353053c883fff352735097c80e867c3d1115a28ed224",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.2.dmg",
+      "build_number": "252.26199.168"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "6d90ba78686a32fdd38a1cc13e06462f6be3490b6611d8c05e6092483161a74b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "7cffd30781aba652d5d1378c2b402c6cfd90a78f2f438c1814c8f6ca95dfd55a",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.2.dmg",
+      "build_number": "252.26199.168"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "ccc7b35691ceb87e3b3103909617e1616c36dcc69cb73c1f7668591c6256ba35",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.dmg",
-      "build_number": "252.26199.154"
+      "version": "2025.2.2.1",
+      "sha256": "7d71f89a9fe2ea6360cf889edbb0514e3a125cea11aa399432099c3800f36524",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.1.dmg",
+      "build_number": "252.26199.190"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -436,10 +436,10 @@
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2025.2.3",
-      "sha256": "cfe4b7f9e9ede9fa15c0e0ce16e98ba3595051b5da1510c0085f89ff7bcbdf50",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3-aarch64.dmg",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "13d41b91c0194078afed78974f5023a793822c46609e6273dfacd831bebecc83",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4-aarch64.dmg",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -501,26 +501,26 @@
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "1afba23b5cc19e42b56bcd35ddb173a9e47c643cb27d9f70aa7dccd3675a9082",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1-aarch64.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "889b404ed93be97876a77a7a0ff592545b086af5261bc746453bebc76469f5b2",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.2-aarch64.dmg",
+      "build_number": "252.26199.168"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "cf54ed7c544f5e21bd563da68725431235ea7b91bebad0ce3c5eecabfd6be0bc",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1-aarch64.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.2",
+      "sha256": "9cf03fd2e3d18fc4ddfc7a640e0d0a7aeaf8b61d92eed9c0f13930e84aa855e1",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.2-aarch64.dmg",
+      "build_number": "252.26199.168"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "f6d1a148123519c33d2ec8822e7d83856af68cbb518ac822c638bbd4b1127ad2",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.154"
+      "version": "2025.2.2.1",
+      "sha256": "c04852ec3bfa25d82c41766329ab1fb6901727986208217dd7fa4622588697f4",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.1-aarch64.dmg",
+      "build_number": "252.26199.190"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -18,16 +18,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip"
       },
       "name": "ideavim"
     },
@@ -69,16 +69,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
       },
       "name": "stringmanipulation"
     },
@@ -100,16 +100,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -131,16 +131,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/6954/841446/Kotlin-252.25557.131-IJ.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/6954/866533/Kotlin-252.26830.24-IJ.zip"
       },
       "name": "kotlin"
     },
@@ -162,16 +162,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": "https://plugins.jetbrains.com/files/6981/846966/ini-252.25557.135.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip"
+        "252.26199.153": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/6981/867123/ini-252.26830.28.zip"
       },
       "name": "ini"
     },
@@ -193,16 +193,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -224,16 +224,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -255,16 +255,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
       },
       "name": "file-watchers"
     },
@@ -297,16 +297,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -346,14 +346,14 @@
       ],
       "builds": {
         "251.25410.129": null,
-        "252.25557.178": "https://plugins.jetbrains.com/files/7322/841474/python-ce-252.25557.131.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip"
       },
       "name": "python-community-edition"
     },
@@ -375,16 +375,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
       },
       "name": "asciidoc"
     },
@@ -406,16 +406,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.153": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.157": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.158": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.159": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.162": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.163": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.169": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "252.26199.190": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -435,18 +435,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -468,16 +468,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": "https://plugins.jetbrains.com/files/7724/841415/clouds-docker-impl-252.25557.130.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip"
+        "252.26199.153": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7724/870151/clouds-docker-impl-252.26830.46.zip"
       },
       "name": "docker"
     },
@@ -499,16 +499,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip"
       },
       "name": "graphql"
     },
@@ -529,15 +529,15 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": null,
         "252.26199.153": null,
-        "252.26199.154": null,
         "252.26199.157": null,
         "252.26199.158": null,
         "252.26199.162": null,
         "252.26199.163": null,
+        "252.26199.168": null,
         "252.26199.169": null,
-        "252.26199.73": null
+        "252.26199.190": null,
+        "252.26830.46": null
       },
       "name": "-deprecated-rust"
     },
@@ -558,15 +558,15 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": null,
         "252.26199.153": null,
-        "252.26199.154": null,
         "252.26199.157": null,
         "252.26199.158": null,
         "252.26199.162": null,
         "252.26199.163": null,
+        "252.26199.168": null,
         "252.26199.169": null,
-        "252.26199.73": null
+        "252.26199.190": null,
+        "252.26830.46": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -587,17 +587,17 @@
       ],
       "builds": {
         "251.25410.129": null,
-        "252.23892.529": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8195/846963/toml-252.25557.135.zip",
+        "252.23892.529": null,
         "252.26199.153": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8195/866732/toml-252.26830.26.zip"
       },
       "name": "toml"
     },
@@ -630,16 +630,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8554/834301/featuresTrainer-252.25557.79.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8554/870153/featuresTrainer-252.26830.46.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -661,16 +661,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
       },
       "name": "nixidea"
     },
@@ -692,16 +692,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip"
       },
       "name": "gherkin"
     },
@@ -723,16 +723,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
       },
       "name": "-env-files"
     },
@@ -765,16 +765,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.153": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.157": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.158": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.159": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.162": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.163": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26199.168": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26199.169": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
+        "252.26199.190": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -796,16 +796,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -827,16 +827,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
       },
       "name": "randomness"
     },
@@ -858,16 +858,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip"
       },
       "name": "csv-editor"
     },
@@ -887,18 +887,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -920,16 +920,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -951,16 +951,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
     },
@@ -981,15 +981,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
       },
       "name": "go-template"
     },
@@ -1011,16 +1011,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip"
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/11349/861955/aws-toolkit-jetbrains-standalone-3.94.251.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/868730/aws-toolkit-jetbrains-standalone-3.95.251.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1060,7 +1060,7 @@
         "rider"
       ],
       "builds": {
-        "252.26199.154": "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1082,16 +1082,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1113,16 +1113,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1144,16 +1144,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1175,16 +1175,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1206,16 +1206,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1237,16 +1237,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1268,16 +1268,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.153": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.157": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.158": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.159": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.162": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.163": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26199.168": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.169": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "252.26199.190": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1299,16 +1299,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.153": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.157": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.158": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.159": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.162": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.163": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26199.168": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.169": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "252.26199.190": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1330,16 +1330,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.153": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.157": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.158": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.159": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.162": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.163": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26199.168": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.169": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
+        "252.26199.190": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
       },
       "name": "which-key"
     },
@@ -1361,16 +1361,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1392,16 +1392,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1423,16 +1423,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1452,18 +1452,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1483,18 +1483,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.23892.529": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.23892.529": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.153": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.157": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.158": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.159": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.162": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.163": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.168": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.169": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26199.190": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1547,16 +1547,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1578,16 +1578,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
       },
       "name": "mermaid"
     },
@@ -1609,16 +1609,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1640,16 +1640,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
       },
       "name": "code-complexity"
     },
@@ -1671,16 +1671,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1697,13 +1697,13 @@
       ],
       "builds": {
         "252.26199.153": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip"
+        "252.26199.169": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip"
       },
       "name": "dev-containers"
     },
@@ -1736,18 +1736,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip"
       },
       "name": "continue"
     },
@@ -1769,16 +1769,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/22857/829212/vcs-gitlab-IU-252.25557.35-IU.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/22857/870143/vcs-gitlab-IU-252.26830.46-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1800,16 +1800,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1831,16 +1831,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1860,18 +1860,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
-        "252.23892.529": null,
-        "252.25557.178": null,
-        "252.26199.153": null,
-        "252.26199.154": null,
-        "252.26199.157": null,
-        "252.26199.158": null,
-        "252.26199.159": null,
-        "252.26199.162": null,
-        "252.26199.163": null,
-        "252.26199.169": null,
-        "252.26199.73": null
+        "251.25410.129": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.153": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.157": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.158": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.159": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.162": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.163": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.169": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26199.190": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip"
       },
       "name": "oxocarbon"
     },
@@ -1893,16 +1893,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1924,16 +1924,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.153": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.157": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.158": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.159": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.162": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.163": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
+        "252.26199.168": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
         "252.26199.169": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip"
+        "252.26199.190": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1951,14 +1951,14 @@
       ],
       "builds": {
         "252.26199.153": null,
-        "252.26199.154": null,
         "252.26199.157": null,
         "252.26199.158": null,
         "252.26199.159": null,
         "252.26199.162": null,
         "252.26199.163": null,
         "252.26199.169": null,
-        "252.26199.73": null
+        "252.26199.190": null,
+        "252.26830.46": null
       },
       "name": "nix-lsp"
     },
@@ -1978,30 +1978,30 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
-        "252.25557.178": null,
         "252.26199.153": null,
-        "252.26199.154": null,
         "252.26199.157": null,
         "252.26199.158": null,
         "252.26199.159": null,
         "252.26199.162": null,
         "252.26199.163": null,
+        "252.26199.168": null,
         "252.26199.169": null,
-        "252.26199.73": null
+        "252.26199.190": null,
+        "252.26830.46": null
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip": "sha256-jk5JisClylJCL6PdQIUC5pyKb9ccEYJl7T7AyAkAkEE=",
-    "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip": "sha256-hB6m8uJ+QpLhYLiBzzcw6TB0yla4enKEJLN6aRLDcGU=",
+    "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip": "sha256-50IFDt9PC6IpjFLL8ggbybhf8dCi4U3ceKDfbDjEK6Q=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
     "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip": "sha256-XKv4jEKOk2O++VdHycGoLgICsusULbWRlQ0J5p+KgAE=",
     "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip": "sha256-iHyO6ZnEaP4rZMywGXZo6+PPMv+2KOjeWRLpdM8qAsU=",
-    "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip": "sha256-RABuHyvvbw1rGzvQpOk4tEpilVghQE75VzLIvRmFNfw=",
-    "https://plugins.jetbrains.com/files/11349/861955/aws-toolkit-jetbrains-standalone-3.94.251.zip": "sha256-y+AdD8SPKUpB1FU5bWknSkW+q1rhQR5j56pHP5s4NXE=",
+    "https://plugins.jetbrains.com/files/11349/868728/aws-toolkit-jetbrains-standalone-3.95.252.zip": "sha256-roleAHWoatrJqXIF4bX7/WG85gfaUNdfKujSBAbCz6A=",
+    "https://plugins.jetbrains.com/files/11349/868730/aws-toolkit-jetbrains-standalone-3.95.251.zip": "sha256-8op4FM98aqWmKh4vOT0tqTjyfVR8oyByHpoaZIY/2PE=",
     "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip": "sha256-XDBmYpBpLhuLGTB8aP0csK1NBEncmMUPKWoPJx2AVao=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
     "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip": "sha256-V3Vk6UYLUSiSmypD+g0DCX1sPw3/wZqvLxFhbkTqY34=",
@@ -2022,9 +2022,9 @@
     "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip": "sha256-g07e6dfHkNbdiG54cqGBChxNsEHQ/5kMBhLlGkK6di4=",
     "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip": "sha256-UN+4+QhGHloiSuaSf5KwTCaSorYBLb0h2OusmOjd64k=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
-    "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip": "sha256-dxZAIsXfdwsdTx+bp/1aaahw+D4HXOSEpyY7JWAhLys=",
-    "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip": "sha256-uAHkTDvFUEzdasYgyB0yn8yVMEHvB8dn+Z5jSoB5PQo=",
-    "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar": "sha256-0QVCCkrgDWEX8tAkfPfiYRpaROd3ELGZn5TBGa3lJXQ=",
+    "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip": "sha256-F37RoWSV96ofEw7ckvhSS4nHaXUJOBuWecEhzaH2Zk4=",
+    "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip": "sha256-v/BwU04VevdH7I40yiU7wOMn6CsFmSc63TKAVAcMiJI=",
+    "https://plugins.jetbrains.com/files/18922/869306/GerryThemes.jar": "sha256-5YVBrhSvwNbYDMV8ea5GQplxO2rWOE8kRlvwvX1u+kw=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip": "sha256-QTh77pyi4lh7V0DGPFx9kERjFCop219d76wTDwD0SYY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
@@ -2033,13 +2033,13 @@
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip": "sha256-uwonawWIgXi9OXZlQaZl/GDt/iHqsyAKV7ifCgcMqWU=",
     "https://plugins.jetbrains.com/files/22407/860027/intellij-rust-252.26199.159.zip": "sha256-/7/PFoHjJpuuqvtW9P8L/cKtiA1o5gRCCROmkGW+dl4=",
-    "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip": "sha256-EvCNPNYeEtQRmNEbLizH6MEIqPNvTwsk2qJm873s8oo=",
+    "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip": "sha256-RyE9IPYalQptgZP206bq03pkK34N/bQPc13fQniLOCc=",
     "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip": "sha256-1fkImbCktws9WcnJSwnMiZ7ULc3hKj9TiFXuNDf+L/U=",
-    "https://plugins.jetbrains.com/files/22857/829212/vcs-gitlab-IU-252.25557.35-IU.zip": "sha256-7fLyaf7JNH3FwKSH+HsQcGNszzzVMUy2qsFmcWgW0/g=",
     "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip": "sha256-dJM8j5aLWD6elv46HtXUhPvYWTdAE77m/jwRqztIwDk=",
+    "https://plugins.jetbrains.com/files/22857/870143/vcs-gitlab-IU-252.26830.46-IU.zip": "sha256-oUw/3Z59PxLb4ND28Clslkftr05ZgdMUNhYvcYhmasc=",
     "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
-    "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip": "sha256-+cLKIu8abGXZqJ3GutQsoQQg3s0wkmk5qKosW0O8RII=",
+    "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip": "sha256-952sONSgui6bSVFYfRhx1PbHWHas24y0SdHl5QhNIdQ=",
     "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip": "sha256-EtPWFr7stHfRSVowuH3BN3r2oBx8mut2T+6Ij8LEgmE=",
     "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip": "sha256-l/PChea8RmVLlD3COrikZ3xTq2iwztbCsJkzKIvUcaQ=",
     "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip": "sha256-2Vrm9k4ZqqpWl/EgDrAFNTpUeBhDSYt48JhAWlSWY1A=",
@@ -2047,10 +2047,10 @@
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
     "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip": "sha256-iWKLgk+eWhUmv/lH9+B2HI97d++EYvLwGgtRsJf4aSE=",
     "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip": "sha256-pQGVguF7zzzasLm2tlmtvqiPtdFN4Q5NKRwYx1r62fM=",
-    "https://plugins.jetbrains.com/files/6954/841446/Kotlin-252.25557.131-IJ.zip": "sha256-ogFUJ+BMATp7fM2vDjWkoGhLCRw9TN+ifopFlpP+q4Q=",
     "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip": "sha256-Fk/Df5MthwTWnhxv/u8/n2ITMLzZXKogj0tRRyPi5Zw=",
-    "https://plugins.jetbrains.com/files/6981/846966/ini-252.25557.135.zip": "sha256-9rrbHi+3fe/dlTkGGSnZ/fKh44vsLDOEbFCx5rPokfQ=",
-    "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip": "sha256-l+ETZNsDuQf+Cjh2vYi6/xi3th2QZeR+UflOtRRcKWI=",
+    "https://plugins.jetbrains.com/files/6954/866533/Kotlin-252.26830.24-IJ.zip": "sha256-61f8f8dtLvrVOs2yiAy0JYjd59atYoX2GGatg1tXSRs=",
+    "https://plugins.jetbrains.com/files/6981/863476/ini-252.26199.168.zip": "sha256-w760QrF+M84dAZ5N7qgTA/5T5lCNoiZLfUmlx9ql4rA=",
+    "https://plugins.jetbrains.com/files/6981/867123/ini-252.26830.28.zip": "sha256-2auC2XPeEY+joW6MajXQ7spJmvqsdw53v0bGgytWJvk=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip": "sha256-KcRoHqvCcC6qRz58DHkQ6AFqnpyqPhETekuMWBQYYw8=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
@@ -2060,24 +2060,23 @@
     "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip": "sha256-ypJOPmcl4881TpMboomVvmspJ3I1sfm5a26l54cfFpo=",
     "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/855846/PHP_Annotations-12.0.1.zip": "sha256-FQmHb4oo9TgXiJ4b7EEEELagOx31C9iQtsTRoqxCnO4=",
-    "https://plugins.jetbrains.com/files/7322/841474/python-ce-252.25557.131.zip": "sha256-OA3GRyoEzIqsIqKCwIHcMss8SSb5u/YqNUo9kEjszsA=",
     "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip": "sha256-fzoj+iBfEEE6gjlGNtqfqpYXqwaEr2LFECNOglMyz5Y=",
+    "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip": "sha256-7Tkcnl2km29lxQtBIX0ahKXShy16Lk1EBiwmKZBjpIc=",
     "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip": "sha256-6VpRIidsf8iWJeR3OarwwgS1NDXj9j6bLnxU/YBskeY=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
-    "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip": "sha256-AEkeSl3yUelw5jOEBXCPPeWZU/Q2cE9ekUSXN409iCw=",
-    "https://plugins.jetbrains.com/files/7724/841415/clouds-docker-impl-252.25557.130.zip": "sha256-u5BDqZlqkx9cEmDuri5+DN6E40YyF9G0f0gLehhtZ2s=",
-    "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip": "sha256-izEzIQxn23ZV2ZClMmd6g9H0sd+jy+OoaISvX94H7hQ=",
+    "https://plugins.jetbrains.com/files/7499/868133/gittoolbox-600.1.11_243-signed.zip": "sha256-7TmOyq0JDkZ+NGDkpB6erswKgBZuwOa3ZYDq/Ue0XT4=",
+    "https://plugins.jetbrains.com/files/7724/863478/clouds-docker-impl-252.26199.168.zip": "sha256-Q56UskX/dUAzcvXSZK5X3Omd6jkdQv1DDTJutBHsTAY=",
+    "https://plugins.jetbrains.com/files/7724/870151/clouds-docker-impl-252.26830.46.zip": "sha256-Neeq7SvjGUMo+eg4WU0ahbZrOme+z/2t/OdbyOXZoFQ=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
     "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip": "sha256-eLh0p5vDNG7fUV7pqbIbkL30dpPj19NE9JbwcDwxZXs=",
     "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip": "sha256-wN3+7++f6i0MvEmOTiWZgAW1QzM5HiD7jSAMS8jWC5s=",
-    "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip": "sha256-CXbS+/k9a4YqYPRxd5OWGxtal2+5ECshavcOSrYqca0=",
-    "https://plugins.jetbrains.com/files/8195/846963/toml-252.25557.135.zip": "sha256-vICiXs86VP1gyMy594bCOcb5jZ+Ptw1Ui7r6dQwIveQ=",
     "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip": "sha256-8miuDbuQkeB4Nc9DsI+NiGbZ9PdEFrFMfEG9sB4FJEM=",
+    "https://plugins.jetbrains.com/files/8195/866732/toml-252.26830.26.zip": "sha256-sLmSpw4/jChEC+X87CGQLCWiUSk6Y+5cIZj+X9tNh/4=",
     "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip": "sha256-mePVZa+63bheH85ylkbX9oOX1Nq/IYLAGHHseOJx520=",
     "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip": "sha256-NOuzQ+CL+Z8n5gwMBaberLyMvS5KNmXKwZ+j88+SFqU=",
     "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip": "sha256-AQLuTcRERFq2ZfzOqUGMte/pLe7/3g6G+9UqNMuUYiY=",
-    "https://plugins.jetbrains.com/files/8554/834301/featuresTrainer-252.25557.79.zip": "sha256-b+Xv06OhVZirdqR8qOsNv+6gXfBo6VOb27iuipmoEJY=",
     "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip": "sha256-euvA9ZNcFcQ6iZ5AC6tpyeJKTkAGzIq4jJ2sdLF0Fno=",
+    "https://plugins.jetbrains.com/files/8554/870153/featuresTrainer-252.26830.46.zip": "sha256-9lVfAepotJABWsdr32PGHAdSL2FCW6Yj3zuqFtJeYM4=",
     "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip": "sha256-JShheBoOBiWM9HubMUJvBn4H3DnWykvqPyrmetaCZiM=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
     "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip": "sha256-KrC3EK4wYLSxWywF8I8nVx6tkclr1wAMya1Z1XF0QY8=",


### PR DESCRIPTION
```
datagrip: 2025.2.3 -> 2025.2.4
pycharm-community: 2025.2.1.1 -> 2025.2.2
pycharm-professional: 2025.2.1.1 -> 2025.2.2
rider: 2025.2.2 -> 2025.2.2.1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
