### PR TITLE
spyder: 6.1.0a2 -> 6.1.0

### DIFF
--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "spyder-kernels";
-  version = "3.1.0b1";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "spyder-ide";
     repo = "spyder-kernels";
     tag = "v${version}";
-    hash = "sha256-bYpNWE6KHDD9CkDmTDIX3gZumLOhAyxITCGyWuSU2+o=";
+    hash = "sha256-FH4n1FsVN3D9WdDvxsrD6FBJiZl+ec/CJFOhs9IjUwI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -37,6 +37,7 @@
   pyls-spyder,
   pyopengl,
   python-lsp-black,
+  python-lsp-ruff,
   python-lsp-server,
   pyuca,
   pyzmq,
@@ -58,12 +59,12 @@
 
 buildPythonPackage rec {
   pname = "spyder";
-  version = "6.1.0a2";
+  version = "6.1.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-KbGfG9T3XkYXntIQx325mYb0Bh8c0idb+25awFlWD9s=";
+    hash = "sha256-UgDGJJuwNzB0VfAMgGM/UIhNarQ6da18XKE9JGJXRjY=";
   };
 
   patches = [ ./dont-clear-pythonpath.patch ];
@@ -106,6 +107,7 @@ buildPythonPackage rec {
     pyopengl
     pyqtwebengine
     python-lsp-black
+    python-lsp-ruff
     python-lsp-server
     pyuca
     pyzmq

--- a/pkgs/development/python-modules/spyder/dont-clear-pythonpath.patch
+++ b/pkgs/development/python-modules/spyder/dont-clear-pythonpath.patch
@@ -1,21 +1,20 @@
 diff --git a/spyder/app/start.py b/spyder/app/start.py
-index ad9f2b8d0..442b4fc46 100644
+index 3f225a164..10e6017b1 100644
 --- a/spyder/app/start.py
 +++ b/spyder/app/start.py
-@@ -6,16 +6,8 @@
- # (see spyder/__init__.py for details)
- # -----------------------------------------------------------------------------
+@@ -9,15 +9,6 @@
+ import os
+ import sys
  
 -# Remove PYTHONPATH paths from sys.path before other imports to protect against
 -# shadowed standard libraries.
- import os
- import sys
 -if os.environ.get('PYTHONPATH'):
 -    for path in os.environ['PYTHONPATH'].split(os.pathsep):
 -        try:
 -            sys.path.remove(path.rstrip(os.sep))
 -        except ValueError:
 -            pass
+-
+ # Remove PYTHONEXECUTABLE. See spyder-ide/spyder#24743
+ os.environ.pop("PYTHONEXECUTABLE", None)
  
- # Standard library imports
- import ctypes


### PR DESCRIPTION
## Things done

Changelog: https://github.com/spyder-ide/spyder/blob/v6.1.0/changelogs/Spyder-6.md


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc