### PR TITLE
civicrm: init at 6.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2723,6 +2723,14 @@
     githubId = 2998834;
     name = "Bruno Rodrigues";
   };
+  b12f = {
+    email = "nixpkgs@benjaminbaedorf.eu";
+    matrix = "@b12f:pub.solar";
+    github = "b12f";
+    githubId = 11312895;
+    name = "b12f";
+    keys = [ { fingerprint = "FC62 3BBC BD26 04D5 CC9D 90BA E77B 0AAA F0D9 B76B"; } ];
+  };
   b4dm4n = {
     email = "fabianm88@gmail.com";
     github = "B4dM4n";

--- a/pkgs/by-name/ci/civicrm/package.nix
+++ b/pkgs/by-name/ci/civicrm/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+}:
+
+stdenv.mkDerivation rec {
+  name = "civicrm-standalone";
+  version = "6.7.0";
+  src = fetchzip {
+    url = "https://download.civicrm.org/civicrm-${version}-standalone.tar.gz";
+    hash = "sha256-/Kh4iqaC+Vt4DrAhe1Kidz2RBJixOn3uRhV4/SyMDU8=";
+  };
+  buildPhase = "";
+  installPhase = ''
+    mkdir -p $out
+    cp -ra * $out
+  '';
+
+  meta = {
+    homepage = "https://civicrm.org/";
+    changelog = "https://download.civicrm.org/release/${version}";
+    description = "Standalone version of CiviCRM, a CRM software for non-profit organizations.";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.b12f ];
+  };
+}

--- a/pkgs/by-name/cv/cv/package.nix
+++ b/pkgs/by-name/cv/cv/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  php,
+  stdenv,
+  fetchurl,
+  writeShellScriptBin,
+}:
+let
+  phar = stdenv.mkDerivation rec {
+    name = "cv";
+    version = "0.3.65";
+    src = fetchurl {
+      url = "https://download.civicrm.org/cv/cv-${version}.phar";
+      hash = "sha256-4ILEWqx6PDvPM07DdFetBrRwqlOs3kIHNibc8jc78OE=";
+    };
+    phases = [ "installPhase" ];
+    installPhase = ''
+      cp -ra $src $out
+    '';
+  };
+in
+(writeShellScriptBin "cv" ''
+  ${php}/bin/php ${phar} $@
+'').overrideAttrs
+  (oldAttrs: {
+    version = phar.version;
+
+    meta = with lib; {
+      homepage = "https://civicrm.org/";
+      changelog = "https://github.com/civicrm/cv/releases/tag/v${version}";
+      description = "CiviCRM CLI Utility";
+      license = lib.licenses.agpl3Plus;
+      maintainers = [ lib.maintainers.b12f ];
+    };
+  })


### PR DESCRIPTION
This adds a a basic CiviCRM standalone package with the corresponding CLI.

No NixOS module yet, I'm currently working on it, but it'll take some time to mature. [link for the interested](https://git.pub.solar/momo/cloud/commit/7450d14978ace37ef2a0451bfb923e3d186aadfc)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.