### PR TITLE
fetchmail: 6.5.1 -> 6.5.6, fetchmail_7: unstable-2022-05-26 -> 7.0.0-alpha11

### DIFF
--- a/pkgs/applications/misc/fetchmail/default.nix
+++ b/pkgs/applications/misc/fetchmail/default.nix
@@ -4,21 +4,24 @@
   fetchurl,
   openssl,
   python3,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
   pname = "fetchmail";
-  version = "6.5.1";
+  version = "6.5.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/fetchmail/fetchmail-${version}.tar.xz";
-    sha256 = "sha256-yj/blRQcJ3rKEJvnf01FtH4D7gEAQwWN2QvBgttRjUo=";
+    hash = "sha256-7BDg4OqkFzE1WTee3nbHRhR2bYOLOUcLZkdIY6ppDas=";
   };
 
   buildInputs = [
     openssl
     python3
   ];
+
+  nativeBuildInputs = [ pkg-config ];
 
   configureFlags = [ "--with-ssl=${openssl.dev}" ];
 

--- a/pkgs/applications/misc/fetchmail/v7.nix
+++ b/pkgs/applications/misc/fetchmail/v7.nix
@@ -1,32 +1,38 @@
 {
   lib,
   stdenv,
-  pkgs,
+  fetchFromGitLab,
+  openssl,
+  python3,
+  autoreconfHook,
+  pkg-config,
+  bison,
+  flex,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fetchmail";
-  version = "unstable-2022-05-26";
+  version = "7.0.0-alpha11";
 
-  src = pkgs.fetchFromGitLab {
+  src = fetchFromGitLab {
     owner = "fetchmail";
     repo = "fetchmail";
-    rev = "30b368fb8660d8fec08be1cdf2606c160b4bcb80";
+    tag = finalAttrs.version;
     hash = "sha256-83D2YlFCODK2YD+oLICdim2NtNkkJU67S3YLi8Q6ga8=";
   };
 
-  buildInputs = with pkgs; [
+  buildInputs = [
     openssl
     python3
   ];
-  nativeBuildInputs = with pkgs; [
+  nativeBuildInputs = [
     autoreconfHook
     pkg-config
     bison
     flex
   ];
 
-  configureFlags = [ "--with-ssl=${pkgs.openssl.dev}" ];
+  configureFlags = [ "--with-ssl=${openssl.dev}" ];
 
   postInstall = ''
     cp -a contrib/. $out/share/fetchmail-contrib
@@ -46,4 +52,4 @@ stdenv.mkDerivation {
     platforms = platforms.unix;
     license = licenses.gpl2Plus;
   };
-}
+})


### PR DESCRIPTION
Fixes CVE-2025-61962.

https://www.fetchmail.info/fetchmail-SA-2025-01.txt

https://sourceforge.net/p/fetchmail/git/ci/6.5.6/tree/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
