### PR TITLE
nanomsg, libcsptr, lemon-graph: CMake 4.0 fixes

### DIFF
--- a/pkgs/by-name/le/lemon-graph/cmake_version.patch
+++ b/pkgs/by-name/le/lemon-graph/cmake_version.patch
@@ -1,0 +1,95 @@
+From 0073156cc16cecc597902e9294e4996dafacc1a3 Mon Sep 17 00:00:00 2001
+From: hiaselhans <simon.klemenc@gmail.com>
+Date: Wed, 21 May 2025 08:12:37 +0200
+Subject: [PATCH] update cmake to work with newer versions
+
+---
+ .gitignore     |  1 +
+ CMakeLists.txt | 61 +++++++++-----------------------------------------
+ 2 files changed, 11 insertions(+), 51 deletions(-)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..c795b05
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1 @@
++build
+\ No newline at end of file
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 03e1cc7..26ec718 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,61 +1,20 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+-
+-CMAKE_POLICY(SET CMP0048 OLD)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.12...5.0)
+ 
+ SET(PROJECT_NAME "LEMON")
+-PROJECT(${PROJECT_NAME})
+-
+-INCLUDE(FindPythonInterp)
+-INCLUDE(FindWget)
+ 
+-IF(EXISTS ${PROJECT_SOURCE_DIR}/cmake/version.cmake)
+-  INCLUDE(${PROJECT_SOURCE_DIR}/cmake/version.cmake)
+-ELSEIF(DEFINED ENV{LEMON_VERSION})
++IF(DEFINED ENV{LEMON_VERSION})
+   SET(LEMON_VERSION $ENV{LEMON_VERSION} CACHE STRING "LEMON version string.")
++ELSEIF(EXISTS ${CMAKE_SOURCE_DIR}/cmake/version.cmake)
++  INCLUDE(${CMAKE_SOURCE_DIR}/cmake/version.cmake)
+ ELSE()
+-  EXECUTE_PROCESS(
+-    COMMAND
+-    hg log -r. --template "{latesttag}"
+-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-    OUTPUT_VARIABLE HG_REVISION_TAG
+-    ERROR_QUIET
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-  )
+-  EXECUTE_PROCESS(
+-    COMMAND
+-    hg log -r. --template "{latesttagdistance}"
+-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-    OUTPUT_VARIABLE HG_REVISION_DIST
+-    ERROR_QUIET
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-  )
+-  EXECUTE_PROCESS(
+-    COMMAND
+-    hg log -r. --template "{node|short}"
+-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-    OUTPUT_VARIABLE HG_REVISION_ID
+-    ERROR_QUIET
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-  )
++  MESSAGE(FATAL_ERROR "LEMON_VERSION is not defined. Please set it in the environment")
++ENDIF()
+ 
+-  IF(HG_REVISION_TAG STREQUAL "")
+-    SET(HG_REVISION_ID "hg-tip")
+-  ELSE()
+-    IF(HG_REVISION_TAG STREQUAL "null")
+-      SET(HG_REVISION_TAG "trunk")
+-    ELSEIF(HG_REVISION_TAG MATCHES "^r")
+-      STRING(SUBSTRING ${HG_REVISION_TAG} 1 -1 HG_REVISION_TAG)
+-    ENDIF()
+-    IF(HG_REVISION_DIST STREQUAL "0")
+-      SET(HG_REVISION ${HG_REVISION_TAG})
+-    ELSE()
+-      SET(HG_REVISION
+-	"${HG_REVISION_TAG}+${HG_REVISION_DIST}-${HG_REVISION_ID}")
+-    ENDIF()
+-  ENDIF()
+ 
+-  SET(LEMON_VERSION ${HG_REVISION} CACHE STRING "LEMON version string.")
+-ENDIF()
++PROJECT(${PROJECT_NAME} VERSION ${LEMON_VERSION})
++
++find_package(Python3 REQUIRED COMPONENTS Interpreter)
++INCLUDE(FindWget)
+ 
+ SET(PROJECT_VERSION ${LEMON_VERSION})
+ 

--- a/pkgs/by-name/le/lemon-graph/package.nix
+++ b/pkgs/by-name/le/lemon-graph/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   cmake,
+  python3,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1j6kp9axhgna47cfnmk1m7vnqn01hwh7pf1fp76aid60yhjwgdvi";
   };
 
+  buildInputs = [ python3 ];
   nativeBuildInputs = [ cmake ];
 
   # error: no viable conversion from ...
@@ -22,6 +24,9 @@ stdenv.mkDerivation rec {
   patches = [
     # error: ISO C++17 does not allow 'register' storage class specifier
     ./remove-register.patch
+
+    # fix cmake compatibility. vendored from https://github.com/The-OpenROAD-Project/lemon-graph/pull/2
+    ./cmake_version.patch
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/li/libcsptr/package.nix
+++ b/pkgs/by-name/li/libcsptr/package.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+
   meta = with lib; {
     description = "Smart pointer constructs for the (GNU) C programming language";
     homepage = "https://github.com/Snaipe/libcsptr";

--- a/pkgs/by-name/na/nanomsg/package.nix
+++ b/pkgs/by-name/na/nanomsg/package.nix
@@ -21,7 +21,12 @@ stdenv.mkDerivation rec {
     # Add pkgconfig fix from https://github.com/nanomsg/nanomsg/pull/1085
     (fetchpatch {
       url = "https://github.com/nanomsg/nanomsg/commit/e3323f19579529d272cb1d55bd6b653c4f34c064.patch";
-      sha256 = "URz7TAqqpKxqjgvQqNX4WNSShwiEzAvO2h0hCZ2NhVY=";
+      hash = "sha256-URz7TAqqpKxqjgvQqNX4WNSShwiEzAvO2h0hCZ2NhVY=";
+    })
+    # Fix compatibility with Cmake 4.0 and up
+    (fetchpatch {
+      url = "https://github.com/nanomsg/nanomsg/commit/eb24489839de3e2419360c67cc38842f223836d9.patch";
+      hash = "sha256-yaQWWZLW4YbiI41oV0nj7zap3lEs0Gwwb9kTD6o3La8=";
     })
   ];
 


### PR DESCRIPTION
Cherry-picked the CMake 4.0 fixes from https://github.com/NixOS/nixpkgs/pull/435899, which can land separately from the rest.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
