### PR TITLE
haskellPackages: more pkgsCross.ucrt64 fixes

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -55,7 +55,8 @@
   gmp,
 
   # If enabled, use -fPIC when compiling static libs.
-  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform,
+  enableRelocatedStaticLibs ?
+    stdenv.targetPlatform != stdenv.hostPlatform && !stdenv.targetPlatform.isWindows,
 
   # Exceeds Hydra output limit (at the time of writing ~3GB) when cross compiled to riscv64.
   # A riscv64 cross-compiler fits into the limit comfortably.
@@ -332,6 +333,8 @@ let
     # documentation) makes the GHC RTS able to load static libraries, which may
     # be needed for TemplateHaskell. This solution was described in
     # https://www.tweag.io/blog/2020-09-30-bazel-static-haskell
+    #
+    # Note `-fexternal-dynamic-refs` causes `undefined reference` errors when building GHC cross compiler for windows
     lib.optionals enableRelocatedStaticLibs [
       "*.*.ghc.*.opts += -fPIC -fexternal-dynamic-refs"
     ]

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1156,7 +1156,6 @@ with haskellLib;
   Cabal-ide-backend = dontCheck super.Cabal-ide-backend;
 
   # This package can't be built on non-Windows systems.
-  Win32 = overrideCabal (drv: { broken = !pkgs.stdenv.hostPlatform.isCygwin; }) super.Win32;
   inline-c-win32 = dontDistribute super.inline-c-win32;
   Southpaw = dontDistribute super.Southpaw;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -36,4 +36,5 @@ self: super: {
   transformers = null;
   unix = null;
   xhtml = null;
+  Win32 = null;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -63,6 +63,7 @@ in
   transformers = null;
   unix = null;
   xhtml = null;
+  Win32 = null;
 
   # “Unfortunately we are unable to support GHC 9.10.”
   apply-refact = dontDistribute (markBroken super.apply-refact);

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -66,6 +66,7 @@ with haskellLib;
   transformers = null;
   unix = null;
   xhtml = null;
+  Win32 = null;
 
   #
   # Hand pick versions that are compatible with ghc 9.12 and base 4.21

--- a/pkgs/development/haskell-modules/configuration-ghc-9.16.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.16.x.nix
@@ -51,4 +51,5 @@ self: super: {
   transformers = null;
   unix = null;
   xhtml = null;
+  Win32 = null;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -50,6 +50,7 @@ self: super: {
   # GHC only bundles the xhtml library if haddock is enabled, check if this is
   # still the case when updating: https://gitlab.haskell.org/ghc/ghc/-/blob/0198841877f6f04269d6050892b98b5c3807ce4c/ghc.mk#L463
   xhtml = if self.ghc.hasHaddock or true then null else doDistribute self.xhtml_3000_4_0_0;
+  Win32 = null;
 
   # Becomes a core package in GHC >= 9.8
   semaphore-compat = doDistribute self.semaphore-compat_1_0_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -58,6 +58,7 @@ in
   transformers = null;
   unix = null;
   xhtml = null;
+  Win32 = null;
 
   # Becomes a core package in GHC >= 9.8
   semaphore-compat = doDistribute self.semaphore-compat_1_0_0;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -61,6 +61,7 @@ in
   transformers = null;
   unix = null;
   xhtml = null;
+  Win32 = null;
 
   # Becomes a core package in GHC >= 9.10
   os-string = doDistribute self.os-string_2_0_8;

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -1,0 +1,16 @@
+{ pkgs, haskellLib }:
+
+let
+  inherit (pkgs) lib;
+in
+
+with haskellLib;
+
+(self: super: {
+  # cabal2nix doesn't properly add dependencies conditional on os(windows)
+  network =
+    if pkgs.stdenv.hostPlatform.isWindows then
+      addBuildDepends [ self.temporary ] super.network
+    else
+      super.network;
+})

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -1,7 +1,7 @@
 { pkgs, haskellLib }:
 
 let
-  inherit (pkgs) lib;
+  inherit (pkgs) fetchpatch lib;
 in
 
 with haskellLib;
@@ -13,4 +13,11 @@ with haskellLib;
       addBuildDepends [ self.temporary ] super.network
     else
       super.network;
+
+  # https://github.com/fpco/streaming-commons/pull/84
+  streaming-commons = appendPatch (fetchpatch {
+    name = "fix-headers-case.patch";
+    url = "https://github.com/fpco/streaming-commons/commit/6da611f63e9e862523ce6ee53262ddbc9681ae24.patch";
+    sha256 = "sha256-giEQqXZfoiAvtCFohdgOoYna2Tnu5aSYAOUH8YVldi0=";
+  }) super.streaming-commons;
 })

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -15,6 +15,7 @@
   configurationNix ? import ./configuration-nix.nix,
   configurationArm ? import ./configuration-arm.nix,
   configurationDarwin ? import ./configuration-darwin.nix,
+  configurationWindows ? import ./configuration-windows.nix,
   configurationJS ? import ./configuration-ghcjs-9.x.nix,
 }:
 
@@ -41,6 +42,9 @@ let
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       (configurationDarwin { inherit pkgs haskellLib; })
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isWindows [
+      (configurationWindows { inherit pkgs haskellLib; })
     ]
     ++ lib.optionals stdenv.hostPlatform.isGhcjs [
       (configurationJS { inherit pkgs haskellLib; })


### PR DESCRIPTION
Long delayed follow-up to #357744 

```
$ uname -mo
x86_64 GNU/Linux

$(nix-build -A wine64)/bin/wine64 $(nix-build -A pkgsCross.ucrt64.haskell.packages.ghc912.hello)/bin/hello.exe
0024:fixme:ntdll:NtQuerySystemInformation info_class SYSTEM_PERFORMANCE_INFORMATION
Hello, World!
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
