### PR TITLE
virter: add dnsmasq to PATH & install shell completions

### DIFF
--- a/pkgs/by-name/vi/virter/package.nix
+++ b/pkgs/by-name/vi/virter/package.nix
@@ -1,5 +1,7 @@
 {
   lib,
+  dnsmasq,
+  makeWrapper,
   buildGoModule,
   fetchFromGitHub,
 }:
@@ -24,6 +26,13 @@ buildGoModule rec {
     "-X github.com/LINBIT/virter/cmd.builddate=builtByNix"
     "-X github.com/LINBIT/virter/cmd.githash=builtByNix"
   ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/virter \
+      --prefix PATH ":" ${lib.makeBinPath [ dnsmasq ]}
+  '';
 
   # requires network access
   doCheck = false;

--- a/pkgs/by-name/vi/virter/package.nix
+++ b/pkgs/by-name/vi/virter/package.nix
@@ -1,7 +1,10 @@
 {
   lib,
+  stdenv,
   dnsmasq,
   makeWrapper,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
   buildGoModule,
   fetchFromGitHub,
 }:
@@ -27,11 +30,21 @@ buildGoModule rec {
     "-X github.com/LINBIT/virter/cmd.githash=builtByNix"
   ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+    writableTmpDirAsHomeHook
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/virter \
       --prefix PATH ":" ${lib.makeBinPath [ dnsmasq ]}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd virter \
+      --bash <($out/bin/virter completion bash) \
+      --fish <($out/bin/virter completion fish) \
+      --zsh <($out/bin/virter completion zsh)
   '';
 
   # requires network access


### PR DESCRIPTION
virter executes `dhcp_release` program here: https://github.com/LINBIT/virter/blob/7552bf931199a134d085aba846d0dda22f7fc6fc/internal/virter/dhcp.go#L444

Ref: https://github.com/LINBIT/virter#dhcp-leases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
