### PR TITLE
nghttp3,ngtcp2: simplify static conditionals

### DIFF
--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -23,16 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags =
-    if stdenv.hostPlatform.isStatic then
-      [
-        (lib.cmakeBool "ENABLE_SHARED_LIB" false)
-        (lib.cmakeBool "ENABLE_STATIC_LIB" true)
-      ]
-    else
-      [
-        (lib.cmakeBool "ENABLE_STATIC_LIB" false)
-      ];
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_SHARED_LIB" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "ENABLE_STATIC_LIB" stdenv.hostPlatform.isStatic)
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -36,19 +36,13 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withJemalloc jemalloc;
 
-  cmakeFlags =
-    if stdenv.hostPlatform.isStatic then
-      [
-        # The examples try to link against `ngtcp2_crypto_ossl` and `ngtcp2` libraries.
-        # This works in the dynamic case where the targets have the same name, but not here where they're suffixed with `_static`.
-        (lib.cmakeBool "ENABLE_LIB_ONLY" true)
-        (lib.cmakeBool "ENABLE_SHARED_LIB" false)
-        (lib.cmakeBool "ENABLE_STATIC_LIB" true)
-      ]
-    else
-      [
-        (lib.cmakeBool "ENABLE_STATIC_LIB" false)
-      ];
+  cmakeFlags = [
+    # The examples try to link against `ngtcp2_crypto_ossl` and `ngtcp2` libraries.
+    # This works in the dynamic case where the targets have the same name, but not here where they're suffixed with `_static`.
+    (lib.cmakeBool "ENABLE_LIB_ONLY" stdenv.hostPlatform.isStatic)
+    (lib.cmakeBool "ENABLE_SHARED_LIB" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "ENABLE_STATIC_LIB" stdenv.hostPlatform.isStatic)
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
Mass-rebuild cleanup after https://github.com/NixOS/nixpkgs/pull/445602 .

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
