### PR TITLE
maintainers: drop evils

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8051,13 +8051,6 @@
     githubId = 6803717;
     name = "Ilya Elenskiy";
   };
-  evils = {
-    email = "evils.devils@protonmail.com";
-    matrix = "@evils:nixos.dev";
-    github = "evils";
-    githubId = 30512529;
-    name = "Evils";
-  };
   evris99 = {
     name = "Evrymachos Koukoumakas";
     github = "evris99";

--- a/nixos/modules/services/hardware/fancontrol.nix
+++ b/nixos/modules/services/hardware/fancontrol.nix
@@ -52,6 +52,4 @@ in
     '';
 
   };
-
-  meta.maintainers = [ lib.maintainers.evils ];
 }

--- a/nixos/modules/services/hardware/rasdaemon.nix
+++ b/nixos/modules/services/hardware/rasdaemon.nix
@@ -176,7 +176,4 @@ in
       };
     };
   };
-
-  meta.maintainers = [ lib.maintainers.evils ];
-
 }

--- a/nixos/modules/services/monitoring/tuptime.nix
+++ b/nixos/modules/services/monitoring/tuptime.nix
@@ -89,7 +89,4 @@ in
       };
     };
   };
-
-  meta.maintainers = [ lib.maintainers.evils ];
-
 }

--- a/nixos/modules/services/monitoring/vnstat.nix
+++ b/nixos/modules/services/monitoring/vnstat.nix
@@ -58,6 +58,4 @@ in
       };
     };
   };
-
-  meta.maintainers = [ lib.maintainers.evils ];
 }

--- a/nixos/tests/fancontrol.nix
+++ b/nixos/tests/fancontrol.nix
@@ -1,8 +1,8 @@
-{ pkgs, ... }:
+{ ... }:
 {
   name = "fancontrol";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ evils ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes.machine =

--- a/nixos/tests/rasdaemon.nix
+++ b/nixos/tests/rasdaemon.nix
@@ -1,8 +1,8 @@
-{ pkgs, ... }:
+{ ... }:
 {
   name = "rasdaemon";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ evils ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes.machine =

--- a/nixos/tests/tuptime.nix
+++ b/nixos/tests/tuptime.nix
@@ -1,8 +1,8 @@
-{ pkgs, ... }:
+{ ... }:
 {
   name = "tuptime";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ evils ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes.machine =

--- a/pkgs/applications/audio/bucklespring/default.nix
+++ b/pkgs/applications/audio/bucklespring/default.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/zevv/bucklespring";
     license = licenses.gpl2Only;
     platforms = platforms.unix;
-    maintainers = [ maintainers.evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -83,14 +83,11 @@ in
       fi
     '';
 
-    meta =
-      with lib;
-      meta
-      // {
-        description = "Helper for screenshots within sway";
-        maintainers = with maintainers; [ evils ];
-        mainProgram = "grimshot";
-      };
+    meta = meta // {
+      description = "Helper for screenshots within sway";
+      maintainers = [ ];
+      mainProgram = "grimshot";
+    };
   };
 
   inactive-windows-transparency =
@@ -114,14 +111,11 @@ in
       '';
 
       meta =
-        with lib;
-        meta
-        // {
+
+        meta // {
           description = "It makes inactive sway windows transparent";
           mainProgram = "${lname}.py";
-          maintainers = with maintainers; [
-            evils # packaged this as a side-effect of grimshot but doesn't use it
-          ];
+          maintainers = [ ];
         };
     };
 

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -326,7 +326,7 @@ stdenv.mkDerivation rec {
       The Programs handle Schematic Capture, and PCB Layout with Gerber output.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ evils ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "kicad";

--- a/pkgs/by-name/bt/btrfs-heatmap/package.nix
+++ b/pkgs/by-name/bt/btrfs-heatmap/package.nix
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/knorrie/btrfs-heatmap";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/f3/f3/package.nix
+++ b/pkgs/by-name/f3/f3/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       makefu
-      evils
     ];
   };
 }

--- a/pkgs/by-name/ra/rasdaemon/package.nix
+++ b/pkgs/by-name/ra/rasdaemon/package.nix
@@ -130,6 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     changelog = "${finalAttrs.meta.homepage}/releases/tag/v${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ evils ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/re/readexe/package.nix
+++ b/pkgs/by-name/re/readexe/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
       isc
       bsd3
     ];
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
     mainProgram = "readexe";
   };
 })

--- a/pkgs/by-name/sc/screentest/package.nix
+++ b/pkgs/by-name/sc/screentest/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/TobiX/screentest";
     changelog = "https://github.com/TobiX/screentest/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ evils ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/st/stepreduce/package.nix
+++ b/pkgs/by-name/st/stepreduce/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     description = "Reduces STEP file size by removing redundancy";
     homepage = "https://gitlab.com/sethhillbrand/stepreduce";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
     mainProgram = "stepreduce";
   };
 }

