### PR TITLE
moonlight: 1.3.28 -> 1.3.30

### DIFF
--- a/pkgs/by-name/mo/moonlight/disable_updates.patch
+++ b/pkgs/by-name/mo/moonlight/disable_updates.patch
@@ -1,7 +1,7 @@
-diff --git a/packages/core-extensions/src/moonbase/host.ts b/packages/core-extensions/src/moonbase/host.ts
-index 8903f41..e5c8709 100644
---- a/packages/core-extensions/src/moonbase/host.ts
-+++ b/packages/core-extensions/src/moonbase/host.ts
+diff --git i/packages/core-extensions/src/moonbase/host.ts w/packages/core-extensions/src/moonbase/host.ts
+index 6bb7b62..71b57b9 100644
+--- i/packages/core-extensions/src/moonbase/host.ts
++++ w/packages/core-extensions/src/moonbase/host.ts
 @@ -79,22 +79,9 @@ electron.app.whenReady().then(() => {
  
      if (!entries.find((e) => e.label === "moonlight")) {
@@ -25,10 +25,10 @@ index 8903f41..e5c8709 100644
        options.push({ label: "About", click: showAbout });
  
        entries.splice(i + 1, 0, {
-diff --git a/packages/core-extensions/src/moonbase/native.ts b/packages/core-extensions/src/moonbase/native.ts
+diff --git i/packages/core-extensions/src/moonbase/native.ts w/packages/core-extensions/src/moonbase/native.ts
 index c6e068f..0adc765 100644
---- a/packages/core-extensions/src/moonbase/native.ts
-+++ b/packages/core-extensions/src/moonbase/native.ts
+--- i/packages/core-extensions/src/moonbase/native.ts
++++ w/packages/core-extensions/src/moonbase/native.ts
 @@ -39,24 +39,7 @@ export default function getNatives(): MoonbaseNatives {
  
    return {
@@ -55,24 +55,24 @@ index c6e068f..0adc765 100644
      },
  
      async updateMoonlight(overrideBranch?: MoonlightBranch) {
-diff --git a/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx b/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-index 302c610..2db7ecd 100644
---- a/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-@@ -108,16 +108,6 @@ function ArrayFormItem({ config }: { config: "repositories" | "devSearchPaths" }
+diff --git i/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx w/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
+index 133a98f..9414e7a 100644
+--- i/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
++++ w/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
+@@ -106,16 +106,6 @@ function ArrayFormItem({ config }: { config: "repositories" | "devSearchPaths" }
  export default function ConfigPage() {
    return (
      <>
--      <FormSwitch
--        className={Margins.marginTop20}
--        value={MoonbaseSettingsStore.getExtensionConfigRaw<boolean>("moonbase", "updateChecking", true) ?? true}
--        onChange={(value: boolean) => {
--          MoonbaseSettingsStore.setExtensionConfig("moonbase", "updateChecking", value);
--        }}
--        note="Checks for updates to moonlight"
--      >
--        Automatic update checking
--      </FormSwitch>
+-      <div className={Margins.marginTop20}>
+-        <FormSwitch
+-          checked={MoonbaseSettingsStore.getExtensionConfigRaw<boolean>("moonbase", "updateChecking", true) ?? true}
+-          onChange={(value: boolean) => {
+-            MoonbaseSettingsStore.setExtensionConfig("moonbase", "updateChecking", value);
+-          }}
+-          label="Automatic update checking"
+-          description="Checks for updates to moonlight"
+-        />
+-      </div>
        <FormItem title="Repositories">
          <FormText className={Margins.marginBottom4}>A list of remote repositories to display extensions from</FormText>
          <ArrayFormItem config="repositories" />

--- a/pkgs/by-name/mo/moonlight/package.nix
+++ b/pkgs/by-name/mo/moonlight/package.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "moonlight";
-  version = "1.3.28";
+  version = "1.3.30";
 
   src = fetchFromGitHub {
     owner = "moonlight-mod";
     repo = "moonlight";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aLjHKVWkb9XHyoMmDBxLG2Ycg4CJFeieLdEg3CWeIwk=";
+    hash = "sha256-H8dngrWspbfis0l7YZaVkselIXVpYN3XWBkbwCEBwxg=";
   };
 
   nativeBuildInputs = [
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     buildInputs = [ nodejs_22 ];
 
     fetcherVersion = 2;
-    hash = "sha256-DvSBiUkIQbDkdgfHBw9h1odo3ApZq+emBDkbcQnx6NA=";
+    hash = "sha256-hPEUb+wiHjGOgbaBu5QCFKsGV93d+GuoYMCFRR+afgI=";
   };
 
   env = {


### PR DESCRIPTION
Diff: https://github.com/moonlight-mod/moonlight/compare/v1.3.28...v1.3.30
Changelog: https://raw.githubusercontent.com/moonlight-mod/moonlight/refs/tags/v1.3.30/CHANGELOG.md


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
