### PR TITLE
ocamlPackages.lsp: 1.23.0 → 1.23.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -10,7 +10,7 @@
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "5.3" then
-      "1.23.0"
+      "1.23.1"
     else if lib.versionAtLeast ocaml.version "5.2" then
       "1.21.0"
     else if lib.versionAtLeast ocaml.version "4.14" then
@@ -26,10 +26,10 @@
 let
   params =
     {
-      "1.23.0" = {
+      "1.23.1" = {
         name = "lsp";
         minimalOCamlVersion = "5.3";
-        sha256 = "sha256-fyvQI7VKgOrOFihtKIkcE2B2iUYFLJOZGKipzZU0Dn0=";
+        sha256 = "sha256-x0fjlAJmOeogRGfoWd6T6o6ZWNv0T3gNyyoYl8VtdXE=";
       };
       "1.22.0" = {
         name = "lsp";
@@ -96,7 +96,9 @@ buildDunePackage rec {
       ];
 
   propagatedBuildInputs =
-    if lib.versionAtLeast version "1.7.0" then
+    if lib.versionAtLeast version "1.23.1" then
+      [ yojson ]
+    else if lib.versionAtLeast version "1.7.0" then
       [ ]
     else
       [

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -24,7 +24,7 @@
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "5.3" then
-      "1.23.0"
+      "1.23.1"
     else if lib.versionAtLeast ocaml.version "5.2" then
       "1.21.0"
     else if lib.versionAtLeast ocaml.version "4.14" then


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
