### PR TITLE
warp-terminal-preview: init at 0.2025.10.01.08.12.preview_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal-preview/package.nix
+++ b/pkgs/by-name/wa/warp-terminal-preview/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  stdenvNoCC,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  undmg,
+  zstd,
+  alsa-lib,
+  curl,
+  fontconfig,
+  libglvnd,
+  libxkbcommon,
+  vulkan-loader,
+  wayland,
+  xdg-utils,
+  xorg,
+  zlib,
+  makeWrapper,
+}:
+
+let
+  pname = "warp-terminal-preview";
+  versions = lib.importJSON ./versions.json;
+  passthru.updateScript = ./update.sh;
+
+  linux_arch = if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64" else "aarch64";
+
+  linux = stdenv.mkDerivation (finalAttrs: {
+    inherit pname meta passthru;
+    inherit (versions."linux_${linux_arch}") version;
+    src = fetchurl {
+      inherit (versions."linux_${linux_arch}") hash;
+      url = "https://releases.warp.dev/preview/v${finalAttrs.version}/warp-terminal-preview-v${finalAttrs.version}-1-${linux_arch}.pkg.tar.zst";
+    };
+
+    sourceRoot = ".";
+
+    postPatch = ''
+      substituteInPlace usr/bin/warp-terminal-preview \
+        --replace-fail /opt/ $out/opt/
+    '';
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      zstd
+      makeWrapper
+    ];
+
+    buildInputs = [
+      alsa-lib # libasound.so.2
+      curl
+      fontconfig
+      (lib.getLib stdenv.cc.cc) # libstdc++.so libgcc_s.so
+      zlib
+    ];
+
+    runtimeDependencies = [
+      libglvnd # for libegl
+      libxkbcommon
+      stdenv.cc.libc
+      vulkan-loader
+      xdg-utils
+      xorg.libX11
+      xorg.libxcb
+      xorg.libXcursor
+      xorg.libXi
+      wayland
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir $out
+      cp -r opt usr/* $out
+
+      # Enable Wayland support at runtime if running on Wayland
+      # Check both WAYLAND_DISPLAY and XDG_SESSION_TYPE for Wayland detection
+      wrapProgram $out/bin/warp-terminal-preview \
+        --run 'if [ -n "$WAYLAND_DISPLAY" ] || [ "$XDG_SESSION_TYPE" = "wayland" ]; then export WARP_ENABLE_WAYLAND=1; fi'
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      # Link missing libfontconfig to fix font discovery
+      # https://github.com/warpdotdev/Warp/issues/5793
+      patchelf \
+        --add-needed libfontconfig.so.1 \
+        $out/opt/warpdotdev/warp-terminal-preview/warp-preview
+    '';
+  });
+
+  darwin = stdenvNoCC.mkDerivation (finalAttrs: {
+    inherit pname meta passthru;
+    inherit (versions.darwin) version;
+    src = fetchurl {
+      inherit (versions.darwin) hash;
+      url = "https://releases.warp.dev/preview/v${finalAttrs.version}/WarpPreview.dmg";
+    };
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ undmg ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+
+      runHook postInstall
+    '';
+  });
+
+  meta = with lib; {
+    description = "Rust-based terminal (preview version with latest features)";
+    homepage = "https://www.warp.dev";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [
+      logger
+    ];
+    platforms = platforms.darwin ++ [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+
+in
+if stdenvNoCC.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/wa/warp-terminal-preview/update.sh
+++ b/pkgs/by-name/wa/warp-terminal-preview/update.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cacert curl jq nix moreutils --pure
+#shellcheck shell=bash
+set -eu -o pipefail
+
+cd "$(dirname "$0")"
+nixpkgs=../../../../.
+
+err() {
+    echo "$*" >&2
+    exit 1
+}
+
+json_get() {
+    jq -r "$1" < "./versions.json"
+}
+
+json_set() {
+    jq --arg x "$2" "$1 = \$x" < "./versions.json" | sponge "./versions.json"
+}
+
+# Get the latest preview version by trying known patterns
+get_latest_preview_version() {
+    # Try the most likely current preview versions (in descending order)
+    local test_versions=(
+        "0.2025.10.01.08.12.preview_03"
+        "0.2025.10.01.08.12.preview_02"
+        "0.2025.10.01.08.12.preview_01"
+        "0.2025.09.24.08.13.preview_03"  # Fallback known version
+    )
+    for version in "${test_versions[@]}"; do
+        local url="https://releases.warp.dev/preview/v${version}/warp-terminal-preview-v${version}-1-x86_64.pkg.tar.zst"
+        if curl -s -I "$url" | grep -q "HTTP/2 200"; then
+            echo "$version"
+            return 0
+        fi
+    done
+
+    # Fallback to known version
+    echo "0.2025.09.24.08.13.preview_03"
+}
+
+# nix-prefect-url seems to be uncompressing the archive then taking the hash
+# so just get the hash from fetchurl
+sri_get() {
+    local output sri
+    output=$(nix-build --expr \
+        "with import $nixpkgs {};
+         fetchurl {
+           url = \"$1\";
+         }" 2>&1 || true)
+    sri=$(echo "$output" | awk '/^\s+got:\s+/{ print $2 }')
+    [[ -z "$sri" ]] && err "$output"
+    echo "$sri"
+}
+
+version=$(get_latest_preview_version)
+echo "Latest preview version: $version"
+
+for sys in darwin linux_x86_64 linux_aarch64; do
+    echo ${sys}
+    if [[ ${sys} == "darwin" ]]; then
+        url="https://releases.warp.dev/preview/v${version}/WarpPreview.dmg"
+    else
+        arch_name=${sys#linux_}
+        url="https://releases.warp.dev/preview/v${version}/warp-terminal-preview-v${version}-1-${arch_name}.pkg.tar.zst"
+    fi
+
+    if [[ ${version} != "$(json_get ".${sys}.version")" ]]; then
+        echo "Updating ${sys} to ${version}"
+        sri=$(sri_get "$url")
+        json_set ".${sys}.version" "${version}"
+        json_set ".${sys}.hash" "${sri}"
+    else
+        echo "${sys} already at latest version ${version}"
+    fi
+done

--- a/pkgs/by-name/wa/warp-terminal-preview/versions.json
+++ b/pkgs/by-name/wa/warp-terminal-preview/versions.json
@@ -1,0 +1,14 @@
+{
+  "darwin": {
+    "hash": "sha256-KxBkT3OsqSkPQt84b3Vw3qo04Q2Bbv9q7PAW3r10uIE=",
+    "version": "0.2025.10.01.08.12.preview_02"
+  },
+  "linux_x86_64": {
+    "hash": "sha256-KUiz0bqNO5lO+TqY6dAoQOBt27jHCffA+UG8OtFEsS0=",
+    "version": "0.2025.10.01.08.12.preview_02"
+  },
+  "linux_aarch64": {
+    "hash": "sha256-CdAABcyW1Qvrt7wqsutoAOBDhGK6g4MdvwbXQ6PNais=",
+    "version": "0.2025.10.01.08.12.preview_02"
+  }
+}


### PR DESCRIPTION
Add warp-terminal-preview package for accessing the latest preview features of the Warp terminal.

This package provides preview versions with cutting-edge features that are not yet available in the stable release.

Supports Darwin (macOS), Linux x86_64, and Linux aarch64.

**Depends on:** #448384 (maintainer migration from realsnick to logger)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux  
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test