### PR TITLE
python3Packages.sphinx-fortran: unstable-2022-03-02 -> 0-unstable-2025-10-03

### DIFF
--- a/pkgs/development/python-modules/sphinx-fortran/default.nix
+++ b/pkgs/development/python-modules/sphinx-fortran/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
-  future,
+  pythonOlder,
   numpy,
   sphinx,
   six,
@@ -11,27 +11,24 @@
 
 buildPythonPackage {
   pname = "sphinx-fortran";
-  version = "unstable-2022-03-02";
+  version = "unstable-2025-10-03";
   format = "setuptools";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "VACUMM";
     repo = "sphinx-fortran";
-    rev = "394ae990b43ed43fcff8beb048632f5e99794264";
-    hash = "sha256-IVKu5u9gqs7/9EZrf4ZYd12K6J31u+/B8kk4+8yfohM=";
+    rev = "b14f438c1cc74d1dbcd5acd9a330c3b509caab56";
+    hash = "sha256-baWzxtu285z9BIH5HzMTASo2nZpOk3Q0rKcdkoul588=";
   };
 
   propagatedBuildInputs = [
-    future
     numpy
     sphinx
     six
   ];
 
   pythonImportsCheck = [ "sphinxfortran" ];
-
-  # Tests are failing because reference files are not updated
-  doCheck = false;
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Update to the latest version which removes `future` and fixes tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
