### PR TITLE
pystack: init at 1.5.1

### DIFF
--- a/pkgs/by-name/py/pystack/package.nix
+++ b/pkgs/by-name/py/pystack/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  elfutils,
+  nix-update-script,
+  versionCheckHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "pystack";
+  version = "1.5.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bloomberg";
+    repo = "pystack";
+    tag = "v${version}";
+    hash = "sha256-CH15LDj7QegoTNn2GeJlF6C00E89WrKlgaclMMHcLi0=";
+  };
+
+  build-system = with python3Packages; [
+    cython
+    pkgconfig
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [ rich ];
+
+  buildInputs = [ elfutils ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Print the stack trace of a running Python process, or of a Python core dump";
+    homepage = "https://bloomberg.github.io/pystack/";
+    downloadPage = "https://github.com/bloomberg/pystack";
+    changelog = "https://github.com/bloomberg/pystack/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    platforms = lib.platforms.unix;
+    mainProgram = "pystack";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds package [pystack](https://github.com/bloomberg/pystack/tree/main). A tool to inspect the call stacks of running python processes and core dump files. The program depends on `libdw` and `libelf` provided by `pkgs.elfutils`. I am not sure if I have set the correct `meta.platforms`

If this PR gets accepted I plan to create a NixOS module to enable the program with `CAP_SYS_PTRACE` capability set.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
