### PR TITLE
zookeeper: 3.9.3 -> 3.9.4

### DIFF
--- a/pkgs/by-name/zo/zookeeper/package.nix
+++ b/pkgs/by-name/zo/zookeeper/package.nix
@@ -10,16 +10,16 @@
 }:
 let
   # Latest supported LTS JDK for Zookeeper 3.9:
-  # https://zookeeper.apache.org/doc/r3.9.2/zookeeperAdmin.html#sc_requiredSoftware
+  # https://zookeeper.apache.org/doc/r3.9.4/zookeeperAdmin.html#sc_requiredSoftware
   jre = jdk11_headless;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zookeeper";
-  version = "3.9.3";
+  version = "3.9.4";
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/zookeeper-${finalAttrs.version}/apache-zookeeper-${finalAttrs.version}-bin.tar.gz";
-    hash = "sha512-1E2HDBaRZi778ai68YWckBuCDcX/Fjs26BvrJ7b7880xtfHwdWl+2q9tPnpMsMyS+STc/2SylO8T1TVYm9rxQw==";
+    hash = "sha512-Nr/65kQO0Nce2DpiG4xSxYOGC0FIEhlzcyN/DBSL0W5rWZl3yQ5euBwPzmuC70SqeCYhU1QXz/xMKgpRpW8s3w==";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/zo/zookeeper_mt/package.nix
+++ b/pkgs/by-name/zo/zookeeper_mt/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${zookeeper.pname}-${version}/apache-${zookeeper.pname}-${version}.tar.gz";
-    hash = "sha512-eo/9yeSPbik+5f3g3uc//N0aTx5VS0KCzkA/+wn/FFtAmHwnLex1GZOoOlQwly4KU10Y+pgY1shKab/aigPSFg==";
+    hash = "sha512-K8HvBwIdf0tHVotFoFuk0uYr2HFPsCKjPmK9xI/hHTxkpT1Tyx11Lxel9NlJppttillKMYAHvgrzinPDcQ7bdg==";
   };
 
   sourceRoot = "apache-${zookeeper.pname}-${version}/zookeeper-client/zookeeper-client-c";


### PR DESCRIPTION
Fixes CVE-2025-58457 (and various others security issues in the deps).
https://lists.apache.org/thread/r5yol0kkhx2fzw22pxk1ozwm3oc6yxrx
https://issues.apache.org/jira/browse/ZOOKEEPER-4964

https://zookeeper.apache.org/doc/r3.9.4/releasenotes.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 448545`
Commit: `aa790dc6a2506165ca5c323cba0a7e8cfc39c274`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>perl538Packages.NetZooKeeper</li>
    <li>perl538Packages.NetZooKeeper.devdoc</li>
    <li>perlPackages.NetZooKeeper (perl540Packages.NetZooKeeper)</li>
    <li>perlPackages.NetZooKeeper.devdoc (perl540Packages.NetZooKeeper.devdoc)</li>
    <li>zkfuse</li>
    <li>zookeeper</li>
    <li>zookeeper_mt</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
