### PR TITLE
odhcp6c: 0-unstable-2026-01-25 -> 0-unstable-2026-06-27, set main program and structuredAttrs

### DIFF
--- a/pkgs/by-name/od/odhcp6c/package.nix
+++ b/pkgs/by-name/od/odhcp6c/package.nix
@@ -7,14 +7,15 @@
   unstableGitUpdater,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "odhcp6c";
-  version = "0-unstable-2026-01-25";
+  version = "0-unstable-2026-06-03";
+  __structuredAttrs = true;
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/odhcp6c.git";
-    rev = "24485bb4b35ab84c17c2e87bd561d026d4c15c00";
-    hash = "sha256-cfBKly95vI+8u6lZ4LyrSrNvCf3ogTKtLDzuodO26qw=";
+    rev = "daf4ec3054e753c99fdcc3ac5464926548b38351";
+    hash = "sha256-UjvDMA+sDfouW8sMjNc6hqNzHYFrtP5E1M2zHkKBX64=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -24,7 +25,10 @@ stdenv.mkDerivation {
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    defaultScript = "${finalAttrs.src}/odhcp6c-example-script.sh";
+  };
 
   meta = {
     description = "Embedded DHCPv6-client for OpenWrt";
@@ -32,5 +36,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ felbinger ];
     platforms = lib.platforms.linux;
+    mainProgram = "odhcp6c";
   };
-}
+})

--- a/pkgs/by-name/od/odhcp6c/package.nix
+++ b/pkgs/by-name/od/odhcp6c/package.nix
@@ -7,14 +7,15 @@
   unstableGitUpdater,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "odhcp6c";
-  version = "0-unstable-2026-01-25";
+  version = "0-unstable-2026-06-27";
+  __structuredAttrs = true;
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/odhcp6c.git";
-    rev = "24485bb4b35ab84c17c2e87bd561d026d4c15c00";
-    hash = "sha256-cfBKly95vI+8u6lZ4LyrSrNvCf3ogTKtLDzuodO26qw=";
+    rev = "10a52220aec9d45803518d8cc4d63e552484ed61";
+    hash = "sha256-IDBbVWs017JcrApJ3s8fjEQghWCwrK1d+E6Wp5eHNX4=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -32,5 +33,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ felbinger ];
     platforms = lib.platforms.linux;
+    mainProgram = "odhcp6c";
   };
-}
+})


### PR DESCRIPTION
The example script can be used as a default to handle the dhcp response.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
