### PR TITLE
{libsForQt5.rlottie-qml,lomiri.teleports}: Fix dependency on rlottie being built via CMake

### DIFF
--- a/pkgs/desktops/lomiri/applications/teleports/1001-app-CMakeLists.txt-Drop-explicit-dependency-on-rlottie.patch
+++ b/pkgs/desktops/lomiri/applications/teleports/1001-app-CMakeLists.txt-Drop-explicit-dependency-on-rlottie.patch
@@ -1,0 +1,27 @@
+From f9dfacc4b92faa7b60ae37489aa58520b4da95d7 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sun, 5 Oct 2025 14:34:43 +0200
+Subject: [PATCH] app/CMakeLists.txt: Drop explicit dependency on rlottie
+
+- If rlottie is built via Meson instead of CMake, then there will be no CMake module to find here.
+- rlottie-qml already links against rlottie, and there is no direct usage of rlottie headers in this project,
+  so explicitly pulling it in shouldn't be necessary.
+---
+ app/CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/app/CMakeLists.txt b/app/CMakeLists.txt
+index c1f0b85..7a59db5 100644
+--- a/app/CMakeLists.txt
++++ b/app/CMakeLists.txt
+@@ -1,7 +1,6 @@
+ find_package(Qt5 COMPONENTS Core Quick Multimedia REQUIRED)
+ 
+ find_package(QuickFlux REQUIRED)
+-find_package(rlottie REQUIRED)
+ find_package(rLottieQml REQUIRED)
+ 
+ #"qtdclient.cpp" "qtdthread.cpp" "qml.qrc"
+-- 
+2.51.0
+

--- a/pkgs/desktops/lomiri/applications/teleports/default.nix
+++ b/pkgs/desktops/lomiri/applications/teleports/default.nix
@@ -58,6 +58,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/apps/teleports/-/commit/dd537c08453be9bfcdb2ee1eb692514c7e867e41.patch";
       hash = "sha256-zxxFvoj6jluGPCA9GQsxuYYweaSOVrkD01hZwCtq52U=";
     })
