### PR TITLE
ocamlPackages.cachet: init at 0.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/cachet/default.nix
+++ b/pkgs/development/ocaml-modules/cachet/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  alcotest,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "cachet";
+  version = "0.0.2";
+
+  minimalOCamlVersion = "4.13";
+
+  src = fetchurl {
+    url = "https://github.com/robur-coop/cachet/releases/download/v${finalAttrs.version}/cachet-${finalAttrs.version}.tbz";
+    hash = "sha256:7cf3d609523592516ee5570c106756168d9dca264412a0ef4085d9864c53cbad";
+  };
+
+  doCheck = true;
+  checkInputs = [
+    alcotest
+  ];
+
+  meta = {
+    description = "A simple cache system for mmap";
+    homepage = "https://git.robur.coop/robur/cachet";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+})

--- a/pkgs/development/ocaml-modules/cachet/lwt.nix
+++ b/pkgs/development/ocaml-modules/cachet/lwt.nix
@@ -1,0 +1,21 @@
+{
+  buildDunePackage,
+  cachet,
+  lwt,
+  alcotest,
+}:
+
+buildDunePackage {
+  pname = "cachet-lwt";
+  inherit (cachet) src version;
+  propagatedBuildInputs = [
+    cachet
+    lwt
+  ];
+  doCheck = true;
+  checkInputs = [ alcotest ];
+
+  meta = cachet.meta // {
+    description = "A simple cache system for mmap and lwt";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -161,6 +161,8 @@ let
 
         ca-certs-nss = callPackage ../development/ocaml-modules/ca-certs-nss { };
 
+        cachet = callPackage ../development/ocaml-modules/cachet { };
+
         cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
         calendar = callPackage ../development/ocaml-modules/calendar { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -163,6 +163,8 @@ let
 
         cachet = callPackage ../development/ocaml-modules/cachet { };
 
+        cachet-lwt = callPackage ../development/ocaml-modules/cachet/lwt.nix { };
+
         cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
         calendar = callPackage ../development/ocaml-modules/calendar { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
