### PR TITLE
home-assistant: 2025.10.0 -> 2025.10.1

### DIFF
--- a/pkgs/development/python-modules/aiohasupervisor/default.nix
+++ b/pkgs/development/python-modules/aiohasupervisor/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "aiohasupervisor";
-  version = "0.3.3b0";
+  version = "0.3.3";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "python-supervisor-client";
     tag = version;
-    hash = "sha256-Uv9chL9GxP5vJu1P6RB7B2b0pRQMeNtE6t1XFr2tBI4=";
+    hash = "sha256-v6w+g1M3VR/an3a5MfWf8fDCHNzRC4+05L7GW45PzWU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/airos/default.nix
+++ b/pkgs/development/python-modules/airos/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "airos";
-  version = "0.5.3";
+  version = "0.5.4";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "CoMPaTech";
     repo = "python-airos";
     tag = "v${version}";
-    hash = "sha256-P9IQ4MBjOZJksKipaq9+6Zgui9uO4zy2Rx74OCLPYCU=";
+    hash = "sha256-IiQ/+Ey+CGQfeKRGnNZ54dUSY3t5YMJ1ws7kgc3SQBg=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyportainer/default.nix
+++ b/pkgs/development/python-modules/pyportainer/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "pyportainer";
-  version = "1.0.1";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "erwindouna";
     repo = "pyportainer";
     tag = "v${version}";
-    hash = "sha256-SAHcIP6M4WjWnrRwz4FlsV6rel1vHzH+cGHT8D/PcQk=";
+    hash = "sha256-Y/O2lhsjkSEKQL7HhdmlzMjY1597uuUOFfI05aLiBXg=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/pytibber/default.nix
+++ b/pkgs/development/python-modules/pytibber/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "pytibber";
-  version = "0.32.1";
+  version = "0.32.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "Danielhiversen";
     repo = "pyTibber";
     tag = version;
-    hash = "sha256-PHd0aqF1Oodfvgyrv25xOD3JSOKC4RUe/ViulQN7sxQ=";
+    hash = "sha256-gMXbDpkb+LVIxVkYliskEeHOrkJxAuJdYxUEC4wp3r8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/universal-silabs-flasher/default.nix
+++ b/pkgs/development/python-modules/universal-silabs-flasher/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "universal-silabs-flasher";
-  version = "0.0.34";
+  version = "0.0.35";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "NabuCasa";
     repo = "universal-silabs-flasher";
     tag = "v${version}";
-    hash = "sha256-08ay5W5DHY1GwzZDwjPGPnVjXfHgiwWUIHzuAZZpS9M=";
+    hash = "sha256-6NOcEH1UUicZHKOQ91o4l7JiC1Qwpc8vWyRR7TRENqs=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.10.0";
+  version = "2025.10.1";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/spook/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/spook/package.nix
@@ -10,16 +10,21 @@
 buildHomeAssistantComponent rec {
   owner = "frenck";
   domain = "spook";
-  version = "3.1.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-IV3n++uFSOvQANPfbCeBj3GP0CCL+w9icKp/k5VO3Qg=";
+    hash = "sha256-0IihrhATgraGmuMRnrbGTUrtlXAR+CooENSIKSWIknY=";
   };
 
   patches = [ ./remove-sub-integration-symlink-hack.patch ];
+
+  postPatch = ''
+    substituteInPlace custom_components/spook/manifest.json \
+      --replace-fail '"version": "0.0.0"' '"version": "${version}"'
+  '';
 
   dependencies = [
     pillow

--- a/pkgs/servers/home-assistant/custom-components/spook/remove-sub-integration-symlink-hack.patch
+++ b/pkgs/servers/home-assistant/custom-components/spook/remove-sub-integration-symlink-hack.patch
@@ -1,18 +1,18 @@
 diff --git a/custom_components/spook/__init__.py b/custom_components/spook/__init__.py
-index 213fb2c..c7dc299 100644
+index 1abc79d..68d48d1 100644
 --- a/custom_components/spook/__init__.py
 +++ b/custom_components/spook/__init__.py
-@@ -23,8 +23,6 @@ from .templating import SpookTemplateFunctionManager
+@@ -22,8 +22,6 @@ from .services import SpookServiceManager
  from .util import (
-     async_ensure_template_environments_exists,
      async_forward_setup_entry,
+     async_setup_all_entity_ids_cache_invalidation,
 -    link_sub_integrations,
 -    unlink_sub_integrations,
  )
-
+ 
  if TYPE_CHECKING:
-@@ -34,48 +32,6 @@ if TYPE_CHECKING:
-
+@@ -35,48 +33,6 @@ if TYPE_CHECKING:
+ 
  async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
      """Set up from a config entry."""
 -    # Symlink all sub integrations from Spook to the parent integrations folder
@@ -57,22 +57,22 @@ index 213fb2c..c7dc299 100644
 -            severity=ir.IssueSeverity.WARNING,
 -            translation_key="restart_required",
 -        )
