### PR TITLE
singularity: remove un-needed backwards compat layer

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -12,16 +12,6 @@
   extraDescription ? "",
   extraMeta ? { },
 }:
-
-let
-  # Backward compatibility layer for the obsolete workaround of
-  # the "vendor-related attributes not overridable" issue (#86349),
-  # whose solution (#225051) is merged and released.
-  # TODO(@ShamrockLee): Remove after the Nixpkgs 25.05 branch-off.
-  _defaultGoVendorArgs = {
-    inherit vendorHash deleteVendor proxyVendor;
-  };
-in
 {
   lib,
   buildGoModule,
@@ -97,28 +87,9 @@ in
   #   "path/to/source/file1" = [ "<originalDefaultPath11>" "<originalDefaultPath12>" ... ];
   # }
   sourceFilesWithDefaultPaths ? { },
-  # Placeholders for the obsolete workaround of #86349
-  # TODO(@ShamrockLee): Remove after the Nixpkgs 25.05 branch-off.
-  vendorHash ? null,
-  deleteVendor ? null,
-  proxyVendor ? null,
-}@args:
+}:
 
 let
-  # Backward compatibility layer for the obsolete workaround of #86349
-  # TODO(@ShamrockLee): Convert to simple inheritance after the Nixpkgs 25.05 branch-off.
-  moduleArgsOverridingCompat =
-    argName:
-    if args.${argName} or null == null then
-      _defaultGoVendorArgs.${argName}
-    else
-      lib.warn
-        "${projectName}: Override ${argName} with .override is deprecated. Use .overrideAttrs instead."
-        args.${argName};
-  vendorHash = moduleArgsOverridingCompat "vendorHash";
-  deleteVendor = moduleArgsOverridingCompat "deleteVendor";
-  proxyVendor = moduleArgsOverridingCompat "proxyVendor";
-
   addShellDoubleQuotes = s: lib.escapeShellArg ''"'' + s + lib.escapeShellArg ''"'';
 in
 (buildGoModule {


### PR DESCRIPTION
Per the deleted comments, this was intended to be removed after 25.05. This doesn't actually cause a rebuild, but I still did try to make sure things worked properly.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
