### PR TITLE
wvkbd: remove unnecessary patch; add myself as maintainer

### DIFF
--- a/pkgs/by-name/wv/wvkbd/package.nix
+++ b/pkgs/by-name/wv/wvkbd/package.nix
@@ -24,11 +24,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-RfZbPAaf8UB4scUZ9XSL12QZ4UkYMzXqfmNt9ObOgQ0=";
   };
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace-fail "pkg-config" "$PKG_CONFIG"
-  '';
-
   nativeBuildInputs = [
     pkg-config
     scdoc

--- a/pkgs/by-name/wv/wvkbd/package.nix
+++ b/pkgs/by-name/wv/wvkbd/package.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
     mainProgram = "wvkbd-mobintl";
+    maintainers = with lib.maintainers; [ colinsane ];
   };
 }


### PR DESCRIPTION
this package has no maintainers: proposing to take over maintainership as i've used it daily for over a year.

upstream Makefile reads `PKG_CONFIG` from the environment, we don't need any extra patching for it to be found.

<https://github.com/jjsullivan5196/wvkbd/blob/ed702f956216b5c638121763687ac5aa305bfba0/Makefile#L13>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux  (via `pkgsCross.aarch64-multiplatform.wvkbd`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] ~~[NixOS tests] in [nixos/tests].~~ package has no nixos tests
  - [ ] ~~[Package tests] at `passthru.tests`.~~ package has no passthru tests
  - [ ] ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~ not applicable
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
