### PR TITLE
python3Packages.click: 8.1.8 -> 8.2.1

### DIFF
--- a/pkgs/by-name/to/todoman/package.nix
+++ b/pkgs/by-name/to/todoman/package.nix
@@ -32,17 +32,19 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   dependencies = with python3.pkgs; [
-    atomicwrites
     click
     click-log
-    click-repl
     humanize
     icalendar
     parsedatetime
+    python-dateutil
     pyxdg
-    tabulate
     urwid
   ];
+
+  optional-dependencies = with python3.pkgs; {
+    repl = [ click-repl ];
+  };
 
   nativeCheckInputs = with python3.pkgs; [
     freezegun

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -9,6 +9,7 @@
   click-plugins,
   click-repl,
   click,
+  cryptography,
   fetchFromGitHub,
   gevent,
   google-cloud-firestore,
@@ -66,6 +67,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
+    auth = [ cryptography ];
     azureblockblob = [
       azure-identity
       azure-storage-blob

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -29,6 +29,9 @@
   pyyaml,
   setuptools,
   vine,
+  # The AMQP REPL depends on click-repl, which is incompatible with our version
+  # of click.
+  withAmqpRepl ? false,
 }:
 
 buildPythonPackage rec {
@@ -43,6 +46,10 @@ buildPythonPackage rec {
     hash = "sha256-+sickqRfSkBxhcO0W9na6Uov4kZ7S5oqpXXKX0iRQ0w=";
   };
 
+  patches = lib.optionals (!withAmqpRepl) [
+    ./remove-amqp-repl.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -50,10 +57,12 @@ buildPythonPackage rec {
     click
     click-didyoumean
     click-plugins
-    click-repl
     kombu
     python-dateutil
     vine
+  ]
+  ++ lib.optionals withAmqpRepl [
+    click-repl
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/celery/remove-amqp-repl.patch
+++ b/pkgs/development/python-modules/celery/remove-amqp-repl.patch
@@ -1,0 +1,32 @@
+diff --git a/celery/bin/celery.py b/celery/bin/celery.py
+index e1fae1a77..cf05a927a 100644
+--- a/celery/bin/celery.py
++++ b/celery/bin/celery.py
+@@ -12,7 +12,6 @@ from click_plugins import with_plugins
+ 
+ from celery import VERSION_BANNER
+ from celery.app.utils import find_app
+-from celery.bin.amqp import amqp
+ from celery.bin.base import CeleryCommand, CeleryOption, CLIContext
+ from celery.bin.beat import beat
+ from celery.bin.call import call
+@@ -186,7 +185,6 @@ celery.add_command(control)
+ celery.add_command(graph)
+ celery.add_command(upgrade)
+ celery.add_command(logtool)
+-celery.add_command(amqp)
+ celery.add_command(shell)
+ celery.add_command(multi)
+ 
+diff --git a/requirements/default.txt b/requirements/default.txt
+index 185b6eddd..fbfc59fd7 100644
+--- a/requirements/default.txt
++++ b/requirements/default.txt
+@@ -3,7 +3,6 @@ kombu>=5.6.0rc1,<5.7
+ vine>=5.1.0,<6.0
+ click>=8.1.2,<9.0
+ click-didyoumean>=0.3.0
+-click-repl>=0.2.0
+ click-plugins>=1.1.1
+ backports.zoneinfo[tzdata]>=0.2.1; python_version < '3.9'
+ python-dateutil>=2.8.2

--- a/pkgs/development/python-modules/click-repl/default.nix
+++ b/pkgs/development/python-modules/click-repl/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    # https://github.com/click-contrib/click-repl/issues/128
+    broken = lib.versionAtLeast click.version "8.2.0";
     homepage = "https://github.com/click-contrib/click-repl";
     description = "Subcommand REPL for click apps";
     license = licenses.mit;

--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   importlib-metadata,
   pytestCheckHook,
@@ -17,24 +16,24 @@
 
 buildPythonPackage rec {
   pname = "click";
-  version = "8.1.8";
+  version = "8.2.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pallets";
     repo = "click";
     tag = version;
-    hash = "sha256-pAAqf8jZbDfVZUoltwIFpov/1ys6HSYMyw3WV2qcE/M=";
+    hash = "sha256-3FfLKwpfkiGfY2+H2fQoZwLBqfPlV46xw2Bc4YEsyps=";
   };
 
   build-system = [ flit-core ];
-  dependencies = lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
+    # for some reason the tests fail to execute cat, even though they run with less just fine,
+    # even adding coreutils to nativeCheckInputs explicitly does not change anything
+    "test_echo_via_pager"
     # test fails with filename normalization on zfs
     "test_file_surrogates"
   ];
@@ -49,14 +48,15 @@ buildPythonPackage rec {
       ;
   };
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/pallets/click/blob/${src.tag}/CHANGES.rst";
     homepage = "https://click.palletsprojects.com/";
     description = "Create beautiful command line interfaces in Python";
     longDescription = ''
       A Python package for creating beautiful command line interfaces in a
       composable way, with as little code as necessary.
     '';
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ nickcao ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nickcao ];
   };
 }

--- a/pkgs/development/python-modules/flasgger/default.nix
+++ b/pkgs/development/python-modules/flasgger/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -30,6 +31,15 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-ULEf9DJiz/S2wKlb/vjGto8VCI0QDcm0pkU5rlOwtiE=";
   };
