### PR TITLE
python3Packages.vllm: disable Blackwell GPU support to fix CUDA build

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -200,16 +200,19 @@ let
         "8.9"
         "9.0"
         "9.0a"
-        "10.0"
-        "10.0a"
-        "10.1"
-        "10.1a"
-        "10.3"
-        "10.3a"
-        "12.0"
-        "12.0a"
-        "12.1"
-        "12.1a"
+        # Blackwell (SM100+) capabilities temporarily disabled due to CUTLASS API incompatibility
+        # FlashMLA kernels require CUTLASS v4.2.1+ APIs not available in bundled v4.0.0
+        # TODO: Re-enable when vLLM upgrades CUTLASS (see https://github.com/vllm-project/vllm/pull/24673)
+        # "10.0"
+        # "10.0a"
+        # "10.1"
+        # "10.1a"
+        # "10.3"
+        # "10.3a"
+        # "12.0"
+        # "12.0a"
+        # "12.1"
+        # "12.1a"
       ];
       ptx = lists.map (x: "${x}+PTX") real;
     in


### PR DESCRIPTION
Fixes type of build failure seen [here](https://hydra.nixos-cuda.org/build/824/nixlog/71).
- vLLM v0.11.0's FlashMLA kernels for Blackwell (SM100+) GPUs require CUTLASS v4.2.1+ APIs that are not available in the bundled v4.0.0
- Temporarily disable these architectures until upstream upgrades CUTLASS

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
