### PR TITLE
nixos/blackbox-exporter: migrate to rfc42

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
@@ -1,85 +1,64 @@
 {
-  config,
   lib,
-  pkgs,
   options,
+  config,
+  pkgs,
   ...
 }:
 
 let
-  logPrefix = "services.prometheus.exporter.blackbox";
   cfg = config.services.prometheus.exporters.blackbox;
-  inherit (lib)
-    mkOption
-    types
-    concatStringsSep
-    escapeShellArg
-    ;
+  settingsFormat = pkgs.formats.yaml { };
 
-  # This ensures that we can deal with string paths, path types and
-  # store-path strings with context.
-  coerceConfigFile =
-    file:
-    if (builtins.isPath file) || (lib.isStorePath file) then
-      file
-    else
-      (lib.warn ''
-        ${logPrefix}: configuration file "${file}" is being copied to the nix-store.
-        If you would like to avoid that, please set enableConfigCheck to false.
-      '' (builtins.toFile (builtins.baseNameOf file) (builtins.readFile file)));
-  checkConfigLocation =
-    file:
-    if lib.hasPrefix "/tmp/" file then
-      throw "${logPrefix}: configuration file must not reside within /tmp - it won't be visible to the systemd service."
-    else
-      file;
-  checkConfig =
-    file:
+  configFile =
     pkgs.runCommand "checked-blackbox-exporter.conf"
       {
         preferLocalBuild = true;
         nativeBuildInputs = [ pkgs.buildPackages.prometheus-blackbox-exporter ];
       }
       ''
-        ln -s ${coerceConfigFile file} $out
+        ln -s ${settingsFormat.generate "blackbox-exporter-unchecked.conf" cfg.settings} $out
         blackbox_exporter --config.check --config.file $out
       '';
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "configFile" ] ''
+      Use services.prometheus.exporters.blackbox.settings instead.
+    '')
+    (lib.mkRemovedOptionModule [ "enableConfigCheck" ] ''
+      The configuration file is now always checked.
+    '')
+    {
+      options.warnings = options.warnings;
+      options.assertions = options.assertions;
+    }
+  ];
+
   port = 9115;
   extraOpts = {
-    configFile = mkOption {
-      type = types.path;
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
       description = ''
-        Path to configuration file.
-      '';
-    };
-    enableConfigCheck = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to run a correctness check for the configuration file. This depends
-        on the configuration file residing in the nix-store. Paths passed as string will
-        be copied to the store.
+        Structured configuration that is being written into blackbox' configFile option.
+
+        See <https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md> for upstream documentation.
+
+        Secrets can be passed using the corresponding `file`-options. (ex. username -> username_file)
+        See the upstream documentation for available `file`-options.
       '';
     };
   };
 
-  serviceOpts =
-    let
-      adjustedConfigFile =
-        if cfg.enableConfigCheck then checkConfig cfg.configFile else checkConfigLocation cfg.configFile;
-    in
-    {
-      serviceConfig = {
-        AmbientCapabilities = [ "CAP_NET_RAW" ]; # for ping probes
-        ExecStart = ''
-          ${pkgs.prometheus-blackbox-exporter}/bin/blackbox_exporter \
-            --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-            --config.file ${escapeShellArg adjustedConfigFile} \
-            ${concatStringsSep " \\\n  " cfg.extraFlags}
-        '';
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-      };
-    };
+  serviceOpts.serviceConfig = {
+    AmbientCapabilities = [ "CAP_NET_RAW" ]; # for ping probes
+    ExecStart = ''
+      ${lib.getExe pkgs.prometheus-blackbox-exporter} \
+        --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+        --config.file ${configFile} \
+        ${lib.concatStringsSep " \\\n  " cfg.extraFlags}
+    '';
+    ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+  };
 }

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -166,18 +166,16 @@ let
       };
 
     blackbox =
-      { pkgs, ... }:
+      { ... }:
       {
         exporterConfig = {
           enable = true;
-          configFile = pkgs.writeText "config.yml" (
-            builtins.toJSON {
-              modules.icmp_v6 = {
-                prober = "icmp";
-                icmp.preferred_ip_protocol = "ip6";
-              };
-            }
-          );
+          settings = {
+            modules.icmp_v6 = {
+              prober = "icmp";
+              icmp.preferred_ip_protocol = "ip6";
+            };
+          };
         };
         exporterTest = ''
           wait_for_unit("prometheus-blackbox-exporter.service")


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
