### PR TITLE
home-assistant-custom-components.spook: 3.1.0 -> 4.0.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/spook/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/spook/package.nix
@@ -10,16 +10,21 @@
 buildHomeAssistantComponent rec {
   owner = "frenck";
   domain = "spook";
-  version = "3.1.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-IV3n++uFSOvQANPfbCeBj3GP0CCL+w9icKp/k5VO3Qg=";
+    hash = "sha256-0IihrhATgraGmuMRnrbGTUrtlXAR+CooENSIKSWIknY=";
   };
 
   patches = [ ./remove-sub-integration-symlink-hack.patch ];
+
+  postPatch = ''
+    substituteInPlace custom_components/spook/manifest.json \
+      --replace-fail '"version": "0.0.0"' '"version": "${version}"'
+  '';
 
   dependencies = [
     pillow

--- a/pkgs/servers/home-assistant/custom-components/spook/remove-sub-integration-symlink-hack.patch
+++ b/pkgs/servers/home-assistant/custom-components/spook/remove-sub-integration-symlink-hack.patch
@@ -1,18 +1,18 @@
 diff --git a/custom_components/spook/__init__.py b/custom_components/spook/__init__.py
-index 213fb2c..c7dc299 100644
+index 1abc79d..68d48d1 100644
 --- a/custom_components/spook/__init__.py
 +++ b/custom_components/spook/__init__.py
-@@ -23,8 +23,6 @@ from .templating import SpookTemplateFunctionManager
+@@ -22,8 +22,6 @@ from .services import SpookServiceManager
  from .util import (
-     async_ensure_template_environments_exists,
      async_forward_setup_entry,
+     async_setup_all_entity_ids_cache_invalidation,
 -    link_sub_integrations,
 -    unlink_sub_integrations,
  )
-
+ 
  if TYPE_CHECKING:
-@@ -34,48 +32,6 @@ if TYPE_CHECKING:
-
+@@ -35,48 +33,6 @@ if TYPE_CHECKING:
+ 
  async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
      """Set up from a config entry."""
 -    # Symlink all sub integrations from Spook to the parent integrations folder
@@ -57,22 +57,22 @@ index 213fb2c..c7dc299 100644
 -            severity=ir.IssueSeverity.WARNING,
 -            translation_key="restart_required",
 -        )
-
-     # Ensure template environments exists
-     async_ensure_template_environments_exists(hass)
-@@ -120,4 +76,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-
+ 
+     # Forward async_setup_entry to ectoplasms
+     await async_forward_setup_entry(hass, entry)
+@@ -131,4 +87,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+ 
  async def async_remove_entry(hass: HomeAssistant, _: ConfigEntry) -> None:
      """Remove a config entry."""
 -    await hass.async_add_executor_job(unlink_sub_integrations, hass)
 diff --git a/custom_components/spook/util.py b/custom_components/spook/util.py
-index 32e9bd2..845d463 100644
+index 6aea27c..1437913 100644
 --- a/custom_components/spook/util.py
 +++ b/custom_components/spook/util.py
-@@ -104,37 +104,6 @@ async def async_forward_platform_entry_setups_to_ectoplasm(
+@@ -284,37 +284,6 @@ async def async_forward_platform_entry_setups_to_ectoplasm(
      )
-
-
+ 
+ 
 -def link_sub_integrations(hass: HomeAssistant) -> bool:
 -    """Link Spook sub integrations."""
 -    LOGGER.debug("Linking up Spook sub integrations")
@@ -105,5 +105,5 @@ index 32e9bd2..845d463 100644
 -
 -
  @callback
- def async_ensure_template_environments_exists(hass: HomeAssistant) -> None:
-     """Ensure default template environments exist.
+ def async_get_all_area_ids(hass: HomeAssistant) -> set[str]:
+     """Return all area IDs, known to Home Assistant."""


### PR DESCRIPTION
Diff: https://github.com/frenck/spook/compare/v3.1.0...v4.0.1

Changelog: https://github.com/frenck/spook/releases/tag/v4.0.1

This fixes `nixosTests.home-assistant`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
