### PR TITLE
basalt-monado: 0-unstable-2024-06-21 -> 0-unstable-2025-09-25

### DIFF
--- a/pkgs/by-name/ba/basalt-monado/package.nix
+++ b/pkgs/by-name/ba/basalt-monado/package.nix
@@ -27,14 +27,14 @@
 }:
 stdenv.mkDerivation {
   pname = "basalt-monado";
-  version = "0-unstable-2024-06-21";
+  version = "0-unstable-2025-09-25";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mateosss";
     repo = "basalt";
-    rev = "385c161f35720df3a6c606054565f9d49a1c5787";
-    hash = "sha256-+2/pc2OWDwE04xPcfHL5GGyhQ1ZTN6o7cCNAilDgd2Y=";
+    rev = "5337898271f5c2ce523258e93e80fd870130be31";
+    hash = "sha256-IoXZlXyOc5y9aSHBU3WCNhHi4L9xzHmbv6VMEvX2ZeE=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/mateosss/basalt/-/compare/385c161f35720df3a6c606054565f9d49a1c5787...5337898271f5c2ce523258e93e80fd870130be31?from_project_id=11632

Bumping to new unstable rev for CMake 4 compat. Tracking issue: #445447

I don't have a headset that uses SLAM tracking to do proper testing with.

Build was failing in `thirdparty/basalt-headers/thirdparty/Sophus/CMakeLists.txt`:

```
      > -- Using Eigen3 from: /build/source/thirdparty/basalt-headers/thirdparty/eigen (include: $<BUILD_INTERFACE:/build/source/thirdparty/basalt-headers/thirdparty/eigen>;$<INSTALL_INTERFACE:include/eigen3>)
       > -- Including internal Sophus from submodule
       > CMake Error at thirdparty/basalt-headers/thirdparty/Sophus/CMakeLists.txt:1 (cmake_minimum_required):
       >   Compatibility with CMake < 3.5 has been removed from CMake.
       >
       >   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
       >   to tell CMake that the project requires at least <min> but has been updated
       >   to work with policies introduced by <max> or earlier.
       >
       >   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
       >
       > 
       > -- Configuring incomplete, errors occurred!
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- **Sorta?** Tested basic functionality of all binary files, usually in `./result/bin/`. Tested monado which loads the .so but not actual SLAM tracking.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
