### PR TITLE
python313Packages.pysilero-vad: disable tests on aarch64

### DIFF
--- a/pkgs/development/python-modules/pysilero-vad/default.nix
+++ b/pkgs/development/python-modules/pysilero-vad/default.nix
@@ -38,9 +38,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pysilero_vad" ];
 
+  # aarch64-linux onnxruntime tries to get cpu information from /sys, which isn't available
+  # inside the nix build sandbox.
+  doCheck = stdenv.buildPlatform.system != "aarch64-linux";
+  dontUsePythonImportsCheck = stdenv.buildPlatform.system == "aarch64-linux";
+
   meta = with lib; {
-    # what():  /build/source/include/onnxruntime/core/common/logging/logging.h:294 static const onnxruntime::logging::Logger& onnxruntime::logging::LoggingManager::DefaultLogger() Attempt to use DefaultLogger but none has been registered.
-    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
     description = "Pre-packaged voice activity detector using silero-vad";
     homepage = "https://github.com/rhasspy/pysilero-vad";
     changelog = "https://github.com/rhasspy/pysilero-vad/blob/${src.tag}/CHANGELOG.md";


### PR DESCRIPTION
Very similar to the following PR: [NixOS/nixpkgs#351917](https://github.com/NixOS/nixpkgs/pull/351917)
The package [pysilero-vad](https://github.com/rhasspy/pysilero-vad/tree/master) is a simple wrapper that loads a model using ONNX Runtime ([see code](https://github.com/rhasspy/pysilero-vad/blob/master/pysilero_vad/__init__.py))

As mentioned in PR #351917, loading ONNX Runtime models fails on aarch64 when running inside the Nix sandbox, because the runtime attempts to read information from `/sys`. However, the build succeeds if `/sys` is made available to the sandbox, so the command:

```
nix build .#python313Packages.pysilero-vad --system aarch64-linux --option extra-sandbox-paths /sys
```
Succeeds!


Since this package only serves as a lightweight wrapper around a model, we can safely disable the tests.

We cannot use [disabledTestPaths](https://ryantm.github.io/nixpkgs/languages-frameworks/python/#using-pytestcheckhook) because all the tests depend on ONNX Runtime (and therefore, require /sys access), and if we use it, pytest exits with code 5 (indicating “no tests collected”), which causes the build to fail.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
