### PR TITLE
[Backport release-25.05] phpExtensions.zstd: 0.14.0+pie -> 0.15.2

### DIFF
--- a/pkgs/development/php-packages/zstd/default.nix
+++ b/pkgs/development/php-packages/zstd/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "0.15.1";
+  version = "0.15.2";
 in
 buildPecl {
   inherit version;
@@ -17,7 +17,7 @@ buildPecl {
     owner = "kjdev";
     repo = "php-ext-zstd";
     rev = version;
-    hash = "sha256-Gf9/A4SmeiPGtUcTXoIU1sOzVRqIIpLAbD1QdTmBaHQ=";
+    hash = "sha256-NGbrbvW2kNhgj3nqqjGLqowcp9EKqYffR1DOBIzdXeA=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/php-packages/zstd/default.nix
+++ b/pkgs/development/php-packages/zstd/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "0.14.0+pie";
+  version = "0.15.0";
 in
 buildPecl {
   inherit version;
@@ -17,7 +17,7 @@ buildPecl {
     owner = "kjdev";
     repo = "php-ext-zstd";
     rev = version;
-    hash = "sha256-BfxYPc7Y9VKjm/RiyO+/thpqNJFGMdD5xK07EZMb+E8=";
+    hash = "sha256-7Ok0Ej5U7N77Y/vXpgIp1diVSFgB9wXXGDQsKmvGxY8=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/php-packages/zstd/default.nix
+++ b/pkgs/development/php-packages/zstd/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "0.15.0";
+  version = "0.15.1";
 in
 buildPecl {
   inherit version;
@@ -17,7 +17,7 @@ buildPecl {
     owner = "kjdev";
     repo = "php-ext-zstd";
     rev = version;
-    hash = "sha256-7Ok0Ej5U7N77Y/vXpgIp1diVSFgB9wXXGDQsKmvGxY8=";
+    hash = "sha256-Gf9/A4SmeiPGtUcTXoIU1sOzVRqIIpLAbD1QdTmBaHQ=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
Manual backport of #433280 #435524 #442318 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  
  
