### PR TITLE
imgui-file-dialog: init at 0.6.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28829,6 +28829,12 @@
     githubId = 71881325;
     name = "Stefan Bordei";
   };
+  ZZBaron = {
+    email = "zzbarona+nix@gmail.com";
+    github = "ZZBaron";
+    githubId = 157318434;
+    name = "ZZBaron";
+  };
   zzzsy = {
     email = "me@zzzsy.top";
     github = "zzzsyyy";

--- a/pkgs/by-name/im/imgui-file-dialog/package.nix
+++ b/pkgs/by-name/im/imgui-file-dialog/package.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  fetchFromGitHub,
+  imgui,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "imgui-file-dialog";
+  version = "0.6.8";
+
+  src = fetchFromGitHub {
+    owner = "aiekick";
+    repo = "ImGuiFileDialog";
+    tag = "v${version}";
+    hash = "sha256-v5ROW4o4of3tUGMN/p/CNH1eWT+RNRlWvhI84HUMEGo=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ imgui ];
+
+  # Propagate imgui so users can find the headers (ImGuiFileDialog.h includes imgui.h)
+  propagatedBuildInputs = [ imgui ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Full featured file dialog for Dear ImGui";
+    homepage = "https://github.com/aiekick/ImGuiFileDialog";
+    changelog = "https://github.com/aiekick/ImGuiFileDialog/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ZZBaron ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

### Description of changes

File dialog library for Dear ImGui applications.

Upstream: https://github.com/aiekick/ImGuiFileDialog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
