### PR TITLE
xdg-desktop-portal-luminous: wrap with runtime dependencies

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
@@ -8,6 +8,7 @@
   rustc,
   cargo,
   rustPlatform,
+  makeWrapper,
   xdg-desktop-portal,
   slurp,
   cairo,
@@ -15,6 +16,7 @@
   libxkbcommon,
   glib,
   pipewire,
+  wayland,
   nix-update-script,
 }:
 
@@ -42,17 +44,23 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     rustPlatform.cargoSetupHook
     rustPlatform.bindgenHook
+    makeWrapper
   ];
 
   buildInputs = [
     xdg-desktop-portal
-    slurp
     cairo
     pango
     glib
     pipewire
     libxkbcommon
   ];
+
+  postInstall = ''
+    wrapProgram $out/libexec/xdg-desktop-portal-luminous \
+      --prefix PATH ":" ${lib.makeBinPath [ slurp ]} \
+      --prefix LD_LIBRARY_PATH ":" ${lib.makeLibraryPath [ wayland ]}
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Wrap `xdg-desktop-portal-luminous` with wayland and slurp to avoid errors when these are missing. I also removed slurp from build-time dependencies because it is not needed.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
