### PR TITLE
vita3k: init at 3821

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7393,6 +7393,12 @@
     name = "Edward Kimber";
     githubId = 99987;
   };
+  ekisu = {
+    email = "dts.ramon@gmail.com";
+    github = "ekisu";
+    name = "Ramon Dantas";
+    githubId = 5082637;
+  };
   eklairs = {
     name = "Eklairs";
     email = "eklairs@proton.me";

--- a/pkgs/by-name/vi/vita3k/package.nix
+++ b/pkgs/by-name/vi/vita3k/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  appimageTools,
+  makeWrapper,
+  nix-update-script,
+  fetchurl,
+}:
+
+appimageTools.wrapType2 rec {
+  pname = "vita3k";
+  version = "3821";
+
+  src = fetchurl {
+    url = "https://github.com/Vita3K/Vita3K-builds/releases/download/${version}/Vita3K-x86_64.AppImage";
+    sha256 = "sha256-U2sGt8zHGODes2DB7qK5xJVAhkxyQ6ku/UCmd1D1184=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraPkgs = pkgs: [ pkgs.sdl3 ];
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extract { inherit pname version src; };
+    in
+    ''
+      install -Dm444 ${appimageContents}/vita3k.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/vita3k.desktop \
+        --replace-fail "Exec=Vita3K" "Exec=vita3k"
+      cp -r ${appimageContents}/usr/share/icons $out/share
+      wrapProgram $out/bin/vita3k \
+        --set APPIMAGE 1
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Experimental PlayStation Vita emulator";
+    homepage = "https://vita3k.org/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ ekisu ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "vita3k";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [Vita3K](https://vita3k.org/), a PS Vita emulator. Apparently building it from source is a bit tough (see https://github.com/NixOS/nixpkgs/pull/195556), so I've opted to wrap the AppImage instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
