### PR TITLE
adaptivecpp: unpin rocmPackages_6

### DIFF
--- a/pkgs/by-name/ad/adaptivecpp/package.nix
+++ b/pkgs/by-name/ad/adaptivecpp/package.nix
@@ -10,7 +10,7 @@
   makeWrapper,
   config,
   cudaPackages,
-  rocmPackages_6,
+  rocmPackages,
   ompSupport ? true,
   openclSupport ? false,
   rocmSupport ? config.rocmSupport,
@@ -23,7 +23,6 @@
 }:
 let
   inherit (llvmPackages) stdenv;
-  rocmPackages = rocmPackages_6;
   llvmPackages = llvmPackages_18;
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
No need to pin any more, adaptive-cpp will work fine with ROCm 7 (tested in [WIP upgrade branch](https://github.com/LunNova/nixpkgs/tree/lunnova/rocm-7-inplace)), this pin was a holdover from when rocmPackages_5/6 coexisted.

## Things done

No rebuilds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
