### PR TITLE
openexr: Disable known-broken tests on big-endian

### DIFF
--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  ctestCheckHook,
   imath,
   libdeflate,
   pkg-config,
@@ -50,6 +51,9 @@ stdenv.mkDerivation rec {
     imath
     libdeflate
   ];
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
 
   # Without 'sse' enforcement tests fail on i686 as due to excessive precision as:
   #   error reading back channel B pixel 21,-76 got -nan expected -nan
@@ -57,6 +61,24 @@ stdenv.mkDerivation rec {
 
   # https://github.com/AcademySoftwareFoundation/openexr/issues/1400
   doCheck = !stdenv.hostPlatform.isAarch32;
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isBigEndian [
+    # https://github.com/AcademySoftwareFoundation/openexr/issues/1175
+    # Not sure if these issues are specific to the tests, or if openexr in general is borked on big-endian.
+    # Optimistically assuming the former here.
+    "OpenEXRCore.testReadDeep"
+    "OpenEXRCore.testDWATable"
+    "OpenEXRCore.testDWAACompression"
+    "OpenEXRCore.testDWABCompression"
+    "OpenEXR.testAttributes"
+    "OpenEXR.testCompression"
+    "OpenEXR.testRgba"
+    "OpenEXR.testCRgba"
+    "OpenEXR.testRgbaThreading"
+    "OpenEXR.testSampleImages"
+    "OpenEXR.testSharedFrameBuffer"
+    "OpenEXR.testTiledRgba"
+  ];
 
   passthru.tests = {
     inherit libjxl;


### PR DESCRIPTION
Upstream tracking issue for these broken tests: https://github.com/AcademySoftwareFoundation/openexr/issues/1175

(situation of these has improved a little since https://github.com/NixOS/nixpkgs/issues/253715, but still need to disable these for now)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
