### PR TITLE
musescore: 4.5.2-unstable-2025-07-03 -> 4.6.0

### DIFF
--- a/nixos/tests/musescore.nix
+++ b/nixos/tests/musescore.nix
@@ -5,9 +5,15 @@ let
   customMuseScoreConfig = hostPkgs.writeText "MuseScore4.ini" ''
     [application]
     hasCompletedFirstLaunchSetup=true
+    welcomeDialogLastShownIndex=0
+    welcomeDialogLastShownVersion=${hostPkgs.musescore.version}
+    welcomeDialogShowOnStartup=false
 
     [project]
     preferredScoreCreationMode=1
+
+    [tours]
+    lastShownTours=",project_opened/input-by-duration"
   '';
 in
 {
@@ -66,7 +72,7 @@ in
 
       machine.sleep(2)
 
-      machine.send_key("tab")
+      machine.send_key("right")
       # Type the beginning of https://de.wikipedia.org/wiki/Alle_meine_Entchen
       machine.send_chars("cdef6gg5aaaa7g")
       machine.sleep(1)
@@ -79,14 +85,13 @@ in
       # Wait until the Print dialogue appears.
       machine.wait_for_window("Print")
 
-      machine.screenshot("MuseScore4")
+      machine.screenshot("MuseScore3")
       machine.send_key("alt-p")
-      machine.sleep(1)
-
-      machine.screenshot("MuseScore5")
 
       # Wait until PDF is exported
       machine.wait_for_file('"/root/Untitled score.pdf"')
+
+      machine.screenshot("MuseScore4")
 
       ## Check that it contains the title of the score
       machine.succeed('pdfgrep "Untitled score" "/root/Untitled score.pdf"')

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -36,13 +36,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore";
-  version = "4.5.2-unstable-2025-07-03";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "musescore";
     repo = "MuseScore";
-    rev = "0ff2476af4e16286ee9f7cf2322715273a0117e0";
-    sha256 = "sha256-0ixQfAyAyRmuIrlPosCV/VucKJYYvxjL2o4pkVb5Sd8=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-+Kmx+jMbBaIzXdulj5tsusF0x9b6tZ6jOTjI+sLP1jU=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
Musescore had a new release, this just updates to it.

*Not done yet* I will have to change the test as the workflow changed (most importantly the Welcome window).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
