### PR TITLE
warp-terminal: 0.2025.09.24.08.11.stable_01 -> 0.2025.10.01.08.12.stable_02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14868,6 +14868,12 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  logger = {
+    name = "Ido Samuelson";
+    email = "ido.samuelson@gmail.com";
+    github = "i-am-logger";
+    githubId = 1440852;
+  };
   logo = {
     email = "logo4poop@protonmail.com";
     matrix = "@logo4poop:matrix.org";
@@ -21608,12 +21614,6 @@
     github = "rdnetto";
     githubId = 1973389;
     name = "Reuben D'Netto";
-  };
-  realsnick = {
-    name = "Ido Samuelson";
-    email = "ido.samuelson@gmail.com";
-    github = "i-am-logger";
-    githubId = 1440852;
   };
   rebmit = {
     name = "Lu Wang";

--- a/pkgs/by-name/fx/fxload/package.nix
+++ b/pkgs/by-name/fx/fxload/package.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     mainProgram = "fxload";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ realsnick ];
+    maintainers = with maintainers; [ logger ];
   };
 }

--- a/pkgs/by-name/li/libusb1/package.nix
+++ b/pkgs/by-name/li/libusb1/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [
       prusnak
-      realsnick
+      logger
     ];
   };
 }

--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -123,6 +123,7 @@ let
       imadnyc
       FlameFlag
       johnrtitor
+      logger
     ];
     platforms = platforms.darwin ++ [
       "x86_64-linux"

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-5lSv9/RLHVu9rusUO2MEGDKCEjteNNOiOfhk9f35a78=",
-    "version": "0.2025.09.24.08.11.stable_01"
+    "hash": "sha256-H8XaO1HKN8L4yKuLd75mMIBm1TWe1guJPOkmg62YLKo=",
+    "version": "0.2025.10.01.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-Ho8xOs9hke5jiM0y4QVsaE9pUfbEc6rjbipxtGRp6Ec=",
-    "version": "0.2025.09.24.08.11.stable_01"
+    "hash": "sha256-19QnAg/ZQuPTEzkCaPb9FdBDnZ3tC06ppfoxr+O4q58=",
+    "version": "0.2025.10.01.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-rdCKoIf6CFltrkaCfGu1X644mhtPC9Z2u+w4msj6Jr4=",
-    "version": "0.2025.09.24.08.11.stable_01"
+    "hash": "sha256-aw+8SVk6Vp9vFKuf5YRZ4Y0mAn69oXhLffzztRAc9XM=",
+    "version": "0.2025.10.01.08.12.stable_02"
   }
 }

--- a/pkgs/development/python-modules/openaiauth/default.nix
+++ b/pkgs/development/python-modules/openaiauth/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/acheong08/OpenAIAuth";
     changelog = "https://github.com/acheong08/OpenAIAuth/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ realsnick ];
+    maintainers = with maintainers; [ logger ];
   };
 }

--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -58,7 +58,7 @@ python3.pkgs.buildPythonApplication rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       ulrikstrid
-      realsnick
+      logger
       chn
     ];
     mainProgram = "legion_gui";


### PR DESCRIPTION
Update warp-terminal to the latest stable release.

This PR updates the warp-terminal package to use the latest version available from the official releases.

**Depends on**: This PR is based on #448384 which migrates the maintainer handle from `realsnick` to `logger` for Ido Samuelson. This PR should be merged after #448384 is merged.

## Changes Made

- Updated from version `0.2025.09.24.08.11.stable_01` to `0.2025.10.01.08.12.stable_02`
- Added `logger` as maintainer (based on the maintainer migration from #448384)
- Updated all platform hashes (darwin, linux_x86_64, linux_aarch64)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Testing Results

- **Build**: ✅ Successfully built on x86_64-linux
- **treefmt**: ✅ All files properly formatted (0 changes needed)
- **Update script**: ✅ Used official update script to fetch latest versions and hashes
- **Binary functionality**: ✅ Package builds and installs correctly

## Context

This is a routine update to the latest stable release of Warp terminal. The package uses the official update script which automatically fetches the latest version and calculates the correct hashes for all supported platforms. The maintainer addition is part of the broader maintainer handle migration described in #448384.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test