### PR TITLE
scanservjs: 2.27.1 -> 3.0.4

### DIFF
--- a/pkgs/by-name/sc/scanservjs/package.nix
+++ b/pkgs/by-name/sc/scanservjs/package.nix
@@ -2,85 +2,31 @@
   lib,
   fetchFromGitHub,
   buildNpmPackage,
-  fetchNpmDeps,
   nodejs_20,
-  replaceVars,
 }:
 
-let
-  # Build fails on node 22, presumably because of esm.
-  # https://github.com/NixOS/nixpkgs/issues/371649
-  nodejs = nodejs_20;
-  version = "2.27.1";
+buildNpmPackage (finalAttrs: {
+  pname = "scanservjs";
+  version = "3.0.4";
+
   src = fetchFromGitHub {
     owner = "sbs20";
     repo = "scanservjs";
-    # rev = "v${version}";
-    # 2.27.1 doesn't have a tag
-    rev = "b15adc6f97fb152fd9819371bb1a9b8118baf55b";
-    hash = "sha256-ne9fEF/eurWPXzmJQzBn5jiy+JgxMWiCXsOdmu2fj6E=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qCJyQO/hSDF4NOupV7sepwvpNyjSElnqT71LJuIKe+A=";
   };
 
-  depsHashes = {
-    server = "sha256-M8t+TrE+ntZaI9X7hEel94bz34DPtW32n0KKMSoCfIs=";
-    client = "sha256-C31WBYE8ba0t4mfKFAuYWrCZtSdN7tQIYmCflDRKuBM=";
-  };
+  npmDepsHash = "sha256-HIWT09G8gqSFt9CIjsjJaDRnj2GO0G6JOGeI0p4/1vw=";
 
-  serverDepsForClient = fetchNpmDeps {
-    inherit src nodejs;
-    sourceRoot = "${src.name}/packages/server";
-    name = "scanservjs";
-    hash = depsHashes.server or lib.fakeHash;
-  };
-
-  # static client files
-  client = buildNpmPackage {
-    pname = "scanservjs-client";
-    inherit version src nodejs;
-
-    sourceRoot = "${src.name}/packages/client";
-    npmDepsHash = depsHashes.client or lib.fakeHash;
-
-    preBuild = ''
-      cd ../server
-      chmod +w package-lock.json . /build/source/
-      npmDeps=${serverDepsForClient} npmConfigHook
-      cd ../client
-    '';
-
-    env.NODE_OPTIONS = "--openssl-legacy-provider";
-
-    dontNpmInstall = true;
-    installPhase = ''
-      mv /build/source/dist/client $out
-    '';
-  };
-
-in
-buildNpmPackage {
-  pname = "scanservjs";
-  inherit version src nodejs;
-
-  sourceRoot = "${src.name}/packages/server";
-  npmDepsHash = depsHashes.server or lib.fakeHash;
-
-  # can't use "patches" since they change the server deps' hash for building the client
-  # (I don't want to maintain one more hash)
-  preBuild = ''
-    chmod +w /build/source
-    patch -p3 <${
-      replaceVars ./decouple-from-source-tree.patch {
-        inherit client;
-      }
-    }
-    substituteInPlace src/api.js --replace 'NIX_OUT_PLACEHOLDER' "$out"
-  '';
+  # Build fails on node 22, presumably because of esm.
+  # https://github.com/NixOS/nixpkgs/issues/371649
+  nodejs = nodejs_20;
 
   postInstall = ''
-    mkdir -p $out/bin
-    makeWrapper ${lib.getExe nodejs} $out/bin/scanservjs \
+    mkdir $out/bin
+    makeWrapper ${lib.getExe finalAttrs.nodejs} $out/bin/scanservjs \
       --set NODE_ENV production \
-      --add-flags "'$out/lib/node_modules/scanservjs-api/src/server.js'"
+      --add-flags "'$out/lib/node_modules/scanservjs/app-server/src/server.js'"
   '';
 
   meta = {
@@ -92,4 +38,4 @@ buildNpmPackage {
     maintainers = with lib.maintainers; [ chayleaf ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/sbs20/scanservjs/releases/tag/v3.0.4
https://github.com/sbs20/scanservjs/compare/b15adc6f97fb152fd9819371bb1a9b8118baf55b...v3.0.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
