### PR TITLE
nail-parquet: init at 1.6.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18262,6 +18262,12 @@
     githubId = 18604892;
     name = "Nathan Ruiz";
   };
+  nathanscully = {
+    email = "nath@nscully.com";
+    github = "nathanscully";
+    githubId = 3359816;
+    name = "Nathan Scully";
+  };
   nathyong = {
     github = "nathyong";
     githubId = 818502;

--- a/pkgs/by-name/na/nail-parquet/package.nix
+++ b/pkgs/by-name/na/nail-parquet/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  testers,
+  nail-parquet,
+  stdenv,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nail-parquet";
+  version = "1.6.5";
+
+  src = fetchFromGitHub {
+    owner = "Vitruves";
+    repo = "nail-parquet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CPiOeaESerQj+nV0hQIGv06/MFP8s7p9olpmhnWpAAg=";
+  };
+
+  cargoHash = "sha256-x4BJZcQkisw9hA/TBzSSdkxh7oUNL0OD3H/v67otYj8=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+  ];
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = nail-parquet;
+      command = "nail --version";
+    };
+  };
+
+  meta = {
+    description = "High-performance command-line utility for working with Parquet files";
+    homepage = "https://github.com/Vitruves/nail-parquet";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nathanscully ];
+    mainProgram = "nail";
+  };
+})


### PR DESCRIPTION
Init of [nail-parquet ](https://github.com/Vitruves/nail-parquet) - a rust based fast parquet command line tool.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
