### PR TITLE
pkgs.formats.plist: init

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -358,6 +358,16 @@ have a predefined type and string generator already declared under
 
     :   Outputs the xml with header.
 
+`pkgs.formats.plist` { escape ? true }
+
+:   A function taking an attribute set with values
+
+    `escape`
+
+    :   Whether to escape XML special characters in string values and keys.
+
+    It returns a set with Property list (plist) specific attributes `type` and `generate` as specified [below](#pkgs-formats-result).
+
 `pkgs.formats.pythonVars` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1125,4 +1125,29 @@ optionalAttrs allowAliases aliases
     else
       throw "pkgs.formats.xml: Unknown format: ${format}";
 
+  plist =
+    {
+      escape ? true,
+    }:
+    {
+      type =
+        let
+          valueType =
+            nullOr (oneOf [
+              bool
+              int
+              float
+              str
+              path
+              (attrsOf valueType)
+              (listOf valueType)
+            ])
+            // {
+              description = "Property list (plist) value";
+            };
+        in
+        valueType;
+
+      generate = name: value: pkgs.writeText name (lib.generators.toPlist { inherit escape; } value);
+    };
 }

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -1005,4 +1005,82 @@ runBuildTests {
       </root>
     '';
   };
+
+  PlistGenerate = shouldPass {
+    format = formats.plist { };
+    input = {
+      null = null;
+      false = false;
+      true = true;
+      int = 10;
+      float = 3.141;
+      str = "foo";
+      attrs.foo = 0;
+      list = [
+        1
+        "hello"
+        {
+          attrs = {
+            key = {
+              value = [
+                [
+                  1
+                  2
+                  3
+                ]
+                "test"
+              ];
+            };
+          };
+        }
+      ];
+      path = ./testfile;
+    };
+    expected = ''
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      ''\t<key>attrs</key>
+      ''\t<dict>
+      ''\t''\t<key>foo</key>
+      ''\t''\t<integer>0</integer>
+      ''\t</dict>
+      ''\t<key>false</key>
+      ''\t<false/>
+      ''\t<key>float</key>
+      ''\t<real>3.141000</real>
+      ''\t<key>int</key>
+      ''\t<integer>10</integer>
+      ''\t<key>list</key>
+      ''\t<array>
+      ''\t''\t<integer>1</integer>
+      ''\t''\t<string>hello</string>
+      ''\t''\t<dict>
+      ''\t''\t''\t<key>attrs</key>
+      ''\t''\t''\t<dict>
+      ''\t''\t''\t''\t<key>key</key>
+      ''\t''\t''\t''\t<dict>
+      ''\t''\t''\t''\t''\t<key>value</key>
+      ''\t''\t''\t''\t''\t<array>
+      ''\t''\t''\t''\t''\t''\t<array>
+      ''\t''\t''\t''\t''\t''\t''\t<integer>1</integer>
+      ''\t''\t''\t''\t''\t''\t''\t<integer>2</integer>
+      ''\t''\t''\t''\t''\t''\t''\t<integer>3</integer>
+      ''\t''\t''\t''\t''\t''\t</array>
+      ''\t''\t''\t''\t''\t''\t<string>test</string>
+      ''\t''\t''\t''\t''\t</array>
+      ''\t''\t''\t''\t</dict>
+      ''\t''\t''\t</dict>
+      ''\t''\t</dict>
+      ''\t</array>
+      ''\t<key>path</key>
+      ''\t<string>${toString ./testfile}</string>
+      ''\t<key>str</key>
+      ''\t<string>foo</string>
+      ''\t<key>true</key>
+      ''\t<true/>
+      </dict>
+      </plist>'';
+  };
 }


### PR DESCRIPTION
The main part of this PR is to add a type for property list values which can be useful in free form options.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
