### PR TITLE
linux/common-config: enable media staging drivers

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -904,6 +904,7 @@ let
       # Enable staging drivers.  These are somewhat experimental, but
       # they generally don't hurt.
       STAGING = yes;
+      STAGING_MEDIA = yes;
     };
 
     proc-events = {


### PR DESCRIPTION
Enables the config setting `STAGING_MEDIA`. With our current default (LTS) kernel 6.12.49, it adds four modules to the `modules` output.

We already enabled staging drivers, as their existence generally won't hurt.  I assume the same holds for the subset of media staging drivers.

The change is also in line with other distributions, e.g. [openSUSE](https://github.com/openSUSE/kernel-source/blob/50583f4464872c4d1abe1a222d75d41027f6d7a7/config/x86_64/default#L9420), [Fedora](https://src.fedoraproject.org/rpms/kernel/blob/9fab601be2e1185cf3aa1658d5f1dc7d6eceb381/f/kernel-x86_64-fedora.config#_7963), [Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/46c65b3f38ffaee2caf38255e81a0f611d6ed3a7/config#L9606), [Ubuntu](https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble/tree/debian.master/config/annotations#n13406)

Notifying kernel maintainer team: @TredwellGit @K900 @Ma27 @NeQuissimus @alyssais

Would it be permissible to backport this to stable NixOS 25.05 ?  I have an old machine that needs one of those modules, but is not powerful enough to compile its own kernel.


## Things done

- Built on platform:
  - [x] x86_64-linux (only linux kernel 6.12, see below)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More:

- [x] `linuxPackages_{5_{4,10,15},6_{1,6,12,16}}.kernel.configfile` all build
- [x] `linuxPackages_6_12.kernel` builds
- [x] after cherry-picking onto [current `nixos-25.05`](https://github.com/NixOS/nixpkgs/tree/3bcc93c5f7a4b30335d31f21e2f1281cba68c318), `linuxPackages_6_12.kernel` builds and boots, the newly built module `dvb-ttpci` works fine with my "Hauppauge Nexus-S" dvb pci card.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
