### PR TITLE
libp11: 0.4.13 -> 0.4.16

### DIFF
--- a/pkgs/by-name/li/libp11/package.nix
+++ b/pkgs/by-name/li/libp11/package.nix
@@ -10,17 +10,18 @@
 
 stdenv.mkDerivation rec {
   pname = "libp11";
-  version = "0.4.13";
+  version = "0.4.16";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "libp11";
     rev = "${pname}-${version}";
-    sha256 = "sha256-teYXlPtCt6ifQDArbCJWGrYl9pdr6V7HVpU4HXTPIco=";
+    sha256 = "sha256-uuFHchf5skoNtyXTmyGHB67hcuI1N2ILasFcf7scTWo=";
   };
 
   configureFlags = [
     "--with-enginesdir=${placeholder "out"}/lib/engines"
+    "--with-modulesdir=${placeholder "out"}/lib/ossl-modules"
   ];
 
   nativeBuildInputs = [
@@ -40,5 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/OpenSC/libp11";
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
+    maintainers = with lib.maintainers; [ joinemm ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

changelog: https://github.com/OpenSC/libp11/releases
diff: https://github.com/OpenSC/libp11/compare/libp11-0.4.13...libp11-0.4.16

Most notable change:
- Added the "pkcs11prov" provider for OpenSSL 3.x (Małgorzata Olszówka)

This provider is now available at `/lib/ossl-modules/`

I also added myself as maintainer as this package seems to have none.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