--- a/pkgs/by-name/tu/tuptime/package.nix
+++ b/pkgs/by-name/tu/tuptime/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/rfrail3/tuptime/blob/master/CHANGELOG";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
-    maintainers = [ maintainers.evils ];
+    maintainers = [ ];
     mainProgram = "tuptime";
   };
 }

--- a/pkgs/by-name/us/usb-reset/package.nix
+++ b/pkgs/by-name/us/usb-reset/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ralight/usb-reset";
     changelog = "https://github.com/ralight/usb-reset/blob/master/ChangeLog.txt";
     license = licenses.mit;
-    maintainers = [ maintainers.evils ];
+    maintainers = [ ];
     platforms = platforms.all;
     mainProgram = "usb-reset";
   };

--- a/pkgs/by-name/vn/vnstat/package.nix
+++ b/pkgs/by-name/vn/vnstat/package.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation rec {
     homepage = "https://humdi.net/vnstat/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/btrfs/default.nix
+++ b/pkgs/development/python-modules/btrfs/default.nix
@@ -24,7 +24,6 @@ buildPythonPackage rec {
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      evils
       Luflosi
     ];
   };

--- a/pkgs/development/python-modules/diffimg/default.nix
+++ b/pkgs/development/python-modules/diffimg/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage {
     description = "Differentiate images in python - get a ratio or percentage difference, and generate a diff image";
     homepage = "https://github.com/nicolashahn/diffimg";
     license = licenses.mit;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/i2c-tools/default.nix
+++ b/pkgs/development/python-modules/i2c-tools/default.nix
@@ -19,6 +19,6 @@ buildPythonPackage {
     description = "Wrapper for i2c-tools' smbus stuff";
     # from py-smbus/smbusmodule.c
     license = [ licenses.gpl2Only ];
-    maintainers = [ maintainers.evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/image-diff/default.nix
+++ b/pkgs/development/python-modules/image-diff/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     mainProgram = "image-diff";
     homepage = "https://github.com/simonw/image-diff";
     license = licenses.asl20;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/imgdiff/default.nix
+++ b/pkgs/development/python-modules/imgdiff/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/mgedmin/imgdiff";
     changelog = "https://github.com/mgedmin/imgdiff/blob/${src.rev}/CHANGES.rst";
     license = licenses.mit;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -83,7 +83,6 @@ buildPythonPackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       arturcygan
-      evils
     ];
     mainProgram = "liquidctl";
   };

--- a/pkgs/development/python-modules/pycflow2dot/default.nix
+++ b/pkgs/development/python-modules/pycflow2dot/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     mainProgram = "cflow2dot";
     homepage = "https://github.com/johnyf/pycflow2dot";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytest-image-diff/default.nix
+++ b/pkgs/development/python-modules/pytest-image-diff/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Pytest helps for compare images and regression";
     homepage = "https://github.com/Apkawa/pytest-image-diff";
     license = licenses.mit;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pytomlpp/default.nix
+++ b/pkgs/development/python-modules/pytomlpp/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     description = "Python wrapper for tomlplusplus";
     homepage = "https://github.com/bobfang1992/pytomlpp";
     license = licenses.mit;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -59,6 +59,6 @@ buildPythonPackage rec {
     description = "Rust based TOML library for Python";
     homepage = "https://github.com/samuelcolvin/rtoml";
     license = licenses.mit;
-    maintainers = with maintainers; [ evils ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/error-inject/default.nix
+++ b/pkgs/os-specific/linux/error-inject/default.nix
@@ -38,7 +38,7 @@
       description = "MCE error injection tool";
       license = licenses.gpl2Only;
       platforms = platforms.linux;
-      maintainers = [ maintainers.evils ];
+      maintainers = [ ];
     };
   };
 
@@ -71,7 +71,7 @@
       description = "PCIE AER error injection tool";
       license = licenses.gpl2Only;
       platforms = platforms.linux;
-      maintainers = [ maintainers.evils ];
+      maintainers = [ ];
     };
   };
 }

--- a/pkgs/os-specific/linux/mm-tools/default.nix
+++ b/pkgs/os-specific/linux/mm-tools/default.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   stdenv,
   linux,
 }:
@@ -12,9 +11,9 @@ stdenv.mkDerivation {
 
   preConfigure = "cd tools/mm";
 
-  meta = with lib; {
+  meta = {
     inherit (linux.meta) license platforms;
     description = "Set of virtual memory tools";
-    maintainers = [ maintainers.evils ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hasn't commented since [this February](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aevils) (which is also the latest they were publicly active on Github in general), hasn't opened any tickets themselves since [May 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Aevils), both of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/6d40c7d426c102023aae52888215699bc024cfd3/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

@evils, you have a week (until 20:00 GMT on Oct 12) to object this. Even if you don't make it, you're still welcome back.

(dang, I should make a template for these)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