+
+  patches = [
+    # https://github.com/flasgger/flasgger/pull/633
+    (fetchpatch {
+      name = "fix-tests-with-click-8.2.patch";
+      url = "https://github.com/flasgger/flasgger/commit/08591b60e988c0002fcf1b1e9f98b78e041d2732.patch";
+      hash = "sha256-DHaaY9W+cta3M2VA8S+ZQWacmgSpeyP03SKTiIlfBRM=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/greynoise/default.nix
+++ b/pkgs/development/python-modules/greynoise/default.nix
@@ -17,6 +17,9 @@
   pytestCheckHook,
   mock,
   pythonOlder,
+  # The REPL depends on click-repl, which is incompatible with our version of
+  # click.
+  withRepl ? false,
 }:
 
 buildPythonPackage rec {
@@ -33,8 +36,16 @@ buildPythonPackage rec {
     hash = "sha256-wJDO666HC3EohfR+LbG5F0Cp/eL7q4kXniWhJfc7C3s=";
   };
 
+  patches = lib.optionals (!withRepl) [
+    ./remove-repl.patch
+  ];
+
   build-system = [
     hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "click"
   ];
 
   dependencies = [
@@ -43,12 +54,14 @@ buildPythonPackage rec {
     cachetools
     colorama
     click-default-group
-    click-repl
     dict2xml
     jinja2
     more-itertools
     requests
     six
+  ]
+  ++ lib.optionals withRepl [
+    click-repl
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/greynoise/remove-repl.patch
+++ b/pkgs/development/python-modules/greynoise/remove-repl.patch
@@ -1,0 +1,37 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 9c5950e..f19a5db 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -33,7 +33,6 @@ dependencies = [
+     "cachetools",
+     "colorama",
+     "click-default-group",
+-    "click-repl",
+     "dict2xml",
+     "jinja2",
+     "more-itertools>=8.14.0",
+@@ -53,4 +52,4 @@ greynoise = "greynoise.cli:main"
+ packages = ["src/greynoise"]
+ 
+ [tool.hatch.build.targets.wheel.shared-data]
+-"src/greynoise/cli/templates/*.j2" = "greynoise/cli/templates" 
+\ No newline at end of file
++"src/greynoise/cli/templates/*.j2" = "greynoise/cli/templates"
+diff --git a/src/greynoise/cli/__init__.py b/src/greynoise/cli/__init__.py
+index a7c22ea..9d26d3e 100644
+--- a/src/greynoise/cli/__init__.py
++++ b/src/greynoise/cli/__init__.py
+@@ -2,7 +2,6 @@
+ 
+ import click
+ from click_default_group import DefaultGroup
+-from click_repl import register_repl
+ 
+ from greynoise.cli import subcommand
+ 
+@@ -24,5 +23,3 @@ SUBCOMMAND_FUNCTIONS = [
+ 
+ for subcommand_function in SUBCOMMAND_FUNCTIONS:
+     main.add_command(subcommand_function)
+-
+-register_repl(main)

--- a/pkgs/development/python-modules/pytest-celery/default.nix
+++ b/pkgs/development/python-modules/pytest-celery/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  buildInput = [ pytest ];
+  buildInputs = [ pytest ];
 
   dependencies = [
     (celery.overridePythonAttrs { doCheck = false; })

--- a/pkgs/development/python-modules/pytest-celery/default.nix
+++ b/pkgs/development/python-modules/pytest-celery/default.nix
@@ -11,7 +11,6 @@
   pytest-docker-tools,
   pytest,
   pythonOlder,
-  setuptools,
   tenacity,
 }:
 
@@ -37,7 +36,11 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "debugpy"
-    "setuptools"
+  ];
+
+  pythonRemoveDeps = [
+    "celery" # cyclic dependency
+    "setuptools" # https://github.com/celery/pytest-celery/pull/464
   ];
 
   build-system = [ poetry-core ];
@@ -45,13 +48,11 @@ buildPythonPackage rec {
   buildInputs = [ pytest ];
 
   dependencies = [
-    (celery.overridePythonAttrs { doCheck = false; })
     debugpy
     docker
     kombu
     psutil
     pytest-docker-tools
-    setuptools
     tenacity
   ];
 

--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = package;
-  version = "0.17.4";
+  version = "0.19.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fastapi";
     repo = "typer";
     tag = version;
-    hash = "sha256-gd4GgoRnQVVmwmW5DprmNRxgjFiRRa8HB6xO9U9wHI8=";
+    hash = "sha256-mMsOEI4FpLkLkpjxjnUdmKdWD65Zx3Z1+L+XsS79k44=";
   };
 
   env.TIANGOLO_BUILD_PACKAGE = package;
@@ -78,12 +78,6 @@ buildPythonPackage rec {
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     "test_install_completion"
-  ];
-
-  disabledTestPaths = [
-    # likely click 8.2 compat issue
-    "tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002_an.py"
-    "tests/test_tutorial/test_parameter_types/test_bool/test_tutorial002.py"
   ];
 
   pythonImportsCheck = [ "typer" ];


### PR DESCRIPTION
The [previous PR](https://github.com/NixOS/nixpkgs/pull/425929) was reverted because it breaks click-repl.
This PR circumvents that problem by removing from `python3Packages.celery` the functionality that depends on click-repl.
In order still give access to the affected AMQP REPL, we introduce a top-level attribute `celery` which uses an overridden Python package set. This however violates https://github.com/NixOS/nixpkgs/pull/421201.
I also don't like the number of packages that have to be rebuilt just to build `celery`. Maybe we shouldn't add the top-level attribute and let our users override click if they need the AMQP REPL?



fixes https://github.com/NixOS/nixpkgs/issues/438287
cc @MultisampledNight @caniko @RaitoBezarius @frogamic 

This breaks at least:

- [ ] python3Packages.greynoise @mbalatsko 
- [x] python3Packages.typer @winpat 
- [x] todoman https://github.com/pimutils/todoman/issues/596 @leenaars @antonmosich 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
