### PR TITLE
ticketbooth: init at 1.2.0

### DIFF
--- a/pkgs/by-name/ti/ticketbooth/package.nix
+++ b/pkgs/by-name/ti/ticketbooth/package.nix
@@ -1,0 +1,69 @@
+{
+  appstream,
+  blueprint-compiler,
+  desktop-file-utils,
+  fetchFromGitHub,
+  gettext,
+  glib,
+  gtk4,
+  lib,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  python3Packages,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ticketbooth";
+  version = "1.2.0";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "aleiepure";
+    repo = "ticketbooth";
+    tag = "v${version}";
+    hash = "sha256-eP5wYNusBcQLMu4MljfcO9QLY74v5Sb8gITx5dDVLpM=";
+  };
+
+  nativeBuildInputs = [
+    appstream # for appstreamcli
+    blueprint-compiler
+    desktop-file-utils # for desktop-file-validate
+    gettext # for msgfmt
+    glib # for glib-compile-schemas
+    gtk4 # for gtk4-update-icon-cache
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "prerelease" false)
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    pillow
+    pygobject3
+    tmdbsimple
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/aleiepure/ticketbooth/releases/tag/${src.tag}";
+    description = "Keep track of your favorite shows";
+    homepage = "https://github.com/aleiepure/ticketbooth";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "ticketbooth";
+    maintainers = [ lib.maintainers.dotlambda ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
[Ticket Booth](https://github.com/aleiepure/ticketbooth) is a GNOME app to keep track of watched movies.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
