### PR TITLE
erlang: simplify generic builder and overriding

### DIFF
--- a/nixos/tests/rabbitmq.nix
+++ b/nixos/tests/rabbitmq.nix
@@ -1,6 +1,6 @@
 # This test runs rabbitmq and checks if rabbitmq is up and running.
 
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 let
   # in real life, you would keep this out of your repo and deploy it to a safe
   # location using safe means.
@@ -40,6 +40,8 @@ in
         ].
       '';
     };
+    systemd.services.rabbitmq.serviceConfig.Restart = lib.mkForce "no";
+
     # Ensure there is sufficient extra disk space for rabbitmq to be happy
     virtualisation.diskSize = 1024;
   };

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -19,8 +19,6 @@
   reproc,
   platform-folders,
   ruby_3_2,
-  erlang,
-  elixir,
   beamPackages,
   alsa-lib,
   rtmidi,
@@ -73,8 +71,8 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     ruby
-    erlang
-    elixir
+    beamPackages.erlang
+    beamPackages.elixir
     beamPackages.hex
   ];
 
@@ -224,8 +222,8 @@ stdenv.mkDerivation rec {
     fi
 
     # Remove runtime Erlang references
-    for file in $(grep -FrIl '${erlang}/lib/erlang' $out/app/server/beam/tau); do
-      substituteInPlace "$file" --replace '${erlang}/lib/erlang' $out/app/server/beam/tau/_build/prod/rel/tau
+    for file in $(grep -FrIl '${beamPackages.erlang}/lib/erlang' $out/app/server/beam/tau); do
+      substituteInPlace "$file" --replace '${beamPackages.erlang}/lib/erlang' $out/app/server/beam/tau/_build/prod/rel/tau
     done
   '';
 

--- a/pkgs/by-name/le/lexical/package.nix
+++ b/pkgs/by-name/le/lexical/package.nix
@@ -2,7 +2,6 @@
   lib,
   beamPackages,
   fetchFromGitHub,
-  elixir,
   nix-update-script,
   versionCheckHook,
 }:
@@ -34,7 +33,7 @@ beamPackages.mixRelease rec {
 
   postInstall = ''
     substituteInPlace "$out/bin/start_lexical.sh" \
-      --replace-fail 'elixir_command=' 'elixir_command="${elixir}/bin/"'
+      --replace-fail 'elixir_command=' 'elixir_command="${beamPackages.elixir}/bin/"'
 
     mv "$out/bin" "$out/libexec"
     makeWrapper "$out/libexec/start_lexical.sh" "$out/bin/lexical" \

--- a/pkgs/by-name/mi/mix2nix/package.nix
+++ b/pkgs/by-name/mi/mix2nix/package.nix
@@ -2,8 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  elixir,
-  erlang,
+  beamPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,8 +16,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-hD4lpP8GPkNXuMMDOOTEmy+rOwOSCxQwR0Mjq8i4oDM=";
   };
 
-  nativeBuildInputs = [ elixir ];
-  buildInputs = [ erlang ];
+  nativeBuildInputs = [ beamPackages.elixir ];
+  buildInputs = [ beamPackages.erlang ];
 
   buildPhase = "mix escript.build";
   installPhase = "install -Dt $out/bin mix2nix";

--- a/pkgs/by-name/pl/plausible/package.nix
+++ b/pkgs/by-name/pl/plausible/package.nix
@@ -12,7 +12,6 @@
   brotli,
   tailwindcss_3,
   esbuild,
-  ...
 }:
 
 let

