### PR TITLE
[Backport release-25.05] mu: 1.12.9 -> 1.12.13 

### DIFF
--- a/pkgs/by-name/mu/mu/package.nix
+++ b/pkgs/by-name/mu/mu/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "mu";
-  version = "1.12.9";
+  version = "1.12.11";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "djcb";
     repo = "mu";
     rev = "v${version}";
-    hash = "sha256-o6K1xHv6dvzv1oRRiAiSXAqTaC0GcPDQ+ymh5kmH98k=";
+    hash = "sha256-t4Jv1RX1mMGwiYg9mFrRuO2j54EfaGM3ouOdg8upds8=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/mu/package.nix
+++ b/pkgs/by-name/mu/mu/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "mu";
-  version = "1.12.11";
+  version = "1.12.12";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "djcb";
     repo = "mu";
     rev = "v${version}";
-    hash = "sha256-t4Jv1RX1mMGwiYg9mFrRuO2j54EfaGM3ouOdg8upds8=";
+    hash = "sha256-ZdVzyfzTsGn3DaeOEXZFA/wX8MxIeD45FaKYU6okr4Y=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/mu/package.nix
+++ b/pkgs/by-name/mu/mu/package.nix
@@ -8,6 +8,8 @@
   pkg-config,
   python3,
   cld2,
+  cli11,
+  fmt_11,
   coreutils,
   emacs,
   glib,
@@ -16,9 +18,9 @@
   xapian,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mu";
-  version = "1.12.12";
+  version = "1.12.13";
 
   outputs = [
     "out"
@@ -28,8 +30,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "djcb";
     repo = "mu";
-    rev = "v${version}";
-    hash = "sha256-ZdVzyfzTsGn3DaeOEXZFA/wX8MxIeD45FaKYU6okr4Y=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-rz0bxgJtz4qHrfHRjJhnvxtFFNM89A39YH9oJ2YGC5g=";
   };
 
   postPatch = ''
@@ -63,7 +65,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cld2
+    cli11
     emacs
+    fmt_11
     glib
     gmime3
     texinfo
@@ -71,9 +75,10 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dguile=disabled"
-    "-Dreadline=disabled"
-    "-Dlispdir=${placeholder "mu4e"}/share/emacs/site-lisp"
+    (lib.strings.mesonEnable "guile" false)
+    (lib.strings.mesonEnable "readline" false)
+    (lib.strings.mesonEnable "tests" finalAttrs.doCheck)
+    (lib.strings.mesonOption "lispdir" "${placeholder "mu4e"}/share/emacs/site-lisp")
   ];
 
   nativeBuildInputs = [
@@ -93,8 +98,8 @@ stdenv.mkDerivation rec {
     description = "Collection of utilities for indexing and searching Maildirs";
     license = licenses.gpl3Plus;
     homepage = "https://www.djcbsoftware.nl/code/mu/";
-    changelog = "https://github.com/djcb/mu/releases/tag/v${version}";
-    maintainers = with maintainers; [
+    changelog = "https://github.com/djcb/mu/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [
       antono
       chvp
       peterhoeg
@@ -102,4 +107,4 @@ stdenv.mkDerivation rec {
     mainProgram = "mu";
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Manual backport of #404126 #426599 #442615 to `release-25.05`.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
