### PR TITLE
protonmail-desktop: restored darwin support

### DIFF
--- a/pkgs/by-name/pr/protonmail-desktop/package.nix
+++ b/pkgs/by-name/pr/protonmail-desktop/package.nix
@@ -6,32 +6,50 @@
   makeWrapper,
   dpkg,
   electron,
+  _7zz,
 }:
 let
   mainProgram = "proton-mail";
   version = "1.9.1";
-
+  linuxHash = "sha256-P2i/uX++F1JUgwSUyndYazjLSCK1mP+XSGICPUoo1VE=";
+  darwinHash = "sha256-U+I0ttToDiLLjEaKlvdb7HhE4dMrLryc251GXBVsQEM=";
 in
 stdenv.mkDerivation {
   pname = "protonmail-desktop";
   inherit version;
 
-  src = fetchurl {
-    url = "https://proton.me/download/mail/linux/${version}/ProtonMail-desktop-beta.deb";
-    hash = "sha256-P2i/uX++F1JUgwSUyndYazjLSCK1mP+XSGICPUoo1VE=";
-  };
+  src =
+    {
+      "x86_64-linux" = fetchurl {
+        url = "https://proton.me/download/mail/linux/${version}/ProtonMail-desktop-beta.deb";
+        hash = linuxHash;
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://proton.me/download/mail/macos/${version}/ProtonMail-desktop.dmg";
+        hash = darwinHash;
+      };
+      "x86_64-darwin" = fetchurl {
+        url = "https://proton.me/download/mail/macos/${version}/ProtonMail-desktop.dmg";
+        hash = darwinHash;
+      };
+    }
+    ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   dontConfigure = true;
   dontBuild = true;
 
-  nativeBuildInputs = [
-    dpkg
-    makeWrapper
-    asar
-  ];
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      dpkg
+      makeWrapper
+      asar
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      _7zz
+    ];
 
   # Rebuild the ASAR archive, hardcoding the resourcesPath
-  preInstall = ''
+  preInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     asar extract usr/lib/proton-mail/resources/app.asar tmp
     rm usr/lib/proton-mail/resources/app.asar
     substituteInPlace tmp/.webpack/main/index.js \
@@ -42,11 +60,17 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/share/proton-mail
     cp -r usr/share/ $out/
     cp -r usr/lib/proton-mail/resources/* $out/share/proton-mail/
-
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications
+    cp -r "Proton Mail.app" $out/Applications/
+  ''
+  + ''
     runHook postInstall
   '';
 
@@ -72,7 +96,8 @@ stdenv.mkDerivation {
     ];
     platforms = [
       "x86_64-linux"
-    ];
+    ]
+    ++ lib.platforms.darwin;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
 
     inherit mainProgram;

--- a/pkgs/by-name/pr/protonmail-desktop/update.sh
+++ b/pkgs/by-name/pr/protonmail-desktop/update.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts jq
+#!nix-shell -i bash -p coreutils jq
 
 # shellcheck disable=SC1008
 
 set -eu -o pipefail
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 latestVersion=$(curl https://proton.me/download/mail/linux/version.json | jq -r 'first(.Releases[])|.Version')
-downloadUrl="https://proton.me/download/mail/linux/${latestVersion}/ProtonMail-desktop-beta.deb"
-latestSha=$(nix store prefetch-file "$downloadUrl" --json | jq -r '.hash')
-update-source-version "protonmail-desktop" "$latestVersion" "$latestSha" --ignore-same-version --file=./pkgs/by-name/pr/protonmail-desktop/package.nix
+linuxDownloadUrl="https://proton.me/download/mail/linux/${latestVersion}/ProtonMail-desktop-beta.deb"
+darwinDownloadUrl="https://proton.me/download/mail/macos/${latestVersion}/ProtonMail-desktop.dmg"
+
+latestLinuxSha=$(nix store prefetch-file "$linuxDownloadUrl" --json | jq -r '.hash')
+latestDarwinSha=$(nix store prefetch-file "$darwinDownloadUrl" --json | jq -r '.hash')
+
+sed -i "s|version = \".*\";|version = \"${latestVersion}\";|" ./package.nix
+sed -i "s|linuxHash = \"sha256-[^\"]*\";|linuxHash = \"${latestLinuxSha}\";|" ./package.nix
+sed -i "s|darwinHash = \"sha256-[^\"]*\";|darwinHash = \"${latestDarwinSha}\";|" ./package.nix


### PR DESCRIPTION
- Restored Darwin support for the package
- Fixed the update script so it also caters for the new platform

<img width="550" height="450" alt="Screenshot 2025-10-02 at 18 08 00" src="https://github.com/user-attachments/assets/d2e14dde-f8c8-4488-8143-dba43752b9a9" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
