### PR TITLE
tree-sitter-grammars.tree-sitter-todotxt: init at 2024-01-15

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -109,6 +109,7 @@
   tree-sitter-tera = lib.importJSON ./tree-sitter-tera.json;
   tree-sitter-tiger = lib.importJSON ./tree-sitter-tiger.json;
   tree-sitter-tlaplus = lib.importJSON ./tree-sitter-tlaplus.json;
+  tree-sitter-todotxt = lib.importJSON ./tree-sitter-todotxt.json;
   tree-sitter-toml = lib.importJSON ./tree-sitter-toml.json;
   tree-sitter-tsq = lib.importJSON ./tree-sitter-tsq.json;
   tree-sitter-turtle = lib.importJSON ./tree-sitter-turtle.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-todotxt.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-todotxt.json
@@ -1,0 +1,12 @@
+{
+  "url": "https://github.com/arnarg/tree-sitter-todotxt",
+  "rev": "3937c5cd105ec4127448651a21aef45f52d19609",
+  "date": "2024-01-15T09:45:57+01:00",
+  "path": "/nix/store/37nxnr79ylm1g1myx2zvhzrymy5z0pw4-tree-sitter-todotxt",
+  "sha256": "0551fdv77bdrxsc04gsi3zrc07si34r4gnhaqjg3h5fwbbkj3q1r",
+  "hash": "sha256-OeAh51rcFTiexAraRzIZUR/A8h9RPwKY7rmtc3ZzoRQ=",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}


### PR DESCRIPTION
# tree-sitter-grammars.tree-sitter-todotxt: init at 2024-01-15

```
tree-sitter-grammars.tree-sitter-todotxt: init at 2024-01-15
```

## Build info of packages affected directly
### tree-sitter-grammars.tree-sitter-todotxt

<details><summary>content of tree-sitter-grammars.tree-sitter-todotxt.out</summary>

```
/nix/store/mmhqbs1vagd0dypbxhh8821gbkcsfkr6-tree-sitter-todotxt-grammar-0.25.6
├── parser
└── queries
    └── highlights.scm

2 directories, 2 files
```
</details>

<details><summary>build log of tree-sitter-grammars.tree-sitter-todotxt</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/3wq2nbq47wxgigdbygyl2g27ifhgv4kr-tree-sitter-todotxt-3937c5c
source root is tree-sitter-todotxt-3937c5c
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/mmhqbs1vagd0dypbxhh8821gbkcsfkr6-tree-sitter-todotxt-grammar-0.25.6
shrinking /nix/store/mmhqbs1vagd0dypbxhh8821gbkcsfkr6-tree-sitter-todotxt-grammar-0.25.6/parser
checking for references to /build/ in /nix/store/mmhqbs1vagd0dypbxhh8821gbkcsfkr6-tree-sitter-todotxt-grammar-0.25.6...
patching script interpreter paths in /nix/store/mmhqbs1vagd0dypbxhh8821gbkcsfkr6-tree-sitter-todotxt-grammar-0.25.6
stripping (with command strip and flags -S -p) in  /nix/store/mmhqbs1vagd0dypbxhh8821gbkcsfkr6-tree-sitter-todotxt-grammar-0.25.6/parser
```
</details>
