### PR TITLE
various: switch from --replace to --replace-fail

### DIFF
--- a/pkgs/applications/audio/ardour/7.nix
+++ b/pkgs/applications/audio/ardour/7.nix
@@ -108,8 +108,8 @@ stdenv.mkDerivation rec {
     sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
     patchShebangs ./tools/
     substituteInPlace libs/ardour/video_tools_paths.cc \
-      --replace 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg}/bin/ffmpeg");' \
-      --replace 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg}/bin/ffprobe");'
+      --replace-fail 'ffmpeg_exe = X_("")' "ffmpeg_exe = X_(\"${lib.getExe ffmpeg}\");" \
+      --replace-fail 'ffprobe_exe = X_("");' "ffprobe_exe = X_(\"${lib.getExe' ffmpeg "ffprobe"}\");"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     cp -r usr/share $out/share
     substitute usr/share/applications/com.bitwig.BitwigStudio.desktop \
       $out/share/applications/com.bitwig.BitwigStudio.desktop \
-      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
+      --replace-fail "Exec=bitwig-studio" "Exec=$out/bin/bitwig-studio"
 
       runHook postInstall
   '';

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
 
     substitute usr/share/applications/com.bitwig.BitwigStudio.desktop \
       $out/share/applications/com.bitwig.BitwigStudio.desktop \
-      --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
+      --replace-fail "Exec=bitwig-studio" "Exec=$out/bin/bitwig-studio"
 
       runHook postInstall
   '';

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -75,13 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
     # --with-appname="$0" is evaluated with $0=.carla-wrapped instead of carla. Fix that.
     for file in $(grep -rl -- '--with-appname="$0"'); do
         filename="$(basename -- "$file")"
-        substituteInPlace "$file" --replace '--with-appname="$0"' "--with-appname=\"$filename\""
+        substituteInPlace "$file" --replace-fail '--with-appname="$0"' "--with-appname=\"$filename\""
     done
   ''
   + lib.optionalString withGtk2 ''
     # Will try to dlopen() libgtk-x11-2.0 at runtime when using the bridge.
     substituteInPlace source/bridges-ui/Makefile \
-        --replace '$(CXX) $(OBJS_GTK2)' '$(CXX) $(OBJS_GTK2) -lgtk-x11-2.0'
+        --replace-fail '$(CXX) $(OBJS_GTK2)' '$(CXX) $(OBJS_GTK2) -lgtk-x11-2.0'
   '';
 
   dontWrapQtApps = true;

--- a/pkgs/applications/audio/codecserver/default.nix
+++ b/pkgs/applications/audio/codecserver/default.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     substituteInPlace "$out"/lib/pkgconfig/codecserver.pc \
-      --replace '=''${prefix}//' '=/' \
-      --replace '=''${exec_prefix}//' '=/'
+      --replace-fail '=''${prefix}//' '=/' \
+      --replace-fail '=''${exec_prefix}//' '=/'
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/miniaudicle/default.nix
+++ b/pkgs/applications/audio/miniaudicle/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     echo '#define GIT_REVISION "${finalAttrs.version}-NixOS"' > git-rev.h
     substituteInPlace miniAudicle.pro \
