### PR TITLE
freedink: 1.08.20121209 -> 109.6, add maintainer

### DIFF
--- a/pkgs/by-name/fr/freedink/package.nix
+++ b/pkgs/by-name/fr/freedink/package.nix
@@ -1,65 +1,106 @@
 {
-  lib,
-  stdenv,
+  cxxtest,
   fetchurl,
-  SDL,
-  SDL_mixer,
-  SDL_image,
-  SDL_ttf,
-  SDL_gfx,
-  pkg-config,
-  intltool,
   fontconfig,
+  glm,
+  help2man,
+  intltool,
+  lib,
   libzip,
+  pkg-config,
+  SDL2,
+  SDL2_gfx,
+  SDL2_image,
+  SDL2_mixer,
+  SDL2_ttf,
+  stdenv,
   zip,
   zlib,
 }:
 
 let
-  version = "1.08.20121209";
 
-  freedink_data = stdenv.mkDerivation rec {
+  freedink_data = stdenv.mkDerivation (finalAttrs: {
     pname = "freedink-data";
-    inherit version;
+    version = "1.08.20190120";
 
     src = fetchurl {
-      url = "mirror://gnu/freedink/${pname}-${version}.tar.gz";
-      sha256 = "1mhns09l1s898x18ahbcy9gabrmgsr8dv7pm0a2ivid8mhxahn1j";
+      url = "mirror://gnu/freedink/freedink-data-${finalAttrs.version}.tar.gz";
+      hash = "sha256-cV9EdzsFtzqeybYrDhUvPygb4aFRL7qqOGF22pTP+50=";
     };
 
-    prePatch = "substituteInPlace Makefile --replace /usr/local $out";
-  };
+    prePatch = "substituteInPlace Makefile --replace-fail /usr/local $out";
+  });
 
 in
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "freedink";
-  inherit version;
+  version = "109.6";
 
   src = fetchurl {
-    url = "mirror://gnu/freedink/${pname}-${version}.tar.gz";
-    sha256 = "19xximbcm6506kvpf3s0q96697kmzca3yrjdr6dgphklp33zqsqr";
+    url = "mirror://gnu/freedink/freedink-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Xgs1rI9G17uH5lbv1fnHwqwabFGakI/FtYHlJleYEAI=";
   };
 
   nativeBuildInputs = [
-    pkg-config
+    cxxtest
+    help2man
     intltool
+    pkg-config
   ];
 
   buildInputs = [
-    SDL
-    SDL_mixer
-    SDL_image
-    SDL_ttf
-    SDL_gfx
     fontconfig
+    glm
     libzip
+    SDL2
+    SDL2_mixer
+    SDL2_image
+    SDL2_ttf
+    SDL2_gfx
     zip
     zlib
   ];
 
-  preConfigure = ''
-    # Build fails on Linux with windres.
-    export ac_cv_prog_ac_ct_WINDRES=
+  preBuild = ''
+        # Fix SDL2_ttf constness error in gfx_fonts.cpp
+        substituteInPlace src/gfx_fonts.cpp \
+          --replace-fail "char *familyname = TTF_FontFaceFamilyName(font);" \
+                    "const char *familyname = TTF_FontFaceFamilyName(font);"
+        substituteInPlace src/gfx_fonts.cpp \
+          --replace-fail "char *stylename = TTF_FontFaceStyleName(font);" \
+                    "const char *stylename = TTF_FontFaceStyleName(font);"
+
+        # Fix missing SDL hint macro error in input.cpp
+        substituteInPlace src/input.cpp \
+          --replace-fail "SDL_SetHint(SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, \"0\");" \
+                    "/* SDL_SetHint(SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, \"0\"); */"
+
+        # Fix config.h errors in some platforms
+        substituteInPlace src/ImageLoader.cpp \
+          --replace-fail '#include "ImageLoader.h"' '#include "../config.h"
+    #include "ImageLoader.h"'
+
+        substituteInPlace src/IOGfxGLFuncs.cpp \
+          --replace-fail '#include "IOGfxGLFuncs.h"' '#include "../config.h"
+    #include "IOGfxGLFuncs.h"'
+
+        substituteInPlace src/IOGfxSurface.cpp \
+          --replace-fail '#include "IOGfxSurface.h"' '#include "../config.h"
+    #include "IOGfxSurface.h"'
+
+        substituteInPlace src/IOGfxSurfaceSW.cpp \
+          --replace-fail '#include "IOGfxSurfaceSW.h"' '#include "../config.h"
+    #include "IOGfxSurfaceSW.h"'
+
+        substituteInPlace src/IOGfxPrimitivesSW.cpp \
+          --replace-fail '#include "SDL.h"' '#include "../config.h"
+    #include "SDL.h"'
+
+        substituteInPlace src/dinkc_console_renderer.cpp \
+          --replace-fail '#include "dinkc_console_renderer.h"' '#include "../config.h"
+    #include "dinkc_console_renderer.h"'
   '';
 
   postInstall = ''
@@ -71,18 +112,15 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Free, portable and enhanced version of the Dink Smallwood game engine";
-
     longDescription = ''
       GNU FreeDink is a new and portable version of the Dink Smallwood
       game engine, which runs the original game as well as its D-Mods,
       with close compatibility, under multiple platforms.
     '';
-
-    homepage = "https://www.gnu.org/software/freedink/"; # Formerly http://www.freedink.org
+    homepage = "https://gnu.org/software/freedink/"; # Formerly http://www.freedink.org
     license = lib.licenses.gpl3Plus;
-
     maintainers = [ ];
     platforms = lib.platforms.all;
-    hydraPlatforms = lib.platforms.linux; # sdl-config times out on darwin
+    mainProgram = "freedink";
   };
-}
+})

--- a/pkgs/by-name/fr/freedink/package.nix
+++ b/pkgs/by-name/fr/freedink/package.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://gnu.org/software/freedink/"; # Formerly http://www.freedink.org
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iedame ];
     platforms = lib.platforms.all;
     mainProgram = "freedink";
   };


### PR DESCRIPTION
Version bump for `freedink` to `109.6`, it now uses `SDL2`.
I added myself to maintainers.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
