### PR TITLE
lenovo-legion-app: 0.0.20 -> 0.0.21-unstable-2025-07-11

### DIFF
--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -8,14 +8,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lenovo-legion-app";
-  version = "0.0.20-unstable-2025-04-01";
+  version = "0.0.21-unstable-2025-07-11";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "johnfanv2";
     repo = "LenovoLegionLinux";
-    rev = "19fef88dbbb077d99052e06f3cd9a3675e7bf3aa";
-    hash = "sha256-0lQ6LyfjZ1/dc6QjB4a1aBcfxY5lIJJEonwuy9a4V4I=";
+    rev = "f559df04cc0705b2b181dfd0404110a4d1d6e2a9";
+    hash = "sha256-WXGDlykH6aBUVotmDcGZ8Y/zC8iBAv57u3hXRnfTaSo=";
   };
 
   sourceRoot = "${src.name}/python/legion_linux";
@@ -25,6 +25,7 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs; [
     pyqt6
     argcomplete
+    pillow
     pyyaml
     darkdetect
     xorg.libxcb


### PR DESCRIPTION
Update lenovo-legion-app to the latest commit from 2025-07-11.

This PR updates the lenovo-legion-app package to use the latest upstream commit, which includes bug fixes and improvements. Also adds the missing pillow dependency that was causing import errors.

**Depends on**: This PR is based on #448384 which migrates the maintainer handle from `realsnick` to `logger` for Ido Samuelson. This PR should be merged after #448384 is merged.

## Changes Made

- Updated from commit `19fef88dbbb077d99052e06f3cd9a3675e7bf3aa` (2025-04-01) to `f559df04cc0705b2b181dfd0404110a4d1d6e2a9` (2025-07-11)
- Added missing `pillow` dependency to fix Python import errors that prevented both CLI and GUI from starting
- Based on the `maintainer-update-realsnick-to-logger` branch from #448384 to include the maintainer name change

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Testing Results

- **nixpkgs-review**: ✅ 13 packages built successfully, 2 packages marked broken (expected for older kernels)
- **treefmt**: ✅ All files properly formatted (0 changes needed)
- **Binary functionality**: ✅ Both `legion_cli --help` and `legion_gui --help` work correctly without Python import errors
- **Dependencies**: ✅ Fixed missing pillow dependency that was causing `ModuleNotFoundError: No module named 'PIL'`

## Context

The lenovo-legion-app package was updated from an older commit that was missing some dependencies. The upstream project has been actively maintained and this brings the package up to the latest stable point as of July 2025. The addition of the pillow dependency ensures that both the CLI and GUI applications can start and run without Python import errors.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test