### PR TITLE
python3Packages.petsctools: init at 2025.2

### DIFF
--- a/pkgs/development/python-modules/petsctools/default.nix
+++ b/pkgs/development/python-modules/petsctools/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  packaging,
+  petsc4py,
+  slepc4py,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "petsctools";
+  version = "2025.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "firedrakeproject";
+    repo = "petsctools";
+    tag = version;
+    hash = "sha256-DC0jFybDEacA6otYvID5DfbUe1ANz5W4UmPXCSsRvOo=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    packaging
+  ];
+
+  optional-dependencies = {
+    petsc4py = [ petsc4py ];
+    slepc4py = [ slepc4py ];
+  };
+
+  pythonImportsCheck = [
+    "petsctools"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ optional-dependencies.petsc4py;
+
+  meta = {
+    homepage = "https://github.com/firedrakeproject/petsctools";
+    description = "Pythonic extensions for petsc4py and slepc4py";
+    changelog = "https://github.com/firedrakeproject/petsctools/releases/tag/${src.tag}";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11672,6 +11672,8 @@ self: super: with self; {
     }
   );
 
+  petsctools = callPackage ../development/python-modules/petsctools { };
+
   pettingzoo = callPackage ../development/python-modules/pettingzoo { };
 
   pex = callPackage ../development/python-modules/pex { };


### PR DESCRIPTION
petsctools is an extension for petsc4py/slepc4py that expose infomation from petscvariable to firedrake.
It is required for upgrading firedrake.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
