### PR TITLE
python3Packages.pyghidra: init at 12.0

### DIFF
--- a/pkgs/development/python-modules/pyghidra/default.nix
+++ b/pkgs/development/python-modules/pyghidra/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  ghidra,
+  buildPythonPackage,
+  jpype1,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "pyghidra";
+  inherit (ghidra) version;
+
+  src = ghidra.src + "/Ghidra/Features/PyGhidra/src/main/py";
+
+  pyproject = true;
+
+  build-system = [ setuptools ];
+  dependencies = [ jpype1 ];
+  pythonRelaxDeps = [ "jpype1" ];
+
+  makeWrapperArgs = [
+    "--set GHIDRA_INSTALL_DIR ${ghidra}/lib/ghidra"
+    "--prefix PATH : ${lib.makeBinPath [ ghidra.jdk ]}"
+  ];
+
+  meta = ghidra.meta // {
+    description = "Python library that provides direct access to the Ghidra API within a native CPython 3 interpreter using JPype";
+    mainProgram = "pyghidra";
+    maintainers = with lib.maintainers; [ vlaci ];
+  };
+}

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -196,6 +196,8 @@ stdenv.mkDerivation (finalAttrs: {
       buildGhidraScripts
       ;
 
+    jdk = openjdk21;
+
     withExtensions = callPackage ./with-extensions.nix { ghidra = finalAttrs.finalPackage; };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13504,6 +13504,8 @@ self: super: with self; {
 
   pygetwindow = callPackage ../development/python-modules/pygetwindow { };
 
+  pyghidra = callPackage ../development/python-modules/pyghidra { };
+
   pyghmi = callPackage ../development/python-modules/pyghmi { };
 
   pygit2 = callPackage ../development/python-modules/pygit2 { };


### PR DESCRIPTION
The package is available on pypi but it is built from Ghidra sources[^1]. I packaged it directly from Ghidra sources, so nixpkgs always has a consistent version of the two.

`pyghidra` can be started both by using the provided cli script or by importing the packages from a Python program.

[^1]: https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/PyGhidra/src/main/py


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
