### PR TITLE
python3Packages.pyocr: disable cuneiform support, cuneiform: fix CMake 4 build and soft-deprecate

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -172,6 +172,8 @@
 
 - `neovimUtils.makeNeovimConfig` now uses `customLuaRC` parameter instead of accepting `luaRcContent`. The old usage is deprecated but still works with a warning.
 
+- `python3Packages.pyocr` no longer supports `cuneiform` on Linux by default. It is still possible to enable it using `withCuneiformSupport` override.
+
 - `telegram-desktop` packages now uses `Telegram` for its binary. The previous name was `telegram-desktop`. This is due to [an upstream decision](https://github.com/telegramdesktop/tdesktop/commit/56ff5808a3d766f892bc3c3305afb106b629ef6f) to make the name consistent with other platforms.
 
 - `hsd` has been upgraded to version 8. See [their changelog](https://github.com/handshake-org/hsd/blob/v8.0.0/docs/release-notes/release-notes-8.x.md) for important instructions before upgrading.

--- a/pkgs/by-name/cu/cuneiform/package.nix
+++ b/pkgs/by-name/cu/cuneiform/package.nix
@@ -7,6 +7,7 @@
   testers,
 }:
 
+# Deprecated: unmaintained, no consumers in nixpkgs as of 2025-10-05, and doesn't compile with gcc 15.
 stdenv.mkDerivation (finalAttrs: {
   pname = "cuneiform";
   version = "1.1.0";

--- a/pkgs/by-name/cu/cuneiform/package.nix
+++ b/pkgs/by-name/cu/cuneiform/package.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     rm cuneiform_src/Kern/hhh/tigerh/h/strings.h
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 2.6.2)' \
+      'cmake_minimum_required(VERSION 3.10)'
   '';
 
   # make the install path match the rpath

--- a/pkgs/development/python-modules/pyocr/default.nix
+++ b/pkgs/development/python-modules/pyocr/default.nix
@@ -12,7 +12,7 @@
   setuptools,
   setuptools-scm,
   withTesseractSupport ? true,
-  withCuneiformSupport ? stdenv.hostPlatform.isLinux,
+  withCuneiformSupport ? false,
 }:
 
 buildPythonPackage rec {
@@ -39,7 +39,7 @@ buildPythonPackage rec {
         tesseractLibraryLocation = "${tesseract}/lib/libtesseract${stdenv.hostPlatform.extensions.sharedLibrary}";
       }
     ))
-    ++ (lib.optional stdenv.hostPlatform.isLinux (
+    ++ (lib.optional withCuneiformSupport (
       replaceVars ./paths-cuneiform.patch {
         inherit cuneiform;
       }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
cc #445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
