### PR TITLE
postgresql_{17,18}: fix build

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -6,6 +6,7 @@ let
       stdenv,
       fetchFromGitHub,
       fetchurl,
+      fetchpatch2,
       lib,
       replaceVars,
       writeShellScriptBin,
@@ -424,6 +425,12 @@ let
       ]
       ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
         ./patches/export-dynamic-darwin-15-.patch
+      ]
+      ++ lib.optionals (atLeast "17") [
+        (fetchpatch2 {
+          url = "https://github.com/postgres/postgres/commit/a48d1ef58652229521ba4b5070e19f857608b22e.patch";
+          hash = "sha256-3FKQS1Vpu+p6z6c1GWs6GlrLl2Bgm9paEU/z81LrEus=";
+        })
       ];
 
       installTargets = [ "install-world" ];


### PR DESCRIPTION
After a recent update of libxml2 the build fails with

    /nix/store/casz7al9kpkg52sn156h6slqijwkybqj-libxml2-2.15.0-bin/bin/xmllint --nonet --path . --path . --output postgres-full.xml --noent --valid postgres.sgml
    ref/pg_combinebackup.sgml:287: validity error : standalone: normalization of attribute linkend on xref by external subset declaration
   state of the cluster using <xref linkend="app-pgchecksums "/> is

Reported in #448752 (not closing on purpose since the issue is actually about another problem).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
