### PR TITLE
deno: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -29,17 +29,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deno";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true; # required for tests
-    hash = "sha256-wpn79xY+Gsn48C5mYF1lryrgZZsr1YJayd+Rl0gbPXY=";
+    hash = "sha256-UqD9Va33XVX73bjwUdb6woZ3kP/Xz6iBVqV1ceRbXq0=";
   };
 
-  cargoHash = "sha256-KAHLZS6BfRgPBlBW0LSdHwPP6sRUN9kksMo0KuDtb5s=";
+  cargoHash = "sha256-OrKg3bOA5AyLQA+LIsHwWpk9DHodhcCVzdKW/S9+mNY=";
 
   patches = [
     # Patch out the remote upgrade (deno update) check.
@@ -53,6 +53,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./patches/0002-tests-replace-hardcoded-paths.patch
     ./patches/0003-tests-linux-no-chown.patch
     ./patches/0004-tests-darwin-fixes.patch
+    # some new TS tests don't identify `deno` location from parent actively
+    # running `deno` instance
+    # https://github.com/denoland/deno/pull/30914
+    ./patches/0005-tests-fix-deno-path.patch
   ];
   postPatch = ''
     # Use patched nixpkgs libffi in order to fix https://github.com/libffi/libffi/pull/857

--- a/pkgs/by-name/de/deno/patches/0005-tests-fix-deno-path.patch
+++ b/pkgs/by-name/de/deno/patches/0005-tests-fix-deno-path.patch
@@ -1,0 +1,34 @@
+From 798fc5e7e87c1b985a383b7b92a7e55c82e41efa Mon Sep 17 00:00:00 2001
+From: 06kellyjac <dev@j-k.io>
+Date: Fri, 3 Oct 2025 14:20:53 +0100
+Subject: [PATCH] test: leverage `Deno.execPath()` matching other tests
+
+Currently most TS tests use `Deno.execPath()` to identify where `deno` lives
+In the event deno is not on the `$PATH` these tests will fail.
+If deno is on the `$PATH` you can end up testing the wrong instance of `deno`.
+---
+ tests/unit/process_test.ts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/unit/process_test.ts b/tests/unit/process_test.ts
+index 7b82fe5ba782f5..1c26a6f990d1b0 100644
+--- a/tests/unit/process_test.ts
++++ b/tests/unit/process_test.ts
+@@ -623,7 +623,7 @@ Deno.test(
+ 
+     // @ts-ignore `Deno.run()` was soft-removed in Deno 2.
+     const p = Deno.run({
+-      cmd: ["deno", "run", "--watch", tempFile],
++      cmd: [Deno.execPath(), "run", "--watch", tempFile],
+       stdout: "piped",
+       stderr: "null",
+     });
+@@ -661,7 +661,7 @@ Deno.serve({ signal: ac.signal }, () => new Response("Hello World"));
+ 
+     // @ts-ignore `Deno.run()` was soft-removed in Deno 2.
+     const p = Deno.run({
+-      cmd: ["deno", "run", "--watch", tempFile],
++      cmd: [Deno.execPath(), "run", "--watch", tempFile],
+       stdout: "piped",
+       stderr: "null",
+     });


### PR DESCRIPTION
Changelog: https://github.com/denoland/deno/releases/tag/v2.5.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
