### PR TITLE
[25.05] qt6: 6.9.2 -> 6.9.3

### DIFF
--- a/pkgs/development/libraries/qt-6/fetch.sh
+++ b/pkgs/development/libraries/qt-6/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.qt.io/official_releases/qt/6.9/6.9.2/submodules/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -37,6 +37,11 @@ qtModule {
     })
     # add version specific QML import path
     ./use-versioned-import-path.patch
+
+    # Fix common crash
+    # Manual backport of https://invent.kde.org/qt/qt/qtdeclarative/-/commit/b1ee7061ba77a7f5dc4148129bb2083f5c28e039
+    # https://bugreports.qt.io/browse/QTBUG-140018
+    ./stackview-crash.patch
   ];
 
   preConfigure =

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/stackview-crash.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/stackview-crash.patch
@@ -1,0 +1,473 @@
+diff --git a/src/quicktemplates/qquickstackelement.cpp b/src/quicktemplates/qquickstackelement.cpp
+index f6a5ffdd74..304bafe4ef 100644
+--- a/src/quicktemplates/qquickstackelement.cpp
++++ b/src/quicktemplates/qquickstackelement.cpp
+@@ -39,7 +39,10 @@ protected:
+     void setInitialState(QObject *object) override
+     {
+         auto privIncubator = QQmlIncubatorPrivate::get(this);
+-        element->incubate(object, privIncubator->requiredProperties());
++        if (QQmlEnginePrivate *enginePriv = privIncubator->enginePriv) {
++            element->incubate(enginePriv->v4engine(), object,
++                              privIncubator->requiredProperties());
++        }
+     }
+ 
+ private:
+@@ -90,7 +93,8 @@ QQuickStackElement::~QQuickStackElement()
+ #endif
+ }
+ 
+-QQuickStackElement *QQuickStackElement::fromString(const QString &str, QQuickStackView *view, QString *error)
++QQuickStackElement *QQuickStackElement::fromString(
++        QQmlEngine *engine, const QString &str, QQuickStackView *view, QString *error)
+ {
+     QUrl url(str);
+     if (!url.isValid()) {
+@@ -102,7 +106,7 @@ QQuickStackElement *QQuickStackElement::fromString(const QString &str, QQuickSta
+         url = qmlContext(view)->resolvedUrl(url);
+ 
+     QQuickStackElement *element = new QQuickStackElement;
+-    element->component = new QQmlComponent(qmlEngine(view), url, view);
++    element->component = new QQmlComponent(engine, url, view);
+     element->ownComponent = true;
+     return element;
+ }
+@@ -127,7 +131,8 @@ QQuickStackElement *QQuickStackElement::fromObject(QObject *object, QQuickStackV
+     return element;
+ }
+ 
+-QQuickStackElement *QQuickStackElement::fromStackViewArg(QQuickStackView *view, QQuickStackViewArg arg)
++QQuickStackElement *QQuickStackElement::fromStackViewArg(
++        QQmlEngine *engine, QQuickStackView *view, QQuickStackViewArg arg)
+ {
+     QQuickStackElement *element = new QQuickStackElement;
+ #if QT_CONFIG(quick_viewtransitions)
+@@ -144,7 +149,7 @@ QQuickStackElement *QQuickStackElement::fromStackViewArg(QQuickStackView *view,
+ 
+         Q_ASSERT(!arg.mUrl.isValid());
+     } else if (arg.mUrl.isValid()) {
+-        element->component = new QQmlComponent(qmlEngine(view), arg.mUrl, view);
++        element->component = new QQmlComponent(engine, arg.mUrl, view);
+         element->ownComponent = true;
+     } else {
+         qFatal("No Item, Component or URL set on arg passed to fromStrictArg");
+@@ -152,7 +157,7 @@ QQuickStackElement *QQuickStackElement::fromStackViewArg(QQuickStackView *view,
+     return element;
+ }
+ 
+-bool QQuickStackElement::load(QQuickStackView *parent)
++bool QQuickStackElement::load(QV4::ExecutionEngine *v4, QQuickStackView *parent)
+ {
+     setView(parent);
+     if (!item) {
+@@ -161,7 +166,7 @@ bool QQuickStackElement::load(QQuickStackView *parent)
+         if (component->isLoading()) {
+             QObject::connect(component, &QQmlComponent::statusChanged, [this](QQmlComponent::Status status) {
+                 if (status == QQmlComponent::Ready)
+-                    load(view);
++                    load(component->engine()->handle(), view);
+                 else if (status == QQmlComponent::Error)
+                     QQuickStackViewPrivate::get(view)->warn(component->errorString().trimmed());
+             });
+@@ -177,22 +182,24 @@ bool QQuickStackElement::load(QQuickStackView *parent)
+         if (component->isError())
+             QQuickStackViewPrivate::get(parent)->warn(component->errorString().trimmed());
+     } else {
+-        initialize(/*required properties=*/nullptr);
++        initialize(v4, /*required properties=*/nullptr);
+     }
+     return item;
+ }
+ 
+-void QQuickStackElement::incubate(QObject *object, RequiredProperties *requiredProperties)
++void QQuickStackElement::incubate(
++        QV4::ExecutionEngine *v4, QObject *object, RequiredProperties *requiredProperties)
+ {
+     item = qmlobject_cast<QQuickItem *>(object);
+     if (item) {
+         QQmlEngine::setObjectOwnership(item, QQmlEngine::CppOwnership);
+         item->setParent(view);
+-        initialize(requiredProperties);
++        initialize(v4, requiredProperties);
+     }
+ }
+ 
+-void QQuickStackElement::initialize(RequiredProperties *requiredProperties)
++void QQuickStackElement::initialize(
++        QV4::ExecutionEngine *v4, RequiredProperties *requiredProperties)
+ {
+     if (!item || init)
+         return;
+@@ -205,11 +212,8 @@ void QQuickStackElement::initialize(RequiredProperties *requiredProperties)
+     item->setParentItem(view);
+ 
+     if (!properties.isUndefined()) {
+-        QQmlEngine *engine = qmlEngine(view);
+-        Q_ASSERT(engine);
+-        QV4::ExecutionEngine *v4 = QQmlEnginePrivate::getV4Engine(engine);
+-        Q_ASSERT(v4);
+         QV4::Scope scope(v4);
++        Q_ASSERT(scope.engine);
+         QV4::ScopedValue ipv(scope, properties.value());
+         QV4::Scoped<QV4::QmlContext> qmlContext(scope, qmlCallingContext.value());
+         QV4::ScopedValue qmlObject(scope, QV4::QObjectWrapper::wrap(v4, item));
+diff --git a/src/quicktemplates/qquickstackelement_p_p.h b/src/quicktemplates/qquickstackelement_p_p.h
+index 5af8149d91..2986a78569 100644
+--- a/src/quicktemplates/qquickstackelement_p_p.h
++++ b/src/quicktemplates/qquickstackelement_p_p.h
+@@ -43,13 +43,14 @@ class QQuickStackElement :
+ public:
+     ~QQuickStackElement();
+ 
+-    static QQuickStackElement *fromString(const QString &str, QQuickStackView *view, QString *error);
++    static QQuickStackElement *fromString(QQmlEngine *engine, const QString &str, QQuickStackView *view, QString *error);
+     static QQuickStackElement *fromObject(QObject *object, QQuickStackView *view, QString *error);
+-    static QQuickStackElement *fromStackViewArg(QQuickStackView *view, QQuickStackViewArg arg);
++    static QQuickStackElement *fromStackViewArg(QQmlEngine *engine, QQuickStackView *view, QQuickStackViewArg arg);
+ 
+-    bool load(QQuickStackView *parent);
+-    void incubate(QObject *object, RequiredProperties *requiredProperties);
+-    void initialize(RequiredProperties *requiredProperties);
++    bool load(QV4::ExecutionEngine *v4, QQuickStackView *parent);
++    void incubate(
++            QV4::ExecutionEngine *v4, QObject *object, RequiredProperties *requiredProperties);
++    void initialize(QV4::ExecutionEngine *v4, RequiredProperties *requiredProperties);
+ 
+     void setIndex(int index);
+     void setView(QQuickStackView *view);
+diff --git a/src/quicktemplates/qquickstackview.cpp b/src/quicktemplates/qquickstackview.cpp
+index cb8854dca8..a0909b7fcb 100644
+--- a/src/quicktemplates/qquickstackview.cpp
++++ b/src/quicktemplates/qquickstackview.cpp
+@@ -457,8 +457,12 @@ QQuickItem *QQuickStackView::get(int index, LoadBehavior behavior)
+     Q_D(QQuickStackView);
+     QQuickStackElement *element = d->elements.value(index);
+     if (element) {
+-        if (behavior == ForceLoad)
+-            element->load(this);
++        if (behavior == ForceLoad) {
++            // It's possible for a slot to still be connected during destruction of the receiver's
++            // parent (QTBUG-140018), so only try to load new things if our engine is alive.
++            if (QQmlEngine *engine = qmlEngine(this))
++                element->load(engine->handle(), this);
++        }
+         return element->item;
+     }
+     return nullptr;
+@@ -492,7 +496,7 @@ QQuickItem *QQuickStackView::find(const QJSValue &callback, LoadBehavior behavio
+     for (int i = d->elements.size() - 1; i >= 0; --i) {
+         QQuickStackElement *element = d->elements.at(i);
+         if (behavior == ForceLoad)
+-            element->load(this);
++            element->load(engine->handle(), this);
+         if (element->item) {
+             QJSValue rv = func.call(QJSValueList() << engine->newQObject(element->item) << i);
+             if (rv.toBool())
+@@ -624,7 +628,7 @@ void QQuickStackView::push(QQmlV4FunctionPtr args)
+ #endif
+ 
+     int oldDepth = d->elements.size();
+-    if (d->pushElements(elements)) {
++    if (d->pushElements(v4, elements)) {
+         d->depthChange(d->elements.size(), oldDepth);
+         QQuickStackElement *enter = d->elements.top();
+ #if QT_CONFIG(quick_viewtransitions)
+@@ -737,7 +741,7 @@ void QQuickStackView::pop(QQmlV4FunctionPtr args)
+ 
+     QPointer<QQuickItem> previousItem;
+ 
+-    if (d->popElements(enter)) {
++    if (d->popElements(v4, enter)) {
+         if (exit) {
+             exit->removal = true;
+             d->removing.insert(exit);
+@@ -907,7 +911,7 @@ void QQuickStackView::replace(QQmlV4FunctionPtr args)
+     if (!d->elements.isEmpty())
+         exit = d->elements.pop();
+ 
+-    if (exit != target ? d->replaceElements(target, elements) : d->pushElements(elements)) {
++    if (exit != target ? d->replaceElements(v4, target, elements) : d->pushElements(v4, elements)) {
+         d->depthChange(d->elements.size(), oldDepth);
+         if (exit) {
+             exit->removal = true;
+@@ -991,10 +995,14 @@ QQuickItem *QQuickStackView::pushItems(QList<QQuickStackViewArg> args, Operation
+         return nullptr;
+     }
+ 
++    QQmlEngine *engine = qmlEngine(this);
++    if (!engine)
++        return nullptr;
++
+     QScopedValueRollback<bool> modifyingElements(d->modifyingElements, true);
+     QScopedValueRollback<QString> operationNameRollback(d->operation, operationName);
+ 
+-    const QList<QQuickStackElement *> stackElements = d->parseElements(args);
++    const QList<QQuickStackElement *> stackElements = d->parseElements(engine, args);
+ 
+ #if QT_CONFIG(quick_viewtransitions)
+     QQuickStackElement *exit = nullptr;
+@@ -1003,7 +1011,7 @@ QQuickItem *QQuickStackView::pushItems(QList<QQuickStackViewArg> args, Operation
+ #endif
+ 
+     const int oldDepth = d->elements.size();
+-    if (d->pushElements(stackElements)) {
++    if (d->pushElements(engine->handle(), stackElements)) {
+         d->depthChange(d->elements.size(), oldDepth);
+         QQuickStackElement *enter = d->elements.top();
+ #if QT_CONFIG(quick_viewtransitions)
+@@ -1109,7 +1117,11 @@ QQuickItem *QQuickStackView::pushItem(const QUrl &url, const QVariantMap &proper
+ QQuickItem *QQuickStackView::popToItem(QQuickItem *item, Operation operation)
+ {
+     Q_D(QQuickStackView);
+-    return d->popToItem(item, operation, QQuickStackViewPrivate::CurrentItemPolicy::DoNotPop);
++    QQmlEngine *engine = qmlEngine(this);
++    if (!engine)
++        return nullptr;
++    return d->popToItem(
++            engine->handle(), item, operation, QQuickStackViewPrivate::CurrentItemPolicy::DoNotPop);
+ }
+ 
+ /*!
+@@ -1149,8 +1161,13 @@ QQuickItem *QQuickStackView::popToIndex(int index, Operation operation)
+     }
+ 
+     QQuickStackElement *element = d->elements.at(index);
+-    element->load(this);
+-    return d->popToItem(element->item, operation, QQuickStackViewPrivate::CurrentItemPolicy::Pop);
++    QQmlEngine *engine = qmlEngine(this);
++    if (!engine)
++        return nullptr;
++    QV4::ExecutionEngine *v4 = engine->handle();
++    element->load(v4, this);
++    return d->popToItem(
++            v4, element->item, operation, QQuickStackViewPrivate::CurrentItemPolicy::Pop);
+ }
+ 
+ /*!
+@@ -1178,7 +1195,13 @@ QQuickItem *QQuickStackView::popCurrentItem(Operation operation)
+         clear(operation);
+         return lastItemRemoved;
+     }
+-    return d->popToItem(d->currentItem, operation, QQuickStackViewPrivate::CurrentItemPolicy::Pop);
++
++    QQmlEngine *engine = qmlEngine(this);
++    if (!engine)
++        return nullptr;
++    return d->popToItem(
++            engine->handle(), d->currentItem, operation,
++            QQuickStackViewPrivate::CurrentItemPolicy::Pop);
+ }
+ 
+ /*!
+@@ -1232,12 +1255,16 @@ QQuickItem *QQuickStackView::replaceCurrentItem(const QList<QQuickStackViewArg>
+         return nullptr;
+     }
+ 
++    QQmlEngine *engine = qmlEngine(this);
++    if (!engine)
++        return nullptr;
++
+     QScopedValueRollback<bool> modifyingElements(d->modifyingElements, true);
+     QScopedValueRollback<QString> operationNameRollback(d->operation, operationName);
+ 
+     QQuickStackElement *currentElement = !d->elements.isEmpty() ? d->elements.top() : nullptr;
+ 
+-    const QList<QQuickStackElement *> stackElements = d->parseElements(args);
++    const QList<QQuickStackElement *> stackElements = d->parseElements(engine, args);
+ 
+     int oldDepth = d->elements.size();
+     QQuickStackElement* exit = nullptr;
+@@ -1245,8 +1272,8 @@ QQuickItem *QQuickStackView::replaceCurrentItem(const QList<QQuickStackViewArg>
+         exit = d->elements.pop();
+ 
+     const bool successfullyReplaced = exit != currentElement
+-        ? d->replaceElements(currentElement, stackElements)
+-        : d->pushElements(stackElements);
++        ? d->replaceElements(engine->handle(), currentElement, stackElements)
++        : d->pushElements(engine->handle(), stackElements);
+     if (successfullyReplaced) {
+         d->depthChange(d->elements.size(), oldDepth);
+         if (exit) {
+@@ -1607,14 +1634,19 @@ void QQuickStackView::componentComplete()
+     QQuickStackElement *element = nullptr;
+     QString error;
+     int oldDepth = d->elements.size();
++
++    QQmlEngine *engine = qmlEngine(this);
++    if (!engine)
++        return;
++
+     if (QObject *o = d->initialItem.toQObject())
+         element = QQuickStackElement::fromObject(o, this, &error);
+     else if (d->initialItem.isString())
+-        element = QQuickStackElement::fromString(d->initialItem.toString(), this, &error);
++        element = QQuickStackElement::fromString(engine, d->initialItem.toString(), this, &error);
+     if (!error.isEmpty()) {
+         d->warn(error);
+         delete element;
+-    } else if (d->pushElement(element)) {
++    } else if (d->pushElement(engine->handle(), element)) {
+         d->depthChange(d->elements.size(), oldDepth);
+         d->setCurrentItem(element);
+         element->setStatus(QQuickStackView::Active);
+diff --git a/src/quicktemplates/qquickstackview_p.cpp b/src/quicktemplates/qquickstackview_p.cpp
+index 0288ff1f4b..8f08f29168 100644
+--- a/src/quicktemplates/qquickstackview_p.cpp
++++ b/src/quicktemplates/qquickstackview_p.cpp
+@@ -109,7 +109,8 @@ QList<QQuickStackElement *> QQuickStackViewPrivate::parseElements(int from, QQml
+     return elements;
+ }
+ 
+-QList<QQuickStackElement *> QQuickStackViewPrivate::parseElements(const QList<QQuickStackViewArg> &args)
++QList<QQuickStackElement *> QQuickStackViewPrivate::parseElements(
++        QQmlEngine *engine, const QList<QQuickStackViewArg> &args)
+ {
+     Q_Q(QQuickStackView);
+     QList<QQuickStackElement *> stackElements;
+@@ -141,8 +142,8 @@ QList<QQuickStackElement *> QQuickStackViewPrivate::parseElements(const QList<QQ
+             return {};
+         }
+ 
+-        QQuickStackElement *element = QQuickStackElement::fromStackViewArg(q, arg);
+-        QV4::ExecutionEngine *v4Engine = qmlEngine(q)->handle();
++        QQuickStackElement *element = QQuickStackElement::fromStackViewArg(engine, q, arg);
++        QV4::ExecutionEngine *v4Engine = engine->handle();
+         element->properties.set(v4Engine, v4Engine->fromVariant(properties));
+         element->qmlCallingContext.set(v4Engine, v4Engine->qmlContext());
+         stackElements.append(element);
+@@ -183,28 +184,33 @@ static QString resolvedUrl(const QString &str, const QQmlRefPointer<QQmlContextD
+     return str;
+ }
+ 
+-QQuickStackElement *QQuickStackViewPrivate::createElement(const QV4::Value &value, const QQmlRefPointer<QQmlContextData> &context, QString *error)
++QQuickStackElement *QQuickStackViewPrivate::createElement(
++        const QV4::Value &value, const QQmlRefPointer<QQmlContextData> &context, QString *error)
+ {
+     Q_Q(QQuickStackView);
+     if (const QV4::String *s = value.as<QV4::String>())
+-        return QQuickStackElement::fromString(resolvedUrl(s->toQString(), context), q, error);
++        return QQuickStackElement::fromString(
++                s->engine()->qmlEngine(), resolvedUrl(s->toQString(), context), q, error);
+     if (const QV4::QObjectWrapper *o = value.as<QV4::QObjectWrapper>())
+         return QQuickStackElement::fromObject(o->object(), q, error);
+     if (const QV4::UrlObject *u = value.as<QV4::UrlObject>())
+-        return QQuickStackElement::fromString(resolvedUrl(u->href(), context), q, error);
++        return QQuickStackElement::fromString(
++                u->engine()->qmlEngine(), resolvedUrl(u->href(), context), q, error);
+ 
+-    if (value.as<QV4::Object>()) {
++    if (const QV4::Object *o = value.as<QV4::Object>()) {
+         const QVariant data = QV4::ExecutionEngine::toVariant(value, QMetaType::fromType<QUrl>());
+         if (data.typeId() == QMetaType::QUrl) {
+-            return QQuickStackElement::fromString(resolvedUrl(data.toUrl(), context).toString(), q,
+-                                                  error);
++            return QQuickStackElement::fromString(
++                    o->engine()->qmlEngine(), resolvedUrl(data.toUrl(), context).toString(), q,
++                    error);
+         }
+     }
+ 
+     return nullptr;
+ }
+ 
+-bool QQuickStackViewPrivate::pushElements(const QList<QQuickStackElement *> &elems)
++bool QQuickStackViewPrivate::pushElements(
++        QV4::ExecutionEngine *v4, const QList<QQuickStackElement *> &elems)
+ {
+     Q_Q(QQuickStackView);
+     if (!elems.isEmpty()) {
+@@ -212,19 +218,19 @@ bool QQuickStackViewPrivate::pushElements(const QList<QQuickStackElement *> &ele
+             e->setIndex(elements.size());
+             elements += e;
+         }
+-        return elements.top()->load(q);
++        return elements.top()->load(v4, q);
+     }
+     return false;
+ }
+ 
+-bool QQuickStackViewPrivate::pushElement(QQuickStackElement *element)
++bool QQuickStackViewPrivate::pushElement(QV4::ExecutionEngine *v4, QQuickStackElement *element)
+ {
+     if (element)
+-        return pushElements(QList<QQuickStackElement *>() << element);
++        return pushElements(v4, QList<QQuickStackElement *>() << element);
+     return false;
+ }
+ 
+-bool QQuickStackViewPrivate::popElements(QQuickStackElement *element)
++bool QQuickStackViewPrivate::popElements(QV4::ExecutionEngine *v4, QQuickStackElement *element)
+ {
+     Q_Q(QQuickStackView);
+     while (elements.size() > 1 && elements.top() != element) {
+@@ -232,10 +238,12 @@ bool QQuickStackViewPrivate::popElements(QQuickStackElement *element)
+         if (!element)
+             break;
+     }
+-    return elements.top()->load(q);
++    return elements.top()->load(v4, q);
+ }
+ 
+-bool QQuickStackViewPrivate::replaceElements(QQuickStackElement *target, const QList<QQuickStackElement *> &elems)
++bool QQuickStackViewPrivate::replaceElements(
++        QV4::ExecutionEngine *v4, QQuickStackElement *target,
++        const QList<QQuickStackElement *> &elems)
+ {
+     if (target) {
+         while (!elements.isEmpty()) {
+@@ -245,10 +253,12 @@ bool QQuickStackViewPrivate::replaceElements(QQuickStackElement *target, const Q
+                 break;
+         }
+     }
+-    return pushElements(elems);
++    return pushElements(v4, elems);
+ }
+ 
+-QQuickItem *QQuickStackViewPrivate::popToItem(QQuickItem *item, QQuickStackView::Operation operation, CurrentItemPolicy currentItemPolicy)
++QQuickItem *QQuickStackViewPrivate::popToItem(
++        QV4::ExecutionEngine *v4, QQuickItem *item, QQuickStackView::Operation operation,
++        CurrentItemPolicy currentItemPolicy)
+ {
+     const QString operationName = QStringLiteral("pop");
+     if (modifyingElements) {
+@@ -301,7 +311,7 @@ QQuickItem *QQuickStackViewPrivate::popToItem(QQuickItem *item, QQuickStackView:
+     }
+ 
+     QQuickItem *previousItem = nullptr;
+-    if (popElements(enter)) {
++    if (popElements(v4, enter)) {
+         if (exit) {
+             exit->removal = true;
+             removing.insert(exit);
+diff --git a/src/quicktemplates/qquickstackview_p_p.h b/src/quicktemplates/qquickstackview_p_p.h
+index 4ae849aa20..8bb95760a4 100644
+--- a/src/quicktemplates/qquickstackview_p_p.h
++++ b/src/quicktemplates/qquickstackview_p_p.h
+@@ -50,20 +50,20 @@ public:
+     void setCurrentItem(QQuickStackElement *element);
+ 
+     QList<QQuickStackElement *> parseElements(int from, QQmlV4FunctionPtr args, QStringList *errors);
+-    QList<QQuickStackElement *> parseElements(const QList<QQuickStackViewArg> &args);
++    QList<QQuickStackElement *> parseElements(QQmlEngine *engine, const QList<QQuickStackViewArg> &args);
+     QQuickStackElement *findElement(QQuickItem *item) const;
+     QQuickStackElement *findElement(const QV4::Value &value) const;
+     QQuickStackElement *createElement(const QV4::Value &value, const QQmlRefPointer<QQmlContextData> &context, QString *error);
+-    bool pushElements(const QList<QQuickStackElement *> &elements);
+-    bool pushElement(QQuickStackElement *element);
+-    bool popElements(QQuickStackElement *element);
+-    bool replaceElements(QQuickStackElement *element, const QList<QQuickStackElement *> &elements);
++    bool pushElements(QV4::ExecutionEngine *v4, const QList<QQuickStackElement *> &elements);
++    bool pushElement(QV4::ExecutionEngine *v4, QQuickStackElement *element);
++    bool popElements(QV4::ExecutionEngine *v4, QQuickStackElement *element);
++    bool replaceElements(QV4::ExecutionEngine *v4, QQuickStackElement *element, const QList<QQuickStackElement *> &elements);
+ 
+     enum class CurrentItemPolicy {
+         DoNotPop,
+         Pop
+     };
+-    QQuickItem *popToItem(QQuickItem *item, QQuickStackView::Operation operation, CurrentItemPolicy currentItemPolicy);
++    QQuickItem *popToItem(QV4::ExecutionEngine *v4, QQuickItem *item, QQuickStackView::Operation operation, CurrentItemPolicy currentItemPolicy);
+ 
+ #if QT_CONFIG(quick_viewtransitions)
+     void ensureTransitioner();

--- a/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtmqtt.nix
@@ -6,13 +6,13 @@
 
 qtModule rec {
   pname = "qtmqtt";
-  version = "6.9.2";
+  version = "6.9.3";
 
   src = fetchFromGitHub {
     owner = "qt";
     repo = "qtmqtt";
     tag = "v${version}";
-    hash = "sha256-/qz93JmMkJW3+lzT+QKvb/VL+xmbg5H8kKaXK+XN2nE=";
+    hash = "sha256-xzh2cNPlGe0VlCdNN1u8vBi+Uq+U2oa2bskAJQTt0ik=";
   };
 
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -115,13 +115,11 @@ qtModule {
     # Reproducibility QTBUG-136068
     ./gn-object-sorted.patch
 
-    # Revert "Create EGLImage with eglCreateDRMImageMESA() for exporting dma_buf"
-    # Mesa 25.2 dropped eglCreateDRMImageMESA, so this no longer works.
-    # There are better ways to do this, but this is the easy fix for now.
+    # Fix GPU rendering with Mesa 25.2
+    # https://bugreports.qt.io/browse/QTBUG-139424
     (fetchpatch {
-      url = "https://invent.kde.org/qt/qt/qtwebengine/-/commit/ddcd30454aa6338d898c9d20c8feb48f36632e16.diff";
-      revert = true;
-      hash = "sha256-ht7C3GIEaPtmMGLzQKOtMqE9sLKdqqYCgi/W6b430YU=";
+      url = "https://invent.kde.org/qt/qt/qtwebengine/-/commit/3cc88e0f85113e38ccb1bfdadb7d150c2389b1bc.diff";
+      hash = "sha256-5tKZ6b93VP4mKVc7jctrbW5Ktl+4Mjxw6bK1ajY62zQ=";
     })
   ];
 

--- a/pkgs/development/libraries/qt-6/srcs.nix
+++ b/pkgs/development/libraries/qt-6/srcs.nix
@@ -4,315 +4,315 @@
 
 {
   qt3d = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qt3d-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0ndn5fbsfj2vbcq3siq1gnk2rgblicd6ri2jrh9g41anicxh4vma";
-      name = "qt3d-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qt3d-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1zvzc88gykbqmks5q06zl9113lvy07gxsxmzmvpd8y8sybfn91ky";
+      name = "qt3d-everywhere-src-6.9.3.tar.xz";
     };
   };
   qt5compat = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qt5compat-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0q2vly836wgs462czw7lg0ysf2h48iwbdy43wwf2gz49qq2rja6b";
-      name = "qt5compat-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qt5compat-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0qa4s1m9f0qzs6msrilpi12wv5hpkgw211s0cqsiqaf24hhsq789";
+      name = "qt5compat-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtactiveqt-everywhere-src-6.9.2.tar.xz";
-      sha256 = "003vgfxswi6cpdp9i8kdzm1n34cbrbzlap4sg9h1ap0i9is51s1w";
-      name = "qtactiveqt-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtactiveqt-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1kzc0pqwyi1h1s8qk8agplfkrib2s9cg7bwpl41z8icngwj76h6v";
+      name = "qtactiveqt-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtbase = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtbase-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0h149x8l2ywfr5m034n20z6cjxnldary39x0vv22jhg0ryg9rgj4";
-      name = "qtbase-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtbase-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0vnwp12wvsab1vsn8zhi4mcvrpg5iacq59xzzs0w0vimc3va58f5";
+      name = "qtbase-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtcharts = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtcharts-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0jzzlh0jq5fidgs9r4aqpilyj0nan30r1d0pigp1hgz7cigz20cz";
-      name = "qtcharts-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtcharts-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0lsckms5s0av6dy8mll7bnspsigz6hpvbddm79n2wshxnfywpmr9";
+      name = "qtcharts-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtconnectivity-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0qq4d8hn6s8bb9r2gglb6gzq6isbb13knqh7n2s2wsnx8rqwdzwa";
-      name = "qtconnectivity-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtconnectivity-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1xfp3p5xkypxfgzvq2a5zcnyc7ms5gav99z5qmb48k0pzdgbl6z2";
+      name = "qtconnectivity-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtdatavis3d-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0p6bvia085hx3jb1la06c2q48m9i897r1a1mf6bi2hbmm2hirzsx";
-      name = "qtdatavis3d-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtdatavis3d-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1v5zdwjpz8j7s1nrkg7sp452vmdmhq09kdxvbsya2ad6jsw4ajxa";
+      name = "qtdatavis3d-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtdeclarative-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0r16qima008y2999r1djvwry01l295nmwwhqg081d2fr1cn2szs7";
-      name = "qtdeclarative-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtdeclarative-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0q52z2iiqdchsvvcs7w6mq38v0ahv2h5jyvbjxfbzbr9f8i1n1ss";
+      name = "qtdeclarative-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtdoc = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtdoc-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0qng2lsqmrrj8n85aqh8vl4nlzc23va9hynvvf6gqr35anvbpniz";
-      name = "qtdoc-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtdoc-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0am13lnmfxqj8ayx9ml5sm2qagl5s6hrki3bvdxfmzfkl07ds694";
+      name = "qtdoc-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtgraphs = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtgraphs-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0wsa4iar52dhiilyl053j7lmsw3xdn47b0pjrylb5a0ij1izp057";
-      name = "qtgraphs-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtgraphs-everywhere-src-6.9.3.tar.xz";
+      sha256 = "13041r244h3mgs95zcyw5x7lfginf4gxs59spz030p0jap867p2h";
+      name = "qtgraphs-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtgrpc = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtgrpc-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0r1z6lbjcsgxhvzylpr8z8wl44ql14ajf99n1hfvf4gy4f43qgd4";
-      name = "qtgrpc-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtgrpc-everywhere-src-6.9.3.tar.xz";
+      sha256 = "00py189v3ihpy9cj51sxapl2dp3ci7k04ikjl6zbxmbjrdwwhqvr";
+      name = "qtgrpc-everywhere-src-6.9.3.tar.xz";
     };
   };
   qthttpserver = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qthttpserver-everywhere-src-6.9.2.tar.xz";
-      sha256 = "06a0f7j1b309xffw3rwydz8lpzxnf5jg67savswskzbd3lfzlhqk";
-      name = "qthttpserver-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qthttpserver-everywhere-src-6.9.3.tar.xz";
+      sha256 = "13rfvmh42h4zd2slb2d0xqdy7wgsy05q8jqy3ldbikx5vf9qg9vs";
+      name = "qthttpserver-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtimageformats = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtimageformats-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0fciahs4i0nn5z0j624gkfncqg6byxswj45bw81drpjp5xz3y0la";
-      name = "qtimageformats-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtimageformats-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1zigaz2418sy6m3na91rddxvlfn3257535kq120f9f6lzgdnpcjg";
+      name = "qtimageformats-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtlanguageserver = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtlanguageserver-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1vlb0qn53y1b4zf7zkpxdvdh5ikr1cidq5gv8blvf6pyw6pnw6vq";
-      name = "qtlanguageserver-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtlanguageserver-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0cwx6rlp9nm0qbzjamfcqhhylbmh2f5kk3z749ln49fbz32ads68";
+      name = "qtlanguageserver-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtlocation = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtlocation-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1ybk3ig69p6zyrxabcfkb4pcyc251gy1m2brkf4q52cmcwcysias";
-      name = "qtlocation-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtlocation-everywhere-src-6.9.3.tar.xz";
+      sha256 = "018nwyr1idh3rfp22w86pw3i25xbj7mv49wir5s1akmgzp8jf4hl";
+      name = "qtlocation-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtlottie = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtlottie-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1iiigsb4p1zwkxm1x9c4pbx5rgwz35krdqi3vkql4nawvp997px4";
-      name = "qtlottie-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtlottie-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0cyzj0xhdhlgkra1pqb4vdazxjfii05sc7r5h0ml9fzhfiai0vhi";
+      name = "qtlottie-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtmultimedia-everywhere-src-6.9.2.tar.xz";
-      sha256 = "04mbwl1mg4rjgai027chldslpjnqrx52c3jxn20j2hx7ayda3y3v";
-      name = "qtmultimedia-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtmultimedia-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1xc6kgqm88rkzr8qzdi8yj8dm4dqfsfzkkba4d8iijb0xbkvwxd2";
+      name = "qtmultimedia-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtnetworkauth-everywhere-src-6.9.2.tar.xz";
-      sha256 = "114c65gyg56v70byyl3if1q7mzhp5kkv1g8sp4y9zaxqirbdjr91";
-      name = "qtnetworkauth-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtnetworkauth-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1ivyrha9ibc2iz4lvrz5309pdqxyccwzbpmyg2m24ghkxm3xrnb7";
+      name = "qtnetworkauth-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtpositioning = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtpositioning-everywhere-src-6.9.2.tar.xz";
-      sha256 = "06mwzlyprwz11ks6fsvzh03ilk5fxy3scr1gqqb4p85xzw0ri6j8";
-      name = "qtpositioning-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtpositioning-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1d1mb1fni42vgfyj9ghk0g6602nx8lwa1y0bmynpmh84yy0ck1qc";
+      name = "qtpositioning-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtquick3d = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquick3d-everywhere-src-6.9.2.tar.xz";
-      sha256 = "002888xfnkxmvn8413fllidl3mm2fcwc4gbzdnbvpjlysaq9f3ig";
-      name = "qtquick3d-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtquick3d-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0wyfran9vwl6fm2i9nc149fpvv8r5k3yvrn2f1rjpb9qkw271cli";
+      name = "qtquick3d-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtquick3dphysics = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquick3dphysics-everywhere-src-6.9.2.tar.xz";
-      sha256 = "12yc0lswcmyaw19yyxzy73j95ncgqw8mlx8svhrwsllgcf2n9z47";
-      name = "qtquick3dphysics-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtquick3dphysics-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0vjs7calgc0vc7fv6hnbghhi37cfiapxim650av9w92xfhnv5myw";
+      name = "qtquick3dphysics-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtquickeffectmaker = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquickeffectmaker-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1yfq1pp0k2d6438x8pn2y73y29bqwg45bjh6msiy64fldr4z31br";
-      name = "qtquickeffectmaker-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtquickeffectmaker-everywhere-src-6.9.3.tar.xz";
+      sha256 = "04lrlp1fakn8kv160ln8j1fsqsfdcjf1dzwlknx5r1m04hfkdw3b";
+      name = "qtquickeffectmaker-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtquicktimeline = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtquicktimeline-everywhere-src-6.9.2.tar.xz";
-      sha256 = "09n51qw0y8v1q83xs1ybwwm4a49j2qhshqrasdkzz25mij6nhrdw";
-      name = "qtquicktimeline-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtquicktimeline-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1xqidk7njn1xiiz3i27ddzwd568caigq8p2ja4ks67x7bsk4nkr8";
+      name = "qtquicktimeline-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtremoteobjects-everywhere-src-6.9.2.tar.xz";
-      sha256 = "09lby6dqc2sfig1krcszg6fkypgxlz2r7hgjjfi95g7g9gqlwqnz";
-      name = "qtremoteobjects-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtremoteobjects-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0nyqmapypw0y745zg58rq9183vcrbm2c71dc3p9sdqflal07r64q";
+      name = "qtremoteobjects-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtscxml = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtscxml-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1dpb687zbw4akx42kfpbb5cpdlq3hcqn8l3l0x7sd5i9061z2sp0";
-      name = "qtscxml-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtscxml-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1drlbdgicqx76gyqi79ri1gy2vrya6l99gig76p8x46za70c12gk";
+      name = "qtscxml-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtsensors = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtsensors-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0qj4674vim2p34mq3kp99spjyf82qvs75w625namzqp274pshk4n";
-      name = "qtsensors-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtsensors-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0s1gz66nar27c3l5cbqqdnza1pxbd7nylz88mnj32xpkwml53nx2";
+      name = "qtsensors-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtserialbus = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtserialbus-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0xia9xcz7sjrbf1c4m63qnhz3ggdxr06pycslmsnqizlzb10f7lm";
-      name = "qtserialbus-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtserialbus-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1ksvfwfk0az47sgfcaqbac936y75lcaga5fip5lbgz0s0zd3k08a";
+      name = "qtserialbus-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtserialport = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtserialport-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0sz2dkas4qjdd6lkfb9g89vi94q18aiq9xdchlqb2yn0qbqb544b";
-      name = "qtserialport-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtserialport-everywhere-src-6.9.3.tar.xz";
+      sha256 = "16427sa9qhk8hsyxjr69fhqmvzlg9n4pdizmqfc4cr7j1w1yq62b";
+      name = "qtserialport-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtshadertools = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtshadertools-everywhere-src-6.9.2.tar.xz";
-      sha256 = "158lpzb1nqspwm0n48d3nfr81q85zka1igrjp6xj8cjlv7wqlrqp";
-      name = "qtshadertools-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtshadertools-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0rs553abb8sdla4cywfpgfh3vvyafm8spy8nnvj06md3hvp09632";
+      name = "qtshadertools-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtspeech = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtspeech-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1cc8l2h1frlraay0m40r5a91nsc7b53n6vksa52pwqqia4vngdmj";
-      name = "qtspeech-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtspeech-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0gmbr65s4j2bka13iln3fmjrhl1i46lp5vlhdv66rf1gfi65lvzq";
+      name = "qtspeech-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtsvg = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtsvg-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1985asvnkd2ar30nh2zyi490qz0vkz6z1f752lfald33yawcm16r";
-      name = "qtsvg-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtsvg-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1qi6f3lvp0r7n79m1iw80690366bd53gyxm5gp76zgnbb0rslxnv";
+      name = "qtsvg-everywhere-src-6.9.3.tar.xz";
     };
   };
   qttools = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qttools-everywhere-src-6.9.2.tar.xz";
-      sha256 = "12d4czfwvh9rfjwnkpsiwzrpx4ga69c6vz85aabhpk3hx7lggdyq";
-      name = "qttools-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qttools-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1sdla2blvk9r4g7v67dhwqjxx7kflyh7cm9pw5f7ziazjw7apxqc";
+      name = "qttools-everywhere-src-6.9.3.tar.xz";
     };
   };
   qttranslations = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qttranslations-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1mky3xj2yhcsrmpz8m28v7pky6ryn7hvdcglakww0rfk3qlbcfy7";
-      name = "qttranslations-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qttranslations-everywhere-src-6.9.3.tar.xz";
+      sha256 = "18chqjzy7ji76crfisl1rya8ds3my97bgsxkg7yldcc1crg58vgk";
+      name = "qttranslations-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtvirtualkeyboard-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1qqizh7kyqbqqnrm1mmlf2709rm1rnflbqdl1bi75yms07d00hbv";
-      name = "qtvirtualkeyboard-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtvirtualkeyboard-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0d2m87fvd11ckjjzy3lj1mbfisig4x9c263phq4fczwy3k4xb851";
+      name = "qtvirtualkeyboard-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtwayland = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwayland-everywhere-src-6.9.2.tar.xz";
-      sha256 = "10bpxwpam56gvymz9vjxkppbqsj1369ddzl3k4pz2s2maq39imya";
-      name = "qtwayland-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtwayland-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1pfsfdjqw985d8220jw13sqacyiip26bzpk1ax30ms33jayd84z4";
+      name = "qtwayland-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebchannel-everywhere-src-6.9.2.tar.xz";
-      sha256 = "0rcf7i1wamdf1qynq3yi88r77ch5dg1jinxywlfjlb2dmlvn72l7";
-      name = "qtwebchannel-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtwebchannel-everywhere-src-6.9.3.tar.xz";
+      sha256 = "01d3dy0fjz4vfy8s1yzpmd31b8mhvqf15z61fzr9qgd1wp0vnmwl";
+      name = "qtwebchannel-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtwebengine = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebengine-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1aq35nkgbvhlsmglnjizbkavr7kb0ymf5n3kkllrpqy2mf90gjwr";
-      name = "qtwebengine-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtwebengine-everywhere-src-6.9.3.tar.xz";
+      sha256 = "0rl9v936sq6spvb3sfkpmc51wwmljrn4ssy3ii0pdn0xsl8kn2ym";
+      name = "qtwebengine-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebsockets-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1vh82w96436pqrp4daf324mqs2zjvn51z78b3ksc5mnqgrk3z0xy";
-      name = "qtwebsockets-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtwebsockets-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1i428awzws4x4cmv6zpdgb27c2m71cs8dqcjbwiwqcfbyf6dlzg2";
+      name = "qtwebsockets-everywhere-src-6.9.3.tar.xz";
     };
   };
   qtwebview = {
-    version = "6.9.2";
+    version = "6.9.3";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/6.9/6.9.2/submodules/qtwebview-everywhere-src-6.9.2.tar.xz";
-      sha256 = "1w8z3d7w7z2xjfb5l15gb37v9w6pa7d71jalkrqda8l2wr5d3ksc";
-      name = "qtwebview-everywhere-src-6.9.2.tar.xz";
+      url = "${mirror}/official_releases/qt/6.9/6.9.3/submodules/qtwebview-everywhere-src-6.9.3.tar.xz";
+      sha256 = "1j1cqj2hq0c8r9lxb1h6mdhnf9clqb95jw2p0nn81jzin701ypn6";
+      name = "qtwebview-everywhere-src-6.9.3.tar.xz";
     };
   };
 }

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -13,11 +13,11 @@ let
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "shiboken6";
-  version = "6.9.2";
+  version = "6.9.3";
 
   src = fetchurl {
     url = "mirror://qt/official_releases/QtForPython/pyside6/PySide6-${finalAttrs.version}-src/pyside-setup-everywhere-src-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nsCHRlNCvcnb5JKjDlj9u8VEhlXerPWYKg/nEj9ZIi0=";
+    hash = "sha256-fNLVq7mPLm9EKw5B9fz5MOcxKuSxf2gTFrGtx7Y7sXI=";
   };
 
   sourceRoot = "pyside-setup-everywhere-src-${finalAttrs.version}/sources/shiboken6";


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/448500.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
