### PR TITLE
[25.05] matrix-conduit: 0.9.0 -> 0.10.9

### DIFF
--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.10.8";
+  version = "0.10.9";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wSh1RPJt0gXp1U4aCBUASSVmvmroTPyhxpH1Exik4ds=";
+    hash = "sha256-rJyuR8Ie/JiNKNjQL21+Q1PWliEAm+lwGraGeDxEHyY=";
   };
 
-  cargoHash = "sha256-3wQGKeLfBeASj82xqAXRhcuESX3CEgkf9P4K/AvquvQ=";
+  cargoHash = "sha256-4ZA+3f8Kt+1JAm9KXnMRxAF+X9z8HSJoJe6Ny63SlnA=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.10.6";
+  version = "0.10.7";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VefM22YY00yOJpk6S6RRoRDbOhTRZ7MfeZHzI0MCPKQ=";
+    hash = "sha256-UI/xrdM4ztH9vhEwSOwl4jTF5jU3FBwgXY7h+0prIOI=";
   };
 
-  cargoHash = "sha256-4Lf6OHWwpNMQGXHp5UFJjQlS/FpKq+pM5Lao+AVzwYs=";
+  cargoHash = "sha256-Capftx1mpo7xWb4w1pBgM7rBsRj1YqUrQCia9MkIOX0=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.10.7";
+  version = "0.10.8";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UI/xrdM4ztH9vhEwSOwl4jTF5jU3FBwgXY7h+0prIOI=";
+    hash = "sha256-wSh1RPJt0gXp1U4aCBUASSVmvmroTPyhxpH1Exik4ds=";
   };
 
-  cargoHash = "sha256-Capftx1mpo7xWb4w1pBgM7rBsRj1YqUrQCia9MkIOX0=";
+  cargoHash = "sha256-3wQGKeLfBeASj82xqAXRhcuESX3CEgkf9P4K/AvquvQ=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.10.3";
+  version = "0.10.4";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cLPfgRchYLJXA13Xr1Yg3v+O/7SvxWYIAxaKvnsm7HM=";
+    hash = "sha256-1EY1YTkNnjRIMOvsjowx57PquYMrkv2+8kolD1z19ls=";
   };
 
-  cargoHash = "sha256-i/x6V/0WgMUuZoG8znREmAnLqw/9lYPk4F5i2SA5mmo=";
+  cargoHash = "sha256-IoqCv7ee+vvo0DLpZS4pLn5gBnOC9FyWMxjgWASCdOk=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.10.4";
+  version = "0.10.5";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1EY1YTkNnjRIMOvsjowx57PquYMrkv2+8kolD1z19ls=";
+    hash = "sha256-N1cs9P63DXCjzKOBweCLrjzR9MiwXWpzx+al3TH1pqc=";
   };
 
-  cargoHash = "sha256-IoqCv7ee+vvo0DLpZS4pLn5gBnOC9FyWMxjgWASCdOk=";
+  cargoHash = "sha256-hQfN6s2uisjOuH9lmZa6nsk1jldncMdRVT4hXM5+lps=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.10.5";
+  version = "0.10.6";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N1cs9P63DXCjzKOBweCLrjzR9MiwXWpzx+al3TH1pqc=";
+    hash = "sha256-VefM22YY00yOJpk6S6RRoRDbOhTRZ7MfeZHzI0MCPKQ=";
   };
 
-  cargoHash = "sha256-hQfN6s2uisjOuH9lmZa6nsk1jldncMdRVT4hXM5+lps=";
+  cargoHash = "sha256-4Lf6OHWwpNMQGXHp5UFJjQlS/FpKq+pM5Lao+AVzwYs=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -10,22 +10,22 @@
   rust-jemalloc-sys,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-conduit";
-  version = "0.9.0";
+  version = "0.10.3";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
-    rev = "v${version}";
-    hash = "sha256-mQLfRAun2G/LDnw3jyFGJbOqpxh2PL8IGzFELRfAgAI=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cLPfgRchYLJXA13Xr1Yg3v+O/7SvxWYIAxaKvnsm7HM=";
   };
 
-  cargoHash = "sha256-r7fOzTug0cKQUGrpXDn1JKb6/lLQDgnA3/colmldA4c=";
+  cargoHash = "sha256-i/x6V/0WgMUuZoG8znREmAnLqw/9lYPk4F5i2SA5mmo=";
 
   # Conduit enables rusqlite's bundled feature by default, but we'd rather use our copy of SQLite.
   preBuild = ''
-    substituteInPlace Cargo.toml --replace "features = [\"bundled\"]" "features = []"
+    substituteInPlace Cargo.toml --replace-fail "features = [\"bundled\"]" "features = []"
     cargo update --offline -p rusqlite
   '';
 
@@ -37,6 +37,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     sqlite
     rust-jemalloc-sys
+    rocksdb
   ];
 
   env = {
@@ -51,14 +52,14 @@ rustPlatform.buildRustPackage rec {
     inherit (nixosTests) matrix-conduit;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Matrix homeserver written in Rust";
     homepage = "https://conduit.rs/";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       pstn
       pimeys
     ];
     mainProgram = "conduit";
   };
-}
+})

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-cLPfgRchYLJXA13Xr1Yg3v+O/7SvxWYIAxaKvnsm7HM=";
   };
 

--- a/pkgs/by-name/ro/rocksdb/package.nix
+++ b/pkgs/by-name/ro/rocksdb/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocksdb";
-  version = "9.10.0";
+  version = "10.2.1";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "rocksdb";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-G+DlQwEUyd7JOCjS1Hg1cKWmA/qAiK8UpUIKcP+riGQ=";
+    hash = "sha256-v8kZShgz0O3nHZwWjTvhcM56qAs/le1XgMVYyvVd4tg=";
   };
 
   patches = lib.optional (

--- a/pkgs/by-name/ro/rocksdb/package.nix
+++ b/pkgs/by-name/ro/rocksdb/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "rocksdb";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-v8kZShgz0O3nHZwWjTvhcM56qAs/le1XgMVYyvVd4tg=";
   };
 

--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -18,14 +18,14 @@
   stalwartEnterprise ? false,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stalwart-mail" + (lib.optionalString stalwartEnterprise "-enterprise");
   version = "0.11.8";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "mail-server";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-VqGosbSQxNeOS+kGtvXAmz6vyz5mJlXvKZM57B1Xue4=";
   };
 
@@ -146,6 +146,9 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
 
+  # Allow network access during tests on Darwin/macOS
+  __darwinAllowLocalNetworking = true;
+
   passthru = {
     inherit rocksdb; # make used rocksdb version available (e.g., for backup scripts)
     webadmin = callPackage ./webadmin.nix { };
@@ -176,4 +179,4 @@ rustPlatform.buildRustPackage rec {
       pandapip1
     ];
   };
-}
+})


### PR DESCRIPTION
This includes the `0.10.8` security release, as per https://gitlab.com/famedly/conduit/-/releases/v0.10.8 and https://matrix.org/blog/2025/08/security-release/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
