### PR TITLE
moxnotify: init at 0.1.0

### DIFF
--- a/pkgs/by-name/mo/moxnotify/package.nix
+++ b/pkgs/by-name/mo/moxnotify/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  clang,
+  libclang,
+  makeWrapper,
+  lua5_4,
+  dbus,
+  wayland,
+  wayland-protocols,
+  pipewire,
+  vulkan-loader,
+  libxkbcommon,
+  libGL,
+  sqlite,
+  fontconfig,
+  freetype,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "moxnotify";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mox-desktop";
+    repo = "moxnotify";
+    rev = "6726af08621072e0c95a147cf4ae63ea66c7e857";
+    hash = "sha256-tTgY/813WaW3K8QKbj6qwCVKOAA8zMqy97Q7Z5qA0JM=";
+  };
+
+  cargoHash = "sha256-o2YyPa7bX9585lsicJjhj1xJ1jMdU5mlxbEn/6zSy8U=";
+
+  nativeBuildInputs = [
+    pkg-config
+    clang
+    makeWrapper
+  ];
+
+  buildInputs = [
+    lua5_4
+    dbus
+    wayland
+    wayland-protocols
+    pipewire
+    vulkan-loader
+    libxkbcommon
+    libGL
+    sqlite
+    fontconfig
+    freetype
+    libclang.lib
+  ];
+
+  # Set LIBCLANG_PATH for bindgen
+  env.LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  # Workspace members - build both daemon and ctl
+  cargoBuildFlags = [ "--workspace" ];
+  cargoTestFlags = [ "--workspace" ];
+
+  # Skip tests for now as they may require display/audio systems
+  doCheck = false;
+
+  # Install both binaries with proper names
+  postInstall = ''
+    # Rename binaries to have more descriptive names
+    mv $out/bin/daemon $out/bin/moxnotify
+    mv $out/bin/ctl $out/bin/moxctl
+
+    # Install D-Bus service file
+    mkdir -p $out/share/dbus-1/services
+    substitute ${src}/pl.mox.notify.service.in $out/share/dbus-1/services/pl.mox.notify.service \
+      --replace-fail "@bindir@" "$out/bin"
+  '';
+
+  # Wrap binaries with runtime dependencies for graphics libraries
+  postFixup = ''
+    wrapProgram $out/bin/moxnotify \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          vulkan-loader
+          libGL
+        ]
+      }
+    wrapProgram $out/bin/moxctl \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          vulkan-loader
+          libGL
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Feature-rich hardware-accelerated keyboard driven Wayland notification daemon";
+    homepage = "https://github.com/mox-desktop/moxnotify";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ logger ];
+    platforms = lib.platforms.linux; # Wayland-specific, Linux only
+    mainProgram = "moxnotify";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds moxnotify, a feature-rich hardware-accelerated keyboard driven Wayland notification daemon.

### Demo

https://github.com/user-attachments/assets/1996d46c-85cc-4d47-bcf1-5088a58d2192

Features:
- VI bindings for keyboard navigation
- Per-notification configuration
- FreeDesktop Desktop Notifications Specification compliance
- Hardware acceleration via Vulkan
- Sound support via PipeWire
- Notification history
- Lua-based configuration

The package builds both the daemon (`moxnotify`) and control utility (`moxctl`) from the Rust workspace.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: Is sandbox = true set in nix.conf? (See Nix manual)
- [x] Tested, as applicable:
  - [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have been tested with the latest nixpkgs-review version
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] 24.05 Release Notes (or backporting 23.11 Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (New packages) Added a release notes entry with name, version, and short description
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Additional context

This notification daemon is designed for Wayland compositors and provides modern features like hardware acceleration and comprehensive keyboard control. It's a good alternative to mako or dunst for users who want more advanced notification management.

Based on PR #448384 (maintainer update realsnick -> logger).