### PR TITLE
superlu: fix build with clang21

### DIFF
--- a/pkgs/by-name/su/superlu/package.nix
+++ b/pkgs/by-name/su/superlu/package.nix
@@ -7,10 +7,7 @@
   ninja,
   gfortran,
   blas,
-  lapack,
 }:
-
-assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "superlu";

--- a/pkgs/by-name/su/superlu/package.nix
+++ b/pkgs/by-name/su/superlu/package.nix
@@ -34,6 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # Prevent clang from crashing when compiling slatms.c from SuperLU’s matgen test code.
+  postPatch = lib.optionalString stdenv.cc.isClang ''
+    echo 'target_compile_options(matgen PRIVATE -fno-vectorize)' >> TESTING/MATGEN/CMakeLists.txt
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja

--- a/pkgs/by-name/su/superlu/package.nix
+++ b/pkgs/by-name/su/superlu/package.nix
@@ -45,11 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
     (lib.cmakeBool "enable_fortran" true)
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # prevent cmake from using Accelerate, which causes tests to segfault
     # https://github.com/xiaoyeli/superlu/issues/155
-    "-DBLA_VENDOR=Generic"
+    (lib.cmakeFeature "BLA_VENDOR" "Generic")
   ];
 
   doCheck = true;

--- a/pkgs/by-name/su/superlu/package.nix
+++ b/pkgs/by-name/su/superlu/package.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "superlu";
-  version = "7.0.0";
+  version = "7.0.1";
 
   src = fetchFromGitHub {
     owner = "xiaoyeli";
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     # * <https://github.com/xiaoyeli/superlu/blob/0bbd6571bd839d866bff6a8ff1eaa812a8c31463/License.txt#L32-L65>
     # * <https://salsa.debian.org/science-team/superlu/-/blob/0acab1b41f332f2f2e3b0b5d28ba7fc9f7539533/debian/copyright>
     postFetch = "rm $out/SRC/mc64ad.* $out/DOC/*.pdf";
-    hash = "sha256-iJiVyY+/vr6kll8FCunvZ8rKBj+w+Rnj4F696XW9xFc=";
+    hash = "sha256-MiQPhYIGZbvmtpIojrNzTG4Xao7lc4Ks/FtxlfdAKmQ=";
   };
 
   patches = [


### PR DESCRIPTION
clang21 crashes when compiling slatms.c from SuperLU’s matgen test code
A temporary fix is to disable the vectorize optimization in test target matgen.

cc https://github.com/NixOS/nixpkgs/pull/444862

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
