### PR TITLE
gegl: 0.4.62 -> 0.4.64

### DIFF
--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -37,7 +37,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gegl";
-  version = "0.4.62";
+  version = "0.4.64";
 
   outputs = [
     "out"
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://download.gimp.org/pub/gegl/${lib.versions.majorMinor finalAttrs.version}/gegl-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WIdXY3Hr8dnpB5fRDkuafxZYIo1IJ1g+eeHbPZRQXGw=";
+    hash = "sha256-DeHJ3SLBYNXkvfw4jSkvA0R8ymJYVBuaEv7Xg9DPfGA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes CVE-2025-10921.

Changes:
https://gitlab.gnome.org/GNOME/gegl/-/commits/GEGL_0_4_64?ref_type=tags


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 448535`
Commit: `3509c9149c8b8749d4e1e6dbc1373407e1fde3af`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 25 packages built:</summary>
  <ul>
    <li>gegl</li>
    <li>gegl.dev</li>
    <li>gegl.devdoc</li>
    <li>gimp (gimpPlugins.gimp)</li>
    <li>gimp-with-plugins</li>
    <li>gimp.dev (gimpPlugins.gimp.dev)</li>
    <li>gimp3 (gimp3Plugins.gimp)</li>
    <li>gimp3-with-plugins</li>
    <li>gimp3.dev (gimp3Plugins.gimp.dev)</li>
    <li>gimp3.devdoc (gimp3Plugins.gimp.devdoc)</li>
    <li>gimp3Plugins.gmic</li>
    <li>gimp3Plugins.lightning</li>
    <li>gimpPlugins.bimp</li>
    <li>gimpPlugins.farbfeld</li>
    <li>gimpPlugins.fourier</li>
    <li>gimpPlugins.gimplensfun</li>
    <li>gimpPlugins.gmic</li>
    <li>gimpPlugins.lightning</li>
    <li>gimpPlugins.lqrPlugin</li>
    <li>gimpPlugins.resynthesizer</li>
    <li>gimpPlugins.texturize</li>
    <li>gimpPlugins.waveletSharpen</li>
    <li>gnome-photos</li>
    <li>gnome-photos.installedTests</li>
    <li>toppler</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
