### PR TITLE
 [Backport release-25.05] LibreSSL: 4.0.0 -> 4.0.1, 4.1.0 -> 4.1.1, delete unsupported 3.9

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -16,9 +16,10 @@ let
       version,
       hash,
       patches ? [ ],
+      postPatch ? "",
       knownVulnerabilities ? [ ],
     }:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation {
       pname = "libressl";
       inherit version;
 
@@ -58,7 +59,8 @@ let
 
       postPatch = ''
         patchShebangs tests/
-      '';
+      ''
+      + postPatch;
 
       doCheck = !(stdenv.hostPlatform.isPower64 || stdenv.hostPlatform.isRiscV);
       preCheck = ''
@@ -151,7 +153,18 @@ in
   };
 
   libressl_4_1 = generic {
-    version = "4.1.0";
-    hash = "sha256-D3HBa9NL2qzNy5al2UpJIb+2EuxuDrp6gNiFTu/Yu2E=";
+    version = "4.1.1";
+    hash = "sha256-x/96fWddX1dzCUDlzP8dvi3NW3QFtTl+D3/9ZqXtVnk=";
+    # Fixes build on loongarch64
+    # https://github.com/libressl/portable/pull/1184
+    postPatch = ''
+      mkdir -p include/arch/loongarch64
+      cp ${
+        fetchurl {
+          url = "https://github.com/libressl/portable/raw/refs/tags/v4.1.0/include/arch/loongarch64/opensslconf.h";
+          hash = "sha256-68dw5syUy1z6GadCMR4TR9+0UQX6Lw/CbPWvjHGAhgo=";
+        }
+      } include/arch/loongarch64/opensslconf.h
+    '';
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -131,8 +131,8 @@ in
   };
 
   libressl_4_0 = generic {
-    version = "4.0.0";
-    hash = "sha256-TYQZVfCsw9/HHQ49018oOvRhIiNQ4mhD/qlzHAJGoeQ=";
+    version = "4.0.1";
+    hash = "sha256-IClLh3eMJidIk4Y5Q8hjWJebSZ03tJl31r+Gj3tZfL0=";
     # Fixes build on loongarch64
     # https://github.com/libressl/portable/pull/1146
     patches = [

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -118,20 +118,6 @@ let
     };
 in
 {
-  libressl_3_9 = generic {
-    version = "3.9.2";
-    hash = "sha256-ewMdrGSlnrbuMwT3/7ddrTOrjJ0nnIR/ksifuEYGj5c=";
-
-    patches = [
-      # Fixes build on ppc64
-      # https://github.com/libressl/portable/pull/1073
-      (fetchpatch {
-        url = "https://github.com/libressl/portable/commit/e6c7de3f03c51fbdcf5ad88bf12fe9e128521f0d.patch";
-        hash = "sha256-LJy3fjbnc9h5DG3/+8bLECwJeBpPxy3hU8sPuhovmcw=";
-      })
-    ];
-  };
-
   libressl_4_0 = generic {
     version = "4.0.1";
     hash = "sha256-IClLh3eMJidIk4Y5Q8hjWJebSZ03tJl31r+Gj3tZfL0=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9325,7 +9325,6 @@ with pkgs;
   openvdb = callPackage ../development/libraries/openvdb { };
 
   inherit (callPackages ../development/libraries/libressl { })
-    libressl_3_9
     libressl_4_0
     libressl_4_1
     ;


### PR DESCRIPTION
Manual backport of #448075 to `release-25.05`.

* [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment