### PR TITLE
ete: init at 0-unstable-2025-08-17

### DIFF
--- a/pkgs/by-name/et/ete-unwrapped/package.nix
+++ b/pkgs/by-name/et/ete-unwrapped/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cjson,
+  cmake,
+  curl,
+  freetype,
+  glew,
+  libjpeg,
+  libogg,
+  libpng,
+  libtheora,
+  libX11,
+  lua5_4,
+  minizip,
+  openal,
+  SDL2,
+  sqlite,
+  zlib,
+}:
+let
+  arch = if stdenv.hostPlatform.isi686 then "x86" else "x86_64";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ete-unwrapped";
+  version = "0-unstable-2025-08-17";
+
+  src = fetchFromGitHub {
+    owner = "etfdevs";
+    repo = "ETe";
+    rev = "f6a9fda3b82c1ca8fd4536ae928571e93ff91fcc";
+    hash = "sha256-oTFtUAgkDYtbcw66EFBBFMMUEYWSHYpTAFAv1izqsuo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    cjson
+    curl
+    freetype
+    glew
+    libjpeg
+    libogg
+    libpng
+    libtheora
+    libX11
+    lua5_4
+    minizip
+    openal
+    SDL2
+    sqlite
+    zlib
+  ];
+
+  cmakeDir = "../src";
+  cmakeFlags = [
+    (lib.cmakeBool "CROSS_COMPILE32" false)
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    (lib.cmakeBool "BUILD_DEDSERVER" true)
+    (lib.cmakeBool "BUILD_CLIENT" true)
+    (lib.cmakeBool "BUILD_ETMAIN_MOD" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/lib/ete")
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    for f in ete-ded.${arch} ete.${arch}; do
+      mv $out/lib/ete/''${f} $out/bin/''${f}
+    done
+  '';
+
+  meta = {
+    description = "Improved Wolfenstein: Enemy Territory Engine";
+    homepage = "https://github.com/etfdevs/ETe";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [
+      ashleyghooper
+      drupol
+    ];
+  };
+})

--- a/pkgs/by-name/et/ete/package.nix
+++ b/pkgs/by-name/et/ete/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  symlinkJoin,
+  etlegacy-assets,
+  ete-unwrapped,
+  makeBinaryWrapper,
+}:
+
+symlinkJoin {
+  pname = "ete";
+  version = ete-unwrapped.version;
+
+  paths = [
+    (etlegacy-assets.overrideAttrs (prev: {
+      postInstall = (prev.postInstall or "") + ''
+        mv $out/lib/etlegacy $out/lib/ete
+      '';
+    }))
+    ete-unwrapped
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postBuild = ''
+    wrapProgram $out/bin/ete.* \
+      --add-flags "+set fs_basepath ${placeholder "out"}/lib/ete"
+    wrapProgram $out/bin/ete-ded.* \
+      --add-flags "+set fs_basepath ${placeholder "out"}/lib/ete"
+  '';
+
+  meta = {
+    description = "Improved Wolfenstein: Enemy Territory Engine";
+    homepage = "https://github.com/etfdevs/ETe";
+    license = with lib.licenses; [
+      gpl3Plus
+      cc-by-nc-sa-30
+    ];
+    mainProgram = "ete." + (if stdenv.hostPlatform.isi686 then "x86" else "x86_64");
+    maintainers = with lib.maintainers; [
+      ashleyghooper
+      drupol
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
