### PR TITLE
sdr-j-fm: 3.16-unstable-2023-12-07 → 3.20-2025-10-07

### DIFF
--- a/pkgs/by-name/sd/sdr-j-fm/package.nix
+++ b/pkgs/by-name/sd/sdr-j-fm/package.nix
@@ -12,6 +12,11 @@
   libusb1,
   libsndfile,
   featuresOverride ? { },
+  airspy,
+  hackrf,
+  libiio,
+  limesuite,
+  rtl-sdr,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,12 +66,25 @@ stdenv.mkDerivation (finalAttrs: {
       # but they don't actually make a difference.
     }
     // featuresOverride;
+    runtimeDependencies = [
+      airspy
+      hackrf
+      libiio
+      limesuite
+      rtl-sdr
+    ];
   };
 
   postInstall = ''
     # Weird default of upstream
     mv $out/linux-bin $out/bin
     mv $out/bin/fmreceiver{-3.15,}
+
+    # Ideally, upstream's cmake files should link these libraries to the
+    # executable, but it'd require a bit of work. See:
+    # https://github.com/JvanKatwijk/sdr-j-fm/issues/27
+    wrapProgram $out/bin/fmreceiver \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.finalPackage.passthru.runtimeDependencies}
   '';
 
   meta = {

--- a/pkgs/by-name/sd/sdr-j-fm/package.nix
+++ b/pkgs/by-name/sd/sdr-j-fm/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   qt5,
@@ -17,22 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdr-j-fm";
-  version = "3.20";
+  version = "3.20-2025-10-07";
 
   src = fetchFromGitHub {
     owner = "JvanKatwijk";
     repo = "sdr-j-fm";
-    tag = finalAttrs.version;
-    hash = "sha256-qNSmBVY1n5+DR9k1d+nY11gBrYS7Ah774R2FMgCR4ks=";
+    rev = "e348cc0a4b4b16f716f36115400dfd861b9a0bd5";
+    hash = "sha256-Do2W+B4U8xxCwGRjrJNWkSpgcXG+2PXoemju5oef+jU=";
   };
-
-  patches = [
-    # Fix linking error, https://github.com/JvanKatwijk/sdr-j-fm/pull/26
-    (fetchpatch {
-      url = "https://github.com/JvanKatwijk/sdr-j-fm/pull/26/commits/b336b5175a267347e037adb333669e571f7bde01.patch";
-      hash = "sha256-xYNR6XZVSKKk+s/DQJFGaSGc2U+P1AWFIeiRnGfpZX8=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -42,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     qt5.qtbase
+    qt5.qtmultimedia
     libsForQt5.qwt6_1
     fftwFloat
     libsamplerate
@@ -56,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
       # All of these features don't require an external dependencies, although it
       # may be implied - upstraem bundles everything they need in their repo.
       AIRSPY = true;
-      SDRPLAY = true;
       SDRPLAY_V3 = true;
       HACKRF = true;
       LIME = true;

--- a/pkgs/by-name/sd/sdr-j-fm/package.nix
+++ b/pkgs/by-name/sd/sdr-j-fm/package.nix
@@ -41,7 +41,11 @@ stdenv.mkDerivation (finalAttrs: {
     libusb1
     libsndfile
   ];
-  cmakeFlags = lib.mapAttrsToList lib.cmakeBool finalAttrs.passthru.features;
+  cmakeFlags = lib.mapAttrsToList lib.cmakeBool finalAttrs.passthru.features ++ [
+    # https://github.com/JvanKatwijk/sdr-j-fm/issues/27#issuecomment-3371932903
+    # https://github.com/NixOS/nixpkgs/issues/445447
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
 
   passthru = {
     features = {

--- a/pkgs/by-name/sd/sdr-j-fm/package.nix
+++ b/pkgs/by-name/sd/sdr-j-fm/package.nix
@@ -3,10 +3,9 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  wrapQtAppsHook,
   pkg-config,
-  qtbase,
-  qwt6_1,
+  qt5,
+  libsForQt5,
   fftwFloat,
   libsamplerate,
   portaudio,
@@ -31,13 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
     pkg-config
   ];
 
   buildInputs = [
-    qtbase
-    qwt6_1
+    qt5.qtbase
+    libsForQt5.qwt6_1
     fftwFloat
     libsamplerate
     portaudio

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8705,8 +8705,6 @@ with pkgs;
   SDL = SDL_compat;
   SDL2 = sdl2-compat;
 
-  sdr-j-fm = libsForQt5.callPackage ../applications/radio/sdr-j-fm { };
-
   sigdigger = libsForQt5.callPackage ../applications/radio/sigdigger { };
 
   sev-snp-measure = with python3Packages; toPythonApplication sev-snp-measure;


### PR DESCRIPTION
https://github.com/JvanKatwijk/sdr-j-fm/compare/8e3a67f8fbf72dd6968cbeb2e3d7d513fd107c71...3.20

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
