### PR TITLE
[25.05] signal-desktop: 7.70.0 -> 7.73.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -24,23 +24,23 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.81.0";
+  version = "0.81.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SOQyps+iGVQ3RWPLmQHzXwmMwmR1PrGIbViCmNg60P4=";
+    hash = "sha256-uhxfVFsoB+c1R5MUOgpJFm8ZD3vgU8BIn35QSfbEp5w=";
   };
 
-  cargoHash = "sha256-O4v9GgNrs4+HpfgoHh6YLy4dNF1LrF1ZS50RaEHh1iM=";
+  cargoHash = "sha256-Q3GSeaW3YveLxLeJPpPXUVwlJ0QLRkAmRGSJetxKl4Y=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-KvMEQ9nJunqF2CDjiP3s3CMoeF+nbUpZDzSIMsImbPg=";
+    hash = "sha256-6Mr3SJn4pO0p6PISXvEOhN9uPk1TIEU03ssclNUg2No=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -24,23 +24,23 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.78.3";
+  version = "0.81.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BRNgNE7BR4mlCKS4sydxx7rrfy+s4bTpQkX9GbEfhTg=";
+    hash = "sha256-SOQyps+iGVQ3RWPLmQHzXwmMwmR1PrGIbViCmNg60P4=";
   };
 
-  cargoHash = "sha256-T8kSQFTvwAYZad9rQRK6vY8vEiilEKv1+fd/1EBlxjI=";
+  cargoHash = "sha256-O4v9GgNrs4+HpfgoHh6YLy4dNF1LrF1ZS50RaEHh1iM=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-e/WyQlea46qTx7x45QuYdlaShezHV5vuB3ptB2DRCVE=";
+    hash = "sha256-KvMEQ9nJunqF2CDjiP3s3CMoeF+nbUpZDzSIMsImbPg=";
   };
 
   nativeBuildInputs = [
@@ -62,22 +62,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./dont-strip-absolute-paths.patch
   ];
   postPatch = ''
-    substituteInPlace node/binding.gyp \
-      --replace-fail "'--out-dir', '<(PRODUCT_DIR)/'," \
-                     "'--out-dir', '$out/lib/<(NODE_OS_NAME)-<(target_arch)/'," \
-      --replace-fail "'target_name': 'libsignal_client_<(NODE_OS_NAME)_<(target_arch).node'," \
-                     "'target_name': '@signalapp+libsignal-client',"
-
     substituteInPlace node/build_node_bridge.py \
-      --replace-fail "dst_base = 'libsignal_client_%s_%s' % (node_os_name, node_arch)" \
-                     "dst_base = '@signalapp+libsignal-client'"
+      --replace-fail "'prebuilds'" "'$out/lib'"
   '';
 
   buildPhase = ''
     runHook preBuild
 
     pushd node
-    npx node-gyp rebuild
+    npm run build -- --copy-to-prebuilds
     popd
 
     runHook postBuild

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -50,13 +50,13 @@ let
     '';
   });
 
-  version = "7.72.1";
+  version = "7.73.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-X+ENbHnlr9VL+flaZAHsOjRSBnXHa32qLNEXntxnRLA=";
+    hash = "sha256-5cwGV0WPOS7O/xnQZ38t/hiQppqFFtVQmGuniGsD6H8=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -132,15 +132,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-7VDIUyQBhFNrAmpfemKcNgjJEuvQ355uU6oZdWM1Hk8="
+        "sha256-9YvNs925xBUYEpF429rHfMXIGPapVYd8j1jZa/yBuhA="
       else
-        "sha256-gpK4WZjD//jZkxLvhAzXVAKmLjya8D1MVCPD4KKJJdA=";
+        "sha256-lcr8EeL+wd6VihKcBgfXNRny8VskX8g7I7WTAkLuBss=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1758811882;
+    SOURCE_DATE_EPOCH = 1759413120;
   };
 
   preBuild = ''

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -3,7 +3,7 @@
   lib,
   nodejs_22,
   pnpm_10,
-  electron_37,
+  electron_38,
   gn_2233,
   python3,
   makeWrapper,
@@ -20,7 +20,7 @@
 let
   nodejs = nodejs_22;
   pnpm = pnpm_10.override { inherit nodejs; };
-  electron = electron_37;
+  electron = electron_38;
   gn = gn_2233;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };
@@ -50,13 +50,13 @@ let
     '';
   });
 
-  version = "7.70.0";
+  version = "7.72.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-y9i9YQPsLt3SLqROyEZsyIkVy/os3hy+1UMUSFMZJTY=";
+    hash = "sha256-X+ENbHnlr9VL+flaZAHsOjRSBnXHa32qLNEXntxnRLA=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -132,15 +132,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-uVVUHvYhBCplKPyuS2+PKCxox8uWU2E/2EXLCG1ot54="
+        "sha256-7VDIUyQBhFNrAmpfemKcNgjJEuvQ355uU6oZdWM1Hk8="
       else