+
+    # Remove when https://gitlab.com/ubports/development/apps/teleports/-/merge_requests/586 merged & in release
+    ./1001-app-CMakeLists.txt-Drop-explicit-dependency-on-rlottie.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/rlottie-qml/1001-Use-upstream-QuaZip-CMake-config.patch
+++ b/pkgs/development/libraries/rlottie-qml/1001-Use-upstream-QuaZip-CMake-config.patch
@@ -1,0 +1,75 @@
+From 5656211dd8ae190795e343f47a3393fd3d8d25a4 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Fri, 2 Feb 2024 12:04:32 +0100
+Subject: [PATCH 1/2] Use upstream QuaZip CMake config
+
+---
+ CMakeLists.txt                  |  5 ++---
+ cmake/FindQuaZip.cmake          | 24 ------------------------
+ cmake/rLottieQmlConfig.cmake.in |  2 +-
+ 3 files changed, 3 insertions(+), 28 deletions(-)
+ delete mode 100644 cmake/FindQuaZip.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4bd97b4..4d06eb5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,10 +21,9 @@ find_package(Qt5 COMPONENTS Core Qml Quick Multimedia CONFIG REQUIRED)
+ # set(rlottie_DIR "${CMAKE_CURRENT_BINARY_DIR}/../rlottie/install/lib/cmake/rlottie")
+ find_package(rlottie REQUIRED)
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+-find_package(QuaZip REQUIRED)
++find_package(QuaZip-Qt5 REQUIRED)
+ 
+-target_include_directories(${PLUGIN} SYSTEM PRIVATE ${QUAZIP_INCLUDE_DIR})
+-target_link_libraries(${PLUGIN} ${QUAZIP_LIBRARIES} rlottie::rlottie)
++target_link_libraries(${PLUGIN} QuaZip::QuaZip rlottie::rlottie)
+ target_link_libraries(${PLUGIN}
+   # PUBLIC
+   Qt5::Qml
+diff --git a/cmake/FindQuaZip.cmake b/cmake/FindQuaZip.cmake
+deleted file mode 100644
+index 76c1d8a..0000000
+--- a/cmake/FindQuaZip.cmake
++++ /dev/null
+@@ -1,24 +0,0 @@
+-# QUAZIP_FOUND                   - QuaZip library was found
+-# QUAZIP_INCLUDE_DIR             - Path to QuaZip include dir
+-# QUAZIP_INCLUDE_DIRS            - Path to QuaZip and zlib include dir (combined from QUAZIP_INCLUDE_DIR + ZLIB_INCLUDE_DIR)
+-# QUAZIP_LIBRARIES               - List of QuaZip libraries
+-# QUAZIP_ZLIB_INCLUDE_DIR        - The include dir of zlib headers
+-
+-if(MINGW)
+-	find_library(QUAZIP_LIBRARIES libquazip5)
+-	find_path(QUAZIP_INCLUDE_DIR quazip.h PATH_SUFFIXES quazip5)
+-	find_path(QUAZIP_ZLIB_INCLUDE_DIR zlib.h)
+-else()
+-	find_library(QUAZIP_LIBRARIES
+-		NAMES quazip5 quazip quazip1-qt5
+-		PATHS /usr/lib /usr/lib64 /usr/local/lib
+-	)
+-	find_path(QUAZIP_INCLUDE_DIR quazip.h
+-		PATHS /usr/include /usr/local/include
+-		PATH_SUFFIXES quazip5 quazip "QuaZip-Qt5-1.1/quazip"
+-	)
+-	find_path(QUAZIP_ZLIB_INCLUDE_DIR zlib.h PATHS /usr/include /usr/local/include)
+-endif()
+-include(FindPackageHandleStandardArgs)
+-set(QUAZIP_INCLUDE_DIRS ${QUAZIP_INCLUDE_DIR} ${QUAZIP_ZLIB_INCLUDE_DIR})
+-find_package_handle_standard_args(QUAZIP DEFAULT_MSG QUAZIP_LIBRARIES QUAZIP_INCLUDE_DIR QUAZIP_ZLIB_INCLUDE_DIR QUAZIP_INCLUDE_DIRS)
+diff --git a/cmake/rLottieQmlConfig.cmake.in b/cmake/rLottieQmlConfig.cmake.in
+index 7848a1d..f606d25 100644
+--- a/cmake/rLottieQmlConfig.cmake.in
++++ b/cmake/rLottieQmlConfig.cmake.in
+@@ -2,7 +2,7 @@ get_filename_component(rLottieQml_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ include(CMakeFindDependencyMacro)
+ 
+ # find_dependency(rlottie REQUIRED)
+-# find_dependency(QuaZip REQUIRED)
++find_dependency(QuaZip-Qt5 REQUIRED)
+ 
+ if(NOT TARGET rLottieQml::rLottieQml)
+     include("${rLottieQml_CMAKE_DIR}/rLottieQmlExport.cmake")
+-- 
+2.51.0
+

--- a/pkgs/development/libraries/rlottie-qml/1002-Find-rlottie-via-pkg-config.patch
+++ b/pkgs/development/libraries/rlottie-qml/1002-Find-rlottie-via-pkg-config.patch
@@ -1,0 +1,35 @@
+From 1935d690c3eead6844093b5df3b0aecff4f95345 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sun, 5 Oct 2025 13:48:29 +0200
+Subject: [PATCH 2/2] Find rlottie via pkg-config
+
+Because availability of the CMake module depends on how rlottie was built - building via Meson doesn't generate the module.
+---
+ CMakeLists.txt | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d06eb5..f12ae3c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,13 +17,15 @@ add_library(${PLUGIN} MODULE ${SRC})
+ # set_target_properties(${PLUGIN} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PLUGIN})
+ # qt5_use_modules(${PLUGIN} Qml Quick DBus Multimedia)
+ 
++find_package(PkgConfig REQUIRED)
+ find_package(Qt5 COMPONENTS Core Qml Quick Multimedia CONFIG REQUIRED)
+ # set(rlottie_DIR "${CMAKE_CURRENT_BINARY_DIR}/../rlottie/install/lib/cmake/rlottie")
+-find_package(rlottie REQUIRED)
++pkg_check_modules(RLOTTIE REQUIRED rlottie)
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ find_package(QuaZip-Qt5 REQUIRED)
+ 
+-target_link_libraries(${PLUGIN} QuaZip::QuaZip rlottie::rlottie)
++target_include_directories(${PLUGIN} PUBLIC ${RLOTTIE_INCLUDE_DIRS})
++target_link_libraries(${PLUGIN} QuaZip::QuaZip ${RLOTTIE_LIBRARIES})
+ target_link_libraries(${PLUGIN}
+   # PUBLIC
+   Qt5::Qml
+-- 
+2.51.0
+

--- a/pkgs/development/libraries/rlottie-qml/default.nix
+++ b/pkgs/development/libraries/rlottie-qml/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   cmake,
+  pkg-config,
   qtbase,
   qtdeclarative,
   qtmultimedia,
@@ -29,11 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Remove when https://gitlab.com/mymike00/rlottie-qml/-/merge_requests/1 merged
-    (fetchpatch {
-      name = "0001-rlottie-qml-Use-upstream-QuaZip-config-module.patch";
-      url = "https://gitlab.com/mymike00/rlottie-qml/-/commit/5656211dd8ae190795e343f47a3393fd3d8d25a4.patch";
-      hash = "sha256-t2NlYVU+D8hKd+AvBWPEavAhJKlk7Q3y2iAQSYtks5k=";
-    })
+    ./1001-Use-upstream-QuaZip-CMake-config.patch
+
+    # Remove when https://gitlab.com/mymike00/rlottie-qml/-/merge_requests/3 merged
+    ./1002-Find-rlottie-via-pkg-config.patch
   ];
 
   postPatch = ''
@@ -47,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    pkg-config
   ];
 
   buildInputs = [


### PR DESCRIPTION
Due to CMake 4 reasons, `rlottie` switches to being built via Meson in #448814.

Fix compat with an `rlottie` that wasn't built via CMake.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
