### PR TITLE
cups-brother-mfcj995dw: init at 1.0.5-0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20548,6 +20548,13 @@
     name = "Kevin Mullins";
     keys = [ { fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A"; } ];
   };
+  poach3r = {
+    name = "poacher";
+    email = "poacherGoneWild@proton.me";
+    github = "poach3r";
+    githubId = 58641438;
+    matrix = "@poacher:we2.ee";
+  };
   podium868909 = {
     email = "89096245@proton.me";
     github = "podium868909";

--- a/pkgs/by-name/cu/cups-brother-mfcj995dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-mfcj995dw/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  ghostscript,
+  file,
+  gnused,
+  gnugrep,
+  coreutils,
+  which,
+  perl,
+  libredirect,
+  autoPatchelfHook,
+}:
+let
+  version = "1.0.5-0";
+  model = "mfcj995dw";
+  interpreter = stdenv.cc.bintools.dynamicLinker;
+in
+stdenv.mkDerivation {
+  pname = "cups-brother-${model}";
+  inherit version;
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103811/mfcj995dwpdrv-${version}.i386.deb";
+    hash = "sha256-QT/UZYMiIkdRQn0uWsHJytdQtNnEqWqICTby0FSNE74=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r $out/usr/bin $out/bin
+
+    mkdir -p $out/lib/cups/filter $out/share/cups/model
+    ln -s $out/opt/brother/Printers/${model}/lpd/filter_${model} $out/lib/cups/filter/brlpdwrapper${model}
+    ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} $out/lib/cups/filter/brother_lpdwrapper_${model}
+    ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model/brother_${model}_printer_en.ppd
+
+    runHook postInstall
+  '';
+
+  postPatch = ''
+    substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter_${model} \
+      --replace-fail /usr/bin/perl ${lib.getExe perl} \
+      --replace-fail "PRINTER =~" "PRINTER = \"${model}\"; #" \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/${model}/\"; #"
+
+    substituteInPlace $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} \
+      --replace-fail /usr/bin/perl ${lib.getExe perl} \
+      --replace-fail "basedir =~ " "basedir = \"$out/opt/brother/Printers/${model}/\"; #" \
+      --replace-fail "PRINTER =~ " "PRINTER = \"${model}\"; #" \
+      --replace-fail "LPDCONFIGEXE=" "LPDCONFIGEXE=\"$out/bin/brprintconf_\"; #"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/opt/brother/Printers/${model}/lpd/filter_${model} \
+        --prefix PATH ":" ${
+          lib.makeBinPath [
+            ghostscript
+            file
+            gnused
+            gnugrep
+            coreutils
+            which
+          ]
+        }
+    wrapProgram $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          gnugrep
+          coreutils
+        ]
+      }
+    wrapProgram $out/bin/brprintconf_${model} \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+    wrapProgram $out/opt/brother/Printers/${model}/lpd/br${model}filter \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+  '';
+
+  meta = {
+    homepage = "https://www.brother.com/";
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=eu_ot&lang=en&prod=${model}_eu&os=128";
+    description = "Brother MFC-J995DW printer driver";
+    license = with lib.licenses; [
+      unfreeRedistributable
+      gpl2Only
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "i686-linux"
+    ];
+    maintainers = with lib.maintainers; [ poach3r ];
+  };
+}


### PR DESCRIPTION
Adds a package for the CUPS driver for the Brother MFCJ995DW printer and adds me as its maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
