### PR TITLE
go: allow backports of the latest Go version to the stable release

### DIFF
--- a/pkgs/build-support/go/README.md
+++ b/pkgs/build-support/go/README.md
@@ -13,7 +13,7 @@ If `gopls` is compiled for Go 1.23, it won't work for projects that require Go 1
 
 Go only ever has two supported toolchains. With a new minor release, the second last Go toolchain is automatically end of life, meaning it won't receive security updates anymore.
 
-Based on this, we align on the following policy for toolchain/builder upgrades:
+Based on this, we align on the following policy for toolchain/builder upgrades for the unstable release:
 
 1. Default toolchain (the `go` package) and builder (`buildGoModule`) are upgraded to the latest minor release of Go as soon as it is released.
   As it is a mass rebuild, this package will be made against the `staging` branch.
@@ -41,5 +41,9 @@ Based on this, we align on the following policy for toolchain/builder upgrades:
 
     If the package won't build with that builder anymore, the package is marked broken.
     It is the package maintainers responsibility to fix the package and get it working with a supported Go toolchain.
+
+For the stable release, we recognize that (1) removing a Go version, or updating the `go_latest` or `go` packages to a new Go minor release, would be a breaking change, and (2) some packages will need backports (e.g. for security reasons) that require the latest Go version.
+Therefore, on the stable release, new Go versions will be backported to the `release-2x.xx` branch, but the old versions will remain, and `go`, `buildGoModule`, `go_latest`, and `buildGoLatestModule` will remain unchanged.
+However, `rc` versions should not be backported to the stable branch.
 
 [1]: http://go.dev/doc/go1compat


### PR DESCRIPTION
Some packages, that need backports (e.g. for security reasons), also require the latest Go version.

This is impossible when the release isn't backported. I therefore propose that we change the Go toolchain/builder upgrade policy to permit backports of the latest Go version, without touching `go`, `buildGoModule`, `go_latest`, or `buildGoLatestModule`, and without removing old versions (both of which would be breaking changes).

Related:
* Motivator: #448728
* Backport for Go 1.25: #448882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
