### PR TITLE
python3Packages.pygame: enable AVX2 detection at build time

### DIFF
--- a/pkgs/development/python-modules/pygame-original/default.nix
+++ b/pkgs/development/python-modules/pygame-original/default.nix
@@ -75,6 +75,9 @@ buildPythonPackage rec {
 
     # https://github.com/pygame/pygame/pull/4651
     ./0001-Use-SDL_AllocFormat-instead-of-creating-it-manually.patch
+
+    # Fix AVX2 detection
+    ./fix-avx2-detection.patch
   ];
 
   postPatch = ''
@@ -109,9 +112,13 @@ buildPythonPackage rec {
     ${python.pythonOnBuildForHost.interpreter} buildconfig/config.py
   '';
 
-  env = lib.optionalAttrs stdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-function-pointer-types";
-  };
+  env =
+    lib.optionalAttrs stdenv.cc.isClang {
+      NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-function-pointer-types";
+    }
+    // {
+      PYGAME_DETECT_AVX2 = "1";
+    };
 
   checkPhase = ''
     runHook preCheck
@@ -133,7 +140,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for games (original distribution)";
     homepage = "https://www.pygame.org/";
-    changelog = "https://github.com/pygame/pygame/releases/tag/${src.tag}";
+    changelog = "https://github.com/pygame/pygame/releases/tag/${version}";
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/python-modules/pygame-original/fix-avx2-detection.patch
+++ b/pkgs/development/python-modules/pygame-original/fix-avx2-detection.patch
@@ -1,0 +1,22 @@
+diff --git a/setup.py b/setup.py
+index fc9292b7..960e7404 100644
+--- a/setup.py
++++ b/setup.py
+@@ -76,7 +76,7 @@ import os
+ # just import these always and fail early if not present
+ from setuptools import setup
+ import distutils
+-
++from distutils import spawn as _distutils_spawn
+ 
+ if os.environ.get('PYGAME_DETECT_AVX2', '') != '':
+     import distutils.ccompiler
+@@ -123,7 +123,7 @@ if os.environ.get('PYGAME_DETECT_AVX2', '') != '':
+                     # filename is found, no need to search any further
+                     break
+ 
+-        distutils.ccompiler.spawn(cmd, dry_run=self.dry_run, **kwargs)
++        distutils.spawn.spawn(cmd, dry_run=self.dry_run, **kwargs)
+ 
+     distutils.ccompiler.CCompiler.__spawn = distutils.ccompiler.CCompiler.spawn
+     distutils.ccompiler.CCompiler.spawn = spawn


### PR DESCRIPTION
- Monkey patch deprecated calls from distutils.ccompiler.spawn to distutils.spawn.spawn

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