-        "sha256-tbfk/tIgqpjDtDiULbTVUOJf5i9eLX9xY7vUPrrjmu0=";
+        "sha256-gpK4WZjD//jZkxLvhAzXVAKmLjya8D1MVCPD4KKJJdA=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1757542492;
+    SOURCE_DATE_EPOCH = 1758811882;
   };
 
   preBuild = ''
@@ -216,10 +216,12 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 $icon $out/share/icons/hicolor/`basename ''${icon%.png}`/apps/signal-desktop.png
     done
 
+    # TODO: Remove --ozone-platform=wayland after next electron update,
+    # see https://github.com/electron/electron/pull/48309
     makeWrapper '${lib.getExe electron}' "$out/bin/signal-desktop" \
       --add-flags "$out/share/signal-desktop/app.asar" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -20,16 +20,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.57.0";
+  version = "2.57.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-m73SXjTES1sHGbQRtn9CjurFd/Xby5Yyn6uLVLigfiU=";
+    hash = "sha256-U3sfNjJInT7QBqLLNK1j/0xzmwi/pfZZGOtL/JZ5gZM=";
   };
 
-  cargoHash = "sha256-LRCgK/w+GcYBCWUKjytErQCxDtS15EnsVOr5Uq6F8ww=";
+  cargoHash = "sha256-DcaZmOPVO/eAMZ9NsqmwnI2d7Vdz/aVmvI4COivvDBM=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -20,16 +20,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.57.1";
+  version = "2.58.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-U3sfNjJInT7QBqLLNK1j/0xzmwi/pfZZGOtL/JZ5gZM=";
+    hash = "sha256-HI+HVDv+nuJp2BPIAVY+PI6Pof1pnB8L6CIAgBT+tJA=";
   };
 
-  cargoHash = "sha256-DcaZmOPVO/eAMZ9NsqmwnI2d7Vdz/aVmvI4COivvDBM=";
+  cargoHash = "sha256-n+1pe202U2lljisSRBWeVvuBLyp7jhXG+ovDDi5WV8Q=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -1,5 +1,5 @@
 {
-  rustPlatform,
+  rustPackages_1_89,
   lib,
   fetchFromGitHub,
   cmake,
@@ -18,7 +18,7 @@ let
     buildSharedLibs = false;
   };
 in
