### PR TITLE
maintainers: realsnick -> logger

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14868,6 +14868,12 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  logger = {
+    name = "Ido Samuelson";
+    email = "ido.samuelson@gmail.com";
+    github = "i-am-logger";
+    githubId = 1440852;
+  };
   logo = {
     email = "logo4poop@protonmail.com";
     matrix = "@logo4poop:matrix.org";
@@ -21608,12 +21614,6 @@
     github = "rdnetto";
     githubId = 1973389;
     name = "Reuben D'Netto";
-  };
-  realsnick = {
-    name = "Ido Samuelson";
-    email = "ido.samuelson@gmail.com";
-    github = "i-am-logger";
-    githubId = 1440852;
   };
   rebmit = {
     name = "Lu Wang";

--- a/pkgs/by-name/fx/fxload/package.nix
+++ b/pkgs/by-name/fx/fxload/package.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     mainProgram = "fxload";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ realsnick ];
+    maintainers = with maintainers; [ logger ];
   };
 }

--- a/pkgs/by-name/li/libusb1/package.nix
+++ b/pkgs/by-name/li/libusb1/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [
       prusnak
-      realsnick
+      logger
     ];
   };
 }

--- a/pkgs/development/python-modules/openaiauth/default.nix
+++ b/pkgs/development/python-modules/openaiauth/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/acheong08/OpenAIAuth";
     changelog = "https://github.com/acheong08/OpenAIAuth/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ realsnick ];
+    maintainers = with maintainers; [ logger ];
   };
 }

--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -58,7 +58,7 @@ python3.pkgs.buildPythonApplication rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       ulrikstrid
-      realsnick
+      logger
       chn
     ];
     mainProgram = "legion_gui";


### PR DESCRIPTION
This PR renames the maintainer handle from `realsnick` to `logger` and updates all package references accordingly.

This is a simple maintainer handle migration with no functional changes to any packages. The same maintainer (Ido Samuelson) will continue maintaining all affected packages, just with a shorter, simpler handle name.

### Changes Made:
- Renamed maintainer attribute from `realsnick` to `logger` in `maintainers/maintainer-list.nix`
- Applied formatting fixes to ensure proper alphabetical ordering
- Updated all package references in:
  - `pkgs/by-name/li/libusb1/package.nix`
  - `pkgs/by-name/fx/fxload/package.nix`
  - `pkgs/development/python-modules/openaiauth/default.nix`
  - `pkgs/os-specific/linux/lenovo-legion/app.nix`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### Testing Done:
- [x] Verified `builtins.hasAttr "logger"` returns `true`
- [x] Verified `builtins.hasAttr "realsnick"` returns `false`
- [x] Successfully built `fxload` package to test reference resolution
- [x] All maintainer references now point to the new `logger` handle
- [x] Applied formatting fixes with treefmt to pass CI linting

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test