### PR TITLE
hledger-fmt: init at 0.3.1

### DIFF
--- a/pkgs/by-name/hl/hledger-fmt/package.nix
+++ b/pkgs/by-name/hl/hledger-fmt/package.nix
@@ -1,0 +1,53 @@
+{
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hledger-fmt";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "mondeja";
+    repo = "hledger-fmt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5dPKSUJLxQ5WXZefuwr3wLhr3MNzy+dzpJkgKFU0/SE=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  cargoHash = "sha256-yErH9AyfBZF0PByqViVhXHB/FAc0awz4bOyAHtcHe0s=";
+
+  # Tests try to invoke the binary from "target/debug/hledger-fmt"
+  # https://github.com/mondeja/hledger-fmt/blob/783abdb32eefb20195c7e9562858552935bb9c8e/src/cli/tests.rs#L5
+  postPatch = ''
+    substituteInPlace src/cli/tests.rs --replace-fail \
+      'target/debug' "target/${stdenv.hostPlatform.rust.rustcTargetSpec}/$cargoCheckType"
+  '';
+
+  buildFeatures = [
+    "manpages"
+  ];
+
+  postInstall = ''
+    installManPage --name hledger-fmt.1 \
+      "target/${stdenv.hostPlatform.rust.rustcTargetSpec}/assets/example.1"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Opinionated hledger's journal files formatter";
+    homepage = "https://github.com/mondeja/hledger-fmt";
+    changelog = "https://github.com/mondeja/hledger-fmt/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dwoffinden ];
+    mainProgram = "hledger-fmt";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
