### PR TITLE
pkgs-lib.formats: fixups for `mkStructuredType`

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -63,6 +63,7 @@ let
 
     Parameters:
     - typeName: String describing the format (e.g. "JSON", "YAML", "XML")
+    - nullable: Whether the structured value type allows `null` values.
 
     Returns a type suitable for structured data formats that supports:
     - Basic types: boolean, integer, float, string, path

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -58,6 +58,37 @@ let
     submodule
     ;
 
+  /*
+    Creates a structured value type suitable for serialization formats.
+
+    Parameters:
+    - typeName: String describing the format (e.g. "JSON", "YAML", "XML")
+
+    Returns a type suitable for structured data formats that supports:
+    - Basic types: boolean, integer, float, string, path
+    - Complex types: attribute sets and lists
+  */
+  mkStructuredType =
+    {
+      typeName,
+      nullable ? true,
+    }:
+    let
+      baseType = oneOf [
+        bool
+        int
+        float
+        str
+        path
+        (attrsOf valueType)
+        (listOf valueType)
+      ];
+      valueType = (if nullable then nullOr baseType else baseType) // {
+        description = "${typeName} value";
+      };
+    in
+    valueType;
+
   # Attributes added accidentally in https://github.com/NixOS/nixpkgs/pull/335232 (2024-08-18)
   # Deprecated in https://github.com/NixOS/nixpkgs/pull/415666 (2025-06)
   allowAliases = pkgs.config.allowAliases or false;
@@ -125,37 +156,6 @@ optionalAttrs allowAliases aliases
   hocon = (import ./formats/hocon/default.nix { inherit lib pkgs; }).format;
 
   php = (import ./formats/php/default.nix { inherit lib pkgs; }).format;
-
-  /*
-    Creates a structured value type suitable for serialization formats.
-
-    Parameters:
-    - typeName: String describing the format (e.g. "JSON", "YAML", "XML")
-
-    Returns a type suitable for structured data formats that supports:
-    - Basic types: boolean, integer, float, string, path
-    - Complex types: attribute sets and lists
-  */
-  mkStructuredType =
-    {
-      typeName,
-      nullable ? true,
-    }:
-    let
-      baseType = oneOf [
-        bool
-        int
-        float
-        str
-        path
-        (attrsOf valueType)
-        (listOf valueType)
-      ];
-      valueType = (if nullable then nullOr baseType else baseType) // {
-        description = "${typeName} value";
-      };
-    in
-    valueType;
 
   json =
     { }:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Quick fixup for #372501, makes the function unreachable except for in `formats.nix` for the time being (there are plans to restructure pkgs-lib later, we might re-expose it in a more sane place than `pkgs.formats` then), adds missing parameter comment.

Ensured that it still evals with nix repl:

```nix
nix-repl> (legacyPackages.x86_64-linux.formats.json { }).type
{
  _type = "option-type";
  check = «lambda check @ /nix/store/vdmlkirf3asf5j8lkhhf08x66s33hh30-source/lib/types.nix:1042:19»;
  deprecationMessage = null;
  description = "JSON value";
  descriptionClass = "conjunction";
  emptyValue = { ... };
  functor = { ... };
  getSubModules = null;
  getSubOptions = «lambda @ /nix/store/vdmlkirf3asf5j8lkhhf08x66s33hh30-source/lib/types.nix:221:25»;
  merge = «lambda merge @ /nix/store/vdmlkirf3asf5j8lkhhf08x66s33hh30-source/lib/types.nix:1044:13»;
  name = "nullOr";
  nestedTypes = { ... };
  substSubModules = «lambda substSubModules @ /nix/store/vdmlkirf3asf5j8lkhhf08x66s33hh30-source/lib/types.nix:1059:29»;
  typeMerge = «lambda defaultTypeMerge @ /nix/store/vdmlkirf3asf5j8lkhhf08x66s33hh30-source/lib/types.nix:122:10»;
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
