### PR TITLE
hyprutils: 0.9.0 -> 0.10.0, add logger as maintainer

### DIFF
--- a/pkgs/by-name/hy/hyprutils/package.nix
+++ b/pkgs/by-name/hy/hyprutils/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprutils";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprutils";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FWB9Xe9iIMlUskfLzKlYH3scvnHpSC5rMyN1EDHUQmE=";
+    hash = "sha256-r1ed7AR2ZEb2U8gy321/Xcp1ho2tzn+gG1te/Wxsj1A=";
   };
 
   nativeBuildInputs = [
@@ -43,5 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;
     teams = [ lib.teams.hyprland ];
+    maintainers = with lib.maintainers; [ logger ];
   };
 })


### PR DESCRIPTION
## Description

This PR updates hyprutils from version 0.8.4 to 0.10.0 and adds `logger` as a maintainer. hyprutils is a small C++ library for utilities used across the Hypr* ecosystem, which is essential for Hyprland functionality.

The package is actively used by Hyprland users and this update provides bug fixes and new features from the upstream release.

## Changes

- Updates `hyprutils` from version `0.8.4` to `0.10.0`
- Updates the source hash for the new version
- Adds `logger` as a maintainer

## Testing

- [x] Package builds successfully on x86_64-linux
- [x] Tested dependent package `hyprlock` builds successfully with new version
- [x] `nix fmt` formatting applied (0 changes needed)
- [x] Dependencies show hyprutils version 0.10.0 is detected correctly

## Release Notes

From [hyprutils v0.10.0](https://github.com/hyprwm/hyprutils/releases/tag/v0.10.0):
- Fix scale() on some systems (fixes region fuckup from 0.9.0)
- Performance boost to pointer architecture 
- Breaks ABI (hence version bump)
- Memory control blocks are now type agnostic

## Checklist

- [x] Built on NixOS
- [x] Tested compilation of dependent packages (hyprlock, hyprlang, etc.)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)

## Changelog

Updates to the latest version of hyprutils which provides improved utilities for the Hyprland ecosystem, including important bug fixes and performance improvements.