### PR TITLE
beets: update test exclusions

### DIFF
--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -172,7 +172,7 @@ python3Packages.buildPythonApplication {
       # if not self._poll(timeout):
       #   raise Empty
       #   _queue.Empty
-      "test/plugins/test_player.py"
+      "test/plugins/test_bpd.py"
     ];
   disabledTests = disabledTests ++ [
     # https://github.com/beetbox/beets/issues/5880

--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -173,6 +173,20 @@ python3Packages.buildPythonApplication {
       #   raise Empty
       #   _queue.Empty
       "test/plugins/test_bpd.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      # fail on Hydra with `RuntimeError: image cannot be obtained without artresizer backend`
+      "test/plugins/test_art.py::AlbumArtOperationConfigurationTest::test_enforce_ratio"
+      "test/plugins/test_art.py::AlbumArtOperationConfigurationTest::test_enforce_ratio_with_percent_margin"
+      "test/plugins/test_art.py::AlbumArtOperationConfigurationTest::test_enforce_ratio_with_px_margin"
+      "test/plugins/test_art.py::AlbumArtOperationConfigurationTest::test_minwidth"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_deinterlaced"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_deinterlaced_and_resized"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_file_not_resized"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_file_resized"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_file_resized_and_scaled"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_file_resized_but_not_scaled"
+      "test/plugins/test_art.py::AlbumArtPerformOperationTest::test_resize"
     ];
   disabledTests = disabledTests ++ [
     # https://github.com/beetbox/beets/issues/5880


### PR DESCRIPTION
1. Darwin: `disabledTestPaths` points to a test that no longer exists. Multiple new flaky tests appeared in one file. Updated `disabledTestPaths` for Darwin.
2. Linux: Multiple tests fail on Hydra with `RuntimeError: image cannot be obtained without artresizer backend`. Updated `disabledTestPaths` for Linux. Fixes issue in https://github.com/NixOS/nixpkgs/pull/444095#issuecomment-3348994285

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
