### PR TITLE
go-webring: init at 2024-12-18, nixos/go-webring: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -10,6 +10,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [go-webring](https://git.sr.ht/~amolith/go-webring), a simple [webring](https://en.wikipedia.org/wiki/Webring) implementation. Available as [services.go-webring](#opt-services.go-webring.enable).
+
 - [Meshtastic](https://meshtastic.org), an open-source, off-grid, decentralised mesh network
   designed to run on affordable, low-power devices. Available as [services.meshtasticd]
   (#opt-services.meshtasticd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1618,6 +1618,7 @@
   ./services/web-apps/glance.nix
   ./services/web-apps/glitchtip.nix
   ./services/web-apps/go-httpbin.nix
+  ./services/web-apps/go-webring.nix
   ./services/web-apps/goatcounter.nix
   ./services/web-apps/gotify-server.nix
   ./services/web-apps/gotosocial.nix

--- a/nixos/modules/services/web-apps/go-webring.nix
+++ b/nixos/modules/services/web-apps/go-webring.nix
@@ -1,0 +1,155 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    literalExpression
+    mkIf
+    ;
+  cfg = config.services.go-webring;
+in
+
+{
+  options = {
+    services.go-webring = {
+      enable = mkEnableOption "go-webring";
+
+      package = mkPackageOption pkgs "go-webring" { };
+
+      contactInstructions = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = "Contact instructions for errors";
+        example = "contact the admin and let them know what's up";
+      };
+
+      host = mkOption {
+        type = types.str;
+        description = "Host this webring runs on, primarily used for validation";
+        example = "my-webri.ng";
+      };
+
+      homePageTemplate = mkOption {
+        type = types.path;
+        description = ''
+          This should be any HTML file with the string "{{ . }}" placed
+          wherever you want the table of members inserted. This table is
+          plain HTML so you can style it with CSS.
+
+          Note: This option expects a file path, not inline HTML content. If you want to provide inline HTML as a template, you can use `pkgs.writeText` to create a file.
+        '';
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1:2857";
+        description = "Host and port go-webring will listen on";
+      };
+
+      members = mkOption {
+        type = types.listOf (
+          types.submodule {
+            options = {
+              username = mkOption {
+                type = types.str;
+                description = "Member's name";
+              };
+              site = mkOption {
+                type = types.str;
+                description = "Member's site URL";
+              };
+            };
+          }
+        );
+        description = "List of members in the webring";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          let
+            usernames = lib.map (member: member.username) cfg.members;
+            uniqueUsernames = lib.unique usernames;
+          in
+          lib.length usernames == lib.length uniqueUsernames;
+        message = "All go-webring member usernames must be unique.";
+      }
+    ];
+
+    systemd.services.go-webring = {
+      description = "Simple Webring HTTP Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      requires = [ "network.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = ''
+          ${lib.getExe cfg.package} \
+            ${
+              lib.optionalString (cfg.contactInstructions != null) (
+                "--contact " + lib.escapeShellArg cfg.contactInstructions
+              )
+            } \
+            --host ${cfg.host} \
+            --index ${cfg.homePageTemplate} \
+            --listen ${cfg.listenAddress} \
+            --members ${
+              pkgs.writeText "list.txt" (
+                lib.concatMapStrings (member: member.username + " " + member.site + "\n") cfg.members
+              )
+            }
+        '';
+        User = "go-webring";
+        DynamicUser = true;
+        RuntimeDirectory = "go-webring";
+        WorkingDirectory = "/var/lib/go-webring";
+        StateDirectory = "go-webring";
+        RuntimeDirectoryMode = "0750";
+        Restart = "always";
+        RestartSec = 5;
+
+        # Hardening
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = [ "" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        UMask = "0077";
+      };
+    };
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -659,6 +659,7 @@ in
   go-csp-collector = runTest ./go-csp-collector.nix;
   go-httpbin = runTest ./go-httpbin.nix;
   go-neb = runTest ./go-neb.nix;
+  go-webring = runTest ./go-webring.nix;
   goatcounter = runTest ./goatcounter.nix;
   gobgpd = runTest ./gobgpd.nix;
   gocd-agent = runTest ./gocd-agent.nix;

--- a/nixos/tests/go-webring.nix
+++ b/nixos/tests/go-webring.nix
@@ -1,0 +1,46 @@
+{ pkgs, ... }:
+
+let
+  port = 3142;
+in
+{
+  name = "go-webring";
+  meta.maintainers = pkgs.go-webring.meta.maintainers;
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        services.go-webring = {
+          enable = true;
+          listenAddress = "127.0.0.1:${toString port}";
+          homePageTemplate = pkgs.writeText "index.html" ''
+            <html>
+            <head><title>My Webring</title></head>
+            <body>
+            <h1>My Webring</h1>
+            {{ . }}
+            </body>
+            </html>
+          '';
+          host = "localhost";
+          members = [
+            {
+              username = "sam";
+              site = "sometilde.com/~sam";
+            }
+            {
+              username = "bob";
+              site = "bobssite.com";
+            }
+          ];
+        };
+      };
+  };
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("go-webring.service")
+    machine.wait_for_open_port(${toString port})
+    machine.succeed("curl --fail 'http://localhost:${toString port}/' | grep 'My Webring'")
+  '';
+}

--- a/pkgs/by-name/go/go-webring/package.nix
+++ b/pkgs/by-name/go/go-webring/package.nix
@@ -1,0 +1,31 @@
+{
+  buildGoModule,
+  fetchgit,
+  lib,
+  nixosTests,
+}:
+buildGoModule {
+  pname = "go-webring";
+  version = "0-unstable-2024-12-18";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~amolith/go-webring";
+    rev = "0b5b1bf21ff91119ea2dd042ee9fe94e9d1cd8d4";
+    hash = "sha256-az6vBOGiZmzfsMjYUacXMHhDeRDmVI/arCKCpHeTcns=";
+  };
+
+  vendorHash = "sha256-3PnXB8AfZtgmYEPJuh0fwvG38dtngoS/lxyx3H+rvFs=";
+
+  passthru.tests.nixos = nixosTests.go-webring;
+
+  meta = {
+    mainProgram = "go-webring";
+    description = "Simple webring implementation";
+    homepage = "https://git.sr.ht/~amolith/go-webring";
+    license = with lib.licenses; [
+      bsd2
+      cc0
+    ];
+    maintainers = [ lib.maintainers.kmein ];
+  };
+}


### PR DESCRIPTION
- added `go-webring` package
- added `go-webring` module (along with 1 test)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
