### PR TITLE
mdbook-pandoc: init at 0.10.5

### DIFF
--- a/pkgs/by-name/md/mdbook-pandoc/package.nix
+++ b/pkgs/by-name/md/mdbook-pandoc/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  pandoc,
+  rustPlatform,
+  texliveSmall,
+}:
+
+let
+  self = rustPlatform.buildRustPackage {
+    pname = "mdbook-pandoc";
+    version = "0.6.4";
+
+    src = fetchFromGitHub {
+      owner = "max-heller";
+      repo = "mdbook-pandoc";
+      rev= "v${self.version}";
+      hash = "sha256-WaRcNfVfex9ujZ1fD8NhQ72phUh4WgyZtI3zuZ63Koc=";
+    };
+
+    cargoHash = "sha256-XT/YkR8kRJ30bCXmfxKQJQL7tPl+eAPr4jIhmStJ8TM=";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    nativeCheckInputs = [
+      pandoc
+      # some tests require pdflatex
+      texliveSmall
+    ];
+
+    checkFlags = let
+      skippedTests = [
+      # require network access
+      "remote_images"
+      "cargo_book"
+      "mdbook_guide"
+      "nomicon"
+      "rust_book"
+      "rust_by_example"
+      "rust_edition_guide"
+      "rust_embedded"
+      "rust_reference"
+      "rustc_dev_guide"
+      # failed because pandoc
+      "code_block_with_very_long_line"
+      "code_block_with_very_long_line_with_special_characters"
+      ];
+    in
+      builtins.map (x: "--skip " + x) skippedTests;
+
+    passthru = {
+      wrapper = callPackage ./wrapper.nix { };
+    };
+
+    meta = {
+      homepage = "https://github.com/max-heller/mdbook-pandoc";
+      description = "A mdbook backend powered by Pandoc";
+      changelog = "https://github.com/max-heller/mdbook-pandoc/releases/tag/${self.src.rev}";
+      license = with lib.licenses; [
+        asl20
+        /* or */
+        mit
+      ];
+      maintainers = with lib.maintainers; [ AndersonTorres ];
+    };
+  };
+in
+self

--- a/pkgs/by-name/md/mdbook-pandoc/package.nix
+++ b/pkgs/by-name/md/mdbook-pandoc/package.nix
@@ -2,69 +2,64 @@
   lib,
   callPackage,
   fetchFromGitHub,
+  stdenv,
   makeWrapper,
   pandoc,
   rustPlatform,
   texliveSmall,
 }:
 
-let
-  self = rustPlatform.buildRustPackage {
-    pname = "mdbook-pandoc";
-    version = "0.6.4";
+rustPlatform.buildRustPackage rec {
+  pname = "mdbook-pandoc";
+  version = "0.10.5";
 
-    src = fetchFromGitHub {
-      owner = "max-heller";
-      repo = "mdbook-pandoc";
-      rev= "v${self.version}";
-      hash = "sha256-WaRcNfVfex9ujZ1fD8NhQ72phUh4WgyZtI3zuZ63Koc=";
-    };
-
-    cargoHash = "sha256-XT/YkR8kRJ30bCXmfxKQJQL7tPl+eAPr4jIhmStJ8TM=";
-
-    nativeBuildInputs = [ makeWrapper ];
-
-    nativeCheckInputs = [
-      pandoc
-      # some tests require pdflatex
-      texliveSmall
-    ];
-
-    checkFlags = let
-      skippedTests = [
-      # require network access
-      "remote_images"
-      "cargo_book"
-      "mdbook_guide"
-      "nomicon"
-      "rust_book"
-      "rust_by_example"
-      "rust_edition_guide"
-      "rust_embedded"
-      "rust_reference"
-      "rustc_dev_guide"
-      # failed because pandoc
-      "code_block_with_very_long_line"
-      "code_block_with_very_long_line_with_special_characters"
-      ];
-    in
-      builtins.map (x: "--skip " + x) skippedTests;
-
-    passthru = {
-      wrapper = callPackage ./wrapper.nix { };
-    };
-
-    meta = {
-      homepage = "https://github.com/max-heller/mdbook-pandoc";
-      description = "A mdbook backend powered by Pandoc";
-      changelog = "https://github.com/max-heller/mdbook-pandoc/releases/tag/${self.src.rev}";
-      license = with lib.licenses; [
-        asl20
-        /* or */
-        mit
-      ];
-      maintainers = with lib.maintainers; [ AndersonTorres ];
-    };
+  src = fetchFromGitHub {
+    owner = "max-heller";
+    repo = "mdbook-pandoc";
+    tag = "v${version}";
+    hash = "sha256-ihKju9XXJy4JciuMLw4EcKhqSQjrBiUJDG0Rd5DbFdk=";
   };
-in
-self
+
+  cargoHash = "sha256-SXXzGOBvfyLYhed5EMFUCzkFWoGEMM73PD3uWjkUcic=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [
+    pandoc
+    # some tests require pdflatex
+    texliveSmall
+  ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # failing subtly
+        "tests::html::rust_reference_regression_nested_elements"
+        "tests::css::css"
+        "tests::definition_lists::dt_attributes"
+        "tests::html::attach_id_to_div_of_stripped_html_elements"
+        "tests::html::link_to_element_by_id"
+        "tests::images::images"
+      ]
+      ++ lib.optional stdenv.buildPlatform.isDarwin "pandoc::tests::five_item_deep_list";
+    in
+    builtins.map (x: "--skip " + x) skippedTests;
+
+  passthru = {
+    wrapper = callPackage ./wrapper.nix { };
+  };
+
+  meta = {
+    homepage = "https://github.com/max-heller/mdbook-pandoc";
+    description = "A mdbook backend powered by Pandoc";
+    changelog = "https://github.com/max-heller/mdbook-pandoc/releases/tag/${src.tag}";
+    license = with lib.licenses; [
+      asl20
+      # or
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      astro
+    ];
+  };
+}

--- a/pkgs/by-name/md/mdbook-pandoc/wrapper.nix
+++ b/pkgs/by-name/md/mdbook-pandoc/wrapper.nix
@@ -1,0 +1,14 @@
+{
+  mdbook-pandoc,
+  pandoc,
+  symlinkJoin,
+}:
+
+symlinkJoin {
+  name = "mdbook-pandoc-wrapped-${mdbook-pandoc.version}";
+
+  paths = [
+    mdbook-pandoc
+    pandoc
+  ];
+}


### PR DESCRIPTION
Reopen of #324856 and version bump

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
