### PR TITLE
[Backport release-25.05] go_1_25: init at 1.25.1

### DIFF
--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -28,11 +28,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.25.0";
+  version = "1.25.1";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-S9AekSlyB7+kUOpA1NWpOxtTGl5DhHOyoG4Y4HciciU=";
+    hash = "sha256-0BDBCc7pTYDv5oHqtGvepJGskGv0ZYPDLp8NuwvRpZQ=";
   };
 
   strictDeps = true;

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -28,11 +28,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.25rc3";
+  version = "1.25.0";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-Rw4LjnCmjyhV59AJ8TXsgLPRgIXSxOU323Xmrkliv3Q=";
+    hash = "sha256-S9AekSlyB7+kUOpA1NWpOxtTGl5DhHOyoG4Y4HciciU=";
   };
 
   strictDeps = true;

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -28,11 +28,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.25rc2";
+  version = "1.25rc3";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-5jFKMjTEwDuNAGvNHRRZTZKBcNGES23/3V+lojM0SeE=";
+    hash = "sha256-Rw4LjnCmjyhV59AJ8TXsgLPRgIXSxOU323Xmrkliv3Q=";
   };
 
   strictDeps = true;

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -1,0 +1,172 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  apple-sdk_12,
+  tzdata,
+  replaceVars,
+  iana-etc,
+  mailcap,
+  buildPackages,
+  pkgsBuildTarget,
+  targetPackages,
+  testers,
+  skopeo,
+  buildGo125Module,
+}:
+
+let
+  goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
+
+  skopeoTest = skopeo.override { buildGoModule = buildGo125Module; };
+
+  # We need a target compiler which is still runnable at build time,
+  # to handle the cross-building case where build != host == target
+  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+
+  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "go";
+  version = "1.25rc2";
+
+  src = fetchurl {
+    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+    hash = "sha256-5jFKMjTEwDuNAGvNHRRZTZKBcNGES23/3V+lojM0SeE=";
+  };
+
+  strictDeps = true;
+  buildInputs =
+    [ ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
+    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [
+    apple-sdk_12
+  ];
+
+  depsBuildTarget = lib.optional isCross targetCC;
+
+  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows targetPackages.threads.package;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  patches = [
+    (replaceVars ./iana-etc-1.25.patch {
+      iana = iana-etc;
+    })
+    # Patch the mimetype database location which is missing on NixOS.
+    # but also allow static binaries built with NixOS to run outside nix
+    (replaceVars ./mailcap-1.17.patch {
+      inherit mailcap;
+    })
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    (replaceVars ./tzdata-1.19.patch {
+      inherit tzdata;
+    })
+    ./remove-tools-1.11.patch
+    ./go_no_vendor_checks-1.23.patch
+  ];
+
+  inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.go.GOOS;
+  GOHOSTARCH = stdenv.buildPlatform.go.GOARCH;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}cc" else null;
+  CXX_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}c++" else null;
+
+  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
+  # Wasi does not support CGO
+  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+
+  GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
+
+  buildPhase = ''
+    runHook preBuild
+    export GOCACHE=$TMPDIR/go-cache
+
+    export PATH=$(pwd)/bin:$PATH
+
+    ${lib.optionalString isCross ''
+      # Independent from host/target, CC should produce code for the building system.
+      # We only set it when cross-compiling.
+      export CC=${buildPackages.stdenv.cc}/bin/cc
+    ''}
+    ulimit -a
+
+    pushd src
+    ./make.bash
+    popd
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  ''
+  + (
+    if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then
+      ''
+        mv bin/*_*/* bin
+        rmdir bin/*_*
+        ${lib.optionalString
+          (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS))
+          ''
+            rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
+          ''
+        }
+      ''
+    else
+      lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
+        rm -rf bin/*_*
+        ${lib.optionalString
+          (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS))
+          ''
+            rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
+          ''
+        }
+      ''
+  );
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/go
+    cp -a bin pkg src lib misc api doc go.env VERSION $out/share/go
+    mkdir -p $out/bin
+    ln -s $out/share/go/bin/* $out/bin
+    runHook postInstall
+  '';
+
+  disallowedReferences = [ goBootstrap ];
+
+  passthru = {
+    inherit goBootstrap skopeoTest;
+    tests = {
+      skopeo = testers.testVersion { package = skopeoTest; };
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "go version";
+        version = "go${finalAttrs.version}";
+      };
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
+    description = "Go Programming language";
+    homepage = "https://go.dev/";
+    license = licenses.bsd3;
+    teams = [ teams.golang ];
+    platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
+    mainProgram = "go";
+  };
+})

--- a/pkgs/development/compilers/go/iana-etc-1.25.patch
+++ b/pkgs/development/compilers/go/iana-etc-1.25.patch
@@ -1,0 +1,26 @@
+diff --git a/src/net/lookup_unix.go b/src/net/lookup_unix.go
+index 7416cb01f8..62722cab14 100644
+--- a/src/net/lookup_unix.go
++++ b/src/net/lookup_unix.go
+@@ -15,7 +15,7 @@ import (
+ // readProtocolsOnce loads contents of /etc/protocols into protocols map
+ // for quick access.
+ var readProtocolsOnce = sync.OnceFunc(func() {
+-	file, err := open("/etc/protocols")
++	file, err := open("@iana@/etc/protocols")
+ 	if err != nil {
+ 		return
+ 	}
+diff --git a/src/net/port_unix.go b/src/net/port_unix.go
+index df73dbabb3..a5dcf2ca1c 100644
+--- a/src/net/port_unix.go
++++ b/src/net/port_unix.go
+@@ -16,7 +16,7 @@ import (
+ var onceReadServices sync.Once
+ 
+ func readServices() {
+-	file, err := open("/etc/services")
++	file, err := open("@iana@/etc/services")
+ 	if err != nil {
+ 		return
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10013,6 +10013,11 @@ with pkgs;
     go = buildPackages.go_1_24;
   };
 
+  go_1_25 = callPackage ../development/compilers/go/1.25.nix { };
+  buildGo125Module = callPackage ../build-support/go/module.nix {
+    go = buildPackages.go_1_25;
+  };
+
   ### DEVELOPMENT / HARE
 
   hareHook = callPackage ../by-name/ha/hare/hook.nix { };


### PR DESCRIPTION
Manual backport of #420392 #431616 #433239 #441005 to `release-25.05`.

I don't touch `go`, `buildGoModule`, `go_latest`, or `buildGoLatestModule`, and without removing old versions because both of these would be breaking changes.


Related:
* Motivator: #448728
* Policy change proposal: #448881

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
