### PR TITLE
[Backport release-25.05] nixos-rebuild-ng: make path part of Flake absolute; do not parse it as a Path

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -142,14 +142,17 @@ python3Packages.buildPythonApplication rec {
         # NOTE: this is a passthru test rather than a build-time test because we
         # want to keep the build closures small
         linters = runCommand "${pname}-linters" { nativeBuildInputs = [ python-with-pkgs ]; } ''
+          export MYPY_CACHE_DIR="$(mktemp -d)"
           export RUFF_CACHE_DIR="$(mktemp -d)"
 
+          pushd ${src}
           echo -e "\x1b[32m## run mypy\x1b[0m"
-          mypy ${src}
+          mypy .
           echo -e "\x1b[32m## run ruff\x1b[0m"
-          ruff check ${src}
+          ruff check .
           echo -e "\x1b[32m## run ruff format\x1b[0m"
-          ruff format --check ${src}
+          ruff format --check .
+          popd
 
           touch $out
         '';

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code=comparison-overlap
 from typing import Final
 
 # Build-time flags

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -86,7 +86,11 @@ class Flake:
 
     @override
     def __str__(self) -> str:
-        return f"{self.path}#{self.attr}"
+        if isinstance(self.path, Path):
+            # https://github.com/NixOS/nixpkgs/issues/433726
+            return f"{self.path.absolute()}#{self.attr}"
+        else:
+            return f"{self.path}#{self.attr}"
 
     @classmethod
     def parse(cls, flake_str: str, target_host: Remote | None = None) -> Self:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar, Self, TypedDict, override
 
 from .process import Remote, run_wrapper
 
-type ImageVariants = list[str]
+type ImageVariants = dict[str, str]
 
 
 class NixOSRebuildError(Exception):

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -77,7 +77,7 @@ def _get_hostname(target_host: Remote | None) -> str | None:
 
 @dataclass(frozen=True)
 class Flake:
-    path: Path | str
+    path: str
     attr: str
     _re: ClassVar = re.compile(r"^(?P<path>[^\#]*)\#?(?P<attr>[^\#\"]*)$")
 
@@ -86,11 +86,7 @@ class Flake:
 
     @override
     def __str__(self) -> str:
-        if isinstance(self.path, Path):
-            # https://github.com/NixOS/nixpkgs/issues/433726
-            return f"{self.path.absolute()}#{self.attr}"
-        else:
-            return f"{self.path}#{self.attr}"
+        return f"{self.path}#{self.attr}"
 
     @classmethod
     def parse(cls, flake_str: str, target_host: Remote | None = None) -> Self:
@@ -101,10 +97,7 @@ class Flake:
             f'nixosConfigurations."{attr or _get_hostname(target_host) or "default"}"'
         )
         path = m.group("path")
-        if ":" in path:
-            return cls(path, nixos_attr)
-        else:
-            return cls(Path(path), nixos_attr)
+        return cls(path, nixos_attr)
 
     @classmethod
     def from_arg(cls, flake_arg: Any, target_host: Remote | None) -> Self | None:  # noqa: ANN401

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -118,6 +118,12 @@ class Flake:
                 else:
                     return None
 
+    def resolve_path_if_exists(self) -> str:
+        try:
+            return str(Path(self.path).resolve(strict=True))
+        except FileNotFoundError:
+            return self.path
+
 
 @dataclass(frozen=True)
 class Generation:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -557,7 +557,7 @@ def repl_flake(flake: Flake, flake_flags: Args | None = None) -> None:
         files(__package__).joinpath(FLAKE_REPL_TEMPLATE).read_text()
     ).substitute(
         flake=flake,
-        flake_path=flake.path.resolve() if isinstance(flake.path, Path) else flake.path,
+        flake_path=flake.resolve_path_if_exists(),
         flake_attr=flake.attr,
         bold="\033[1m",
         blue="\033[34;1m",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -14,7 +14,7 @@ class LogFormatter(logging.Formatter):
     }
 
     @override
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: logging.LogRecord) -> Any:
         record.levelname = record.levelname.lower()
         formatter = self.formatters.get(record.levelno, self.formatters["DEFAULT"])
         return formatter.format(record)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -71,6 +71,14 @@ def test_flake_to_attr() -> None:
     )
 
 
