### PR TITLE
tealdeer: 1.7.2 -> 1.8.0

### DIFF
--- a/pkgs/by-name/te/tealdeer/package.nix
+++ b/pkgs/by-name/te/tealdeer/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tealdeer";
-  version = "1.7.2";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
-    owner = "dbrgn";
+    owner = "tealdeer-rs";
     repo = "tealdeer";
     rev = "v${version}";
-    hash = "sha256-GZN7WE12f3MEoBfswag0O04UOCmZeYwt5CbYwddmwHs=";
+    hash = "sha256-TJdmcxxUmAiEb4lLrLrRIJIGs1iC0mjHBOECOHDB1Uc=";
   };
 
-  cargoHash = "sha256-Zk2L4cq7j9CkSc+cnZRWwhtfWP6y5faiMVGFFNkBwwA=";
+  cargoHash = "sha256-HJFJWJezEUE2/ZukDfEROegdPxakpu+TX6W+2x0KmkQ=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -37,11 +37,13 @@ rustPlatform.buildRustPackage rec {
     "--skip test_quiet_old_cache"
     "--skip test_spaces_find_command"
     "--skip test_update_cache"
+    "--skip test_update_language_arg"
   ];
 
   meta = with lib; {
     description = "Very fast implementation of tldr in Rust";
-    homepage = "https://github.com/dbrgn/tealdeer";
+    homepage = "https://github.com/tealdeer-rs/tealdeer";
+    changelog = "https://github.com/tealdeer-rs/tealdeer/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [
       davidak
       newam


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: <https://github.com/tealdeer-rs/tealdeer/blob/v1.8.0/CHANGELOG.md>
Diff: https://github.com/tealdeer-rs/tealdeer/compare/v1.7.2...v1.8.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
