### PR TITLE
pythonPackages.nlopt: respect current python interpreter

### DIFF
--- a/pkgs/development/python-modules/nlopt/default.nix
+++ b/pkgs/development/python-modules/nlopt/default.nix
@@ -1,5 +1,12 @@
 {
   toPythonModule,
   pkgs,
+  python,
 }:
-toPythonModule (pkgs.nlopt.override { withPython = true; })
+toPythonModule (
+  pkgs.nlopt.override {
+    withPython = true;
+    python3 = python;
+    python3Packages = python.pkgs;
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

### Issue
`pythonPackages312.nlopt` does not currently work (but it works for `pythonPackages313.nlopt`)
```
> nix-shell -p 'python312.withPackages (ps: [ ps.nlopt ])' --run 'python -c "import nlopt; print(nlopt.__version__)"'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'nlopt'
```

### Solution
I believe this is because we don't pass `python3` and `python3Packages` so it always binds to nixpkgs' default, and not the version of those in the environment we create. Which explains why it works with 3.13 and not 3.12.

With my patch I get:
```
> nix-shell -I nixpkgs=/home/sheevy/code/nixpkgs -p 'python312.withPackages (ps: [ ps.nlopt ])' --run 'python -c "import nlopt; print(nlopt.__version__)"'
2.10.0
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
