### PR TITLE
oneDNN_2: reintroduce and unbreak, rocmPackages.migraphx: use oneDNN_2

### DIFF
--- a/pkgs/by-name/on/oneDNN_2/package.nix
+++ b/pkgs/by-name/on/oneDNN_2/package.nix
@@ -1,0 +1,53 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+
+# This was originally called mkl-dnn, then it was renamed to dnnl, and it has
+# just recently been renamed again to oneDNN. See here for details:
+# https://github.com/oneapi-src/oneDNN#oneapi-deep-neural-network-library-onednn
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oneDNN";
+  version = "2.7.5";
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneDNN";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-oMPBORAdL2rk2ewyUrInYVHYBRvuvNX4p4rwykO3Rhs=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  # Tests fail on some Hydra builders, because they do not support SSE4.2.
+  doCheck = false;
+
+  # Fixup bad cmake paths
+  postInstall = ''
+    substituteInPlace $out/lib/cmake/dnnl/dnnl-config.cmake \
+      --replace "\''${PACKAGE_PREFIX_DIR}/" ""
+
+    substituteInPlace $out/lib/cmake/dnnl/dnnl-targets.cmake \
+      --replace "\''${_IMPORT_PREFIX}/" ""
+  '';
+
+  meta = {
+    changelog = "https://github.com/oneapi-src/oneDNN/releases/tag/v${finalAttrs.version}";
+    description = "oneAPI Deep Neural Network Library (oneDNN)";
+    homepage = "https://01.org/oneDNN";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      alexarice
+      bhipple
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/on/oneDNN_2/package.nix
+++ b/pkgs/by-name/on/oneDNN_2/package.nix
@@ -44,10 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "oneAPI Deep Neural Network Library (oneDNN)";
     homepage = "https://01.org/oneDNN";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      alexarice
-      bhipple
-    ];
+    teams = [ lib.teams.rocm ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/on/oneDNN_2/package.nix
+++ b/pkgs/by-name/on/oneDNN_2/package.nix
@@ -8,6 +8,8 @@
 # This was originally called mkl-dnn, then it was renamed to dnnl, and it has
 # just recently been renamed again to oneDNN. See here for details:
 # https://github.com/oneapi-src/oneDNN#oneapi-deep-neural-network-library-onednn
+# oneDNN_2 is currently only consumed by rocmPackages.migraphx and likely
+# to be dropped once migraphx can migrate to 3
 stdenv.mkDerivation (finalAttrs: {
   pname = "oneDNN";
   version = "2.7.5";
@@ -18,6 +20,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-oMPBORAdL2rk2ewyUrInYVHYBRvuvNX4p4rwykO3Rhs=";
   };
+
+  # Substituting for CMake 4 compat.
+  # There's an upstream patch in v3 which does not cleanly apply.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8.12)" \
+      "cmake_minimum_required(VERSION 2.8.12...3.13)"
+  '';
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/6/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/6/migraphx/default.nix
@@ -21,7 +21,9 @@
   boost,
   msgpack-cxx,
   sqlite,
-  oneDNN,
+  # TODO(@LunNova): Swap to `oneDNN` once v3 is supported
+  # Upstream issue: https://github.com/ROCm/AMDMIGraphX/issues/4351
+  oneDNN_2,
   blaze,
   texliveSmall,
   doxygen,
@@ -53,15 +55,6 @@ let
       ]
     )
   );
-  oneDNN' = oneDNN.overrideAttrs rec {
-    version = "2.7.5";
-    src = fetchFromGitHub {
-      owner = "oneapi-src";
-      repo = "oneDNN";
-      tag = "v${version}";
-      hash = "sha256-oMPBORAdL2rk2ewyUrInYVHYBRvuvNX4p4rwykO3Rhs=";
-    };
-  };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "migraphx";
@@ -120,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     msgpack-cxx
     sqlite
-    oneDNN'
+    oneDNN_2
     blaze
     python3Packages.pybind11
     python3Packages.onnx

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1928,7 +1928,6 @@ mapAliases {
   odoo15 = throw "odoo15 has been removed from nixpkgs as it is unsupported; migrate to a newer version of odoo"; # Added 2025-05-06
   offrss = throw "offrss has been removed due to lack of upstream maintenance; consider using another rss reader"; # Added 2025-06-01
   oil = lib.warnOnInstantiate "Oil has been replaced with the faster native C++ version and renamed to 'oils-for-unix'. See also https://github.com/oils-for-unix/oils/wiki/Oils-Deployments" oils-for-unix; # Added 2024-10-22
-  oneDNN_2 = throw "oneDNN_2 has been removed as it was only used by rocmPackages.migraphx"; # added 2025-07-18
   onevpl-intel-gpu = lib.warnOnInstantiate "onevpl-intel-gpu has been renamed to vpl-gpu-rt" vpl-gpu-rt; # Added 2024-06-04
   openai-triton-llvm = triton-llvm; # added 2024-07-18
   openai-whisper-cpp = whisper-cpp; # Added 2024-12-13


### PR DESCRIPTION
Reintroducing oneDNN_2 for compliance with #421201 and fixing its build with CMake 4 (#445447).

Upstream issue for oneDNN 3 compat in migraphx: https://github.com/ROCm/AMDMIGraphX/issues/4351

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
