### PR TITLE
github-mcp-server: 0.15.0 -> 0.17.1, add logger as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14868,6 +14868,12 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  logger = {
+    name = "Ido Samuelson";
+    email = "ido.samuelson@gmail.com";
+    github = "i-am-logger";
+    githubId = 1440852;
+  };
   logo = {
     email = "logo4poop@protonmail.com";
     matrix = "@logo4poop:matrix.org";
@@ -21608,12 +21614,6 @@
     github = "rdnetto";
     githubId = 1973389;
     name = "Reuben D'Netto";
-  };
-  realsnick = {
-    name = "Ido Samuelson";
-    email = "ido.samuelson@gmail.com";
-    github = "i-am-logger";
-    githubId = 1440852;
   };
   rebmit = {
     name = "Lu Wang";

--- a/pkgs/by-name/fx/fxload/package.nix
+++ b/pkgs/by-name/fx/fxload/package.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     mainProgram = "fxload";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ realsnick ];
+    maintainers = with maintainers; [ logger ];
   };
 }

--- a/pkgs/by-name/gi/github-mcp-server/package.nix
+++ b/pkgs/by-name/gi/github-mcp-server/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "github-mcp-server";
-  version = "0.15.0";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "github-mcp-server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D6oEnaHrGnFfuO6NXRYbJ665OlWcwHo+JLfCPrdDkE4=";
+    hash = "sha256-A9kl/XIo2WxckPxRItw6yswhqLENGkzky9EBWJXTetc=";
   };
 
-  vendorHash = "sha256-0QqgyjK3QID72aMI6l6ofXAUt94PYFqO8dWech7yaFw=";
+  vendorHash = "sha256-esd4Ly8cbN3z9fxC1j4wQqotV2ULqK3PDf1bEovewUY=";
 
   ldflags = [
     "-s"
@@ -41,6 +41,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/github/github-mcp-server";
     license = lib.licenses.mit;
     mainProgram = "github-mcp-server";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ logger ];
   };
 })

--- a/pkgs/by-name/gi/github-mcp-server/update.sh
+++ b/pkgs/by-name/gi/github-mcp-server/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts coreutils curl jq
+
+set -euo pipefail
+
+current_version="$(nix --extra-experimental-features nix-command eval -f . github-mcp-server.version --raw)"
+latest_version="$(curl -s -H "Accept: application/vnd.github.v3+json" \
+            ${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
+            "https://api.github.com/repos/github/github-mcp-server/releases/latest" | jq -r ".tag_name")"
+latest_version="${latest_version#v}" # v0.17.1 -> 0.17.1
+
+if [[ "$latest_version" == "$current_version" ]]; then
+    echo "github-mcp-server is already up to date: $current_version"
+    exit 0
+fi
+
+echo "Updating github-mcp-server from $current_version to $latest_version"
+update-source-version github-mcp-server "$latest_version"
+
+echo "Updating Go modules hash..."
+$(nix-build -A github-mcp-server.goModules --no-out-link 2>/dev/null || true)

--- a/pkgs/by-name/li/libusb1/package.nix
+++ b/pkgs/by-name/li/libusb1/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [
       prusnak
-      realsnick
+      logger
     ];
   };
 }

--- a/pkgs/development/python-modules/openaiauth/default.nix
+++ b/pkgs/development/python-modules/openaiauth/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/acheong08/OpenAIAuth";
     changelog = "https://github.com/acheong08/OpenAIAuth/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ realsnick ];
+    maintainers = with maintainers; [ logger ];
   };
 }

--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -58,7 +58,7 @@ python3.pkgs.buildPythonApplication rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       ulrikstrid
-      realsnick
+      logger
       chn
     ];
     mainProgram = "legion_gui";


### PR DESCRIPTION
## Description

This PR updates GitHub's official MCP Server from version 0.15.0 to 0.17.1 and adds `logger` as a maintainer. The package is actively used and this update provides bug fixes and new features from the upstream release.

This version removes the `update_project_item` tool that was causing issues with input schema validation, improving stability.

## Changes

- Updates `github-mcp-server` from version `0.15.0` to `0.17.1`
- Updates the source hash for the new version
- Updates the `vendorHash` for Go modules
- Adds `logger` as a maintainer
- Adds update script for automated future updates

## Testing

- [x] Package builds successfully on x86_64-linux
- [x] Version check passes (`github-mcp-server --version` reports correct version)
- [x] All tests pass
- [x] `treefmt` formatting applied
- [x] `nixpkgs-review` shows no package rebuilds

## Dependencies

This PR depends on #448384 (maintainer update from `realsnick` to `logger`) and should be merged after that PR.

## Checklist

- [x] Built on NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside `nixos/tests`)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)