### PR TITLE
warpinator: fix "Connect manually" not working

### DIFF
--- a/pkgs/by-name/wa/warpinator/package.nix
+++ b/pkgs/by-name/wa/warpinator/package.nix
@@ -19,7 +19,9 @@
 
 let
   pythonEnv = python3.withPackages (
-    pp: with pp; [
+    pp:
+    with pp;
+    [
       grpcio-tools
       protobuf
       pygobject3
@@ -35,6 +37,7 @@ let
       ifaddr
       qrcode
     ]
+    ++ qrcode.optional-dependencies.pil
   );
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
When you clicked on "Connect manually" in the menu, nothing will happen and in the console you see

```
  File "/nix/store/764ilfz0lhln19gx470fas661l9g7324-warpinator-1.8.10/libexec/warpinator/warpinator.py", line 839, in manual_connect
    self.connect_dialog = ManualConnectDialog(self)
                          ~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/nix/store/764ilfz0lhln19gx470fas661l9g7324-warpinator-1.8.10/libexec/warpinator/warpinator.py", line 1215, in __init__
    img = qr.make_image()
  File "/nix/store/8akrxjps12p9jgj3j26dd0av7iz04q3h-python3-3.13.7-env/lib/python3.13/site-packages/qrcode/main.py", line 364, in make_image
    from qrcode.image.pil import Image, PilImage
  File "/nix/store/8akrxjps12p9jgj3j26dd0av7iz04q3h-python3-3.13.7-env/lib/python3.13/site-packages/qrcode/image/pil.py", line 2, in <module>
    from PIL import Image, ImageDraw
ModuleNotFoundError: No module named 'PIL'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
