### PR TITLE
python3Packages.vllm: add update.py

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -474,8 +474,7 @@ buildPythonPackage rec {
   passthru = {
     # make internal dependency available to overlays
     vllm-flash-attn = vllm-flash-attn';
-    # updates the cutlass fetcher instead
-    skipBulkUpdate = true;
+    updateScript = ./update.py;
   };
 
   meta = {

--- a/pkgs/development/python-modules/vllm/update.py
+++ b/pkgs/development/python-modules/vllm/update.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 python3Packages.sh sd nix-prefetch-github common-updater-scripts
+
+"""
+Updates the main vLLM package and three external dependencies.
+"""
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from urllib.request import Request, urlopen
+import sh
+
+
+API_BASE = 'https://api.github.com/repos'
+RAW_BASE = 'https://raw.githubusercontent.com'
+
+NIX_FILE = str(Path(__file__).resolve().parent / 'default.nix')
+GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN', '')
+HEADERS = {'Accept': 'application/vnd.github.v3+json'} | (
+    {'Authorization': f'bearer {GITHUB_TOKEN}'} if GITHUB_TOKEN else {}
+)
+
+PKG_NAME = 'python3Packages.vllm'
+PKG_REPO = 'vllm-project/vllm'
+TAG_PATTERN = r'(repo = "vllm";\s+)tag = "v\$\{version\}";'
+REV_PATTERN = r'(repo = "vllm";\s+)rev = "[a-f0-9]{40}";'
+
+DEPENDENCIES = {
+    'NVIDIA/cutlass': {
+        'upstream_file': 'CMakeLists.txt',
+        'upstream_pattern': r'CUTLASS_REVISION "([^"]+)"',
+        'update_pattern': r'(cutlass = fetchFromGitHub.*?tag = ")[^"]+(";.*?hash = ")[^"]+(";)',
+    },
+    'vllm-project/FlashMLA': {
+        'upstream_file': 'cmake/external_projects/flashmla.cmake',
+        'upstream_pattern': r'GIT_TAG ([a-f0-9]+)',
+        'update_pattern': r'(flashmla = stdenv\.mkDerivation.*?rev = ")[^"]+(";.*?hash = ")[^"]+(";)',
+        'version_config': {
+            'source_file': 'setup.py',
+            'version_pattern': r'"([0-9]+\.[0-9]+\.[0-9]+)"',
+            'update_pattern': r'(flashmla = stdenv\.mkDerivation.*?version = ")[^"]+(";)',
+        },
+    },
+    'vllm-project/flash-attention': {
+        'upstream_file': 'cmake/external_projects/vllm_flash_attn.cmake',
+        'upstream_pattern': r'GIT_TAG ([a-f0-9]+)',
+        'update_pattern': r"(vllm-flash-attn' = lib\.defaultTo.*?rev = \")[^\"]+(\";.*?hash = \")[^\"]+(\";)",
+        'version_config': {
+            'source_file': 'vllm_flash_attn/__init__.py',
+            'version_pattern': r'__version__\s*=\s*"([^"]+)"',
+            'update_pattern': r"(vllm-flash-attn' = lib\.defaultTo.*?version = \")[^\"]+(\";)",
+        },
+    },
+}
+
+
+def fetch_json(url: str) -> dict:
+    with urlopen(Request(url, headers=HEADERS)) as r:
+        return json.loads(r.read())
+
+def fetch_text(url: str) -> str:
+    with urlopen(Request(url, headers=HEADERS)) as r:
+        return r.read().decode('utf-8')
+
+
+def update_git_dep(github_repo: str, config: dict, pkg_ref: str) -> None:
+    upstream_url = f'{RAW_BASE}/{PKG_REPO}/{pkg_ref}/{config["upstream_file"]}'
+    new_revision = re.search(config['upstream_pattern'], fetch_text(upstream_url)).group(1)
+    sri_hash = json.loads(sh.nix_prefetch_github(*github_repo.split('/'), '--rev', new_revision).strip())['hash']
+    sh.sd('--flags', 'ms', config['update_pattern'], rf'${{1}}{new_revision}${{2}}{sri_hash}${{3}}', NIX_FILE)
+    if version_config := config.get('version_config'):
+        source_url = f'{RAW_BASE}/{github_repo}/{new_revision}/{version_config["source_file"]}'
+        version = re.search(version_config['version_pattern'], fetch_text(source_url)).group(1)
+        sh.sd('--flags', 'ms', version_config['update_pattern'], rf'${{1}}{version}${{2}}', NIX_FILE)
+
+
+def update_primary_package(mode: str) -> str:
+    release_data = fetch_json(f'{API_BASE}/{PKG_REPO}/releases/latest')
+    main_data = fetch_json(f'{API_BASE}/{PKG_REPO}/commits/main')
+    rc_data = next(tag for tag in fetch_json(f'{API_BASE}/{PKG_REPO}/tags') if 'rc' in tag['name'])
+    rc_version = rc_data['name'].lstrip('v')
+    dev_commit_count = fetch_json(f'{API_BASE}/{PKG_REPO}/compare/{rc_data['name']}...{main_data['sha']}')['ahead_by']
+    stable_version = release_data['tag_name'].lstrip('v')
+
+    match mode:
+        case "dev":
+            version, ref = f"{rc_version}.dev{dev_commit_count}", 'main'
+            sh.sd('--flags', 'ms', TAG_PATTERN, rf'${{1}}rev = "{main_data["sha"]}";', NIX_FILE)
+        case "rc":
+            version, ref = rc_version, rc_data['name']
+        case _:
+            version, ref = stable_version, release_data['tag_name']
+
+    if mode != "dev":
+        sh.sd('--flags', 'ms', REV_PATTERN, r'${1}tag = "v$${version}";', NIX_FILE)
+
+    sh.update_source_version(PKG_NAME, version, '--ignore-same-version')
+    return ref
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Update vLLM package and dependencies')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--dev', action='store_true', help='Update to main branch dev version')
+    group.add_argument('--rc', action='store_true', help='Update to latest release candidate')
+    args = parser.parse_args()
+    if not GITHUB_TOKEN:
+        print("Warning: No GITHUB_TOKEN set - may hit GitHub API rate limits")
+    mode = "dev" if args.dev else "rc" if args.rc else "stable"
+    pkg_ref = update_primary_package(mode)
+    for repo, config in DEPENDENCIES.items():
+        update_git_dep(repo, config, pkg_ref)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Removes `passthru.skipBulkUpdate` since automated updates are now safe
- Adds `passthru.updateScript` that coordinates updates of vLLM and its external dependencies (CUTLASS, FlashMLA, flash-attention). The script parses upstream CMake configurations to extract git revisions, computes nix hashes, and updates the derivation file
- Adds Pythonic script with the `sh` library to invoke external tools (`sd`, `nix-prefetch-github`, `nix`, `update-source-version`) while handling HTTP and JSON natively. Regex patterns are pre-computed in configuration for maintainability
- Script structure is designed for reusability: package-specific configuration is isolated in top-level constants, making it straightforward to adapt for other packages with similar bespoke update requirements

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
