### PR TITLE
[Backport release-25.05] bcachefs-tools: 1.31.0 -> 1.31.6; Bcachefs out of tree module, Bcachefs package and scrub nixos option

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -230,12 +230,24 @@ in
           }
         ];
 
+        warnings = lib.mkIf config.boot.kernelPackages.bcachefs.meta.broken [
+          ''
+            Using unmaintained in-tree bcachefs kernel module. This
+            will be removed in 26.05. Please use a kernel supported
+            by the out-of-tree module package.
+          ''
+        ];
+
         # Bcachefs upstream recommends using the latest kernel
         boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
         # needed for systemd-remount-fs
         system.fsPackages = [ cfg.package ];
         services.udev.packages = [ cfg.package ];
+
+        boot.extraModulePackages = lib.optionals (!config.boot.kernelPackages.bcachefs.meta.broken) [
+          config.boot.kernelPackages.bcachefs
+        ];
 
         systemd = {
           packages = [ cfg.package ];

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -175,25 +175,6 @@ let
             '';
       };
     };
-
-  assertions = [
-    {
-      assertion =
-        let
-          kernel = config.boot.kernelPackages.kernel;
-        in
-        (
-          kernel.kernelAtLeast "6.7"
-          || (lib.elem (kernel.structuredExtraConfig.BCACHEFS_FS or null) [
-            lib.kernel.module
-            lib.kernel.yes
-            (lib.kernel.option lib.kernel.yes)
-          ])
-        );
-
-      message = "Linux 6.7-rc1 at minimum or a custom linux kernel with bcachefs support is required";
-    }
-  ];
 in
 
 {
@@ -230,7 +211,24 @@ in
   config = lib.mkIf (config.boot.supportedFilesystems.bcachefs or false) (
     lib.mkMerge [
       {
-        inherit assertions;
+        assertions = [
+          {
+            assertion =
+              let
+                kernel = config.boot.kernelPackages.kernel;
+              in
+              (
+                kernel.kernelAtLeast "6.7"
+                || (lib.elem (kernel.structuredExtraConfig.BCACHEFS_FS or null) [
+                  lib.kernel.module
+                  lib.kernel.yes
+                  (lib.kernel.option lib.kernel.yes)
+                ])
+              );
+
+            message = "Linux 6.7-rc1 at minimum or a custom linux kernel with bcachefs support is required";
+          }
+        ];
 
         # Bcachefs upstream recommends using the latest kernel
         boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
@@ -248,7 +246,6 @@ in
       }
 
       (lib.mkIf ((config.boot.initrd.supportedFilesystems.bcachefs or false) || (bootFs != { })) {
-        inherit assertions;
         boot.initrd.availableKernelModules = [
           "bcachefs"
           "sha256"

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -231,6 +231,10 @@ in
     lib.mkMerge [
       {
         inherit assertions;
+
+        # Bcachefs upstream recommends using the latest kernel
+        boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
         # needed for systemd-remount-fs
         system.fsPackages = [ cfg.package ];
         services.udev.packages = [ cfg.package ];

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -93,19 +93,27 @@ let
     let
       mountUnit = "${utils.escapeSystemdPath (prefix + (lib.removeSuffix "/" fs.mountPoint))}.mount";
       device = firstDevice fs;
-      deviceUnit = "${utils.escapeSystemdPath device}.device";
+      mkDeviceUnit = device: "${utils.escapeSystemdPath device}.device";
+      deviceUnit = mkDeviceUnit device;
+      extractProperty =
+        prop: options: (map (lib.removePrefix "${prop}=") (builtins.filter (lib.hasPrefix prop) options));
+      normalizeUnits = unit: if lib.hasPrefix "/" unit then mkDeviceUnit unit else unit;
+      requiredUnits = map normalizeUnits (extractProperty "x-systemd.requires" fs.options);
+      wantedUnits = map normalizeUnits (extractProperty "x-systemd.wants" fs.options);
     in
     {
       name = "unlock-bcachefs-${utils.escapeSystemdPath fs.mountPoint}";
       value = {
         description = "Unlock bcachefs for ${fs.mountPoint}";
         requiredBy = [ mountUnit ];
-        after = [ deviceUnit ];
+        after = [ deviceUnit ] ++ requiredUnits ++ wantedUnits;
         before = [
           mountUnit
           "shutdown.target"
         ];
         bindsTo = [ deviceUnit ];
+        requires = requiredUnits;
+        wants = wantedUnits;
         conflicts = [ "shutdown.target" ];
         unitConfig.DefaultDependencies = false;
         serviceConfig = {

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -228,8 +228,6 @@ in
         inherit assertions;
         # needed for systemd-remount-fs
         system.fsPackages = [ pkgs.bcachefs-tools ];
-        # FIXME: Remove this line when the LTS (default) kernel is at least version 6.7
-        boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
         services.udev.packages = [ pkgs.bcachefs-tools ];
 
         systemd = {

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -7,6 +7,7 @@
 }:
 
 let
+  cfgScrub = config.services.bcachefs.autoScrub;
 
   bootFs = lib.filterAttrs (
     n: fs: (fs.fsType == "bcachefs") && (utils.fsNeededForBoot fs)
@@ -159,6 +160,32 @@ let
 in
 
 {
+  options.services.bcachefs.autoScrub = {
+    enable = lib.mkEnableOption "regular bcachefs scrub";
+
+    fileSystems = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      example = [ "/" ];
+      description = ''
+        List of paths to bcachefs filesystems to regularly call {command}`bcachefs scrub` on.
+        Defaults to all mount points with bcachefs filesystems.
+      '';
+    };
+
+    interval = lib.mkOption {
+      default = "monthly";
+      type = lib.types.str;
+      example = "weekly";
+      description = ''
+        Systemd calendar expression for when to scrub bcachefs filesystems.
+        The recommended period is a month but could be less.
+        See
+        {manpage}`systemd.time(7)`
+        for more information on the syntax.
+      '';
+    };
+  };
+
   config = lib.mkIf (config.boot.supportedFilesystems.bcachefs or false) (
     lib.mkMerge [
       {
@@ -208,6 +235,95 @@ in
         );
 
         boot.initrd.systemd.services = lib.mapAttrs' (mkUnits "/sysroot") bootFs;
+      })
+
+      (lib.mkIf (cfgScrub.enable) {
+        assertions = [
+          {
+            assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.14";
+            message = "Bcachefs scrubbing is supported from kernel version 6.14 or later.";
+          }
+          {
+            assertion = cfgScrub.enable -> (cfgScrub.fileSystems != [ ]);
+            message = ''
+              If 'services.bcachefs.autoScrub' is enabled, you need to have at least one
+              bcachefs file system mounted via 'fileSystems' or specify a list manually
+              in 'services.bcachefs.autoScrub.fileSystems'.
+            '';
+          }
+        ];
+
+        # This will remove duplicated units from either having a filesystem mounted multiple
+        # time, or additionally mounted subvolumes, as well as having a filesystem span
+        # multiple devices (provided the same device is used to mount said filesystem).
+        services.bcachefs.autoScrub.fileSystems =
+          let
+            isDeviceInList = list: device: builtins.filter (e: e.device == device) list != [ ];
+
+            uniqueDeviceList = lib.foldl' (
+              acc: e: if isDeviceInList acc e.device then acc else acc ++ [ e ]
+            ) [ ];
+          in
+          lib.mkDefault (
+            map (e: e.mountPoint) (
+              uniqueDeviceList (
+                lib.mapAttrsToList (name: fs: {
+                  mountPoint = fs.mountPoint;
+                  device = fs.device;
+                }) (lib.filterAttrs (name: fs: fs.fsType == "bcachefs") config.fileSystems)
+              )
+            )
+          );
+
+        systemd.timers =
+          let
+            scrubTimer =
+              fs:
+              let
+                fs' = utils.escapeSystemdPath fs;
+              in
+              lib.nameValuePair "bcachefs-scrub-${fs'}" {
+                description = "regular bcachefs scrub timer on ${fs}";
+
+                wantedBy = [ "timers.target" ];
+                timerConfig = {
+                  OnCalendar = cfgScrub.interval;
+                  AccuracySec = "1d";
+                  Persistent = true;
+                };
+              };
+          in
+          lib.listToAttrs (map scrubTimer cfgScrub.fileSystems);
+
+        systemd.services =
+          let
+            scrubService =
+              fs:
+              let
+                fs' = utils.escapeSystemdPath fs;
+              in
+              lib.nameValuePair "bcachefs-scrub-${fs'}" {
+                description = "bcachefs scrub on ${fs}";
+                # scrub prevents suspend2ram or proper shutdown
+                conflicts = [
+                  "shutdown.target"
+                  "sleep.target"
+                ];
+                before = [
+                  "shutdown.target"
+                  "sleep.target"
+                ];
+
+                script = "${lib.getExe pkgs.bcachefs-tools} data scrub ${fs}";
+
+                serviceConfig = {
+                  Type = "oneshot";
+                  Nice = 19;
+                  IOSchedulingClass = "idle";
+                };
+              };
+          in
+          lib.listToAttrs (map scrubService cfgScrub.fileSystems);
       })
     ]
   );

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -111,7 +111,7 @@ let
       deviceUnit = mkDeviceUnit device;
       mountUnit = mkMountUnit (prefix + fs.mountPoint);
       extractProperty =
-        prop: options: (map (lib.removePrefix "${prop}=") (builtins.filter (lib.hasPrefix prop) options));
+        prop: options: (map (lib.removePrefix prop) (builtins.filter (lib.hasPrefix prop) options));
       normalizeUnits =
         unit:
         if lib.hasPrefix "/dev/" unit then
@@ -120,8 +120,8 @@ let
           mkMountUnit unit
         else
           unit;
-      requiredUnits = map normalizeUnits (extractProperty "x-systemd.requires" fs.options);
-      wantedUnits = map normalizeUnits (extractProperty "x-systemd.wants" fs.options);
+      requiredUnits = map normalizeUnits (extractProperty "x-systemd.requires=" fs.options);
+      wantedUnits = map normalizeUnits (extractProperty "x-systemd.wants=" fs.options);
     in
     {
       name = "unlock-bcachefs-${utils.escapeSystemdPath fs.mountPoint}";

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -122,6 +122,8 @@ let
           unit;
       requiredUnits = map normalizeUnits (extractProperty "x-systemd.requires=" fs.options);
       wantedUnits = map normalizeUnits (extractProperty "x-systemd.wants=" fs.options);
+      requiredMounts = extractProperty "x-systemd.requires-mounts-for=" fs.options;
+      wantedMounts = extractProperty "x-systemd.wants-mounts-for=" fs.options;
     in
     {
       name = "unlock-bcachefs-${utils.escapeSystemdPath fs.mountPoint}";
@@ -136,6 +138,10 @@ let
         bindsTo = [ deviceUnit ];
         requires = requiredUnits;
         wants = wantedUnits;
+        unitConfig = {
+          RequiresMountsFor = requiredMounts;
+          WantsMountsFor = wantedMounts;
+        };
         conflicts = [ "shutdown.target" ];
         unitConfig.DefaultDependencies = false;
         serviceConfig = {

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -242,7 +242,7 @@ in
           }
         ];
 
-        warnings = lib.mkIf config.boot.kernelPackages.bcachefs.meta.broken [
+        warnings = lib.mkIf cfg.modulePackage.meta.broken [
           ''
             Using unmaintained in-tree bcachefs kernel module. This
             will be removed in 26.05. Please use a kernel supported

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -316,7 +316,7 @@ in
             scrubTimer =
               fs:
               let
-                fs' = utils.escapeSystemdPath fs;
+                fs' = if fs == "/" then "root" else utils.escapeSystemdPath fs;
               in
               lib.nameValuePair "bcachefs-scrub-${fs'}" {
                 description = "regular bcachefs scrub timer on ${fs}";
@@ -336,7 +336,7 @@ in
             scrubService =
               fs:
               let
-                fs' = utils.escapeSystemdPath fs;
+                fs' = if fs == "/" then "root" else utils.escapeSystemdPath fs;
               in
               lib.nameValuePair "bcachefs-scrub-${fs'}" {
                 description = "bcachefs scrub on ${fs}";

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -178,8 +178,20 @@ let
 in
 
 {
-  options.boot.bcachefs.package = lib.mkPackageOption pkgs "bcachefs-tools" { } // {
-    description = "Configured Bcachefs userspace package.";
+  options.boot.bcachefs = {
+    package = lib.mkPackageOption pkgs "bcachefs-tools" {
+      extraDescription = ''
+        This package should also provide a passthru 'kernelModule'
+        attribute to build the out-of-tree kernel module.
+      '';
+    };
+
+    modulePackage = lib.mkOption {
+      type = lib.types.package;
+      # See NOTE in linux-kernels.nix
+      default = config.boot.kernelPackages.callPackage cfg.package.kernelModule { };
+      internal = true;
+    };
   };
 
   options.services.bcachefs.autoScrub = {
@@ -245,8 +257,8 @@ in
         system.fsPackages = [ cfg.package ];
         services.udev.packages = [ cfg.package ];
 
-        boot.extraModulePackages = lib.optionals (!config.boot.kernelPackages.bcachefs.meta.broken) [
-          config.boot.kernelPackages.bcachefs
+        boot.extraModulePackages = lib.optionals (!cfg.modulePackage.meta.broken) [
+          cfg.modulePackage
         ];
 
         systemd = {

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -97,7 +97,15 @@ let
       deviceUnit = mkDeviceUnit device;
       extractProperty =
         prop: options: (map (lib.removePrefix "${prop}=") (builtins.filter (lib.hasPrefix prop) options));
-      normalizeUnits = unit: if lib.hasPrefix "/" unit then mkDeviceUnit unit else unit;
+      mkMountUnit = path: "${utils.escapeSystemdPath path}.mount";
+      normalizeUnits =
+        unit:
+        if lib.hasPrefix "/dev/" unit then
+          mkDeviceUnit unit
+        else if lib.hasPrefix "/" unit then
+          mkMountUnit unit
+        else
+          unit;
       requiredUnits = map normalizeUnits (extractProperty "x-systemd.requires" fs.options);
       wantedUnits = map normalizeUnits (extractProperty "x-systemd.wants" fs.options);
     in

--- a/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
@@ -1,7 +1,7 @@
+bcachefs-tools:
 {
   lib,
   stdenv,
-  bcachefs-tools,
   kernelModuleMakeFlags,
   kernel,
 }:

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -114,6 +114,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    # See NOTE in linux-kernels.nix
+    kernelModule = import ./kernel-module.nix finalAttrs.finalPackage;
+
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bcachefs-tools";
-  version = "1.31.0";
+  version = "1.31.3";
 
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs-tools";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wYlfU4PTcVSPSHbIIDbl8pBOJsBAAl44XBapwFZ528U=";
+    hash = "sha256-sXv6YFM91T08WF5dPU7iQNqWbB/QiL2kMaXm6ZtIDqI=";
   };
 
   nativeBuildInputs = [
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-ZCzw3cDpQ8fb2jLYdIWrmlNTPStikIs09jx6jzzC2vM=";
+    hash = "sha256-04YrgYfhZ5NfA2BcF2H6Np1SXRiH6CJpkgc9hzlbMAo=";
   };
 
   makeFlags = [
@@ -96,11 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
   checkFlags = [ "BCACHEFS_TEST_USE_VALGRIND=no" ];
 
-  postInstall = ''
-    substituteInPlace $out/libexec/bcachefsck_all \
-      --replace-fail "/usr/bin/python3" "${python3.interpreter}"
-  ''
-  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd bcachefs \
       --bash <($out/sbin/bcachefs completions bash) \
       --zsh  <($out/sbin/bcachefs completions zsh) \

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -67,16 +67,26 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-04YrgYfhZ5NfA2BcF2H6Np1SXRiH6CJpkgc9hzlbMAo=";
   };
 
+  outputs = [
+    "out"
+    "dkms"
+  ];
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "VERSION=${finalAttrs.version}"
     "INITRAMFS_DIR=${placeholder "out"}/etc/initramfs-tools"
+    "DKMSDIR=${placeholder "dkms"}"
 
     # Tries to install to the 'systemd-minimal' and 'udev' nix installation paths
     "PKGCONFIG_SERVICEDIR=$(out)/lib/systemd/system"
     "PKGCONFIG_UDEVDIR=$(out)/lib/udev"
   ]
   ++ lib.optional fuseSupport "BCACHEFS_FUSE=1";
+  installFlags = [
+    "install"
+    "install_dkms"
+  ];
 
   env = {
     CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bcachefs-tools";
-  version = "1.31.3";
+  version = "1.31.6";
 
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs-tools";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sXv6YFM91T08WF5dPU7iQNqWbB/QiL2kMaXm6ZtIDqI=";
+    hash = "sha256-9oiXMMrMMfu9VR0zSFM4yCAQaBgThDdEILSrxH9a84k=";
   };
 
   nativeBuildInputs = [
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-04YrgYfhZ5NfA2BcF2H6Np1SXRiH6CJpkgc9hzlbMAo=";
+    hash = "sha256-E2d9uAaja6OsCMhmWFyqIVbGdad5fJ+tw3S7+X7YzpM=";
   };
 
   outputs = [

--- a/pkgs/os-specific/linux/bcachefs-kernel-module/default.nix
+++ b/pkgs/os-specific/linux/bcachefs-kernel-module/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  bcachefs-tools,
+  kernelModuleMakeFlags,
+  kernel,
+}:
+
+stdenv.mkDerivation {
+  pname = "bcachefs";
+  version = "${kernel.version}-${bcachefs-tools.version}";
+
+  __structuredAttrs = true;
+
+  src = bcachefs-tools.dkms;
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  enableParallelBuilding = true;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build M=$(pwd) modules_install "''${makeFlags[@]}" "''${installFlags[@]}"
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit (bcachefs-tools.passthru) tests;
+  };
+
+  meta = {
+    description = "out-of-tree bcachefs kernel module";
+
+    inherit (bcachefs-tools.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+
+    broken = !(lib.versionAtLeast kernel.version "6.16" && lib.versionOlder kernel.version "6.18");
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -383,6 +383,8 @@ in
 
         bbswitch = callPackage ../os-specific/linux/bbswitch { };
 
+        bcachefs = callPackage ../os-specific/linux/bcachefs-kernel-module { };
+
         ch9344 = callPackage ../os-specific/linux/ch9344 { };
 
         chipsec = callPackage ../tools/security/chipsec {

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -383,7 +383,11 @@ in
 
         bbswitch = callPackage ../os-specific/linux/bbswitch { };
 
-        bcachefs = callPackage ../os-specific/linux/bcachefs-kernel-module { };
+        # NOTE: The bcachefs module is called this way to facilitate
+        # easy overriding, as it is expected many users will want to
+        # pull from the upstream git repo, which may include
+        # unreleased changes to the module build process.
+        bcachefs = callPackage pkgs.bcachefs-tools.kernelModule { };
 
         ch9344 = callPackage ../os-specific/linux/ch9344 { };
 


### PR DESCRIPTION
As much as I hate backporting feature updates to stable, this has become necessary with 6.18 no longer having Bcachefs in tree module.

This backports: 

1. https://github.com/NixOS/nixpkgs/pull/415614
2. https://github.com/NixOS/nixpkgs/pull/419473
3. https://github.com/NixOS/nixpkgs/pull/419830
4. https://github.com/NixOS/nixpkgs/pull/422961
5. https://github.com/NixOS/nixpkgs/pull/434476
6. https://github.com/NixOS/nixpkgs/pull/442667
7. https://github.com/NixOS/nixpkgs/pull/444428
8. https://github.com/NixOS/nixpkgs/pull/447552
9. https://github.com/NixOS/nixpkgs/pull/445441
10. https://github.com/NixOS/nixpkgs/pull/446975
11. https://github.com/NixOS/nixpkgs/pull/447453

While I realise we could have shaved off some unrelated feature updates (like the scrub module and systemd stuff), everything from unstable has been backported just so we don't have to deal with conflict resolution.

Scrub module and also the bcachefs option meet the backport criteria (they are new modules essentially).

This was tested by running `bcachefs.passthru.tests`.