### PR TITLE
monado: Remove protobuf override for opencv

### DIFF
--- a/pkgs/by-name/mo/monado/package.nix
+++ b/pkgs/by-name/mo/monado/package.nix
@@ -41,7 +41,6 @@
   orc,
   pcre2,
   pkg-config,
-  protobuf_21,
   python3,
   SDL2,
   shaderc,
@@ -64,14 +63,7 @@
   serviceSupport ? true,
   tracingSupport ? false,
 }:
-let
-  # For some reason protobuf 32 causes a segfault during startup
-  # Pin to last (known) working version
-  # See https://github.com/NixOS/nixpkgs/issues/439075
-  opencv4' = opencv4.override {
-    protobuf = protobuf_21;
-  };
-in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "monado";
   version = "25.0.0";
@@ -133,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     libXext
     libXrandr
     onnxruntime
-    opencv4'
+    opencv4
     openhmd
     openvr
     orc


### PR DESCRIPTION
The override was originally added in #442919 because monado depends on protobuf through two paths:

- monado -> opencv4 -> protobuf
- monado -> onnxruntime -> protobuf

And since, *at that time*, onnxruntime has protobuf pinned to protobuf_21, we had to override opencv4 with protobuf_21 as well to avoid mixing two different versions of protobuf. Otherwise, mayhem occurs on initialization, manifesting as crashes or deadlocks. This does not seem to be known when https://github.com/NixOS/nixpkgs/pull/442919 was written.

With #437307, onnxruntime is no longer pinned to protobuf_21, so the same mixing problem was introduced back into monado, just the other direction.

Revert the override for opencv4 to fix it.

cc @Scrumplex from #442919, @MatthewCroughan for testing

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`. (Runs)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
