### PR TITLE
hyprspace: 0-unstable-2025-07-16 -> 0-unstable-2025-09-28

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
@@ -7,13 +7,13 @@
 
 mkHyprlandPlugin {
   pluginName = "hyprspace";
-  version = "0-unstable-2025-07-16";
+  version = "0-unstable-2025-09-28";
 
   src = fetchFromGitHub {
     owner = "KZDKM";
     repo = "hyprspace";
-    rev = "0a82e3724f929de8ad8fb04d2b7fa128493f24f7";
-    hash = "sha256-rTItuAWpzICMREF8Ww8cK4hYgNMRXJ4wjkN0akLlaWE=";
+    rev = "e54884da1d6a1af76af9d053887bf3750dd554fd";
+    hash = "sha256-QhcOFLJYC9CiSVPkci62ghMEAJChzl+L98To1pKvnRQ=";
   };
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
## Description

Updates hyprspace to the latest commit which fixes compatibility with hyprutils 0.10.0.

This update resolves build failures that occur when building hyprspace with the new hyprutils version due to ABI changes.

## Changes

- Updates hyprspace from `0-unstable-2025-07-16` to `0-unstable-2025-09-28`
- Fixes AnimationManager header path compatibility issue
- Resolves build failures with hyprutils 0.10.0

## Background

The upstream commit includes a critical fix for the AnimationManager include path:
- **Before**: `hyprland/src/managers/AnimationManager.hpp`
- **After**: `hyprland/src/managers/animation/AnimationManager.hpp`

This change was necessary due to header reorganization in the hyprland/hyprutils ecosystem.

## Testing

- [x] Package builds successfully on x86_64-linux
- [x] Tested with `nix-build -A hyprlandPlugins.hyprspace`
- [x] Used `nix-update` for automated version update
- [x] Applied formatting with `nix fmt`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test