### PR TITLE
eaglemode: 0.96.2 -> 0.96.3, modernise

### DIFF
--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -32,12 +32,12 @@
   extraRuntimeDeps ? [ ],
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "eaglemode";
   version = "0.96.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/eaglemode/eaglemode-${version}.tar.bz2";
+    url = "mirror://sourceforge/eaglemode/eaglemode-${finalAttrs.version}.tar.bz2";
     hash = "sha256:1al5n2mcjp0hmsvi4hsdmzd7i0id5i3255xplk0il1nmzydh312a";
   };
 
@@ -120,7 +120,7 @@ stdenv.mkDerivation rec {
       exec = "eaglemode";
       icon = "eaglemode";
       desktopName = "Eagle Mode";
-      genericName = meta.description;
+      genericName = "Zoomable User Interface";
       categories = [
         "Game"
         "Graphics"
@@ -145,4 +145,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eaglemode";
-  version = "0.96.2";
+  version = "0.96.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/eaglemode/eaglemode-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-SoQBm//VBhrBpLeXIkYsLYJ42q9NQxK3rhBcyaqwhao=";
+    hash = "sha256-AHeupgEnyQylRWFDrPeo4b0mNONqG+6QwWnRpYknqOQ=";
   };
 
   # Fixes "Error: No time zones found." on the clock

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -43,7 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Fixes "Error: No time zones found." on the clock
   postPatch = ''
-    substituteInPlace src/emClock/emTimeZonesModel.cpp --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
+    substituteInPlace src/emClock/emTimeZonesModel.cpp \
+      --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = directoryListingUpdater {
     url = "https://eaglemode.sourceforge.net/download.html";
-    extraRegex = "(?!.*(x86_64|setup64|livecd)).*";
+    extraRegex = "(?!.*(x86_64|setup64|livecd|amd64)).*";
   };
 
   meta = {

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -12,7 +12,7 @@
   pkg-config,
   librsvg,
   glib,
-  gtk2,
+  gtk3,
   libXext,
   libXxf86vm,
   poppler,
@@ -45,6 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/emClock/emTimeZonesModel.cpp \
       --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
+
+    substituteInPlace makers/emPdf.maker.pm \
+      --replace-fail gtk+-2.0 gtk+-3.0
   '';
 
   nativeBuildInputs = [
@@ -62,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     libwebp
     librsvg
     glib
-    gtk2
+    gtk3
     libXxf86vm
     libXext
     poppler

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   version = "0.96.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/eaglemode/${pname}-${version}.tar.bz2";
+    url = "mirror://sourceforge/eaglemode/eaglemode-${version}.tar.bz2";
     hash = "sha256:1al5n2mcjp0hmsvi4hsdmzd7i0id5i3255xplk0il1nmzydh312a";
   };
 
@@ -109,16 +109,16 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/eaglemode --set EM_DIR "$out" --prefix LD_LIBRARY_PATH : "$out/lib" --prefix PATH : "${runtimeDeps}"
       for i in 32 48 96; do
         mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
-        ln -s $out/res/icons/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
+        ln -s $out/res/icons/eaglemode$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/eaglemode.png
       done
       runHook postInstall
     '';
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
-      exec = pname;
-      icon = pname;
+      name = "eaglemode";
+      exec = "eaglemode";
+      icon = "eaglemode";
       desktopName = "Eagle Mode";
       genericName = meta.description;
       categories = [

--- a/pkgs/by-name/ea/eaglemode/package.nix
+++ b/pkgs/by-name/ea/eaglemode/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://sourceforge/eaglemode/eaglemode-${finalAttrs.version}.tar.bz2";
-    hash = "sha256:1al5n2mcjp0hmsvi4hsdmzd7i0id5i3255xplk0il1nmzydh312a";
+    hash = "sha256-SoQBm//VBhrBpLeXIkYsLYJ42q9NQxK3rhBcyaqwhao=";
   };
 
   # Fixes "Error: No time zones found." on the clock


### PR DESCRIPTION
Also patches the source code to use gtk3 instead because of the [ongoing effort to get rid of gtk2](https://github.com/NixOS/nixpkgs/issues/410814)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
