### PR TITLE
zitadel: 2.71.7 -> 4.3.0

### DIFF
--- a/pkgs/by-name/zi/zitadel/console-use-local-protobuf-plugins.patch
+++ b/pkgs/by-name/zi/zitadel/console-use-local-protobuf-plugins.patch
@@ -1,16 +1,16 @@
 diff --git a/console/buf.gen.yaml b/console/buf.gen.yaml
-index 1737c2ded..d6affa8bc 100644
+index bfb5f7e51..4b5641bbd 100644
 --- a/console/buf.gen.yaml
 +++ b/console/buf.gen.yaml
 @@ -3,12 +3,12 @@ version: v1
  managed:
    enabled: true
  plugins:
--  - plugin: buf.build/protocolbuffers/js
+-  - plugin: buf.build/protocolbuffers/js:v3.21.4
 +  - plugin: js
      out: src/app/proto/generated
      opt: import_style=commonjs,binary
--  - plugin: buf.build/grpc/web
+-  - plugin: buf.build/grpc/web:v1.5.0
 +  - plugin: grpc-web
      out: src/app/proto/generated
      opt: import_style=typescript,mode=grpcweb

--- a/pkgs/by-name/zi/zitadel/console.nix
+++ b/pkgs/by-name/zi/zitadel/console.nix
@@ -5,58 +5,172 @@
 }:
 
 {
+  lib,
   stdenv,
-  fetchYarnDeps,
-  yarnConfigHook,
-  yarnBuildHook,
+  pnpm,
   nodejs,
-
   grpc-gateway,
+  protoc-gen-connect-go,
   protoc-gen-grpc-web,
-  protoc-gen-js,
+  buf,
+  fetchFromGitHub,
+  pkg-config,
+  protobuf_27,
 }:
 
 let
+  protoc-gen-js = stdenv.mkDerivation (finalAttrs: {
+    pname = "protoc-gen-js";
+    version = "3.21.4";
+
+    src = fetchFromGitHub {
+      owner = "protocolbuffers";
+      repo = "protobuf-javascript";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-eIOtVRnHv2oz4xuVc4aL6JmhpvlODQjXHt1eJHsjnLg=";
+    };
+
+    nativeBuildInputs = [
+      pkg-config
+      stdenv.cc
+    ];
+
+    buildInputs = [
+      protobuf_27
+      protobuf_27.passthru.abseil-cpp
+    ];
+
+    doCheck = false;
+
+    buildPhase = ''
+      runHook preBuild
+
+      $CXX -std=c++17 \
+        -I. \
+        $(pkg-config --cflags protobuf) \
+        generator/*.cc \
+        -o protoc-gen-js \
+        $(pkg-config --libs protobuf) \
+        -lprotoc
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 protoc-gen-js $out/bin/protoc-gen-js
+
+      runHook postInstall
+    '';
+  });
+
   protobufGenerated = generateProtobufCode {
     pname = "zitadel-console";
     inherit version;
     nativeBuildInputs = [
       grpc-gateway
+      protoc-gen-connect-go
       protoc-gen-grpc-web
       protoc-gen-js
     ];
     workDir = "console";
     bufArgs = "../proto --include-imports --include-wkt";
     outputPath = "src/app/proto";
-    hash = "sha256-UzmwUUYg0my3noAQNtlUEBQ+K6GVnBSkWj4CzoaoLKw=";
+    hash = "sha256-Bv0wlGOUpb2y5mU2Z1fj5RO5oBmyJ704A3FNzO++pFE=";
   };
+
+  zitadelProtobufGenerated = generateProtobufCode {
+    pname = "zitadel-proto";
+    inherit version;
+    workDir = "packages/zitadel-proto";
+    bufArgs = "../../proto";
+    outputPath = ".";
+    hash = "sha256-baPS1wbsUQzelI55zswTPvX7ojXbPts967lwgcZGvlE=";
+  };
+
+  client = stdenv.mkDerivation (finalAttrs: {
+    pname = "zitadel-client";
+    inherit version;
+    src = zitadelRepo;
+
+    pnpmDeps = pnpm.fetchDeps {
+      inherit (finalAttrs) pname version src;
+      fetcherVersion = 2;
+      hash = "sha256-53G8vWbaFDFufh3KLGq+KzrHB4CEICElkMCGudDHYcc=";
+    };
+
+    pnpmWorkspaces = [
+      "@zitadel/proto"
+      "@zitadel/client"
+    ];
+
+    nativeBuildInputs = [
+      pnpm.configHook
+      nodejs
+      buf
+    ];
+
+    preBuild = ''
+      cp -r ${zitadelProtobufGenerated}/{cjs,es,types} packages/zitadel-proto
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm --filter=@zitadel/client run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r packages/zitadel-client/dist "$out"
+      runHook postInstall
+    '';
+  });
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zitadel-console";
   inherit version;
 
   src = zitadelRepo;
 
-  sourceRoot = "${zitadelRepo.name}/console";
-
-  offlineCache = fetchYarnDeps {
-    yarnLock = "${zitadelRepo}/console/yarn.lock";
-    hash = "sha256-ekgLd5DTOBZWuT63QnTjx40ZYvLKZh+FXCn+h5vj9qQ=";
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 2;
+    hash = "sha256-53G8vWbaFDFufh3KLGq+KzrHB4CEICElkMCGudDHYcc=";
   };
 
+  pnpmWorkspaces = [
+    "@zitadel/proto"
+    "@zitadel/client"
+    "console"
+  ];
+
   nativeBuildInputs = [
-    yarnConfigHook
-    yarnBuildHook
+    pnpm.configHook
     nodejs
+    buf
   ];
 
   preBuild = ''
-    cp -r ${protobufGenerated} src/app/proto
+    cp -r ${protobufGenerated} console/src/app/proto
+    cp -r ${zitadelProtobufGenerated}/{cjs,es,types} packages/zitadel-proto
+    cp -r ${client} packages/zitadel-client/dist
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=console build
+
+    runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    cp -r dist/console "$out"
+
+    cp -r console/dist/console "$out"
+
     runHook postInstall
   '';
-}
+})


### PR DESCRIPTION
This PR updates Zitadel to v4.3.0. CockroachDB support has been dropped as of the 4.x release, and PostgreSQL is now the default database. This resolves #431585. Many thanks to @sandydoo who basically did [all of the work](https://github.com/NixOS/nixpkgs/issues/431585#issuecomment-3224910981).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
