### PR TITLE
pkgsCross.ghcjs.haskellPackages.reflex-dom: re-enable jobs

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -35,9 +35,16 @@ with haskellLib;
   patch = haskellLib.disableParallelBuilding super.patch;
   reflex-dom-core = haskellLib.disableParallelBuilding super.reflex-dom-core;
 
-  reflex-dom = super.reflex-dom.override (drv: {
-    jsaddle-webkit2gtk = null;
-  });
+  # Marked as dontDistribute in -common because of jsaddle-webkit2gtk
+  # which requires an unmaintained version of libsoup. Since this dep
+  # is unnecessary for the JS backend, we can re-enable these jobs here.
+  reflex-dom = doDistribute (
+    super.reflex-dom.override (drv: {
+      jsaddle-webkit2gtk = null;
+    })
+  );
+  reflex-localize-dom = doDistribute super.reflex-localize-dom;
+  trasa-reflex = doDistribute super.trasa-reflex;
 
   miso-examples = pkgs.lib.pipe super.miso-examples [
     (addBuildDepends (


### PR DESCRIPTION
This is possible since the platform configuration is applied after configuration-common.nix (which contains the dontDistributes).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
