### PR TITLE
dreamchess: fix default engine propagation

### DIFF
--- a/pkgs/by-name/dr/dreamchess/package.nix
+++ b/pkgs/by-name/dr/dreamchess/package.nix
@@ -6,6 +6,7 @@
   bison,
   flex,
   gettext,
+  makeWrapper,
   SDL2,
   SDL2_image,
   SDL2_mixer,
@@ -48,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     flex
     gettext
+    makeWrapper
   ];
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
@@ -55,10 +57,18 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_DATAROOTDIR" "${placeholder "out"}/share")
   ];
 
+  # This makes sure the default engine (dreamer) will be called from
+  # the /nix/store/ as well when starting a new game
+  postFixup = ''
+    wrapProgram $out/bin/dreamchess \
+      --prefix PATH : $out/bin
+  '';
+
   doInstallCheck = true;
 
   postInstallCheck = ''
     stat "''${!outputBin}/bin/${finalAttrs.meta.mainProgram}"
+    stat "''${!outputBin}/bin/dreamer"
   '';
 
   meta = {


### PR DESCRIPTION
Currently, `dreamer` is not being properly fetched as the default game engine. This is a small change to make sure that it is picked at the right place in the `/nix/store/`.

To reproduce the original issue:

1. `nix run nixpkgs#dreamchess --`
2. Play the game against the CPU.

<img width="1672" height="286" alt="2025-10-03-165437_hyprshot" src="https://github.com/user-attachments/assets/ade4ccf8-f7ae-4a03-9247-bb42d7674744" />

![2025-10-03-165421_hyprshot](https://github.com/user-attachments/assets/60a86454-2019-4d65-ab9b-c4837b07cd41)

After the fix:

```
nix-build -A dreamchess
./result/bin/dreamchess  
```

<img width="1976" height="464" alt="2025-10-03-164815_hyprshot" src="https://github.com/user-attachments/assets/9f5e8257-7ea1-4838-b456-12955385a921" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
