### PR TITLE
[Backport release-25.05] llvmPackages_21: 21.1.0-rc1 -> 21.1.0-rc2

### DIFF
--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -18,14 +18,19 @@
 let
   pname = "libc";
 
-  src' = runCommand "${pname}-src-${version}" { } ''
-    mkdir -p "$out"
-    cp -r ${monorepoSrc}/cmake "$out"
-    cp -r ${monorepoSrc}/runtimes "$out"
-    cp -r ${monorepoSrc}/llvm "$out"
-    cp -r ${monorepoSrc}/compiler-rt "$out"
-    cp -r ${monorepoSrc}/${pname} "$out"
-  '';
+  src' = runCommand "${pname}-src-${version}" { } (
+    ''
+      mkdir -p "$out"
+      cp -r ${monorepoSrc}/cmake "$out"
+      cp -r ${monorepoSrc}/runtimes "$out"
+      cp -r ${monorepoSrc}/llvm "$out"
+      cp -r ${monorepoSrc}/compiler-rt "$out"
+      cp -r ${monorepoSrc}/${pname} "$out"
+    ''
+    + lib.optionalString (lib.versionAtLeast release_version "21") ''
+      cp -r ${monorepoSrc}/third-party "$out"
+    ''
+  );
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname version patches;

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -32,7 +32,7 @@ let
     "18.1.8".officialRelease.sha256 = "sha256-iiZKMRo/WxJaBXct9GdAcAT3cz9d9pnAcO1mmR6oPNE=";
     "19.1.7".officialRelease.sha256 = "sha256-cZAB5vZjeTsXt9QHbP5xluWNQnAHByHtHnAhVDV0E6I=";
     "20.1.8".officialRelease.sha256 = "sha256-ysyB/EYxi2qE9fD5x/F2zI4vjn8UDoo1Z9ukiIrjFGw=";
-    "21.1.0-rc1".officialRelease.sha256 = "sha256-EZMG3kNqGTvKSuvslbrtNnyqBCG5C2gN9Y2qHbiuh8Q=";
+    "21.1.0-rc2".officialRelease.sha256 = "sha256-7qE5MAYuB+gr5NmQm+7jJWCarIjoDUtyd8SDiJwvITw=";
     "22.0.0-git".gitRelease = {
       rev = "cac0635ee9e947b5f90130df2f471aa4b722e04b";
       rev-version = "22.0.0-unstable-2025-09-28";


### PR DESCRIPTION
Manual backport of #429385 and afd965280e1f52dace0327474b6176f23e8c386f to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.