### PR TITLE
libsupermesh: doCheck on aarch64-darwin

### DIFF
--- a/pkgs/by-name/li/libsupermesh/package.nix
+++ b/pkgs/by-name/li/libsupermesh/package.nix
@@ -51,12 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ mpiCheckPhaseHook ];
 
-  # On aarch64-darwin platform, the test program segfault at the line
-  # https://github.com/firedrakeproject/libsupermesh/blob/09af7c9a3beefc715fbdc23e46fdc96da8169ff6/src/tests/test_parallel_p1_inner_product_2d.F90#L164
-  # in defining the lambda subroutine pack_data_b with variable field_b.
-  # This error is test source and compiler related and does not indicate broken functionality of libsupermesh.
-  doCheck = !(stdenv.hostPlatform.system == "aarch64-darwin");
-
   passthru = {
     tests = {
       pkg-config = testers.hasPkgConfigModules {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
