### PR TITLE
maintainers: drop IogaMaster

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11082,12 +11082,6 @@
     githubId = 7348004;
     name = "Benjamin Levy";
   };
-  iogamaster = {
-    email = "iogamastercode+nixpkgs@gmail.com";
-    name = "IogaMaster";
-    github = "IogaMaster";
-    githubId = 67164465;
-  };
   ionutnechita = {
     email = "ionut_n2001@yahoo.com";
     github = "ionutnechita";

--- a/pkgs/by-name/hy/hypridle/package.nix
+++ b/pkgs/by-name/hy/hypridle/package.nix
@@ -53,9 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Hyprland's idle daemon";
     homepage = "https://github.com/hyprwm/hypridle";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      iogamaster
-    ];
     teams = [ lib.teams.hyprland ];
     mainProgram = "hypridle";
     platforms = [

--- a/pkgs/by-name/hy/hyprlang/package.nix
+++ b/pkgs/by-name/hy/hyprlang/package.nix
@@ -39,9 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Official implementation library for the hypr config language";
     license = lib.licenses.lgpl3Only;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [
-      iogamaster
-    ];
     teams = [ lib.teams.hyprland ];
   };
 })

--- a/pkgs/by-name/in/intelli-shell/package.nix
+++ b/pkgs/by-name/in/intelli-shell/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     description = "Like IntelliSense, but for shells";
     homepage = "https://github.com/lasantosr/intelli-shell";
     license = licenses.asl20;
-    maintainers = with maintainers; [ iogamaster ];
+    maintainers = [ ];
     mainProgram = "intelli-shell";
   };
 }

--- a/pkgs/by-name/ka/kalamine/package.nix
+++ b/pkgs/by-name/ka/kalamine/package.nix
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Keyboard Layout Maker";
     homepage = "https://github.com/OneDeadKey/kalamine/";
     license = licenses.mit;
-    maintainers = with maintainers; [ iogamaster ];
+    maintainers = [ ];
     mainProgram = "kalamine";
   };
 }

--- a/pkgs/by-name/ku/kubefwd/package.nix
+++ b/pkgs/by-name/ku/kubefwd/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
     description = "Bulk port forwarding Kubernetes services for local development";
     homepage = "https://github.com/txn2/kubefwd";
     license = licenses.asl20;
-    maintainers = with maintainers; [ iogamaster ];
+    maintainers = [ ];
     mainProgram = "kubefwd";
   };
 }

--- a/pkgs/by-name/le/leaf/package.nix
+++ b/pkgs/by-name/le/leaf/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple system fetch written in rust";
     homepage = "https://github.com/IogaMaster/leaf";
     license = licenses.mit;
-    maintainers = with maintainers; [ iogamaster ];
+    maintainers = [ ];
     mainProgram = "leaf";
   };
 }

--- a/pkgs/by-name/ma/manix/package.nix
+++ b/pkgs/by-name/ma/manix/package.nix
@@ -22,7 +22,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/manix";
     license = licenses.mpl20;
     maintainers = with maintainers; [
-      iogamaster
       lecoqjacob
     ];
     mainProgram = "manix";

--- a/pkgs/by-name/ni/niri/package.nix
+++ b/pkgs/by-name/ni/niri/package.nix
@@ -138,7 +138,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/YaLTeR/niri/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      iogamaster
       foo-dogsquared
       sodiboo
       getchoo

--- a/pkgs/by-name/no/noice/package.nix
+++ b/pkgs/by-name/no/noice/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     homepage = "https://git.2f30.org/noice/";
     license = licenses.bsd2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ iogamaster ];
+    maintainers = [ ];
     mainProgram = "noice";
   };
 }

--- a/pkgs/by-name/nu/nufmt/package.nix
+++ b/pkgs/by-name/nu/nufmt/package.nix
@@ -36,7 +36,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/nushell/nufmt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      iogamaster
       khaneliman
     ];
     mainProgram = "nufmt";


### PR DESCRIPTION
Hasn't commented since [this May](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aiogamaster), hasn't opened any tickets themselves since [this April](https://github.com/NixOS/nixpkgs/issues?q=author%3Aiogamaster), both of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/6d40c7d426c102023aae52888215699bc024cfd3/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs. Also, based on their public activity, haven't been active on Github in general since July.

@IogaMaster, you have a week (until 16:00 GMT on Oct 10) to object this. Even if you don't make it, you're still welcome back.

If Wolfgang stumbles upon: I already set up a reminder to `@` you in a week.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
