### PR TITLE
python: fix venv creation; resolve sys.prefix to realpath

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1279,7 +1279,8 @@ someVar=$(stripHash $name)
 
 ### `wrapProgram` \<executable\> \<makeWrapperArgs\> {#fun-wrapProgram}
 
-Convenience function for `makeWrapper` that replaces `<executable>` with a wrapper that executes the original program. It takes all the same arguments as `makeWrapper`, except for `--inherit-argv0` (used by the `makeBinaryWrapper` implementation) and `--argv0` (used by both `makeWrapper` and `makeBinaryWrapper` wrapper implementations).
+Convenience function for `makeWrapper` that replaces `<executable>` with a wrapper that executes the original program. It takes all the same arguments as `makeWrapper`, except for `--inherit-argv0` (used by the `makeBinaryWrapper` implementation), `--resolve-argv0`
+(also used by `makeBinaryWrapper`), and `--argv0` (used by both `makeWrapper` and `makeBinaryWrapper` wrapper implementations).
 
 If you will apply it multiple times, it will overwrite the wrapper file and you will end up with double wrapping, which should be avoided.
 

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -15,7 +15,6 @@ assertExecutable() {
 #                          (if unset or empty, defaults to EXECUTABLE)
 # --inherit-argv0        : the executable inherits argv0 from the wrapper.
 #                          (use instead of --argv0 '$0')
-# --resolve-argv0        : if argv0 doesn't include a / character, resolve it against PATH
 # --set          VAR VAL : add VAR with value VAL to the executable's environment
 # --set-default  VAR VAL : like --set, but only adds VAR if not already set in
 #                          the environment
@@ -188,9 +187,6 @@ makeShellWrapper() {
         elif [[ "$p" == "--inherit-argv0" ]]; then
             # Whichever comes last of --argv0 and --inherit-argv0 wins
             argv0='$0'
-        elif [[ "$p" == "--resolve-argv0" ]]; then
-            # this is noop in shell wrappers, since bash will always resolve $0
-            resolve_argv0=1
         else
             die "makeWrapper doesn't understand the arg $p"
         fi

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildEnv,
+  runCommand,
   makeBinaryWrapper,
 
   # manually pased
@@ -22,7 +23,11 @@
 let
   env =
     let
-      paths = requiredPythonModules (extraLibs ++ [ python ]);
+      paths = requiredPythonModules (extraLibs ++ [ python ]) ++ [
+        (runCommand "bin" { } ''
+          mkdir -p $out/bin
+        '')
+      ];
       pythonPath = "${placeholder "out"}/${python.sitePackages}";
       pythonExecutable = "${placeholder "out"}/bin/${python.executable}";
     in
@@ -36,21 +41,27 @@ let
       nativeBuildInputs = [ makeBinaryWrapper ];
 
       postBuild = ''
-        if [ -L "$out/bin" ]; then
-            unlink "$out/bin"
-        fi
-        mkdir -p "$out/bin"
-
         for path in ${lib.concatStringsSep " " paths}; do
           if [ -d "$path/bin" ]; then
             cd "$path/bin"
             for prg in *; do
-              if [ -f "$prg" ]; then
+              if [ -f "$prg" ] && [ -x "$prg" ]; then
                 rm -f "$out/bin/$prg"
-                if [ -x "$prg" ]; then
-                  makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONPREFIX "$out" --set NIX_PYTHONEXECUTABLE ${pythonExecutable} --set NIX_PYTHONPATH ${pythonPath} ${
-                    lib.optionalString (!permitUserSite) ''--set PYTHONNOUSERSITE "true"''
-                  } ${lib.concatStringsSep " " makeWrapperArgs}
+                if [ "$prg" = "${python.executable}" ]; then
+                  makeWrapper "${python.interpreter}" "$out/bin/$prg" \
+                    --inherit-argv0 \
+                    --resolve-argv0 \
+                    ${lib.optionalString (!permitUserSite) ''--set PYTHONNOUSERSITE "true"''} \
+                    ${lib.concatStringsSep " " makeWrapperArgs}
+                elif [ "$(readlink "$prg")" = "${python.executable}" ]; then
+                  ln -s "${python.executable}" "$out/bin/$prg"
+                else
+                  makeWrapper "$path/bin/$prg" "$out/bin/$prg" \
+                    --set NIX_PYTHONPREFIX "$out" \
+                    --set NIX_PYTHONEXECUTABLE ${pythonExecutable} \
+                    --set NIX_PYTHONPATH ${pythonPath} \
+                    ${lib.optionalString (!permitUserSite) ''--set PYTHONNOUSERSITE "true"''} \
+                    ${lib.concatStringsSep " " makeWrapperArgs}
                 fi
               fi
             done


### PR DESCRIPTION
An attempt tring to fix python's sys.prefix not targetting the realpath in python-env or python-venv .  See https://github.com/NixOS/nixpkgs/pull/442540

Before
```
> nix-build -I nixpkgs=$HOME/nixpkgs -E '{pkgs ? import <nixpkgs> {}}: pkgs.python3.withPackages (ps: [])' -o result
> result/bin/python3 -c 'import sys; print(sys.base_prefix); print(sys.prefix)'
/home/qbisi/nixpkgs/result
/home/qbisi/nixpkgs/result

> result/bin/python3 -m venv --system-site-packages result-venv 
> result-venv/bin/python3 -c 'import sys; print(sys.base_prefix); print(sys.prefix)'
/home/qbisi/nixpkgs/result
/home/qbisi/nixpkgs/result-venv
> ls -al result-venv/bin/python3
/home/qbisi/nixpkgs/result/bin/python3
```
After
```
> nix-build -I nixpkgs=$HOME/nixpkgs -E '{pkgs ? import <nixpkgs> {}}: pkgs.python3.withPackages (ps: [])' -o result
> result/bin/python3 -c 'import sys; print(sys.base_prefix); print(sys.prefix)'
/nix/store/82hqqjwsg9xgm0mxmbj495hk6sfwd0iv-python3-3.13.7-env
/nix/store/82hqqjwsg9xgm0mxmbj495hk6sfwd0iv-python3-3.13.7-env

> result/bin/python3 -m venv --system-site-packages result-venv 
> result-venv/bin/python3 -c 'import sys; print(sys.base_prefix); print(sys.prefix)'
/nix/store/82hqqjwsg9xgm0mxmbj495hk6sfwd0iv-python3-3.13.7-env
/home/qbisi/nixpkgs/result-venv
> ls -al result-venv/bin/python3
/nix/store/82hqqjwsg9xgm0mxmbj495hk6sfwd0iv-python3-3.13.7-env/bin/python3
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
