### PR TITLE
 containerlab: 0.69.3 -> 0.70.2

### DIFF
--- a/pkgs/by-name/co/containerlab/package.nix
+++ b/pkgs/by-name/co/containerlab/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "containerlab";
-  version = "0.69.3";
+  version = "0.70.2";
 
   src = fetchFromGitHub {
     owner = "srl-labs";
     repo = "containerlab";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RJNJ5LUCGaARn5NOSepTL/0Owr/ozFUYAvlynDTyqfY=";
+    hash = "sha256-QBv0SZ7XxVc0yWbOxPKdfzk9AKYlMJyeZwpAx1jbamk=";
   };
 
-  vendorHash = "sha256-28Q1R6P2rpER5RxagnsKy9W3b4FUeRRbkPPovzag//U=";
+  vendorHash = "sha256-XttJ/GXhNKVHLR33A/o3N3OYHsyKWHBhD5QOz0AlfFk=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -27,9 +27,9 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/srl-labs/containerlab/cmd/version.Version=${finalAttrs.version}"
-    "-X github.com/srl-labs/containerlab/cmd/version.commit=${finalAttrs.src.rev}"
-    "-X github.com/srl-labs/containerlab/cmd/version.date=1970-01-01T00:00:00Z"
+    "-X github.com/srl-labs/containerlab/cmd.Version=${finalAttrs.version}"
+    "-X github.com/srl-labs/containerlab/cmd.commit=${finalAttrs.src.rev}"
+    "-X github.com/srl-labs/containerlab/cmd.date=1970-01-01T00:00:00Z"
   ];
 
   preCheck = ''
@@ -37,9 +37,10 @@ buildGoModule (finalAttrs: {
     export USER="runner"
   '';
 
-  # TestVerifyLinks wants to use docker.sock, which is not available in the Nix build environment.
+  # TestVerifyLinks wants to use docker.sock which is not available in the Nix build env
+  # KernelModulesLoaded wants to use /proc/modules which is not available in Nix build env
   checkFlags = [
-    "-skip=^TestVerifyLinks$"
+    "-skip=^TestVerifyLinks$|^TestIsKernelModuleLoaded$"
   ];
 
   postInstall = ''


### PR DESCRIPTION
https://github.com/srl-labs/containerlab/releases/tag/v0.70.2

Version update, excluded TestIsKernelModuleLoaded as it tries to access /proc/modules which is not possible in the nix build sandbox and fixed version tag

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
