### PR TITLE
[Backport release-25.05] typora: 1.10.8 -> 1.11.5

### DIFF
--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -24,7 +24,10 @@ let
   pname = "typora";
   version = "1.10.8";
   src = fetchurl {
-    url = "https://download.typora.io/linux/typora_${version}_amd64.deb";
+    urls = [
+      "https://download.typora.io/linux/typora_${version}_amd64.deb"
+      "https://download2.typoraio.cn/linux/typora_${version}_amd64.deb"
+    ];
     hash = "sha256-7auxTtdVafvM2fIpQVvEey1Q6eLVG3mLdjdZXcqSE/Q=";
   };
 

--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -22,13 +22,13 @@
 
 let
   pname = "typora";
-  version = "1.10.8";
+  version = "1.11.5";
   src = fetchurl {
     urls = [
       "https://download.typora.io/linux/typora_${version}_amd64.deb"
       "https://downloads.typoraio.cn/linux/typora_${version}_amd64.deb"
     ];
-    hash = "sha256-7auxTtdVafvM2fIpQVvEey1Q6eLVG3mLdjdZXcqSE/Q=";
+    hash = "sha256-CpUF8pRLzR3RzFD85Cobbmo3BInaeCee0NWKsmelPGs=";
   };
 
   typoraBase = stdenv.mkDerivation {
@@ -133,7 +133,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "Markdown editor, a markdown reader";
+    description = "A minimal Markdown editor and reader.";
     homepage = "https://typora.io/";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ npulidomateo ];

--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -26,7 +26,7 @@ let
   src = fetchurl {
     urls = [
       "https://download.typora.io/linux/typora_${version}_amd64.deb"
-      "https://download2.typoraio.cn/linux/typora_${version}_amd64.deb"
+      "https://downloads.typoraio.cn/linux/typora_${version}_amd64.deb"
     ];
     hash = "sha256-7auxTtdVafvM2fIpQVvEey1Q6eLVG3mLdjdZXcqSE/Q=";
   };


### PR DESCRIPTION
Manual backport of #422651 #432443 #437664 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
