### PR TITLE
vscode-extensions.pranaygp.vscode-css-peek: init at 4.4.3

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3764,6 +3764,8 @@ let
 
       prince781.vala = callPackage ./prince781.vala { };
 
+      pranaygp.vscode-css-peek = callPackage ./pranaygp.vscode-css-peek { };
+
       prisma.prisma = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "prisma";

--- a/pkgs/applications/editors/vscode/extensions/pranaygp.vscode-css-peek/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/pranaygp.vscode-css-peek/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  vscode-utils,
+}:
+let
+  version = "4.4.3";
+in
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    publisher = "pranaygp";
+    name = "vscode-css-peek";
+    inherit version;
+    hash = "sha256-oY+mpDv2OTy5hFEk2DMNHi9epFm4Ay4qi0drCXPuYhU=";
+  };
+
+  meta = {
+    description = "Allow peeking to css ID and class strings as definitions from html files to respective CSS";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=pranaygp.vscode-css-peek";
+    homepage = "https://github.com/pranaygp/vscode-css-peek";
+    changelog = "https://github.com/pranaygp/vscode-css-peek/blob/v${version}/README.md#changelog";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.kozm9000 ];
+  };
+}


### PR DESCRIPTION
This extension adds support for Go To Definition and Go To Symbol in Workspace for css/scss/less classes and IDs found in HTML/React/Vue/Svelte/Pug/ejs/etc. 7M+ users . Last updated - 3/5/2025, 7:06:12 AM
Add maintainer commit : 57476455c447bfc88a04ede207d3dca75b5eda59 awaiting approval in https://github.com/NixOS/nixpkgs/pull/447852
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
