### PR TITLE
pkgs-lib/formats/systemd: make format a function

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -253,6 +253,8 @@
 
 - The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.
 
+- Direct use of `pkgs.formats.systemd` has been deprecated, and should now be instantiated with `pkgs.formats.systemd { }` similarly to other items in `pkgs.formats`.
+
 - The Postfix module has been updated and likely requires configuration changes:
   - The `services.postfix.sslCert` and `sslKey` options were removed and you now need to configure
     - [services.postfix.settings.main.smtpd_tls_chain_files](#opt-services.postfix.settings.main.smtpd_tls_chain_files) for server certificates,

--- a/nixos/modules/system/boot/systemd/journald-remote.nix
+++ b/nixos/modules/system/boot/systemd/journald-remote.nix
@@ -7,7 +7,7 @@
 
 let
   cfg = config.services.journald.remote;
-  format = pkgs.formats.systemd;
+  format = pkgs.formats.systemd { };
 
   cliArgs = lib.cli.toGNUCommandLineShell { } {
     inherit (cfg) output;

--- a/nixos/modules/system/boot/systemd/journald-upload.nix
+++ b/nixos/modules/system/boot/systemd/journald-upload.nix
@@ -7,7 +7,7 @@
 
 let
   cfg = config.services.journald.upload;
-  format = pkgs.formats.systemd;
+  format = pkgs.formats.systemd { };
 in
 {
   meta.maintainers = [ lib.maintainers.raitobezarius ];

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -425,10 +425,22 @@ optionalAttrs allowAliases aliases
     let
       mkValueString = mkValueStringDefault { };
       mkKeyValue = k: v: if v == null then "# ${k} is unset" else "${k} = ${mkValueString v}";
+
+      rawFormat = ini {
+        listsAsDuplicateKeys = true;
+        inherit mkKeyValue;
+      };
     in
-    ini {
-      listsAsDuplicateKeys = true;
-      inherit mkKeyValue;
+    rawFormat
+    // {
+      generate =
+        name: value:
+        lib.warn
+          "Direct use of `pkgs.formats.systemd` has been deprecated, please use `pkgs.formats.systemd { }` instead."
+          rawFormat.generate
+          name
+          value;
+      __functor = self: { }: rawFormat;
     };
 
   keyValue =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`pkgs.formats.systemd` does not follow the usual pattern of formats being functions. This fixes both the formats and its usage within nixpkgs.

There is unfortunately [a bit of usage outside of nixpkgs already](https://github.com/search?q=lang%3Anix+formats.systemd+-is%3Afork&type=code), but even there there is an example of someone trying to use it as a function...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
