### PR TITLE
maxflow: fix build with CMake 4

### DIFF
--- a/pkgs/by-name/ma/maxflow/0001-Raise-minimum-CMake-version.patch
+++ b/pkgs/by-name/ma/maxflow/0001-Raise-minimum-CMake-version.patch
@@ -1,0 +1,42 @@
+From e4d8d49beebea53f5ed71d7134528a806e89d95f Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sun, 5 Oct 2025 00:35:33 +0200
+Subject: [PATCH] Raise minimum CMake version
+
+Compatibility with CMake versions older than 3.5 is removed in CMake 4
+and older than 3.10 is deprecated.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ CMakeLists.txt | 12 +-----------
+ 1 file changed, 1 insertion(+), 11 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68c9781..c77176c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,20 +13,10 @@
+ # You should have received a copy of the GNU General Public License
+ # along with MAXFLOW.  If not, see <http://www.gnu.org/licenses/>.
+ 
++CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
+ 
+ PROJECT("maxflow")
+ 
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5 FATAL_ERROR)
+-
+-if(COMMAND cmake_policy)
+-  cmake_policy(SET CMP0003 NEW)
+-  cmake_policy(SET CMP0012 NEW)
+-  IF(${CMAKE_VERSION} VERSION_GREATER 3.0.0) 
+-    cmake_policy(SET CMP0042 NEW)
+-  ENDIF()
+-endif(COMMAND cmake_policy)
+-
+-
+ SET(PACKAGE_NAME "maxflow")
+ SET(MAJOR_VERSION 3)
+ SET(MINOR_VERSION 0)
+-- 
+2.51.0
+

--- a/pkgs/by-name/ma/maxflow/package.nix
+++ b/pkgs/by-name/ma/maxflow/package.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-a84SxGMnfBEaoMEeeIFffTOtErSN5yzZBrAUDjkalGY=";
   };
 
+  patches = [
+    # https://github.com/gerddie/maxflow/pull/7
+    ./0001-Raise-minimum-CMake-version.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
cc https://github.com/NixOS/nixpkgs/issues/445447
## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
