### PR TITLE
luaPackages.buildLuarocksPackages: build package BEFORE testing package

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -435,6 +435,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 - `waydroid-nftables` is a new variant of `waydroid` that supports nftables instead of iptables.
   If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
 
+- `buildLuarocksPackage` now builds the package in the `buildPhase` rather than the `installPhase` so that the tests in `checkPhase` are ran after the package is built. This is because `luarocks test` expects compiled modules to be built already in order for tests to `require` them.
+
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/448437

This seems to be a working fix for the mentioned issue, but there may be a cleaner fix too idk

If I do not set installPhase at all it throws, so I left it as a blank phase.

Also hopefully this solves some of the flakiness in the tests when we update? Maybe maybe not.

But, yes. This does mean we were running tests on packages that did not have any build commands ran on them yet for quite a few years. Which, considering most lua tests require the finished package, is kinda a problem XD

I have looked through all the packages using an override on top of their generated buildLuarocksPackage derivation

I do not see any that override buildPhase or installPhase, and all the variables that were being set, are still being set

It will not break any generated unmodified calls to buildLuarocksPackage

I dont see buildLuarocksPackage used anywhere else.

I also picked some random packages, some compiled, some not, mostly ones with overrides. About 20. It seems fine?

This should cause no issues and will be a large improvement.

Before, it was not really possible to use buildLuarocksPackage with your compiled module AND use it to run your tests without making modifications. And when making those modifications, it was still needlessly difficult, as there is both a checkPhase AND a setupHook which runs them. I had to do the modification this PR does myself in an override instead of modifying the tests.

With this, you can and it works just fine.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
