### PR TITLE
nixos/ipa: cleanup

### DIFF
--- a/nixos/modules/security/ipa.nix
+++ b/nixos/modules/security/ipa.nix
@@ -43,8 +43,8 @@ in
         '';
         example = literalExpression ''
           pkgs.fetchurl {
-            url = http://ipa.example.com/ipa/config/ca.crt;
-            sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+            url = "http://ipa.example.com/ipa/config/ca.crt";
+            hash = lib.fakeHash;
           };
         '';
       };
@@ -191,12 +191,12 @@ in
       '';
 
       "ldap.conf".source = ldapConf;
-    };
 
-    environment.etc."chromium/policies/managed/freeipa.json" = mkIf cfg.chromiumSupport {
-      text = ''
-        { "AuthServerWhitelist": "*.${cfg.domain}" }
-      '';
+      "chromium/policies/managed/freeipa.json" = mkIf cfg.chromiumSupport {
+        text = builtins.toJSON {
+          AuthServerWhitelist = "*.${cfg.domain}";
+        };
+      };
     };
 
     systemd.services."ipa-activation" = {
@@ -207,8 +207,10 @@ in
       ];
       conflicts = [ "shutdown.target" ];
       unitConfig.DefaultDependencies = false;
-      serviceConfig.Type = "oneshot";
-      serviceConfig.RemainAfterExit = true;
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
       script = ''
         # libcurl requires a hard copy of the certificate
         if ! ${pkgs.diffutils}/bin/diff ${cfg.certificate} /etc/ipa/ca.crt > /dev/null 2>&1; then
@@ -226,58 +228,61 @@ in
             4. Restart sssd systemd service: sudo systemctl restart sssd
 
         EOF
+        # let service fail, to raise awareness
+        exit 1
         fi
       '';
     };
 
-    services.sssd.config = ''
-      [domain/${cfg.domain}]
-      id_provider = ipa
-      auth_provider = ipa
-      access_provider = ipa
-      chpass_provider = ipa
+    services.sssd = {
+      enable = true;
+      config = ''
+        [domain/${cfg.domain}]
+        id_provider = ipa
+        auth_provider = ipa
+        access_provider = ipa
+        chpass_provider = ipa
 
-      ipa_domain = ${cfg.domain}
-      ipa_server = _srv_, ${cfg.server}
-      ipa_hostname = ${cfg.ipaHostname}
+        ipa_domain = ${cfg.domain}
+        ipa_server = _srv_, ${cfg.server}
+        ipa_hostname = ${cfg.ipaHostname}
 
-      cache_credentials = ${pyBool cfg.cacheCredentials}
-      krb5_store_password_if_offline = ${pyBool cfg.offlinePasswords}
-      ${optionalString ((toLower cfg.domain) != (toLower cfg.realm)) "krb5_realm = ${cfg.realm}"}
+        cache_credentials = ${pyBool cfg.cacheCredentials}
+        krb5_store_password_if_offline = ${pyBool cfg.offlinePasswords}
+        ${optionalString ((toLower cfg.domain) != (toLower cfg.realm)) "krb5_realm = ${cfg.realm}"}
 
-      dyndns_update = ${pyBool cfg.dyndns.enable}
-      dyndns_iface = ${cfg.dyndns.interface}
+        dyndns_update = ${pyBool cfg.dyndns.enable}
+        dyndns_iface = ${cfg.dyndns.interface}
 
-      ldap_tls_cacert = /etc/ipa/ca.crt
-      ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber, lock:nsaccountlock
+        ldap_tls_cacert = /etc/ipa/ca.crt
+        ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber, lock:nsaccountlock
 
-      [sssd]
-      services = nss, sudo, pam, ssh, ifp
-      domains = ${cfg.domain}
+        [sssd]
+        services = nss, sudo, pam, ssh, ifp
+        domains = ${cfg.domain}
 
-      [nss]
-      homedir_substring = /home
+        [nss]
+        homedir_substring = /home
 
-      [pam]
-      pam_pwd_expiration_warning = 3
-      pam_verbosity = 3
+        [pam]
+        pam_pwd_expiration_warning = 3
+        pam_verbosity = 3
 
-      [sudo]
+        [sudo]
 
-      [autofs]
+        [autofs]
 
-      [ssh]
+        [ssh]
 
-      [pac]
+        [pac]
 
-      [ifp]
-      user_attributes = +mail, +telephoneNumber, +givenname, +sn, +lock
-      allowed_uids = ${concatStringsSep ", " cfg.ifpAllowedUids}
-    '';
+        [ifp]
+        user_attributes = +mail, +telephoneNumber, +givenname, +sn, +lock
+        allowed_uids = ${concatStringsSep ", " cfg.ifpAllowedUids}
+      '';
+    };
 
-    services.ntp.servers = singleton cfg.server;
-    services.sssd.enable = true;
-    services.ntp.enable = true;
+    networking.timeServers = singleton cfg.server;
 
     security.pki.certificateFiles = singleton cfg.certificate;
   };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