--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -1,9 +1,8 @@
 {
   lib,
+  beamPackages,
   stdenv,
   fetchurl,
-  erlang,
-  elixir,
   python3,
   libxml2,
   libxslt,
@@ -27,7 +26,7 @@
 let
   runtimePath = lib.makeBinPath (
     [
-      erlang
+      beamPackages.erlang
       getconf # for getting memory limits
       socat
       gnused
@@ -62,8 +61,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    erlang
-    elixir
+    beamPackages.erlang
+    beamPackages.elixir
     libxml2
     libxslt
     glibcLocales

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -34,25 +34,21 @@ rec {
   callErlang =
     drv: args:
     let
-      builder = callPackage ../../development/interpreters/erlang/generic-builder.nix args;
+      genericBuilder =
+        versionArgs: import ../../development/interpreters/erlang/generic-builder.nix (versionArgs // args);
     in
-    callPackage drv {
-      mkDerivation = pkgs.makeOverridable builder;
-    };
+    pkgs.callPackage (import drv genericBuilder) { };
 
   /*
     Uses generic-builder to evaluate provided drv containing Elixir version
     specific data.
 
-    drv: package containing version-specific args;
-    builder: generic builder for all Erlang versions;
+    drv: file containing version-specific args;
+    genericBuilder: generic builder for all Erlang versions;
     args: arguments merged into version-specific args, used mostly to customize
-          dependencies;
+          high level options;
 
     Arguments passed to the generic-builder are overridable.
-
-    Please note that "mkDerivation" defined here is the one called from 1.4.nix
-    and similar files.
   */
   callElixir =
     drv: args:

--- a/pkgs/development/interpreters/erlang/26.nix
+++ b/pkgs/development/interpreters/erlang/26.nix
@@ -1,6 +1,6 @@
-{ mkDerivation }:
+genericBuilder:
 
-mkDerivation {
+genericBuilder {
   version = "26.2.5.15";
-  sha256 = "sha256-D2JfB7D9mhbmYvJfjSMbcdNrlYNWa/BfqAeqsbjTZlE=";
+  hash = "sha256-D2JfB7D9mhbmYvJfjSMbcdNrlYNWa/BfqAeqsbjTZlE=";
 }

--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
-{ mkDerivation }:
+genericBuilder:
 
-mkDerivation {
+genericBuilder {
   version = "27.3.4.3";
-  sha256 = "sha256-p4M1PPrbpNq6la4kgTTCOa2f5/oYxNwMaSi59mhlM4o=";
+  hash = "sha256-p4M1PPrbpNq6la4kgTTCOa2f5/oYxNwMaSi59mhlM4o=";
 }

--- a/pkgs/development/interpreters/erlang/28.nix
+++ b/pkgs/development/interpreters/erlang/28.nix
@@ -1,6 +1,6 @@
-{ mkDerivation }:
+genericBuilder:
 
-mkDerivation {
+genericBuilder {
   version = "28.1";
-  sha256 = "sha256-rR31Zj7c2eNf608HhLNlrGnVQN/Nymug6EcPfeNHfqk=";
+  hash = "sha256-rR31Zj7c2eNf608HhLNlrGnVQN/Nymug6EcPfeNHfqk=";
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -31,9 +31,9 @@
   baseName ? "erlang",
   version,
   sha256 ? null,
-  rev ? "OTP-${version}",
+  tag ? "OTP-${version}",
   src ? fetchFromGitHub {
-    inherit rev sha256;
+    inherit tag sha256;
     owner = "erlang";
     repo = "otp";
   },
@@ -79,14 +79,7 @@ let
   major = builtins.head (builtins.splitVersion version);
 in
 stdenv.mkDerivation {
-  # name is used instead of pname to
-  # - not have to pass pnames as argument
-  # - have a separate pname for erlang (main module)
-  name =
-    "${baseName}"
-    + optionalString javacSupport "_javac"
-    + optionalString odbcSupport "_odbc"
-    + "-${version}";
+  pname = "${baseName}" + optionalString javacSupport "_javac" + optionalString odbcSupport "_odbc";
 
   inherit src version;
 

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -54,29 +54,6 @@
     xorg.libX11
     wrapGAppsHook3
   ],
-  preUnpack ? "",
-  postUnpack ? "",
-  patches ? [ ],
-  patchPhase ? "",
-  prePatch ? "",
-  postPatch ? "",
-  configureFlags ? [ ],
-  configurePhase ? "",
-  preConfigure ? "",
-  postConfigure ? "",
-  buildPhase ? "",
-  preBuild ? "",
-  postBuild ? "",
-  installPhase ? "",
-  preInstall ? "",
-  postInstall ? "",
-  checkPhase ? "",
-  preCheck ? "",
-  postCheck ? "",
-  fixupPhase ? "",
-  preFixup ? "",
-  postFixup ? "",
-  meta ? { },
 }:
 
 assert
@@ -95,159 +72,116 @@ let
   inherit (lib)
     optional
     optionals
-    optionalAttrs
     optionalString
     ;
   wxPackages2 = if stdenv.hostPlatform.isDarwin then [ wxGTK ] else wxPackages;
 
   major = builtins.head (builtins.splitVersion version);
 in
-stdenv.mkDerivation (
-  {
-    # name is used instead of pname to
-    # - not have to pass pnames as argument
-    # - have a separate pname for erlang (main module)
-    name =
-      "${baseName}"
-      + optionalString javacSupport "_javac"
-      + optionalString odbcSupport "_odbc"
-      + "-${version}";
+stdenv.mkDerivation {
+  # name is used instead of pname to
+  # - not have to pass pnames as argument
+  # - have a separate pname for erlang (main module)
+  name =
+    "${baseName}"
+    + optionalString javacSupport "_javac"
+    + optionalString odbcSupport "_odbc"
+    + "-${version}";
 
-    inherit src version;
+  inherit src version;
 
-    LANG = "C.UTF-8";
+  LANG = "C.UTF-8";
 
-    nativeBuildInputs = [
-      makeWrapper
-      perl
-      gnum4
-      libxslt
-      libxml2
-    ];
+  nativeBuildInputs = [
+    makeWrapper
+    perl
+    gnum4
+    libxslt
+    libxml2
+  ];
 
-    env = {
-      # only build man pages and shell/IDE docs
-      DOC_TARGETS = "man chunks";
+  env = {
+    # only build man pages and shell/IDE docs
+    DOC_TARGETS = "man chunks";
+  };
+
+  buildInputs = [
+    ncurses
+    opensslPackage
+    zlib
+  ]
+  ++ optionals wxSupport wxPackages2
+  ++ optionals odbcSupport odbcPackages
+  ++ optionals javacSupport javacPackages
+  ++ optional systemdSupport systemd;
+
+  debugInfo = enableDebugInfo;
+
+  # On some machines, parallel build reliably crashes on `GEN    asn1ct_eval_ext.erl` step
+  enableParallelBuilding = parallelBuild;
+
+  configureFlags = [
+    "--with-ssl=${lib.getOutput "out" opensslPackage}"
+  ]
+  ++ [ "--with-ssl-incl=${lib.getDev opensslPackage}" ] # This flag was introduced in R24
+  ++ optional enableThreads "--enable-threads"
+  ++ optional enableSmpSupport "--enable-smp-support"
+  ++ optional enableKernelPoll "--enable-kernel-poll"
+  ++ optional enableHipe "--enable-hipe"
+  ++ optional javacSupport "--with-javac"
+  ++ optional odbcSupport "--with-odbc=${unixODBC}"
+  ++ optional wxSupport "--enable-wx"
+  ++ optional systemdSupport "--enable-systemd"
+  ++ optional stdenv.hostPlatform.isDarwin "--enable-darwin-64bit"
+  # make[3]: *** [yecc.beam] Segmentation fault: 11
+  ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) "--disable-jit";
+
+  installPhase = ''
+    runHook preInstall
+
+    make install
+    make install-docs
+
+    ln -sv $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
+
+    wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
+    wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${
+      lib.makeBinPath [
+        gnused
+        gawk
+      ]
+    }"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "OTP-(${major}.*)"
+        "--override-filename"
+        "pkgs/development/interpreters/erlang/${major}.nix"
+      ];
     };
+  };
 
-    buildInputs = [
-      ncurses
-      opensslPackage
-      zlib
-    ]
-    ++ optionals wxSupport wxPackages2
-    ++ optionals odbcSupport odbcPackages
-    ++ optionals javacSupport javacPackages
-    ++ optional systemdSupport systemd;
+  meta = {
+    homepage = "https://www.erlang.org/";
+    downloadPage = "https://www.erlang.org/download.html";
+    description = "Programming language used for massively scalable soft real-time systems";
 
-    debugInfo = enableDebugInfo;
-
-    # On some machines, parallel build reliably crashes on `GEN    asn1ct_eval_ext.erl` step
-    enableParallelBuilding = parallelBuild;
-
-    postPatch = ''
-      patchShebangs make
-
-      ${postPatch}
-    ''
-    + optionalString (lib.versionOlder "25" version) ''
-      substituteInPlace lib/os_mon/src/disksup.erl \
-        --replace-fail '"sh ' '"${runtimeShell} '
+    longDescription = ''
+      Erlang is a programming language used to build massively scalable
+      soft real-time systems with requirements on high availability.
+      Some of its uses are in telecoms, banking, e-commerce, computer
+      telephony and instant messaging. Erlang's runtime system has
+      built-in support for concurrency, distribution and fault
+      tolerance.
     '';
 
-    configureFlags = [
-      "--with-ssl=${lib.getOutput "out" opensslPackage}"
-    ]
-    ++ [ "--with-ssl-incl=${lib.getDev opensslPackage}" ] # This flag was introduced in R24
-    ++ optional enableThreads "--enable-threads"
-    ++ optional enableSmpSupport "--enable-smp-support"
-    ++ optional enableKernelPoll "--enable-kernel-poll"
-    ++ optional enableHipe "--enable-hipe"
-    ++ optional javacSupport "--with-javac"
-    ++ optional odbcSupport "--with-odbc=${unixODBC}"
-    ++ optional wxSupport "--enable-wx"
-    ++ optional systemdSupport "--enable-systemd"
-    ++ optional stdenv.hostPlatform.isDarwin "--enable-darwin-64bit"
-    # make[3]: *** [yecc.beam] Segmentation fault: 11
-    ++ optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) "--disable-jit"
-    ++ configureFlags;
-
-    # install-docs will generate and install manpages and html docs
-    # (PDFs are generated only when fop is available).
-    installTargets = [
-      "install"
-      "install-docs"
-    ];
-
-    postInstall = ''
-      ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
-
-      ${postInstall}
-    '';
-
-    # Some erlang bin/ scripts run sed and awk
-    postFixup = ''
-      wrapProgram $out/lib/erlang/bin/erl --prefix PATH ":" "${gnused}/bin/"
-      wrapProgram $out/lib/erlang/bin/start_erl --prefix PATH ":" "${
-        lib.makeBinPath [
-          gnused
-          gawk
-        ]
-      }"
-    '';
-
-    passthru = {
-      updateScript = nix-update-script {
-        extraArgs = [
-          "--version-regex"
-          "OTP-(${major}.*)"
-          "--override-filename"
-          "pkgs/development/interpreters/erlang/${major}.nix"
-        ];
-      };
-    };
-
-    meta =
-      with lib;
-      (
-        {
-          homepage = "https://www.erlang.org/";
-          downloadPage = "https://www.erlang.org/download.html";
-          description = "Programming language used for massively scalable soft real-time systems";
-
-          longDescription = ''
-            Erlang is a programming language used to build massively scalable
-            soft real-time systems with requirements on high availability.
-            Some of its uses are in telecoms, banking, e-commerce, computer
-            telephony and instant messaging. Erlang's runtime system has
-            built-in support for concurrency, distribution and fault
-            tolerance.
-          '';
-
-          platforms = platforms.unix;
-          teams = [ teams.beam ];
-          license = licenses.asl20;
-        }
-        // meta
-      );
-  }
-  // optionalAttrs (preUnpack != "") { inherit preUnpack; }
-  // optionalAttrs (postUnpack != "") { inherit postUnpack; }
-  // optionalAttrs (patches != [ ]) { inherit patches; }
-  // optionalAttrs (prePatch != "") { inherit prePatch; }
-  // optionalAttrs (patchPhase != "") { inherit patchPhase; }
-  // optionalAttrs (configurePhase != "") { inherit configurePhase; }
-  // optionalAttrs (preConfigure != "") { inherit preConfigure; }
-  // optionalAttrs (postConfigure != "") { inherit postConfigure; }
-  // optionalAttrs (buildPhase != "") { inherit buildPhase; }
-  // optionalAttrs (preBuild != "") { inherit preBuild; }
-  // optionalAttrs (postBuild != "") { inherit postBuild; }
-  // optionalAttrs (checkPhase != "") { inherit checkPhase; }
-  // optionalAttrs (preCheck != "") { inherit preCheck; }
-  // optionalAttrs (postCheck != "") { inherit postCheck; }
-  // optionalAttrs (installPhase != "") { inherit installPhase; }
-  // optionalAttrs (preInstall != "") { inherit preInstall; }
-  // optionalAttrs (fixupPhase != "") { inherit fixupPhase; }
-  // optionalAttrs (preFixup != "") { inherit preFixup; }
-  // optionalAttrs (postFixup != "") { inherit postFixup; }
-)
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.beam ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/servers/mobilizon/default.nix
+++ b/pkgs/servers/mobilizon/default.nix
@@ -10,7 +10,6 @@
   nixosTests,
   nixfmt,
   mobilizon-frontend,
-  ...
 }:
 
 let

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -12,7 +12,6 @@
   pkg-config,
   glib,
   fetchpatch,
-  ...
 }:
 
 beamPackages.mixRelease rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1719,7 +1719,6 @@ with pkgs;
   lukesmithxyz-bible-kjv = callPackage ../applications/misc/kjv/lukesmithxyz-kjv.nix { };
 
   plausible = callPackage ../by-name/pl/plausible/package.nix {
-    elixir = elixir_1_18;
     beamPackages = beamPackages.extend (self: super: { elixir = elixir_1_18; });
   };
 
@@ -2214,7 +2213,6 @@ with pkgs;
   mkspiffs-presets = recurseIntoAttrs (callPackages ../tools/filesystems/mkspiffs/presets.nix { });
 
   mobilizon = callPackage ../servers/mobilizon {
-    elixir = beam.packages.erlang_26.elixir_1_15;
     beamPackages = beam.packages.erlang_26.extend (self: super: { elixir = self.elixir_1_15; });
     mobilizon-frontend = callPackage ../servers/mobilizon/frontend.nix { };
   };
@@ -3890,7 +3888,6 @@ with pkgs;
   tautulli = python3Packages.callPackage ../servers/tautulli { };
 
   pleroma = callPackage ../servers/pleroma {
-    elixir = elixir_1_17;
     beamPackages = beam.packages.erlang_26.extend (self: super: { elixir = elixir_1_17; });
   };
 
@@ -9987,9 +9984,8 @@ with pkgs;
 
   qremotecontrol-server = libsForQt5.callPackage ../servers/misc/qremotecontrol-server { };
 
-  rabbitmq-server = callPackage ../by-name/ra/rabbitmq-server/package.nix rec {
-    erlang = erlang_27;
-    elixir = elixir_1_17.override { inherit erlang; };
+  rabbitmq-server = callPackage ../by-name/ra/rabbitmq-server/package.nix {
+    beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_17; });
   };
 
   rethinkdb = callPackage ../servers/nosql/rethinkdb {

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -2,7 +2,6 @@
   lib,
   beam,
   callPackage,
-  wxGTK32,
   stdenv,
   wxSupport ? true,
   systemd,
@@ -29,20 +28,14 @@ in
     # Three versions are supported according to https://github.com/erlang/otp/security
 
     erlang_28 = self.beamLib.callErlang ../development/interpreters/erlang/28.nix {
-      wxGTK = wxGTK32;
-      parallelBuild = true;
       inherit wxSupport systemdSupport;
     };
 
     erlang_27 = self.beamLib.callErlang ../development/interpreters/erlang/27.nix {
-      wxGTK = wxGTK32;
-      parallelBuild = true;
       inherit wxSupport systemdSupport;
     };
 
     erlang_26 = self.beamLib.callErlang ../development/interpreters/erlang/26.nix {
-      wxGTK = wxGTK32;
-      parallelBuild = true;
       inherit wxSupport systemdSupport;
     };
 


### PR DESCRIPTION
The existing API for overriding the erlang package itself is awkward, requires a lot of unnecessary code, and isn't idiomatic. In this I've removed one level of callPackage and simplified the API that's used internally.

My testing shows this to be an improvement with no breakage, but I would appreciate assistance in any cases others can think of.

I've wanted to do this for a while, and it's likely a breaking change, so I'd like to get this in before non-critical freeze if possible.

I also included moving internal packages to use beamPackages. I strongly recommend doing this with an extend if necessary, as it ensures consistent erlang/elixir/etc packages throughout the package set.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