-      --replace "/usr/local" $out
+      --replace-fail "/usr/local" $out
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bl/blackfire/package.nix
+++ b/pkgs/by-name/bl/blackfire/package.nix
@@ -35,15 +35,15 @@ stdenv.mkDerivation rec {
       # Fix ExecStart path and replace deprecated directory creation method,
       # use dynamic user.
       substituteInPlace "$out/lib/systemd/system/blackfire-agent.service" \
-        --replace '/usr/' "$out/" \
-        --replace 'ExecStartPre=/bin/mkdir -p /var/run/blackfire' 'RuntimeDirectory=blackfire' \
-        --replace 'ExecStartPre=/bin/chown blackfire: /var/run/blackfire' "" \
-        --replace 'User=blackfire' 'DynamicUser=yes' \
-        --replace 'PermissionsStartOnly=true' ""
+        --replace-fail '/usr/' "$out/" \
+        --replace-fail 'ExecStartPre=/bin/mkdir -p /var/run/blackfire' 'RuntimeDirectory=blackfire' \
+        --replace-fail 'ExecStartPre=/bin/chown blackfire: /var/run/blackfire' "" \
+        --replace-fail 'User=blackfire' 'DynamicUser=yes' \
+        --replace-fail 'PermissionsStartOnly=true' ""
 
       # Modernize socket path.
       substituteInPlace "$out/etc/blackfire/agent" \
-        --replace '/var/run' '/run'
+        --replace-fail '/var/run' '/run'
     else
       mkdir $out
 

--- a/pkgs/by-name/bl/blast/package.nix
+++ b/pkgs/by-name/bl/blast/package.nix
@@ -46,14 +46,14 @@ stdenv.mkDerivation rec {
         scripts/common/impl/report_duplicates.awk; do
 
         substituteInPlace $awks \
-              --replace /usr/bin/awk ${gawk}/bin/awk
+              --replace-fail "/usr/bin/awk" "${gawk}/bin/awk"
     done
 
     for mk in src/build-system/Makefile.meta.in \
         src/build-system/helpers/run_with_lock.c ; do
 
         substituteInPlace $mk \
-        --replace /bin/rm ${coreutils}/bin/rm
+        --replace-fail "/bin/rm" "${coreutils}/bin/rm"
     done
 
     for mk in src/build-system/Makefile.meta.gmake=no \
@@ -63,27 +63,27 @@ stdenv.mkDerivation rec {
         src/build-system/Makefile.rules_with_autodep.in; do
 
         substituteInPlace $mk \
-            --replace /bin/echo ${coreutils}/bin/echo
+            --replace-fail "/bin/echo" "${coreutils}/bin/echo"
     done
     for mk in src/build-system/Makefile.meta_p \
         src/build-system/Makefile.rules_with_autodep.in \
         src/build-system/Makefile.protobuf.in ; do
 
         substituteInPlace $mk \
-            --replace /bin/mv ${coreutils}/bin/mv
+            --replace-fail "/bin/mv" "${coreutils}/bin/mv"
     done
 
 
     substituteInPlace src/build-system/configure \
-        --replace /bin/pwd ${coreutils}/bin/pwd \
-        --replace /bin/ln ${coreutils}/bin/ln
+        --replace-fail "/bin/pwd" "${coreutils}/bin/pwd" \
+        --replace-fail "/bin/ln" "${coreutils}/bin/ln"
 
     substituteInPlace src/build-system/configure.ac \
-        --replace /bin/pwd ${coreutils}/bin/pwd \
-        --replace /bin/ln ${coreutils}/bin/ln
+        --replace-fail "/bin/pwd" "${coreutils}/bin/pwd" \
+        --replace-fail "/bin/ln" "${coreutils}/bin/ln"
 
     substituteInPlace src/build-system/Makefile.meta_l \
-        --replace /bin/date ${coreutils}/bin/date
+        --replace-fail "/bin/date" "${coreutils}/bin/date"
   '';
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/bin/get_species_taxids.sh \
-        --replace /bin/rm ${lib.getExe' coreutils "rm"}
+        --replace-fail "/bin/rm" "${coreutils}/bin/rm"
   '';
   patches = [ ./no_slash_bin.patch ];
 

--- a/pkgs/by-name/tu/tuxtype/package.nix
+++ b/pkgs/by-name/tu/tuxtype/package.nix
@@ -32,14 +32,14 @@ stdenv.mkDerivation rec {
     patchShebangs data/themes/hungarian/scripts/sed-linux.sh
 
     substituteInPlace Makefile.am \
-      --replace "\$(MKDIR_P) -m 2755 " "\$(MKDIR_P) -m 755 " \
-      --replace "chown root:games \$(DESTDIR)\$(pkglocalstatedir)/words" " "
+      --replace-fail "\$(MKDIR_P) -m 2755 " "\$(MKDIR_P) -m 755 " \
+      --replace-fail "chown root:games \$(DESTDIR)\$(pkglocalstatedir)/words" " "
 
     # required until the following has been merged:
     # https://salsa.debian.org/tux4kids-pkg-team/tuxtype/merge_requests/1
     substituteInPlace configure.ac \
-      --replace 'CFLAGS="$CFLAGS $SDL_IMAGE"' 'CFLAGS="$CFLAGS $SDL_IMAGE_CFLAGS"' \
-      --replace 'PKG_CHECK_MODULES([SDL_ttf],' 'PKG_CHECK_MODULES([SDL_TTF],'
+      --replace-fail 'CFLAGS="$CFLAGS $SDL_IMAGE"' 'CFLAGS="$CFLAGS $SDL_IMAGE_CFLAGS"' \
+      --replace-fail 'PKG_CHECK_MODULES([SDL_ttf],' 'PKG_CHECK_MODULES([SDL_TTF],'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
- ran nix-build -A package --check on packages
- fix bad Exec paths after switching to replace-fail in Bitwig Studio 4 and 5
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