+def test_flake__str__(monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+    assert str(m.Flake("github:nixos/nixpkgs", "attr")) == "github:nixos/nixpkgs#attr"
+    assert str(m.Flake(Path("/etc/nixos"), "attr")) == "/etc/nixos#attr"
+    with monkeypatch.context() as patch_context:
+        patch_context.chdir(tmpdir)
+        assert str(m.Flake(Path("."), "attr")) == f"{tmpdir}#attr"
+
+
 @patch("platform.node", autospec=True)
 def test_flake_from_arg(
     mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -71,11 +71,26 @@ def test_flake_to_attr() -> None:
     )
 
 
-def test_flake__str__(monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_flake__str__() -> None:
     assert str(m.Flake("github:nixos/nixpkgs", "attr")) == "github:nixos/nixpkgs#attr"
     assert str(m.Flake("/etc/nixos", "attr")) == "/etc/nixos#attr"
     assert str(m.Flake(".", "attr")) == ".#attr"
     assert str(m.Flake("", "attr")) == "#attr"
+
+
+def test_flake_resolve_path_if_exists(monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+    assert (
+        m.Flake("github:nixos/nixpkgs", "attr").resolve_path_if_exists()
+        == "github:nixos/nixpkgs"
+    )
+    assert (
+        m.Flake("/an/inexistent/path", "attr").resolve_path_if_exists()
+        == "/an/inexistent/path"
+    )
+    with monkeypatch.context() as patch_context:
+        patch_context.chdir(tmpdir)
+        assert m.Flake(str(tmpdir), "attr").resolve_path_if_exists() == str(tmpdir)
+        assert m.Flake(".", "attr").resolve_path_if_exists() == str(tmpdir)
 
 
 @patch("platform.node", autospec=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -54,7 +54,7 @@ def test_build(mock_run: Mock) -> None:
 )
 def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     monkeypatch.chdir(tmpdir)
-    flake = m.Flake.parse(".#hostname")
+    flake = m.Flake.parse("/flake.nix#hostname")
 
     assert n.build_flake(
         "config.system.build.toplevel",
@@ -68,7 +68,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
             "nix-command flakes",
             "build",
             "--print-out-paths",
-            '.#nixosConfigurations."hostname".config.system.build.toplevel',
+            '/flake.nix#nixosConfigurations."hostname".config.system.build.toplevel',
             "--no-link",
             "--nix-flag",
             "foo",
@@ -173,7 +173,7 @@ def test_build_remote_flake(
     mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
 ) -> None:
     monkeypatch.chdir(tmpdir)
-    flake = m.Flake.parse(".#hostname")
+    flake = m.Flake.parse("/flake.nix#hostname")
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
@@ -194,7 +194,7 @@ def test_build_remote_flake(
                     "nix-command flakes",
                     "eval",
                     "--raw",
-                    '.#nixosConfigurations."hostname".config.system.build.toplevel.drvPath',
+                    '/flake.nix#nixosConfigurations."hostname".config.system.build.toplevel.drvPath',
                     "--flake",
                 ],
                 stdout=PIPE,
@@ -308,7 +308,7 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_edit_flake(mock_run: Mock) -> None:
-    flake = m.Flake.parse(".#attr")
+    flake = m.Flake.parse("/flake.nix#attr")
     n.edit_flake(flake, {"commit_lock_file": True})
     mock_run.assert_called_with(
         [
@@ -318,7 +318,7 @@ def test_edit_flake(mock_run: Mock) -> None:
             "edit",
             "--commit-lock-file",
             "--",
-            '.#nixosConfigurations."attr"',
+            '/flake.nix#nixosConfigurations."attr"',
         ],
         check=False,
     )
@@ -402,7 +402,7 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
     ),
 )
 def test_get_build_image_variants_flake(mock_run: Mock) -> None:
-    flake = m.Flake(Path("flake.nix"), "myAttr")
+    flake = m.Flake(Path("/flake.nix"), "myAttr")
     assert n.get_build_image_variants_flake(flake, {"eval_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
@@ -412,7 +412,7 @@ def test_get_build_image_variants_flake(mock_run: Mock) -> None:
             "nix",
             "eval",
             "--json",
-            "flake.nix#myAttr.config.system.build.images",
+            "/flake.nix#myAttr.config.system.build.images",
             "--apply",
             "builtins.attrNames",
             "--eval-flag",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -402,7 +402,7 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
     ),
 )
 def test_get_build_image_variants_flake(mock_run: Mock) -> None:
-    flake = m.Flake(Path("/flake.nix"), "myAttr")
+    flake = m.Flake("/flake.nix", "myAttr")
     assert n.get_build_image_variants_flake(flake, {"eval_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
@@ -591,7 +591,7 @@ def test_repl(mock_run: Mock) -> None:
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_repl_flake(mock_run: Mock) -> None:
-    n.repl_flake(m.Flake(Path("flake.nix"), "myAttr"), {"nix_flag": True})
+    n.repl_flake(m.Flake("flake.nix", "myAttr"), {"nix_flag": True})
     # See nixos-rebuild-ng.tests.repl for a better test,
     # this is mostly for sanity check
     assert mock_run.call_count == 1


### PR DESCRIPTION
Manual backport of #433743 #445188 to `release-25.05`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
