### PR TITLE
emacsPackages.eaf-*: fix dependencies issue

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-airshare/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-airshare/package.nix
@@ -33,7 +33,6 @@ melpaBuild {
         qrcode
       ]
       ++ ps.qrcode.optional-dependencies.pil;
-    eafOtherDeps = [ ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-browser/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-browser/default.nix
@@ -36,6 +36,12 @@ melpaBuild (finalAttrs: {
     npmHooks.npmConfigHook
   ];
 
+  postPatch = ''
+    substituteInPlace buffer.py \
+      --replace-fail "aria2_args = [\"aria2c\"]" \
+                     "aria2_args = [\"${lib.getExe aria2}\"]"
+  '';
+
   files = ''
     ("*.el"
      "*.py"
@@ -55,9 +61,6 @@ melpaBuild (finalAttrs: {
       ps: with ps; [
         pysocks
       ];
-    eafOtherDeps = [
-      aria2
-    ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-camera/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-camera/package.nix
@@ -55,7 +55,6 @@ melpaBuild (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
     eafPythonDeps = ps: [ ];
-    eafOtherDeps = [ ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-file-manager/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-file-manager/package.nix
@@ -36,6 +36,14 @@ melpaBuild (finalAttrs: {
     npmHooks.npmConfigHook
   ];
 
+  postPatch = ''
+    substituteInPlace buffer.py \
+      --replace-fail "shutil.which(\"fd\")" \
+                     "shutil.which(\"${lib.getExe fd}\")" \
+      --replace-fail "return \"fd\"" \
+                     "return \"${lib.getExe fd}\""
+  '';
+
   postBuild = ''
     npm run build
   '';
@@ -62,9 +70,6 @@ melpaBuild (finalAttrs: {
         pygments
         exif
       ];
-    eafOtherDeps = [
-      fd
-    ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-git/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-git/default.nix
@@ -37,6 +37,16 @@ melpaBuild (finalAttrs: {
     npmHooks.npmConfigHook
   ];
 
+  postPatch = ''
+    substituteInPlace eaf-git.el \
+      --replace-fail "(defcustom eaf-git-delta-executable \"delta\"" \
+                     "(defcustom eaf-git-delta-executable \"${lib.getExe delta}\""
+
+    substituteInPlace buffer.py \
+      --replace-fail "command = \"rg '{}' {}" \
+                     "command = \"${lib.getExe ripgrep} '{}' {}"
+  '';
+
   postBuild = ''
     npm run build
   '';
@@ -65,10 +75,6 @@ melpaBuild (finalAttrs: {
         pygments
         unidiff
       ];
-    eafOtherDeps = [
-      delta
-      ripgrep
-    ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-image-viewer/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-image-viewer/package.nix
@@ -49,7 +49,6 @@ melpaBuild (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
     eafPythonDeps = ps: [ ];
-    eafOtherDeps = [ ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-js-video-player/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-js-video-player/package.nix
@@ -55,7 +55,6 @@ melpaBuild (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
     eafPythonDeps = ps: [ ];
-    eafOtherDeps = [ ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-map/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-map/package.nix
@@ -60,7 +60,6 @@ melpaBuild (finalAttrs: {
         pycurl
         python-tsp
       ];
-    eafOtherDeps = [ ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pdf-viewer/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pdf-viewer/package.nix
@@ -31,7 +31,6 @@ melpaBuild {
         packaging
         pymupdf
       ];
-    eafOtherDeps = [ ];
   };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pyqterminal/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pyqterminal/package.nix
@@ -31,7 +31,6 @@ melpaBuild {
         pyte
         psutil
       ];
-    eafOtherDeps = [ ];
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I finally found that if we put binary files into the $out/bin/ directory, then the `executable-find` command in Emacs can find those binary, but the `shell-command` or `shell-command-to-string` cannot use them, and the Python side calling like `subprocess.Popen` also cannot. That means our binary dependency mechanism does not work, in fact. The reason why we did not find this issue is that EAF basic functions can run without those binaries.

To solve that issue, I remove the `eafOtherDeps` interface, and just do patch on the source code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
