### PR TITLE
ocamlPackages.synchronizer: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21630,6 +21630,11 @@
     githubId = 77415970;
     name = "Redhawk";
   };
+  redianthus = {
+    github = "redianthus";
+    githubId = 16472988;
+    name = "redianthus";
+  };
   redlonghead = {
     email = "git@beardit.net";
     github = "Redlonghead";

--- a/pkgs/development/ocaml-modules/synchronizer/default.nix
+++ b/pkgs/development/ocaml-modules/synchronizer/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  prelude,
+}:
+
+buildDunePackage rec {
+  pname = "synchronizer";
+  version = "0.1";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchFromGitHub {
+    owner = "OCamlPro";
+    repo = "synchronizer";
+    tag = version;
+    hash = "sha256-VlKqORXTXafT88GXHIYkz+A1VkEL3jP9SMqDdMyEdrw=";
+  };
+
+  propagatedBuildInputs = [
+    prelude
+  ];
+
+  meta = {
+    homepage = "https://github.com/OCamlPro/synchronizer";
+    description = "Synchronizer to make datastructures thread-safe";
+    changelog = "https://raw.githubusercontent.com/OCamlPro/synchronizer/${src.rev}/CHANGES.md";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1977,6 +1977,8 @@ let
 
         swhid_core = callPackage ../development/ocaml-modules/swhid_core { };
 
+        synchronizer = callPackage ../development/ocaml-modules/synchronizer { };
+
         syslog = callPackage ../development/ocaml-modules/syslog { };
 
         syslog-message = callPackage ../development/ocaml-modules/syslog-message { };


### PR DESCRIPTION
Hi,

This is the first release of the [synchronizer](https://github.com/ocamlpro/synchronizer) OCaml library.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
