### PR TITLE
broot: 1.49.1 -> 1.50.0

### DIFF
--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -11,21 +11,20 @@
   buildPackages,
   versionCheckHook,
   withClipboard ? true,
-  withTrash ? !stdenv.hostPlatform.isDarwin,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "broot";
-  version = "1.49.1";
+  version = "1.50.0";
 
   src = fetchFromGitHub {
     owner = "Canop";
     repo = "broot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zDy494qIoo4r+oCnrMvYSetmqsWCWfS5PAVlp8sU8Zk=";
+    hash = "sha256-izNuTXteNtoliDqfssEICUx3ynTBGoT6a7Ux2n+2cRo=";
   };
 
-  cargoHash = "sha256-zHvfZAsEoCtdxtFP7yqrC9t49UIMji2qTm+I1bhu63A=";
+  cargoHash = "sha256-ZwooHnQ2ZQigfMOYhEzMEJA2GrfHe4U8COtiblnFcOA=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -40,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zlib
   ];
 
-  buildFeatures = lib.optionals withTrash [ "trash" ] ++ lib.optionals withClipboard [ "clipboard" ];
+  buildFeatures = lib.optionals withClipboard [ "clipboard" ];
 
   env.RUSTONIG_SYSTEM_LIBONIG = true;
 


### PR DESCRIPTION
## Description

Updates broot from version 1.49.1 to 1.50.0, the latest stable release.

## Changes

- Update version to 1.50.0
- Update src and cargoHash for new version
- Remove 'trash' buildFeature as it's no longer available in 1.50.0
- Remove 'withTrash' parameter as trash functionality is now platform-dependent

## Upstream Changes

From the [v1.50.0 release notes](https://github.com/Canop/broot/releases/tag/v1.50.0):
- Big text files now only partially loaded for initial display, remaining being done in background
- Better support of kitty image protocol over tmux, ssh or unknown terminals
- "trash" compilation feature removed: trash related features are built depending on the platform
- Build chain revised with future official Mac binary releases
- Fix crash on double unstage of last entry in stage panel
- Fallback to transparent background for text preview when the skin specifies nothing

## Testing

- [x] Package builds successfully on x86_64-linux
- [x] Version check passes (`broot --version` reports correct version)
- [x] Basic functionality tested
- [x] `nix fmt` applied

## Checklist

- [x] Built on NixOS
- [x] Tested basic functionality of binary
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)