### PR TITLE
gavin-bc: 6.5.0 -> 7.1.0

### DIFF
--- a/pkgs/by-name/ga/gavin-bc/package.nix
+++ b/pkgs/by-name/ga/gavin-bc/package.nix
@@ -1,57 +1,33 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
-  editline,
-  readline,
-  historyType ? "internal",
-  predefinedBuildType ? "BSD",
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
 }:
-
-assert lib.elem historyType [
-  "editline"
-  "readline"
-  "internal"
-];
-assert lib.elem predefinedBuildType [
-  "BSD"
-  "GNU"
-  "GDH"
-  "DBG"
-  ""
-];
 stdenv.mkDerivation (finalAttrs: {
   pname = "gavin-bc";
-  version = "6.5.0";
+  version = "7.1.0";
 
-  src = fetchFromGitea {
-    domain = "git.gavinhoward.com";
-    owner = "gavin";
+  src = fetchFromGitHub {
+    owner = "gavinhoward";
     repo = "bc";
     rev = finalAttrs.version;
-    hash = "sha256-V0L5OmpcI0Zu5JvESjuhp4wEs5Bu/CvjF6B5WllTEqo=";
+    hash = "sha256-bIQk0HzUzL1Ju4+iDpFj1n+GKCj9a3AUAbYA3yX5TNg=";
   };
 
-  buildInputs =
-    (lib.optional (historyType == "editline") editline)
-    ++ (lib.optional (historyType == "readline") readline);
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/bc";
+  doInstallCheck = true;
 
-  configureFlags = [
-    "--disable-nls"
-  ]
-  ++ (lib.optional (predefinedBuildType != "") "--predefined-build-type=${predefinedBuildType}")
-  ++ (lib.optional (historyType == "editline") "--enable-editline")
-  ++ (lib.optional (historyType == "readline") "--enable-readline")
-  ++ (lib.optional (historyType == "internal") "--enable-internal-history");
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://git.gavinhoward.com/gavin/bc";
+    homepage = "https://github.com/gavinhoward/bc";
     description = "Gavin Howard's BC calculator implementation";
-    changelog = "https://git.gavinhoward.com/gavin/bc/raw/tag/${finalAttrs.version}/NEWS.md";
+    changelog = "https://github.com/gavinhoward/bc/blob/${finalAttrs.version}/NEWS.md";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ delafthi ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })
-# TODO: cover most of configure settings


### PR DESCRIPTION
https://github.com/gavinhoward/bc/blob/7.1.0/NEWS.md

- remove configure options; users which want to adjust these should use `overrideAttrs`
- fetch source from GitHub (for the time being gavin has moved the sources there)
- added `versionCheckHook`
- added default update script
- update homepage and changelog accordingly
- added delafthi as maintainer
- remove darwin from the broken platforms


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
