### PR TITLE
python3Packages.hoomd-blue: 2.3.4 -> 6.0.0, unbreak

### DIFF
--- a/pkgs/development/python-modules/hoomd-blue/default.nix
+++ b/pkgs/development/python-modules/hoomd-blue/default.nix
@@ -1,69 +1,70 @@
 {
   lib,
   buildPythonPackage,
-  fetchgit,
   cmake,
+  eigen,
+  fetchFromGitHub,
+  mpi,
   pkgconfig,
   python,
-  mpi ? null,
+  # true or false to enable/disable; null to use upstream defaults
+  withHpmc ? null,
+  withMd ? null,
+  withMetal ? null,
+  withMpcd ? null,
 }:
 
 let
-  components = {
-    cgcmm = true;
-    depreciated = true;
-    hpmc = true;
-    md = true;
-    metal = true;
-  };
-  onOffBool = b: if b then "ON" else "OFF";
-  withMPI = (mpi != null);
+  optionalCmakeBool = name: value: lib.optionals (value != null) [ (lib.cmakeBool name value) ];
 in
 buildPythonPackage rec {
-  version = "2.3.4";
+  version = "6.0.0";
   pname = "hoomd-blue";
   pyproject = false; # Built with cmake
 
-  src = fetchgit {
-    url = "https://bitbucket.org/glotzer/hoomd-blue";
-    rev = "v${version}";
-    sha256 = "0in49f1dvah33nl5n2qqbssfynb31pw1ds07j8ziryk9w252j1al";
-  };
-
-  passthru = {
-    inherit components mpi;
+  src = fetchFromGitHub {
+    owner = "glotzerlab";
+    repo = "hoomd-blue";
+    tag = "v${version}";
+    hash = "sha256-dmDBAJU6FxMQXuMO+nE1yzOY1m6/x43eH3USBQNVu8A=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
     cmake
     pkgconfig
   ];
-  buildInputs = lib.optionals withMPI [ mpi ];
-  propagatedBuildInputs = [ python.pkgs.numpy ] ++ lib.optionals withMPI [ python.pkgs.mpi4py ];
+  buildInputs = [
+    eigen
+    mpi
+  ];
+
+  dependencies = with python.pkgs; [
+    numpy
+    mpi4py
+    pybind11
+  ];
 
   dontAddPrefix = true;
   cmakeFlags = [
-    "-DENABLE_MPI=${onOffBool withMPI}"
-    "-DBUILD_CGCMM=${onOffBool components.cgcmm}"
-    "-DBUILD_DEPRECIATED=${onOffBool components.depreciated}"
-    "-DBUILD_HPMC=${onOffBool components.hpmc}"
-    "-DBUILD_MD=${onOffBool components.md}"
-    "-DBUILD_METAL=${onOffBool components.metal}"
-    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/${python.sitePackages}"
-  ];
+    (lib.cmakeBool "BUILD_TESTING" doCheck)
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/${python.sitePackages}")
+  ]
+  ++ optionalCmakeBool "BUILD_MD" withMd
+  ++ optionalCmakeBool "BUILD_HPMC" withHpmc
+  ++ optionalCmakeBool "BUILD_METAL" withMetal
+  ++ optionalCmakeBool "BUILD_MPCD" withMpcd;
 
-  # tests fail but have tested that package runs properly
-  doCheck = false;
-  checkTarget = "test";
+  # Tests are performed as part of the installPhase when -DBUILD_TESTING=TRUE,
+  # not the checkPhase or installCheckPhase.
+  # But leave doCheck here so people can override it as they may expect.
+  doCheck = true;
 
   meta = {
-    homepage = "http://glotzerlab.engin.umich.edu/hoomd-blue/";
+    homepage = "https://glotzerlab.engin.umich.edu/software/";
     description = "HOOMD-blue is a general-purpose particle simulation toolkit";
-    license = lib.licenses.bsdOriginal;
-    platforms = [ "x86_64-linux" ];
+    changelog = "https://github.com/glotzerlab/hoomd-blue/blob/${src.tag}/CHANGELOG.rst";
+    license = lib.licenses.bsd3;
     maintainers = [ ];
-    # Has compilation errors since some dependencies got updated, will probably
-    # be fixed if updated by itself to the latest version.
-    broken = true;
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/glotzerlab/hoomd-blue/blob/v6.0.0/CHANGELOG.rst

Diff: https://github.com/glotzerlab/hoomd-blue/compare/refs/tags/v2.3.4...refs/tags/v6.0.0

Closes: #337140
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
