### PR TITLE
qgit: 2.11 -> 2.12

### DIFF
--- a/pkgs/applications/version-management/qgit/default.nix
+++ b/pkgs/applications/version-management/qgit/default.nix
@@ -8,36 +8,36 @@
   wrapQtAppsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qgit";
   version = "2.12";
 
   src = fetchFromGitHub {
     owner = "tibirna";
     repo = "qgit";
-    rev = "qgit-${version}";
+    rev = "qgit-${finalAttrs.version}";
     hash = "sha256-q81nY9D/8riMTFP8gDRbY2PjVo+NwRu/XEN1Yn0P/pk=";
   };
-
-  buildInputs = [
-    qtbase
-    qt5compat
-  ];
 
   nativeBuildInputs = [
     cmake
     wrapQtAppsHook
   ];
 
-  meta = with lib; {
-    license = licenses.gpl2Only;
+  buildInputs = [
+    qtbase
+    qt5compat
+  ];
+
+  meta = {
+    license = lib.licenses.gpl2Only;
     homepage = "https://github.com/tibirna/qgit";
     description = "Graphical front-end to Git";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       peterhoeg
       markuskowa
     ];
     inherit (qtbase.meta) platforms;
     mainProgram = "qgit";
   };
-}
+})

--- a/pkgs/applications/version-management/qgit/default.nix
+++ b/pkgs/applications/version-management/qgit/default.nix
@@ -1,25 +1,33 @@
 {
-  mkDerivation,
+  stdenv,
   lib,
   fetchFromGitHub,
   cmake,
   qtbase,
+  qt5compat,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qgit";
-  version = "2.11";
+  version = "2.12";
 
   src = fetchFromGitHub {
     owner = "tibirna";
     repo = "qgit";
-    rev = "${pname}-${version}";
-    sha256 = "sha256-DmwxOy71mIklLQ7V/qMzi8qCMtKa9nWHlkjEr/9HJIU=";
+    rev = "qgit-${version}";
+    hash = "sha256-q81nY9D/8riMTFP8gDRbY2PjVo+NwRu/XEN1Yn0P/pk=";
   };
 
-  buildInputs = [ qtbase ];
+  buildInputs = [
+    qtbase
+    qt5compat
+  ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
 
   meta = with lib; {
     license = licenses.gpl2Only;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1261,7 +1261,7 @@ with pkgs;
     python3Packages.callPackage ../applications/version-management/pass-git-helper
       { };
 
-  qgit = qt5.callPackage ../applications/version-management/qgit { };
+  qgit = qt6Packages.callPackage ../applications/version-management/qgit { };
 
   silver-platter = python3Packages.callPackage ../applications/version-management/silver-platter { };
 


### PR DESCRIPTION
Changelog: https://github.com/tibirna/qgit/releases/tag/qgit-2.12
Switch to Qt6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
