### PR TITLE
[Backport release-25.05] tests.stdenv: remove __attrsFailEvaluation, use system from stdenv.{build,host}Platform

### DIFF
--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -298,7 +298,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           dep2 = derivation {
             name = "dep2";
@@ -307,7 +307,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           passAsFile = [ "dep2" ];
         })
@@ -338,7 +338,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           dep2 = derivation {
             name = "dep2";
@@ -347,7 +347,7 @@ in
               "-c"
               ": > $out"
             ];
-            system = builtins.currentSystem;
+            inherit (stdenv.buildPlatform) system;
           };
           name = "meow";
           outputHash = "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -218,9 +218,6 @@ let
 in
 
 {
-  # Disable on Darwin due to assumptions with __bootPackages
-  __attrsFailEvaluation = stdenv.hostPlatform.isDarwin;
-
   # tests for hooks in `stdenv.defaultNativeBuildInputs`
   hooks = lib.recurseIntoAttrs (
     import ./hooks.nix {


### PR DESCRIPTION
Manual backport of b494b7ed40435689165c70be2d24d7b10ab0ff24 and #447555 to `release-25.05`.

I left out e432d5321e571c18154aec08982c4795d5132b35, as I think we ought to still support it on stable?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
