### PR TITLE
gradle: use official Gradle wrapper

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -26,6 +26,8 @@
   If your SQLite database is corrupted, the migration might fail and require [manual intervention](https://github.com/louislam/uptime-kuma/issues/5281).
   See the [migration guide](https://github.com/louislam/uptime-kuma/wiki/Migration-From-v1-To-v2) for more information.
 
+- We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
+
 ## Nixpkgs Library {#sec-nixpkgs-release-26.05-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -68,8 +68,8 @@ let
               ''
                 cp -a $src/* .
                 substituteInPlace ./build.gradle --replace-fail '@JAVA_VERSION@' '${javaMajorVersion}'
-                env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
-                gradle run --no-daemon --quiet --console plain > $out
+                env GRADLE_USER_HOME=$TMPDIR/gradle GRADLE_OPTS=-Dorg.gradle.native.dir=$TMPDIR/native \
+                  gradle run --no-daemon --quiet --console plain > $out
                 actual="$(<$out)"
                 if [[ "${javaVersion}" != "$actual"* ]]; then
                   echo "Error: Expected '${javaVersion}', to start with '$actual'" >&2
@@ -275,7 +275,7 @@ let
         version = testers.testVersion {
           package = finalAttrs.finalPackage;
           command = ''
-            env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
+            env GRADLE_USER_HOME=$TMPDIR/gradle GRADLE_OPTS=-Dorg.gradle.native.dir=$TMPDIR/native \
               gradle --version
           '';
         };
@@ -291,7 +291,11 @@ let
               }
               ''
                 cp -a $src/* .
-                env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
+
+                # Make sure GRADLE_OPTS works.
+                env \
+                  GRADLE_USER_HOME=$TMPDIR/gradle \
+                  GRADLE_OPTS="-Dorg.gradle.native.dir=$TMPDIR/native -Dnix.test.mainClass=Main" \
                   gradle run --no-daemon --quiet --console plain > $out
               '';
         };

--- a/pkgs/development/tools/build-managers/gradle/tests/java-application/build.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/java-application/build.gradle
@@ -2,6 +2,14 @@ plugins {
     id('application')
 }
 
+String getPropOrDie(String prop, String message) {
+    def ret = System.getProperty(prop)
+    if (!ret) {
+        throw new RuntimeException(message)
+    }
+    return ret
+}
+
 application {
-    mainClass = 'Main'
+    mainClass = getPropOrDie('nix.test.mainClass', 'No main class defined, perhaps GRADLE_OPTS broke?')
 }


### PR DESCRIPTION
Not using the official Gradle wrapper causes papercuts like GRADLE_OPTS
and JAVA_HOME not working or misbehaving. Use the default wrapper script
and allow override of JAVA_HOME so we preserve the default Gradle wrapper
behavior.

Move the Gradle jars and bin to $out/libexec while we're at it so we
don't have to make any modifications to the wrapper ourselves
except for patching the shebang on install.

Tested with `gradle_{7,8,9}.tests` and a `nixpkgs-review rev HEAD`
to check reverse dependencies.

Fixes: https://github.com/NixOS/nixpkgs/issues/72220
Fixes: https://github.com/NixOS/nixpkgs/issues/402297
Fixes: https://github.com/NixOS/nixpkgs/issues/453296

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
