### PR TITLE
[Backport release-25.05] squid: 7.0.1 -> 7.1

### DIFF
--- a/pkgs/by-name/sq/squid/package.nix
+++ b/pkgs/by-name/sq/squid/package.nix
@@ -17,16 +17,15 @@
   ipv6 ? true,
   nixosTests,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "squid";
-  version = "7.0.1";
+  version = "7.1";
 
   src = fetchurl {
     url = "https://github.com/squid-cache/squid/releases/download/SQUID_${
       builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }/squid-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Bw3Y5iGtItRdcAYF6xnSysG2zae3PwTzRXjTw/2N35s=";
+    hash = "sha256-djtaeFYc7cTkdjT6QrjmuNRsh8lJoVG056wjltL5feo=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -81,17 +80,16 @@ stdenv.mkDerivation (finalAttrs: {
     cd test-suite/
   '';
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin $out/libexec $out/etc $out/share
+  # exit from test-suite/ dir back to src root for correct makefile
+  postCheck = ''
     cd ..
-    cp src/squid $out/bin
-    cp src/unlinkd $out/libexec
-    cp src/mime.conf.default $out/etc/mime.conf
-    cp src/log/file/log_file_daemon $out/libexec
-    cp -r icons $out/share
-    cp -r errors $out/share
-    runHook postInstall
+  '';
+
+  # remove unusual nixos paths (pre-made /var dirs, config grammar) and rename sbin output
+  postInstall = ''
+    rm -r $out/var
+    rm $out/share/mib.txt
+    mv $out/sbin $out/bin
   '';
 
   passthru.tests.squid = nixosTests.squid;

--- a/pkgs/by-name/sq/squid/package.nix
+++ b/pkgs/by-name/sq/squid/package.nix
@@ -88,6 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp src/squid $out/bin
     cp src/unlinkd $out/libexec
     cp src/mime.conf.default $out/etc/mime.conf
+    cp src/log/file/log_file_daemon $out/libexec
     cp -r icons $out/share
     cp -r errors $out/share
     runHook postInstall


### PR DESCRIPTION
Manual backport of #431043 #440445 to `release-25.05`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
