### PR TITLE
python3Packages.firedrake: 2025.4.2 -> 2025.10.1

### DIFF
--- a/pkgs/development/python-modules/firedrake-fiat/default.nix
+++ b/pkgs/development/python-modules/firedrake-fiat/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "firedrake-fiat";
-  version = "2025.4.2";
+  version = "2025.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "firedrakeproject";
     repo = "fiat";
     tag = version;
-    hash = "sha256-SIi/4JW9L4kyFxEmbG9pqe0QtY80UMOh7LSFLmrHhZY=";
+    hash = "sha256-kyQe4VFzcK1idMt/NNND2cytGUryyhh5+ZP292zxT7c=";
   };
 
   postPatch =

--- a/pkgs/development/python-modules/pyadjoint-ad/default.nix
+++ b/pkgs/development/python-modules/pyadjoint-ad/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyadjoint-ad";
-  version = "2025.04.1";
+  version = "2025.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dolfin-adjoint";
     repo = "pyadjoint";
     tag = version;
-    hash = "sha256-S9A0qCatnnLuOkqWsEC4tjVY1HZqqi2T5iXu+WUoN24=";
+    hash = "sha256-caW2X4q0mHnD8CEh5jjelD4xBth/R/8/P3m0tTeO/LQ=";
   };
 
   build-system = [
@@ -30,8 +30,6 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [
-    # The firedrake_adjoint module is deprecated and requires a cyclic dependency of firedrake
-    # "firedrake_adjoint"
     "numpy_adjoint"
     "pyadjoint"
     "pyadjoint.optimization"


### PR DESCRIPTION
python3Packages.firedrake 2025.4.2 -> 2025.10.1

Diff: https://github.com/firedrakeproject/firedrake/compare/2025.4.2...2025.10.1
ChangeLog: https://github.com/firedrakeproject/firedrake/releases/tag/2025.10.1


python3Packages.pyadjoint-ad: 2025.4.1 -> 2025.10.0

Diff: https://github.com/dolfin-adjoint/pyadjoint/compare/2025.04.1...2025.10.0
ChangeLog: https://github.com/dolfin-adjoint/pyadjoint/releases/tag/2025.10.0


python3Packages.firedrake-fiat: 2025.4.2 -> 2025.10.0

Diff: https://github.com/firedrakeproject/fiat/compare/2025.4.2...2025.10.0
ChangeLog: https://github.com/firedrakeproject/fiat/releases/tag/2025.10.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
