### PR TITLE
soapy{sdr,rtlsdr,uhd}: fix cmake 4 build

### DIFF
--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -18,16 +18,15 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "soapysdr";
   # Don't forget to change passthru.abiVersion
-  version = "0.8.1-unstable-2025-03-30-03";
+  version = "0.8.1-unstable-2025-10-05-03";
 
   src = fetchFromGitHub {
     owner = "pothosware";
     repo = "SoapySDR";
 
-    # Instead of applying several patches for Python 3.12 compat, just take the latest, from:
-    # use old get python lib for v2 (#437)
-    rev = "fbf9f3c328868f46029284716df49095ab7b99a6";
-    hash = "sha256-W4915c6hV/GR5PZRRXZJW3ERsZmQQQ08EA9wYp2tAVk=";
+    # update to include latest patch for newer cmake support
+    rev = "1667b4e6301d7ad47b340dcdcd6e9969bf57d843";
+    hash = "sha256-UCpYBUb2k1bHy1z2Mvmv+1ZX1BloSsPrTydFV3Ga3Os=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/so/soapyrtlsdr/package.nix
+++ b/pkgs/by-name/so/soapyrtlsdr/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   pkg-config,
   rtl-sdr,
@@ -26,6 +27,20 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     rtl-sdr
     soapysdr
+  ];
+
+  patches = [
+    (fetchpatch2 {
+      name = "cmake-update.patch";
+      url = "https://github.com/pothosware/SoapyRTLSDR/commit/448c9d0d326c2600905b7ce84222ff9d72ba2189.patch?full_index=1";
+      hash = "sha256-hWlNowkf9yZM6p+EGh+IiUm2JfG5mLe8Qq8gTVIdIak=";
+    })
+
+    (fetchpatch2 {
+      name = "fix-cmake4-build.patch";
+      url = "https://github.com/pothosware/SoapyRTLSDR/commit/bb2d1511b957138051764c9193a3d6971e912b85.patch?full_index=1";
+      hash = "sha256-C90B5WMjx1lJKiX0F/cAfGmz2WRc2BA84FTmVmnC+DI=";
+    })
   ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];

--- a/pkgs/by-name/so/soapyuhd/package.nix
+++ b/pkgs/by-name/so/soapyuhd/package.nix
@@ -11,13 +11,14 @@
 
 stdenv.mkDerivation {
   pname = "soapyuhd";
-  version = "0.4.1-unstable-2025-02-13";
+  version = "0.4.1-unstable-2025-10-05";
 
   src = fetchFromGitHub {
     owner = "pothosware";
     repo = "SoapyUHD";
-    rev = "6b521393cc45c66770f3d4bc69eac7dda982174c";
-    sha256 = "qg0mbw3S973cnok6tVx7Y38ijOQcJdHtPLi889uo7tI=";
+    # version that supports cmake 4
+    rev = "cf78b9ca3bddfc9263d2acb7e8afcb0036938163";
+    hash = "sha256-/hJ78dUL477gX3c2kV8kUknIk01PUf+ie1Gl7Ujq1Ac=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updated soapysdr and soapyuhd to the latest git commit on master which fixes cmake v4 build
Added upstream patches to soapyrtlsdr to fix cmake 4 build
Cmake 4 tracking issue: #445447
Most failed builds from nixpkgs-review seem to be related to still missing cmake fixes
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `b2eeb6bab79606982d641c1f0375b5a7fc87186c`

---
### `x86_64-linux`
<details>
  <summary>:x: 50 packages failed to build:</summary>
  <ul>
    <li>abracadabra</li>
    <li>cubicsdr</li>
    <li>dump1090-fa</li>
    <li>dumphfdl</li>
    <li>dumpvdl2</li>
    <li>gnss-sdr</li>
    <li>gnuradio</li>
    <li>gnuradioMinimal</li>
    <li>gnuradioPackages.bladeRF</li>
    <li>gnuradioPackages.fosphor</li>
    <li>gnuradioPackages.lora_sdr</li>
    <li>gnuradioPackages.lora_sdr.dev</li>
    <li>gnuradioPackages.osmosdr</li>
    <li>gnuradioPackages.osmosdr.dev</li>
    <li>gqrx</li>
    <li>gqrx-gr-audio</li>
    <li>gqrx-portaudio</li>
    <li>indi-3rdparty.indi-limesdr</li>
    <li>indi-full</li>
    <li>indi-full-nonfree</li>
    <li>inspectrum</li>
    <li>kstars</li>
    <li>limesuite</li>
    <li>limesuiteWithGui</li>
    <li>openwebrx</li>
    <li>openwebrx.dist</li>
    <li>phd2</li>
    <li>pothos</li>
    <li>python312Packages.soapysdr-with-plugins</li>
    <li>python313Packages.soapysdr-with-plugins</li>
    <li>qradiolink</li>
    <li>rtl_433</li>
    <li>sdrangel</li>
    <li>sdrpp</li>
    <li>sigdigger</li>
    <li>soapyairspy</li>
    <li>soapyaudio</li>
    <li>soapybladerf</li>
    <li>soapyhackrf</li>
    <li>soapyplutosdr</li>
    <li>soapyremote</li>
    <li>soapysdr-with-plugins</li>
    <li>soapysdrplay</li>
    <li>srsran</li>
    <li>srsran.dev</li>
    <li>suscan</li>
    <li>trunk-recorder</li>
    <li>urh</li>
    <li>urh.dist</li>
    <li>welle-io</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>fm-tune</li>
    <li>python312Packages.soapysdr</li>
    <li>python313Packages.soapysdr</li>
    <li>soapyrtlsdr</li>
    <li>soapysdr</li>
    <li>soapyuhd</li>
    <li>tests.pkg-config.defaultPkgConfigPackages.SoapySDR</li>
  </ul>
</details>