-
-     # Ensure template environments exists
-     async_ensure_template_environments_exists(hass)
-@@ -120,4 +76,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-
+ 
+     # Forward async_setup_entry to ectoplasms
+     await async_forward_setup_entry(hass, entry)
+@@ -131,4 +87,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+ 
  async def async_remove_entry(hass: HomeAssistant, _: ConfigEntry) -> None:
      """Remove a config entry."""
 -    await hass.async_add_executor_job(unlink_sub_integrations, hass)
 diff --git a/custom_components/spook/util.py b/custom_components/spook/util.py
-index 32e9bd2..845d463 100644
+index 6aea27c..1437913 100644
 --- a/custom_components/spook/util.py
 +++ b/custom_components/spook/util.py
-@@ -104,37 +104,6 @@ async def async_forward_platform_entry_setups_to_ectoplasm(
+@@ -284,37 +284,6 @@ async def async_forward_platform_entry_setups_to_ectoplasm(
      )
-
-
+ 
+ 
 -def link_sub_integrations(hass: HomeAssistant) -> bool:
 -    """Link Spook sub integrations."""
 -    LOGGER.debug("Linking up Spook sub integrations")
@@ -105,5 +105,5 @@ index 32e9bd2..845d463 100644
 -
 -
  @callback
- def async_ensure_template_environments_exists(hass: HomeAssistant) -> None:
-     """Ensure default template environments exist.
+ def async_get_all_area_ids(hass: HomeAssistant) -> set[str]:
+     """Return all area IDs, known to Home Assistant."""

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -330,7 +330,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.10.0";
+  hassVersion = "2025.10.1";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -351,13 +351,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-E+rA6Pwzcoz0yPmbZ8NqEswZQ1Kmdc9H2BXZTgjnumk=";
+    hash = "sha256-1C7Lg/pL1C+pUoo4RiL1TVECTqtEn6jnZ6muLohYPcw=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-6HmHTG37hLtBFX/lMbqoNUrbVJjdTswug41y7ziuHdg=";
+    hash = "sha256-cVARVLg80wVkruSed7ywrnK+lutLWbMJL2MBIwAapBA=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.277";
+  version = "0.13.285";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-khlvhMYO2Oj84EJ5/RTnx7uNZYZnv4InCesgMmCgYiA=";
+    hash = "sha256-pP8zUjOhhaXE+cbx3fKlJaoNBBprOfAKS0F92Tf8hjI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.10.0";
+  version = "2025.10.1";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-WxuOHHOgzbF+9XJwn+5dAk+m5hZ4fSRjzhfWEHVghTE=";
+    hash = "sha256-uLr6ZBasZNsCqD2DmOV/zestPW0lak9MSvvvUVWgUqQ=";
   };
 
   build-system = [


### PR DESCRIPTION
    https://github.com/frenck/spook/releases/tag/v4.0.1
    https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/blob/refs/tags/0.13.285/CHANGELOG.md
    https://github.com/home-assistant/core/releases/tag/2025.10.1
    https://github.com/NabuCasa/universal-silabs-flasher/releases/tag/v0.0.35
    https://github.com/erwindouna/pyportainer/releases/tag/v1.0.3
    https://github.com/CoMPaTech/python-airos/releases/tag/v0.5.4
    https://github.com/Danielhiversen/pyTibber/compare/0.32.1...0.32.2
    https://github.com/Danielhiversen/pyTibber/releases/tag/0.32.2
    https://github.com/home-assistant-libs/python-supervisor-client/compare/0.3.3b0...0.3.3
    https://github.com/home-assistant-libs/python-supervisor-client/releases/tag/0.3.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