-rustPlatform.buildRustPackage (finalAttrs: {
+rustPackages_1_89.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
   version = "2.58.1";
 

--- a/pkgs/development/compilers/rust/1_89.nix
+++ b/pkgs/development/compilers/rust/1_89.nix
@@ -1,0 +1,140 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+
+{
+  stdenv,
+  lib,
+  newScope,
+  callPackage,
+  pkgsBuildTarget,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+  makeRustPlatform,
+  wrapRustcWith,
+  llvmPackages_20,
+  llvm_20,
+  wrapCCWith,
+  overrideCC,
+  fetchpatch,
+}@args:
+let
+  llvmSharedFor =
+    pkgSet:
+    pkgSet.llvmPackages_20.libllvm.override (
+      {
+        enableSharedLibraries = true;
+      }
+      // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+        # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
+        stdenv = pkgSet.stdenv.override {
+          allowedRequisites = null;
+          cc = pkgSet.pkgsBuildHost.llvmPackages_20.clangUseLLVM;
+        };
+      }
+    );
+in
+import ./default.nix
+  {
+    rustcVersion = "1.89.0";
+    rustcSha256 = "sha256-JXb59EDdmbAVG9KPWaoKxhAtXE8+1O+KgQyN0FBXJQ0=";
+
+    llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
+    llvmSharedForHost = llvmSharedFor pkgsBuildHost;
+    llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
+
+    # For use at runtime
+    llvmShared = llvmSharedFor pkgsHostTarget;
+
+    # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+    llvmPackages =
+      if (stdenv.targetPlatform.useLLVM or false) then
+        callPackage (
+          {
+            pkgs,
+            bootBintoolsNoLibc ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintoolsNoLibc,
+            bootBintools ? if stdenv.targetPlatform.linker == "lld" then null else pkgs.bintools,
+          }:
+          let
+            llvmPackages = llvmPackages_20;
+
+            setStdenv =
+              pkg:
+              pkg.override {
+                stdenv = stdenv.override {
+                  allowedRequisites = null;
+                  cc = pkgsBuildHost.llvmPackages_20.clangUseLLVM;
+                };
+              };
+          in
+          rec {
+            inherit (llvmPackages) bintools;
+
+            libunwind = setStdenv llvmPackages.libunwind;
+            llvm = setStdenv llvmPackages.llvm;
+
+            libcxx = llvmPackages.libcxx.override {
+              stdenv = stdenv.override {
+                allowedRequisites = null;
+                cc = pkgsBuildHost.llvmPackages_20.clangNoLibcxx;
+                hostPlatform = stdenv.hostPlatform // {
+                  useLLVM = !stdenv.hostPlatform.isDarwin;
+                };
+              };
+              inherit libunwind;
+            };
+
+            clangUseLLVM = llvmPackages.clangUseLLVM.override { inherit libcxx; };
+
+            stdenv = overrideCC args.stdenv clangUseLLVM;
+          }
+        ) { }
+      else
+        llvmPackages_20;
+
+    # Note: the version MUST be the same version that we are building. Upstream
+    # ensures that each released compiler can compile itself:
+    # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
+    bootstrapVersion = "1.89.0";
+
+    # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+    bootstrapHashes = {
+      i686-unknown-linux-gnu = "676ef74ce8ce3137ca66e3941b0221516e1713862053d8aa219e91b491417dd9";
+      x86_64-unknown-linux-gnu = "542f517d0624cbee516627221482b166bf0ffe5fd560ec32beb778c01f5c99b6";
+      x86_64-unknown-linux-musl = "35695721d53d7eb83ce0153be4c399babf5afd8597bed84f3386d9aac2b4b391";
+      arm-unknown-linux-gnueabihf = "e618d08b1547c143cfbfc040023914f4a33a4fcf7addff6778d7cfccbd444c5e";
+      armv7-unknown-linux-gnueabihf = "09a295d2d6821a404ca3bf5d1163b9642139105618d0583241b05b7dbf6e22dc";
+      aarch64-unknown-linux-gnu = "26d6de84ac59da702aa8c2f903e3c344e3259da02e02ce92ad1c735916b29a4a";
+      aarch64-unknown-linux-musl = "b5fdcad8289adf94c45727c33773a05acca994b01b333cf7a508f95fa6adc454";
+      x86_64-apple-darwin = "8590528cade978ecb5249184112887489c9d77ae846539e3ef4d04214a6d8663";
+      aarch64-apple-darwin = "87baeb57fb29339744ac5f99857f0077b12fa463217fc165dfd8f77412f38118";
+      powerpc64-unknown-linux-gnu = "30d97f8d757c6ff171815c8af36eed85e44401a58c5e04f25b721c7776ed8337";
+      powerpc64le-unknown-linux-gnu = "80db8e203357a050780fb8a2cdc027b81d5ae1634fa999c3be69cf8a2e10bbf6";
+      riscv64gc-unknown-linux-gnu = "3885629641fd670e50c9e6553bdc6505457ef2163757a27dbf33fbc6351b2161";
+      s390x-unknown-linux-gnu = "696dad74886467a5092ee8bd2265aaab85039fc563803166966c7cae389e2ef7";
+      loongarch64-unknown-linux-gnu = "171696c45e4a91ccf17a239f00d5a3a8bbd40125d7a274506e1630423d714bec";
+      loongarch64-unknown-linux-musl = "86e5d8b0f0c868559de3ec2a0902d0e516a710adb845c8904595c54807e821c2";
+      x86_64-unknown-freebsd = "4baf0d5a44e64eecc91dc7ab89d8b0a8f8607e1d39b6989767861b34459a0396";
+    };
+
+    selectRustPackage = pkgs: pkgs.rust_1_89;
+  }
+
+  (
+    removeAttrs args [
+      "llvmPackages_20"
+      "llvm_20"
+      "wrapCCWith"
+      "overrideCC"
+      "pkgsHostTarget"
+      "fetchpatch"
+    ]
+  )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6044,6 +6044,9 @@ with pkgs;
   rust_1_88 = callPackage ../development/compilers/rust/1_88.nix {
     llvm_20 = llvmPackages_20.libllvm;
   };
+  rust_1_89 = callPackage ../development/compilers/rust/1_89.nix {
+    llvm_20 = llvmPackages_20.libllvm;
+  };
   rust = rust_1_86;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -6054,6 +6057,7 @@ with pkgs;
 
   rustPackages_1_86 = rust_1_86.packages.stable;
   rustPackages_1_88 = rust_1_88.packages.stable;
+  rustPackages_1_89 = rust_1_89.packages.stable;
   rustPackages = rustPackages_1_86;
 
   inherit (rustPackages)


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/446377 and https://github.com/NixOS/nixpkgs/pull/448613.
Resolved merge conflicts caused by:
- https://github.com/NixOS/nixpkgs/commit/899cd214d943ee7fc18a0f4278da06307964bb81
- https://github.com/NixOS/nixpkgs/pull/423089

Also adds `rust_1_89` to fix the failing `ringrtc` build:
```
   Compiling zkgroup v0.9.0 (https://github.com/signalapp/libsignal?tag=v0.78.3#9e2bcb2a)
    error[E0658]: use of unstable library feature `result_flattening`
        --> src/rust/src/webrtc/audio_device_module.rs:1532:14
         |
    1532 |             .flatten()
         |              ^^^^^^^
         |
         = note: see issue #70142 <https://github.com/rust-lang/rust/issues/70142> for more information

    For more information about this error, try `rustc --explain E0658`.
    error: could not compile `ringrtc` (lib) due to 1 previous error
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
