### PR TITLE
zigfetch: init at 0.23.0

### DIFF
--- a/pkgs/by-name/zi/zigfetch/darwin.patch
+++ b/pkgs/by-name/zi/zigfetch/darwin.patch
@@ -1,0 +1,14 @@
+diff --git a/build.zig b/build.zig
+index 8093504..5ab12ca 100644
+--- a/build.zig
++++ b/build.zig
+@@ -27,6 +27,9 @@ pub fn build(b: *std.Build) void {
+     if (target.result.os.tag == .macos) {
+         exe.linkFramework("CoreFoundation");
+         exe.linkFramework("IOKit");
++        exe.root_module.addFrameworkPath(.{
++            .cwd_relative = "@darwin-frameworks@",
++        });
+     }
+ 
+     if (target.result.os.tag == .linux) {

--- a/pkgs/by-name/zi/zigfetch/package.nix
+++ b/pkgs/by-name/zi/zigfetch/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+  pciutils,
+  apple-sdk,
+  replaceVars,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "zigfetch";
+  version = "0.23.0";
+
+  src = fetchFromGitHub {
+    owner = "utox39";
+    repo = "zigfetch";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-WDCaU/qCwSCSCVD2gY2EuTM4KBJb+foZ+7REazp+dpY=";
+  };
+
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    (replaceVars ./darwin.patch {
+      darwin-frameworks = "${apple-sdk.sdkroot}/System/Library/Frameworks";
+    })
+  ];
+
+  nativeBuildInputs = [
+    zig.hook
+  ];
+
+  buildInputs = [
+    pciutils
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Minimal neofetch/fastfetch like system information tool";
+    homepage = "https://github.com/utox39/zigfetch";
+    changelog = "https://github.com/utox39/zigfetch/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ heisfer ];
+    mainProgram = "zigfetch";
+    inherit (zig.meta) platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/utox39/zigfetch
Like other system info fetch tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
