### PR TITLE
python3Packages.questionary, python3Packages.kantoku, commitizen: fixes

### DIFF
--- a/pkgs/by-name/co/commitizen/package.nix
+++ b/pkgs/by-name/co/commitizen/package.nix
@@ -1,15 +1,31 @@
 {
   lib,
+  python3,
+  fetchPypi,
   fetchFromGitHub,
   gitMinimal,
   stdenv,
   installShellFiles,
   nix-update-script,
-  python3Packages,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
-
+let
+  # commitizen 4.9.1 is not compatible with version 3.0.52 of prompt-toolkit
+  python = python3.override {
+    packageOverrides = self: super: {
+      prompt-toolkit = super.prompt-toolkit.overridePythonAttrs (oldAttrs: rec {
+        version = "3.0.51";
+        pname = "prompt_toolkit";
+        src = fetchPypi {
+          inherit pname version;
+          hash = "sha256-kxoWLjsn/JDIbxtIux+yxSjCdhR15XycBt4TMRx7VO0=";
+        };
+      });
+    };
+  };
+  python3Packages = python.pkgs;
+in
 python3Packages.buildPythonPackage rec {
   pname = "commitizen";
   version = "4.9.1";
@@ -41,6 +57,7 @@ python3Packages.buildPythonPackage rec {
     importlib-metadata
     jinja2
     packaging
+    prompt-toolkit
     pyyaml
     questionary
     termcolor

--- a/pkgs/development/python-modules/kantoku/default.nix
+++ b/pkgs/development/python-modules/kantoku/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   flit-core,
@@ -46,7 +47,14 @@ buildPythonPackage rec {
   disabledTests = [
     # AssertionError
     "test_streams"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Assertion error when test_socketstats hits a permission error
+    "test_resource_watcher_max_mem"
+    "test_resource_watcher_max_mem_abs"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "A Process & Socket Manager built with zmq";

--- a/pkgs/development/python-modules/questionary/default.nix
+++ b/pkgs/development/python-modules/questionary/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
     "test_blank_line_fix"
 
     # TypeError: Attrs.__new__() missing 1 required positional argument: 'dim'
+    # https://github.com/tmbo/questionary/issues/461
     "test_print_with_style"
   ];
 


### PR DESCRIPTION
1. `questionary`: Test failure due to a newer version of prompt-toolkit adding a required param. Disabled the test.
2. `commitizen`: `python3Packages.prompt-toolkit` 3.0.52 breaks the latest `commitizen`, so pin prompt-toolkit at 3.0.51. Depends on `questionary`.
3. `python3Packages.kantoku` depends on previous. Memory usage tests break on Darwin, disabled. 

Closes #449702

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
