### PR TITLE
[Backport release-25.05] gamescope: 3.16.9 -> 3.16.17

### DIFF
--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.14.2";
+  version = "3.16.15";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-l8SK8LQmFK0KeWxag7CX2lnME+HOvGpn4s3FqUNsK1Q=";
+    hash = "sha256-/JMk1ZzcVDdgvTYC+HQL09CiFDmQYWcu6/uDNgYDfdM=";
   };
 
   patches = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.10";
+  version = "3.16.11";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-MZhIsnSp2uGMQds5zEhF8WZgGNHDGH+3A2TGjB6Vn10=";
+    hash = "sha256-Hj/o5QcjCtMoteKOFU9uZmPIQ28ZlM83BT4MAQTmqQQ=";
   };
 
   patches = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.12";
+  version = "3.16.14";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-uh2MHatpgSnEH5LJE+TFCONDM5oxxPPv24vwD/iQh7U=";
+    hash = "sha256-i1a3nTospbGR/uPbwuM0z6cATANvw3QCFXd99e3tXCs=";
   };
 
   patches = [
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Replace gamescopereeaper with absolute path
     substituteInPlace src/Utils/Process.cpp --subst-var-by "gamescopereaper" "$out/bin/gamescopereaper"
-    patchShebangs default_scripts_install.sh
+    patchShebangs default_extras_install.sh
   '';
 
   mesonFlags = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -129,6 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
     pipewire
     hwdata
     xorg.libX11
+    xorg.libxcb
     wayland
     wayland-protocols
     vulkan-loader

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.14";
+  version = "3.16.14.2";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-i1a3nTospbGR/uPbwuM0z6cATANvw3QCFXd99e3tXCs=";
+    hash = "sha256-l8SK8LQmFK0KeWxag7CX2lnME+HOvGpn4s3FqUNsK1Q=";
   };
 
   patches = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.15";
+  version = "3.16.17";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-/JMk1ZzcVDdgvTYC+HQL09CiFDmQYWcu6/uDNgYDfdM=";
+    hash = "sha256-eKAOlmU0wc1DViZkUSrPFVjypa/kGfe+1+0lkXbaVJI=";
   };
 
   patches = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.9";
+  version = "3.16.10";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-Dw9EErOINGoOlnNqroKR+fbRfMGL7Q13gP3E5iw4RhU=";
+    hash = "sha256-MZhIsnSp2uGMQds5zEhF8WZgGNHDGH+3A2TGjB6Vn10=";
   };
 
   patches = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -49,14 +49,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope";
-  version = "3.16.11";
+  version = "3.16.12";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-Hj/o5QcjCtMoteKOFU9uZmPIQ28ZlM83BT4MAQTmqQQ=";
+    hash = "sha256-uh2MHatpgSnEH5LJE+TFCONDM5oxxPPv24vwD/iQh7U=";
   };
 
   patches = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -108,10 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     ninja
     wayland-scanner
-    # For `libdisplay-info`
-    python3
-    hwdata
-    edid-decode
+
     # For OpenVR
     cmake
 
@@ -121,6 +118,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableExecutable [
     makeBinaryWrapper
     glslang
+
+    # For `libdisplay-info`
+    python3
+    hwdata
+    edid-decode
   ];
 
   buildInputs = [
@@ -130,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     vulkan-loader
-    luajit
   ]
   ++ lib.optionals enableWsi [
     vulkan-headers
@@ -160,6 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
       pixman
       libcap
       lcms
+      luajit
     ]
   );
 

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -65,17 +65,11 @@ stdenv.mkDerivation (finalAttrs: {
     # patch relative gamescopereaper path with absolute
     ./gamescopereaper.patch
 
-    # Revert change to always use vendored stb/glm libraries
-    # Upstream discussion: https://github.com/ValveSoftware/gamescope/pull/1751
+    # Pending upstream patch to allow using system libraries
+    # See: https://github.com/ValveSoftware/gamescope/pull/1846
     (fetchpatch {
-      url = "https://github.com/ValveSoftware/gamescope/commit/baae74c4b13676fa76a8b200f21ac78f55079734.patch";
-      revert = true;
-      hash = "sha256-XpbyLQ4R9KgBR3hlrgPzmM7Zxr2jm4Q10zGjyhh/Qxw=";
-    })
-    (fetchpatch {
-      url = "https://github.com/ValveSoftware/gamescope/commit/72bae179ba2ebbbc91ed07c7f66e7e4964a4cd9e.patch";
-      revert = true;
-      hash = "sha256-aglfGvEuycNyPlaFYxqqvPAgFpWns3xZ3B2GiAefxtg=";
+      url = "https://github.com/ValveSoftware/gamescope/commit/4ce1a91fb219f570b0871071a2ec8ac97d90c0bc.diff";
+      hash = "sha256-O358ScIIndfkc1S0A8g2jKvFWoCzcXB/g6lRJamqOI4=";
     })
   ];
 
@@ -95,6 +89,9 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     (lib.mesonBool "enable_gamescope" enableExecutable)
     (lib.mesonBool "enable_gamescope_wsi_layer" enableWsi)
+
+    (lib.mesonOption "glm_include_dir" "${lib.getInclude glm}/include")
+    (lib.mesonOption "stb_include_dir" "${lib.getInclude stb}/include/stb")
   ];
 
   # don't install vendored vkroots etc
@@ -133,7 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     vulkan-loader
-    glm
     luajit
   ]
   ++ lib.optionals enableWsi [
@@ -163,7 +159,6 @@ stdenv.mkDerivation (finalAttrs: {
       gbenchmark
       pixman
       libcap
-      stb
       lcms
     ]
   );


### PR DESCRIPTION
Manual backport of #411521 #413623 #416270 #418066 #429538 #429538 #430181 #433420 #438531 #441368 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.