### PR TITLE
buildGraalvm: fix native-image on darwin

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
@@ -224,7 +224,7 @@ let
           # -H:+StaticExecutableWithDynamicLibC is only available in Linux
           lib.optionalString (stdenv.hostPlatform.isLinux && !useMusl) ''
             echo "Ahead-Of-Time compilation with -H:+StaticExecutableWithDynamicLibC"
-            $out/bin/native-image -H:+UnlockExperimentalVMOptions -H:+StaticExecutableWithDynamicLibC -march=compatibility $extraNativeImageArgs HelloWorld
+            $out/bin/native-image -H:+UnlockExperimentalVMOptions -H:+StaticExecutableWithDynamicLibC -march=compatibility HelloWorld
             ./helloworld | fgrep 'Hello World'
           ''
         }
@@ -233,7 +233,7 @@ let
           # --static is only available in x86_64 Linux
           lib.optionalString (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64 && useMusl) ''
             echo "Ahead-Of-Time compilation with --static and --libc=musl"
-            $out/bin/native-image $extraNativeImageArgs -march=compatibility --libc=musl --static HelloWorld
+            $out/bin/native-image -march=compatibility --libc=musl --static HelloWorld
             ./helloworld | fgrep 'Hello World'
           ''
         }

--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
@@ -137,8 +137,8 @@ let
 
       postInstall =
         let
-          cLibsAsFlags = (map (l: "--add-flags '-H:CLibraryPath=${l}/lib'") cLibs);
-          preservedNixVariables = [
+          cLibsFlags = (map (l: "-H:CLibraryPath=${l}/lib") cLibs);
+          preservedNixVarFlags = [
             "-ENIX_BINTOOLS"
             "-ENIX_BINTOOLS_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}"
             "-ENIX_BUILD_CORES"
@@ -161,7 +161,6 @@ let
             "-EMACOSX_DEPLOYMENT_TARGET_FOR_TARGET"
             "-ENIX_APPLE_SDK_VERSION"
           ];
-          preservedNixVariablesAsFlags = (map (f: "--add-flags '${f}'") preservedNixVariables);
         in
         ''
           # jni.h expects jni_md.h to be in the header search path.
@@ -182,7 +181,7 @@ let
 
           wrapProgram $out/bin/native-image \
             --prefix PATH : ${binPath} \
-            ${toString (cLibsAsFlags ++ preservedNixVariablesAsFlags)}
+            --add-flags "${toString (cLibsFlags ++ preservedNixVarFlags)}"
         '';
 
       preFixup = lib.optionalString (stdenv.hostPlatform.isLinux) ''

--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
@@ -161,6 +161,10 @@ let
             "-EMACOSX_DEPLOYMENT_TARGET_FOR_TARGET"
             "-ENIX_APPLE_SDK_VERSION"
           ];
+          checkToolchainFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+            "-H:+UnlockExperimentalVMOptions"
+            "-H:-CheckToolchain"
+          ];
         in
         ''
           # jni.h expects jni_md.h to be in the header search path.
@@ -181,7 +185,7 @@ let
 
           wrapProgram $out/bin/native-image \
             --prefix PATH : ${binPath} \
-            --add-flags "${toString (cLibsFlags ++ preservedNixVarFlags)}"
+            --add-flags "${toString (cLibsFlags ++ preservedNixVarFlags ++ checkToolchainFlags)}"
         '';
 
       preFixup = lib.optionalString (stdenv.hostPlatform.isLinux) ''
@@ -216,7 +220,7 @@ let
         $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld | fgrep 'Hello World'
 
         echo "Ahead-Of-Time compilation"
-        $out/bin/native-image -H:+UnlockExperimentalVMOptions -H:-CheckToolchain -H:+ReportExceptionStackTraces -march=compatibility HelloWorld
+        $out/bin/native-image -H:+ReportExceptionStackTraces -march=compatibility HelloWorld
         ./helloworld | fgrep 'Hello World'
 
         ${


### PR DESCRIPTION
On Darwin, it is apparently Oracle's intention to be hostile towards
builds of Clang which are not by Apple.
    
see
- https://github.com/oracle/graal/issues/12041
    
If you want native-image to both work on Darwin and use the nix-provided CC
then you must pass it the flags to disable toolchain checking entirely.
Since the flags are mandatory for functionality,
they should be part of the wrapper.

Additional bits of cleanup:

- Simplifies the flag-handling code by using only one --add-flags,
rather than treating --add-flags like --add-flag by mapping it onto every flag

- Removes remaining uses of unset bash var $extraNativeImageArgs
which commit bc1bc1aa3 forgot to remove when deleting the var.

## Things done

Built on an M1 Macbook; tried using native-image to build [a clojure project](https://codeberg.org/jyn514/flower) in a nix-shell with clojure. Prior to this change, fails with the err in the above-linked Graal issue. After this change, it works, producing a native binary for that clojure project.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc