### PR TITLE
nixos/vagrant-virtualbox-image: Fixed quoting issue

### DIFF
--- a/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
+++ b/nixos/modules/virtualisation/vagrant-virtualbox-image.nix
@@ -45,20 +45,20 @@
     VAGRANTFILE
 
     # 3. add the exported VM files
-    tar xvf ${config.system.build.virtualBoxOVA}/*.ova
+    tar xvf "${config.system.build.virtualBoxOVA}"/*.ova
 
     # 4. move the ovf to the fixed location
-    mv *.ovf box.ovf
+    mv -- *.ovf box.ovf
 
     # 5. generate OVF manifest file
-    rm *.mf
+    rm -- *.mf
     touch box.mf
     for fname in *; do
-      checksum=$(sha256sum $fname | cut -d' ' -f 1)
+      checksum=$(sha256sum "$fname" | cut -d' ' -f 1)
       echo "SHA256($fname)= $checksum" >> box.mf
     done
 
     # 6. compress everything back together
-    tar --owner=0 --group=0 --sort=name --numeric-owner -czf $out .
+    tar --owner=0 --group=0 --sort=name --numeric-owner -czf "$out" .
   '';
 }


### PR DESCRIPTION
If we make an image with nix-generate, an artifact's name ends up having a space, causing a spacing error on this line
https://github.com/NixOS/nixpkgs/blob/afd64ceb0a6525bebcffec8c3e1b969d43cb7063/nixos/modules/virtualisation/vagrant-virtualbox-image.nix#L57
This fix includes also other potential quoting and globbing issues
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
