### PR TITLE
xfce.xfce4-settings: add withXrandr option

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings/default.nix
@@ -13,6 +13,7 @@
   libxfce4ui,
   libxfce4util,
   libxklavier,
+  withXrandr ? true,
   upower,
   # Disabled by default on upstream and actually causes issues:
   # https://gitlab.xfce.org/xfce/xfce4-settings/-/issues/222
@@ -57,6 +58,7 @@ mkXfceDerivation {
   configureFlags = [
     "--enable-pluggable-dialogs"
     "--enable-sound-settings"
+    (lib.enableFeature withXrandr "xrandr")
   ]
   ++ lib.optionals withUpower [ "--enable-upower-glib" ]
   ++ lib.optionals withColord [ "--enable-colord" ];


### PR DESCRIPTION
On my system I prefer configuring xrandr manually, and xfce settings conflict with that. Added a handy withXrandr to optionally disable xfce4-settings xrandr support.

```
* Installation prefix:              /nix/store/r5kvsyy1baxzwg09zn3vani35n4knv0w-xfce4-settings-4.20.2
* Debug Support:                    minimum
* X11 Support:                      yes
  * Xrandr support:                 no
  * Xcursor support:                yes
  * Xorg libinput support:          yes
  * Libxklavier support:            yes
  * Libnotify support:              yes
* Wayland Support:                  yes
  * GTK Layer Shell support:        yes
* UPower support:                   no
* Colord support:                   yes
* Sounds settings support:          yes
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
