### PR TITLE
prl-tools: 26.0.1-57243 -> 26.1.1-57288

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -361,3 +361,5 @@
 - `sparkleshare` has been removed as it no longer builds and has been abandoned upstream.
 
 - The `open-webui` package's postgres support have been moved to optional dependencies to comply with upstream changes in 0.6.26.
+
+- `prl-tools` has been moved out of `linuxPackages` because Parallels Guest Tools become driverless since 26.1.0.

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -27,20 +28,11 @@ in
         type = types.bool;
         default = false;
         description = ''
-          This enables Parallels Tools for Linux guests, along with provided
-          video, mouse and other hardware drivers.
+          This enables Parallels Tools for Linux guests.
         '';
       };
 
-      package = mkOption {
-        type = types.nullOr types.package;
-        default = config.boot.kernelPackages.prl-tools;
-        defaultText = "config.boot.kernelPackages.prl-tools";
-        example = literalExpression "config.boot.kernelPackages.prl-tools";
-        description = ''
-          Defines which package to use for prl-tools. Override to change the version.
-        '';
-      };
+      package = lib.mkPackageOption pkgs "prl-tools" { };
     };
 
   };
@@ -52,10 +44,6 @@ in
     environment.systemPackages = [ prl-tools ];
 
     boot.extraModulePackages = [ prl-tools ];
-
-    boot.kernelModules = [
-      "prl_tg"
-    ];
 
     services.timesyncd.enable = false;
 

--- a/pkgs/by-name/pr/prl-tools/update.sh
+++ b/pkgs/by-name/pr/prl-tools/update.sh
@@ -4,7 +4,7 @@
 set -eu -o pipefail
 
 nixpkgs="$(git rev-parse --show-toplevel)"
-path="$nixpkgs/pkgs/os-specific/linux/prl-tools/default.nix"
+path="$nixpkgs/pkgs/by-name/pr/prl-tools/default.nix"
 
 # Currently this script only supports Parallels 26
 # Please change the knowledge base url after each major release

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -598,8 +598,6 @@ in
 
         netatop = callPackage ../os-specific/linux/netatop { };
 
-        prl-tools = callPackage ../os-specific/linux/prl-tools { };
-
         isgx = callPackage ../os-specific/linux/isgx { };
 
         rr-zen_workaround = callPackage ../development/tools/analysis/rr/zen_workaround.nix { };
@@ -731,6 +729,7 @@ in
         system76-scheduler = lib.warnOnInstantiate "kernelPackages.system76-scheduler is now pkgs.system76-scheduler" pkgs.system76-scheduler; # Added 2024-10-16
         tuxedo-keyboard = self.tuxedo-drivers; # Added 2024-09-28
         phc-intel = throw "phc-intel drivers are no longer supported by any kernel >=4.17"; # added 2025-07-18
+        prl-tools = throw "Parallel Tools no longer provide any kernel module, please use pkgs.prl-tools instead."; # added 2025-10-04
       }
     );
 


### PR DESCRIPTION
https://kb.parallels.com/en/131014

This is a **breaking change**.

Since Parallels 26.1.0, prl-tools becomes driverless and no longer provide any kernel module. Thus, this PR moves `prl-tools` out of kernel packages and made according changes to the parallels-guest module.

Tested on real VM:

<img width="1404" height="941" alt="image" src="https://github.com/user-attachments/assets/5bbcab18-cb01-4a34-b02b-57641ccdb8f0" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
