### PR TITLE
[WIP] sentry-cli: fix on macOS

### DIFF
--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -6,43 +6,74 @@
   openssl,
   pkg-config,
   stdenv,
+  swift,
+  swiftpm,
+  writeShellScriptBin,
+  darwin,
 }:
-rustPlatform.buildRustPackage rec {
-  pname = "sentry-cli";
-  version = "2.55.0";
-
-  src = fetchFromGitHub {
-    owner = "getsentry";
-    repo = "sentry-cli";
-    rev = version;
-    hash = "sha256-QOYk/WT/4rOjNMU4h22+Lbl9X6Ezw1oBE5yVZZwLNo4=";
-  };
-  doCheck = false;
-
-  # Needed to get openssl-sys to use pkgconfig.
-  OPENSSL_NO_VENDOR = 1;
-
-  buildInputs = [ openssl ];
-  nativeBuildInputs = [
-    installShellFiles
-    pkg-config
-  ];
-
-  cargoHash = "sha256-8OIBIMlR0XAhJrYNd0gtBhApuZF6r2+7iHrATQdMfr0=";
-
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd sentry-cli \
-        --bash <($out/bin/sentry-cli completions bash) \
-        --fish <($out/bin/sentry-cli completions fish) \
-        --zsh <($out/bin/sentry-cli completions zsh)
+let
+  # TODO: This should probably be in the `darwin` package set.
+  xcode-select = writeShellScriptBin "xcode-select" ''
+    echo ${darwin.xcode}/Contents/Developer
   '';
+in
+rustPlatform.buildRustPackage (
+   rec {
+    pname = "sentry-cli";
+    version = "2.55.0";
 
-  meta = {
-    homepage = "https://docs.sentry.io/cli/";
-    license = lib.licenses.bsd3;
-    description = "Command line utility to work with Sentry";
-    mainProgram = "sentry-cli";
-    changelog = "https://github.com/getsentry/sentry-cli/raw/${version}/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ rizary ];
-  };
-}
+    src = fetchFromGitHub {
+      owner = "getsentry";
+      repo = "sentry-cli";
+      rev = version;
+      hash = "sha256-QOYk/WT/4rOjNMU4h22+Lbl9X6Ezw1oBE5yVZZwLNo4=";
+    };
+    doCheck = false;
+
+    # `build.rs` wants to run a Swift build 😩
+    postPatch = lib.optionalString stdenv.isDarwin ''
+      substituteInPlace \
+        apple-catalog-parsing/native/swift/AssetCatalogParser/Package.swift \
+        --replace-fail "// swift-tools-version: 5.10" \
+                       "// swift-tools-version: 5.8"
+
+    '';
+
+    # Needed to get openssl-sys to use pkgconfig.
+    OPENSSL_NO_VENDOR = 1;
+
+    buildInputs = [ openssl ];
+    nativeBuildInputs = [
+      installShellFiles
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      swift
+      swiftpm
+      xcode-select
+    ];
+
+    cargoHash = "sha256-8OIBIMlR0XAhJrYNd0gtBhApuZF6r2+7iHrATQdMfr0=";
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd sentry-cli \
+          --bash <($out/bin/sentry-cli completions bash) \
+          --fish <($out/bin/sentry-cli completions fish) \
+          --zsh <($out/bin/sentry-cli completions zsh)
+    '';
+
+    meta = {
+      homepage = "https://docs.sentry.io/cli/";
+      license = lib.licenses.bsd3;
+      description = "Command line utility to work with Sentry";
+      mainProgram = "sentry-cli";
+      changelog = "https://github.com/getsentry/sentry-cli/raw/${version}/CHANGELOG.md";
+      maintainers = with lib.maintainers; [ rizary ];
+    };
+  }
+  // lib.optionalAttrs stdenv.isDarwin {
+    # Disable the `swiftpm` `setupHook`.
+    dontUseSwiftpmBuild = true;
+    dontUseSwiftpmCheck = true;
+  }
+)


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
