### PR TITLE
scotch: doCheck

### DIFF
--- a/pkgs/by-name/sc/scotch/fix-cmake-suffix-fortran-file.patch
+++ b/pkgs/by-name/sc/scotch/fix-cmake-suffix-fortran-file.patch
@@ -1,0 +1,13 @@
+diff --git a/src/check/CMakeLists.txt b/src/check/CMakeLists.txt
+index 8c83ca1..8242c5a 100644
+--- a/src/check/CMakeLists.txt
++++ b/src/check/CMakeLists.txt
+@@ -90,7 +90,7 @@ function(suffix_fortran_file src)
+     "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/cmake_sed_${file_we}.cmake"
+ "
+ file(READ \"${file_we}.tmp\" FILE_CONTENTS)
+-string(REGEX REPLACE \"SCOTCHMETISNAMEFU[ \\t\\r\\n]*\\\\(([A-Za-z0-9_]*)\\\\)\" \"\${SCOTCH_METIS_PREFIXFU}\\\\1\" FILE_CONTENTS \"\${FILE_CONTENTS}\")
++string(REGEX REPLACE \"SCOTCHMETISNAMEFU[ \\t\\r\\n]*\\\\(([A-Za-z0-9_]*)\\\\)\" \"${SCOTCH_METIS_PREFIXFU}\\\\1\" FILE_CONTENTS \"\${FILE_CONTENTS}\")
+ file(WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/${file_we}\" \"\${FILE_CONTENTS}\")
+ "
+ )

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-qeMgTkoM/RDsZa0T6hmrDLbLuSeR8WNxllyHSlkMVzA=";
   };
 
+  patches = [
+    ./fix-cmake-suffix-fortran-file.patch
+  ];
+
   outputs = [
     "bin"
     "dev"
@@ -39,8 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_PTSCOTCH" withPtScotch)
     # Prefix Scotch version of MeTiS routines
     (lib.cmakeBool "SCOTCH_METIS_PREFIX" true)
-    # building tests is broken with SCOTCH_METIS_PREFIX enabled, at least since 7.0.9
-    (lib.cmakeBool "ENABLE_TESTS" false)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   nativeBuildInputs = [
@@ -59,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = lib.optionals withPtScotch [
     mpi
   ];
+
+  doCheck = true;
 
   # SCOTCH provide compatibility with Metis/Parmetis interface.
   # We install the metis compatible headers to subdirectory to


### PR DESCRIPTION
what the patch do:
fix cmake regex replacement of test_libmetis_dual_f.f90.in to test_libmetis_dual_f.f90,
previously `\${SCOTCH_METIS_PREFIXFU}` expand to env variable, however we should use cmake variable `${SCOTCH_METIS_PREFIXFU}` here.

cc @nim65s can you help submit the patch to upstream. I would like to unvendor this patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
