### PR TITLE
scip: 0.5.1 -> 0.6.1

### DIFF
--- a/pkgs/by-name/sc/scip/package.nix
+++ b/pkgs/by-name/sc/scip/package.nix
@@ -10,20 +10,19 @@
 
 buildGo124Module (finalAttrs: {
   pname = "scip";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "sourcegraph";
     repo = "scip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZyU1CmDBVDNP6zCXpvqEoQ3ttWNPGLCIjkj4mezUcKc=";
+    hash = "sha256-l68xhOMgwt+ySChk7BCyklcuC6r51GgobAg3lRLvOCU=";
   };
 
-  vendorHash = "sha256-RwBlzBqGd/xEaTL6m3sm6e/tcNUc7Mfdf213qzuMPug=";
+  vendorHash = "sha256-8HgeG/SXkM7ptOwKSi/PUH3VySxFqqoIpXI7bZtbO4A=";
 
   ldflags = [
     "-s"
-    "-w"
     "-X=main.Reproducible=true"
   ];
 
@@ -56,6 +55,6 @@ buildGo124Module (finalAttrs: {
     homepage = "https://github.com/sourcegraph/scip";
     changelog = "https://github.com/sourcegraph/scip/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = [  ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/sc/scip/package.nix
+++ b/pkgs/by-name/sc/scip/package.nix
@@ -1,23 +1,25 @@
 {
   lib,
-  buildGoModule,
+  stdenv,
+  buildGo124Module,
   fetchFromGitHub,
-  testers,
-  scip,
+  libredirect,
+  iana-etc,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGo124Module (finalAttrs: {
   pname = "scip";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "sourcegraph";
     repo = "scip";
-    rev = "v${version}";
-    hash = "sha256-UXa5lMFenynHRIvA4MOXkjMVd705LBWs372s3MFAc+8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZyU1CmDBVDNP6zCXpvqEoQ3ttWNPGLCIjkj4mezUcKc=";
   };
 
-  vendorHash = "sha256-6vx3Dt0ZNR0rY5bEUF5X1hHj/gv21920bhfd+JJ9bYk=";
+  vendorHash = "sha256-RwBlzBqGd/xEaTL6m3sm6e/tcNUc7Mfdf213qzuMPug=";
 
   ldflags = [
     "-s"
@@ -25,25 +27,35 @@ buildGoModule rec {
     "-X=main.Reproducible=true"
   ];
 
-  # update documentation to fix broken test
-  postPatch = ''
-    substituteInPlace docs/CLI.md \
-      --replace 0.3.0 0.3.1
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libredirect.hook ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestParseCompat" # could not locate sample indexes directory starting from parents of working directory
+        "TestParseSymbol_ZeroAllocationsIfMemoryAvailable"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  __darwinAllowLocalNetworking = true;
+
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/services=${iana-etc}/etc/services
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = scip;
-      version = "v${version}";
-    };
-  };
+  doInstallCheck = stdenv.hostPlatform.isLinux;
 
-  meta = with lib; {
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "--version";
+
+  meta = {
     description = "SCIP Code Intelligence Protocol CLI";
     mainProgram = "scip";
     homepage = "https://github.com/sourcegraph/scip";
-    changelog = "https://github.com/sourcegraph/scip/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [ ];
+    changelog = "https://github.com/sourcegraph/scip/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [  ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/sourcegraph/scip/compare/v0.5.1...v0.6.1

Changelog: https://github.com/sourcegraph/scip/blob/v0.6.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
