### PR TITLE
fetchit: use callPackage-style finalAttrs and clean up meta

### DIFF
--- a/pkgs/by-name/fe/fetchit/package.nix
+++ b/pkgs/by-name/fe/fetchit/package.nix
@@ -8,15 +8,15 @@
   pkg-config,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "fetchit";
   version = "0.0.1";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "fetchit";
-    rev = "v${version}";
-    sha256 = "sha256-hxS/+/fbYOpMJ5VfvvG5l7wWKBUUR22rYn9X79DzUUk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hxS/+/fbYOpMJ5VfvvG5l7wWKBUUR22rYn9X79DzUUk=";
   };
 
   vendorHash = "sha256-SyPd8P9s8R2YbGEPqFeztF98W1QyGSBumtirSdpm8VI=";
@@ -66,7 +66,7 @@ buildGoModule rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tool to manage the life cycle and configuration of Podman containers";
     mainProgram = "fetchit";
     longDescription = ''
@@ -79,9 +79,9 @@ buildGoModule rec {
       the containers running on the host.
     '';
     homepage = "https://fetchit.readthedocs.io";
-    changelog = "https://github.com/containers/fetchit/releases/tag/${src.rev}";
-    license = licenses.agpl3Plus;
+    changelog = "https://github.com/containers/fetchit/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ guylamar2006 ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
- switch buildGoModule from `rec` to `finalAttrs` form
- use `tag`/`hash` instead of `rev`/`sha256`
- drop `with lib;` in meta, qualify licenses/platforms explicitly
- changelog now references v${finalAttrs.version}
- ran nix-build -A fetchit --check

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
