### PR TITLE
nixos/tests: add systemd-networkd-batadv

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1460,6 +1460,7 @@ in
   systemd-machinectl = runTest ./systemd-machinectl.nix;
   systemd-misc = runTest ./systemd-misc.nix;
   systemd-networkd = runTest ./systemd-networkd.nix;
+  systemd-networkd-batadv = runTest ./systemd-networkd-batadv.nix;
   systemd-networkd-bridge = runTest ./systemd-networkd-bridge.nix;
   systemd-networkd-dhcpserver = runTest ./systemd-networkd-dhcpserver.nix;
   systemd-networkd-dhcpserver-static-leases = runTest ./systemd-networkd-dhcpserver-static-leases.nix;

--- a/nixos/tests/systemd-networkd-batadv.nix
+++ b/nixos/tests/systemd-networkd-batadv.nix
@@ -1,0 +1,134 @@
+{ lib, ... }:
+{
+  name = "systemd-networkd-batadv";
+
+  meta = with lib.maintainers; {
+    maintainers = [ herbetom ];
+  };
+
+  nodes = {
+    machineA =
+      { config, pkgs, ... }:
+      {
+        virtualisation.vlans = [ 1 ];
+        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+
+        networking = {
+          useNetworkd = true;
+          useDHCP = false;
+          firewall.enable = false;
+        };
+
+        # Use default batman_adv module from kernel
+        boot.extraModulePackages = [ ];
+
+        environment.systemPackages = [
+          pkgs.batctl
+          pkgs.jq
+        ];
+
+        systemd.network = {
+          networks."10-eth1" = {
+            matchConfig.Name = "eth1";
+            networkConfig = {
+              BatmanAdvanced = config.systemd.network.netdevs."20-bat0".netdevConfig.Name;
+              IPv6AcceptRA = false;
+            };
+          };
+          netdevs."20-bat0" = {
+            netdevConfig = {
+              Name = "bat0";
+              Kind = "batadv";
+              MACAddress = "00:00:5e:00:53:00";
+            };
+            batmanAdvancedConfig = {
+              OriginatorIntervalSec = "5";
+              RoutingAlgorithm = "batman-iv";
+            };
+          };
+          networks."20-bat0" = {
+            matchConfig.Name = config.systemd.network.netdevs."20-bat0".netdevConfig.Name;
+            networkConfig.IPv6AcceptRA = false;
+            address = [
+              "10.0.0.1/24"
+              "2001:db8::a/64"
+            ];
+
+          };
+        };
+      };
+    machineB =
+      { config, pkgs, ... }:
+      {
+        virtualisation.vlans = [ 1 ];
+        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+
+        networking = {
+          useNetworkd = true;
+          useDHCP = false;
+          firewall.enable = false;
+        };
+
+        # Use batman_adv module from nixpkgs
+        boot.extraModulePackages = [ config.boot.kernelPackages.batman_adv ];
+
+        environment.systemPackages = [
+          pkgs.batctl
+          pkgs.jq
+        ];
+
+        systemd.network = {
+          networks."10-eth1" = {
+            matchConfig.Name = "eth1";
+            networkConfig = {
+              BatmanAdvanced = config.systemd.network.netdevs."20-bat0".netdevConfig.Name;
+              IPv6AcceptRA = false;
+            };
+          };
+          netdevs."20-bat0" = {
+            netdevConfig = {
+              Name = "bat0";
+              Kind = "batadv";
+              MACAddress = "00:00:5e:00:53:10";
+            };
+            batmanAdvancedConfig = {
+              OriginatorIntervalSec = "5";
+              RoutingAlgorithm = "batman-iv";
+            };
+          };
+          networks."20-bat0" = {
+            matchConfig.Name = config.systemd.network.netdevs."20-bat0".netdevConfig.Name;
+            networkConfig.IPv6AcceptRA = false;
+            address = [
+              "10.0.0.2/24"
+              "2001:db8::b/64"
+            ];
+
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    machineA.wait_for_unit("default.target")
+    machineB.wait_for_unit("default.target")
+
+    print(machineA.succeed("batctl -v").strip())
+    print(machineB.succeed("batctl -v").strip())
+
+    machineA.wait_until_succeeds('batctl neighbors_json | jq -e ".[0].neigh_address | select(length > 0)"')
+
+    print(machineA.succeed("batctl n").strip())
+    print(machineB.succeed("batctl n").strip())
+
+    print(machineA.wait_until_succeeds("batctl ping -c 5 00:00:5e:00:53:10").strip())
+    print(machineB.wait_until_succeeds("batctl ping -c 5 00:00:5e:00:53:00").strip())
+
+    print(machineA.wait_until_succeeds("ping -c 5 2001:db8::b"))
+    print(machineB.wait_until_succeeds("ping -c 5 10.0.0.1"))
+
+    machineA.fail("ping -c 3 10.0.0.99")
+  '';
+}

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -4,6 +4,7 @@
   fetchurl,
   kernel,
   kernelModuleMakeFlags,
+  nixosTests,
 }:
 
 let
@@ -30,6 +31,10 @@ stdenv.mkDerivation rec {
     sed -i -e "s,INSTALL_MOD_DIR=,INSTALL_MOD_PATH=$out INSTALL_MOD_DIR=," \
       -e /depmod/d Makefile
   '';
+
+  passthru.tests = {
+    systemd-networkd-batadv = nixosTests.systemd-networkd-batadv;
+  };
 
   meta = {
     homepage = "https://www.open-mesh.org/projects/batman-adv/wiki/Wiki";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a simple batman-adv test with networkd. Useful when bumping batman-adv to make sure it's working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
