### PR TITLE
brave-sync: Add package brave-sync to nixpkgs.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17230,6 +17230,11 @@
     github = "mohe2015";
     githubId = 13287984;
   };
+  moinakb001 = {
+    name = "Moinak Bhattacharyya";
+    github = "moinakb001";
+    githubId = 3363259;
+  };
   momeemt = {
     name = "Mutsuha Asada";
     email = "me@momee.mt";

--- a/pkgs/by-name/br/brave-sync/package.nix
+++ b/pkgs/by-name/br/brave-sync/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "brave-sync";
+  version = "0.1.21-unstable-2025-10-02";
+
+  vendorHash = "sha256-zJaaLj/44oGFyIaX5V4F13zUOHRt4UawpPaglxdcYKI=";
+
+  src = fetchFromGitHub {
+    owner = "brave";
+    repo = "go-sync";
+    rev = "9aaf1352afe5250fe3565361f82e80b95f8a5792";
+    hash = "sha256-NdPdjpN6EX9OLfyW0XXwUaKzj2N4K3J/ToI5Tja1MzY=";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/brave/go-sync/server.version=${version}"
+    "-X github.com/brave/go-sync/server.buildTime=0"
+    "-X github.com/brave/go-sync/server.commit=${src.rev}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/go-sync $out/bin/brave-sync
+  '';
+
+  # Network tests hang (only in the nixbld environment) and there
+  # are a few timeouts. Disabling for now.
+  doCheck = false;
+
+  meta = {
+    description = "Sync server implemented in go to communicate with Brave sync clients";
+    mainProgram = "brave-sync";
+    homepage = "https://github.com/brave/go-sync";
+    maintainers = with lib.maintainers; [
+      moinakb001
+    ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Also add self to mantainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
