### PR TITLE
stripe-cli: 1.30.0 -> 1.31.0, maintenance

### DIFF
--- a/pkgs/by-name/st/stripe-cli/package.nix
+++ b/pkgs/by-name/st/stripe-cli/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule rec {
   pname = "stripe-cli";
-  version = "1.30.0";
+  version = "1.31.0";
 
   src = fetchFromGitHub {
     owner = "stripe";
     repo = "stripe-cli";
     rev = "v${version}";
-    hash = "sha256-qDrEDP3gDHggXxavMVuVitFN+OWz5WlamePS/1/zlq8=";
+    hash = "sha256-fvemd1yo8WOWob/l3TU9lHcFc7OAI/oaX5XEK38vDwo=";
   };
   vendorHash = "sha256-EDdRgApJ7gv/4ma/IfaHi+jjpTPegsUfqHbvoFMn048=";
 

--- a/pkgs/by-name/st/stripe-cli/package.nix
+++ b/pkgs/by-name/st/stripe-cli/package.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "stripe-cli";
   version = "1.31.0";
 
   src = fetchFromGitHub {
     owner = "stripe";
     repo = "stripe-cli";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-fvemd1yo8WOWob/l3TU9lHcFc7OAI/oaX5XEK38vDwo=";
   };
   vendorHash = "sha256-EDdRgApJ7gv/4ma/IfaHi+jjpTPegsUfqHbvoFMn048=";
@@ -23,7 +23,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/stripe/stripe-cli/pkg/version.Version=${version}"
+    "-X github.com/stripe/stripe-cli/pkg/version.Version=${finalAttrs.version}"
   ];
 
   preCheck = ''
@@ -64,13 +64,13 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/stripe --help
-    $out/bin/stripe --version | grep "${version}"
+    $out/bin/stripe --version | grep "${finalAttrs.version}"
     runHook postInstallCheck
   '';
 
   meta = {
     homepage = "https://stripe.com/docs/stripe-cli";
-    changelog = "https://github.com/stripe/stripe-cli/releases/tag/v${version}";
+    changelog = "https://github.com/stripe/stripe-cli/releases/tag/v${finalAttrs.version}";
     description = "Command-line tool for Stripe";
     longDescription = ''
       The Stripe CLI helps you build, test, and manage your Stripe integration
@@ -90,4 +90,4 @@ buildGoModule rec {
     ];
     mainProgram = "stripe";
   };
-}
+})

--- a/pkgs/by-name/st/stripe-cli/package.nix
+++ b/pkgs/by-name/st/stripe-cli/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stripe";
     repo = "stripe-cli";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-fvemd1yo8WOWob/l3TU9lHcFc7OAI/oaX5XEK38vDwo=";
   };
   vendorHash = "sha256-EDdRgApJ7gv/4ma/IfaHi+jjpTPegsUfqHbvoFMn048=";
@@ -70,7 +70,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     homepage = "https://stripe.com/docs/stripe-cli";
-    changelog = "https://github.com/stripe/stripe-cli/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/stripe/stripe-cli/releases/tag/${finalAttrs.src.tag}";
     description = "Command-line tool for Stripe";
     longDescription = ''
       The Stripe CLI helps you build, test, and manage your Stripe integration


### PR DESCRIPTION
- stripe-cli: 1.30.0 -> 1.31.0
- stripe-cli: move to finalAttrs
- stripe-cli: fetch src by tag
- stripe-cli: fix completion when cross-compiling
- stripe-cli: properly skip tests and fix for darwin sandbox

replaces #447871

Draft to check if tests work on aarch64, related: https://github.com/stripe/stripe-cli/issues/850


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
