### PR TITLE
atuin-desktop: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21441,6 +21441,12 @@
     github = "randomdude16671";
     githubId = 210965013;
   };
+  randoneering = {
+    name = "randoneering";
+    email = "justin@randoneering.tech";
+    github = "randoneering";
+    githubId = 127273550;
+  };
   rane = {
     name = "Rane";
     email = "rane+git@junkyard.systems";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7157,6 +7157,12 @@
     githubId = 15128988;
     name = "Maksim Dzabraev";
   };
+  dzervas = {
+    name = "Dimitris Zervas";
+    email = "dzervas@dzervas.gr";
+    github = "dzervas";
+    githubId = 1029195;
+  };
   dzmitry-lahoda = {
     email = "dzmitry@lahoda.pro";
     github = "dzmitry-lahoda";

--- a/pkgs/by-name/at/atuin-desktop/package.nix
+++ b/pkgs/by-name/at/atuin-desktop/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  wrapGAppsHook4,
+  nix-update-script,
+
+  cargo-tauri,
+  nodejs,
+  pkg-config,
+  pnpm,
+
+  glib-networking,
+  libappindicator-gtk3,
+  openssl,
+  webkitgtk_4_1,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "atuin-desktop";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "atuinsh";
+    repo = "desktop";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-woYWWDJ2JeyghlRh5IKhPfDy4WmcAGlBJgjBPg1hHq8=";
+  };
+
+  cargoRoot = "backend";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoHash = "sha256-tyN9gM8U8kOl62Z0N/plcpTOCbOPuT0kkLI/EKLv/mQ=";
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 2;
+    hash = "sha256-y+WZF30R/+nvAVr50SWmMN5kfVb1kYiylAd1IBftoVA=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    pnpm.configHook
+
+    nodejs
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    libappindicator-gtk3
+    openssl
+    webkitgtk_4_1
+  ];
+
+  env = {
+    # Used upstream: https://github.com/atuinsh/desktop/blob/2f9a90963c4a6299bf35d8a49b0a2ffb8a28ee32/.envrc.
+    NODE_OPTIONS = "--max-old-space-size=5120";
+  };
+
+  # Otherwise tauri will look for a private key we don't have.
+  tauriConf = builtins.toJSON { bundle.createUpdaterArtifacts = false; };
+  passAsFile = [ "tauriConf" ];
+  preBuild = ''
+    npm rebuild ts-tiny-activerecord
+    tauriBuildFlags+=(
+      "--config"
+      "$tauriConfPath"
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local-first, executable runbook editor";
+    homepage = "https://atuin.sh";
+    downloadPage = "https://github.com/atuinsh/desktop";
+    changelog = "https://github.com/atuinsh/desktop/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      adda
+      dzervas
+      randoneering
+    ];
+    mainProgram = "atuin-desktop";
+    platforms = with lib.platforms; windows ++ darwin ++ linux;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
This PR adds [Atuin Desktop](https://atuin.sh/), a freshly out-of-closed-beta local-first, executable runbook editor. 

Supersedes #448422 which takes pre-built binary from `atuinsh/desktop` [GitHub repo](https://github.com/atuinsh/desktop).

Let me know, @randoneering and @dzervas, whether you want to be added as maintainers as well.
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
