### PR TITLE
petsc: 3.23.7 -> 3.24.0; slepc: 3.23.3 -> 3.24.0

### DIFF
--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -110,12 +110,25 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "petsc";
-  version = "3.23.7";
+  version = "3.24.0";
 
   src = fetchzip {
     url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${finalAttrs.version}.tar.gz";
-    hash = "sha256-6jP1EEYGMkttmEh0Fvtm0Fgp0NwHQlG21fY7cnLmXTI=";
+    hash = "sha256-5jqYTo5sfwLNByOlpry0zpI+q3u7ErwJJ97h7w5bvNQ=";
   };
+
+  patches = [
+    (replaceVars ./fix-petsc4py-install-prefix.patch {
+      PYTHON_SITEPACKAGES = python3Packages.python.sitePackages;
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs ./lib/petsc/bin
+
+    substituteInPlace config/example_template.py \
+      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
+  '';
 
   strictDeps = true;
 
@@ -150,19 +163,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withSuitesparse petscPackages.suitesparse;
 
   propagatedBuildInputs = lib.optional pythonSupport python3Packages.numpy;
-
-  patches = [
-    (replaceVars ./fix-petsc4py-install-prefix.patch {
-      PYTHON_SITEPACKAGES = python3Packages.python.sitePackages;
-    })
-  ];
-
-  postPatch = ''
-    patchShebangs ./lib/petsc/bin
-
-    substituteInPlace config/example_template.py \
-      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
-  '';
 
   configureFlags = [
     "--with-blaslapack=1"

--- a/pkgs/by-name/sl/slepc/package.nix
+++ b/pkgs/by-name/sl/slepc/package.nix
@@ -15,13 +15,13 @@ assert petsc.mpiSupport;
 assert pythonSupport -> petsc.pythonSupport;
 stdenv.mkDerivation (finalAttrs: {
   pname = "slepc";
-  version = "3.23.3";
+  version = "3.24.0";
 
   src = fetchFromGitLab {
     owner = "slepc";
     repo = "slepc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j0sUJet4eViFxOR0XOAxNSprnL+kN4OW1npGihT0Q4Y=";
+    hash = "sha256-nvzX0p/H3EYR8+7jD+I4FdvU+WstxR/U4Upcn7yZULk=";
   };
 
   postPatch = ''
@@ -31,14 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
       "slepc.prefixdir,'${python3Packages.python.sitePackages}'"
 
     patchShebangs lib/slepc/bin
-  '';
-
-  # Usually this project is being built as part of a `petsc` build or as part of
-  # other projects, e.g when `petsc` is `./configure`d with
-  # `--download-slepc=1`. This instructs the slepc to be built as a standalone
-  # project.
-  preConfigure = ''
-    export SLEPC_DIR=$PWD
   '';
 
   nativeBuildInputs = [
@@ -99,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Scalable Library for Eigenvalue Problem Computations";
     homepage = "https://slepc.upv.es";
-    changelog = "https://gitlab.com/slepc/slepc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://gitlab.com/slepc/slepc/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       bsd2
     ];


### PR DESCRIPTION
petsc: 3.23.7 -> 3.24.0

Diff: https://gitlab.com/petsc/petsc/-/compare/v3.23.7...v3.24.0
ChangeLog: https://petsc.org/release/changes/324

slepc: 3.23.3 -> 3.24.0

Diff: https://gitlab.com/slepc/slepc/-/compare/v3.23.3...v3.24.0
ChangeLog: https://gitlab.com/slepc/slepc/blob/v3.24.0/CHANGELOG.md

built on darwin if [superlu](https://github.com/NixOS/nixpkgs/pull/448396) is fixed.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
