### PR TITLE
[25.05] poco: apply patch for CVE-2025-6375

### DIFF
--- a/pkgs/by-name/po/poco/package.nix
+++ b/pkgs/by-name/po/poco/package.nix
@@ -67,6 +67,16 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/pocoproject/poco/pull/4879.patch";
       hash = "sha256-VFWuRuf0GPYFp43WKI8utl+agP+7a5biLg7m64EMnVo=";
     })
+    (fetchpatch {
+      name = "CVE-2025-6375.patch";
+      url = "https://github.com/pocoproject/poco/commit/6f2f85913c191ab9ddfb8fae781f5d66afccf3bf.patch";
+      hash = "sha256-lkwYidX79UFQMubSj/qmvxv91OGeVSAc5fDYUv5c0Iw=";
+    })
+    (fetchpatch {
+      name = "sec-fix-crash-NTLMCredentials-parseChallengeMessage.patch";
+      url = "https://github.com/pocoproject/poco/commit/da7fcba551a06c4f91a5e06ba983a6afc2480ae6.patch";
+      hash = "sha256-WYQ5MYHE2iBbstamWKmCQaZdK8DxeklEhCFH7mlHYiI=";
+    })
   ];
 
   postFixup = ''


### PR DESCRIPTION
Not backported the upgrade to 1.14.2 #443831 since the changelog mention a breaking change.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 448540`
Commit: `21e3fa9df429a4d8dd8018dab0a132627512e6f9`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 15 packages built:</summary>
  <ul>
    <li>collabora-online</li>
    <li>craftos-pc</li>
    <li>ioq3-scion</li>
    <li>ioquake3</li>
    <li>multipass</li>
    <li>mumble</li>
    <li>mumble_overlay</li>
    <li>murmur</li>
    <li>poco</li>
    <li>poco.dev</li>
    <li>pothos</li>
    <li>projectm-sdl-cpp</li>
    <li>quake3demo</li>
    <li>sanjuuni</li>
    <li>vscode-extensions.jackmacwindows.craftos-pc</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
