### PR TITLE
Kagen: 1.1.0 -> 1.2.0; cgal: propagate boost

### DIFF
--- a/pkgs/by-name/cg/cgal/package.nix
+++ b/pkgs/by-name/cg/cgal/package.nix
@@ -6,6 +6,7 @@
   boost,
   gmp,
   mpfr,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -17,18 +18,31 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-8wxb58JaKj6iS8y6q1z2P6/aY8AnnzTX5/izISgh/tY=";
   };
 
+  patches = [ ./cgal_path.patch ];
+
+  nativeBuildInputs = [ cmake ];
+
   # note: optional component libCGAL_ImageIO would need zlib and opengl;
   #   there are also libCGAL_Qt{3,4} omitted ATM
   buildInputs = [
-    boost
     gmp
     mpfr
   ];
-  nativeBuildInputs = [ cmake ];
 
-  patches = [ ./cgal_path.patch ];
+  propagatedBuildInputs = [
+    boost
+  ];
 
   doCheck = false;
+
+  passthru = {
+    tests = {
+      cmake-config = testers.hasCmakeConfigModules {
+        moduleNames = [ "CGAL" ];
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
 
   meta = {
     description = "Computational Geometry Algorithms Library";

--- a/pkgs/by-name/ka/kagen/package.nix
+++ b/pkgs/by-name/ka/kagen/package.nix
@@ -5,16 +5,14 @@
   cmake,
   pkg-config,
   mpi,
-  cgal_5,
-  boost,
-  gmp,
-  mpfr,
+  cgal,
   sparsehash,
   imagemagick,
   gtest,
   ctestCheckHook,
   mpiCheckPhaseHook,
   withExamples ? false,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,14 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    mpi
-    cgal_5
-    sparsehash
     imagemagick
-    # should be propagated by cgal
-    boost
-    gmp
-    mpfr
+  ];
+
+  propagatedBuildInputs = [
+    mpi
+    cgal
+    sparsehash
   ];
 
   cmakeFlags = [
@@ -72,6 +69,15 @@ stdenv.mkDerivation (finalAttrs: {
     "test_permutation.2cores"
     "test_permutation.4cores"
   ];
+
+  passthru = {
+    tests = {
+      cmake-config = testers.hasCmakeConfigModules {
+        moduleNames = [ "KaGen" ];
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
 
   meta = {
     description = "Communication-free Massively Distributed Graph Generators";

--- a/pkgs/by-name/ka/kagen/package.nix
+++ b/pkgs/by-name/ka/kagen/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   cmake,
   pkg-config,
   mpi,
@@ -20,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kagen";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "KarlsruheGraphGeneration";
@@ -28,25 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     # use vendor libmorton and xxHash
     fetchSubmodules = true;
-    hash = "sha256-FSlTNOQgwPGOn4mIVIgFejvU0dpyydomHYJOKPz1UjU=";
+    hash = "sha256-2jXHHS9Siu6hXrYPIrZSOWe6D2PgsvrbMw/7Ykpc3wk=";
   };
-
-  patches = [
-    # replace asm by builtin function to ensure compatibility with arm64
-    (fetchpatch2 {
-      url = "https://github.com/KarlsruheGraphGeneration/KaGen/commit/cab9d5dc6cc256972e52675ad9c385524d40ecd9.patch?full_index=1";
-      hash = "sha256-DCsuwUiE98UKZMxlUI9p36/wq486uHHrUphrIVqM+Cc=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace tests/CMakeLists.txt \
-      --replace-fail "FetchContent_MakeAvailable(googletest)" "find_package(GTest REQUIRED)"\
-      --replace-fail "set_property(DIRECTORY" "#set_property(DIRECTORY"
-
-    substituteInPlace kagen/CMakeLists.txt \
-      --replace-fail "OBJECT" ""
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -66,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "KAGEN_USE_BUNDLED_GTEST" false)
     (lib.cmakeBool "KAGEN_BUILD_EXAMPLES" withExamples)
     (lib.cmakeBool "KAGEN_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
@@ -80,15 +63,15 @@ stdenv.mkDerivation (finalAttrs: {
     mpiCheckPhaseHook
   ];
 
-  disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    # flaky tests on aarch64-darwin
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # flaky tests on darwin
     "test_rgg2d.2cores"
     "test_rgg2d.4cores"
+    "test_edge_weights.2cores"
+    "test_edge_weights.4cores"
+    "test_permutation.2cores"
+    "test_permutation.4cores"
   ];
-
-  postInstall = ''
-    cmake --install . --component tools
-  '';
 
   meta = {
     description = "Communication-free Massively Distributed Graph Generators";


### PR DESCRIPTION
shamely stolen from https://github.com/NixOS/nixpkgs/pull/448009

Diff: https://github.com/KarlsruheGraphGeneration/KaGen/compare/v1.1.0...v1.2.0

cc @dsalwasser 

Todo: unvendor xxHash so as to build shared lib for kagen. ( should kagen propagate xxHash in their cmake-config module? )

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
