### PR TITLE
libcec_platform: add cmake 4 support

### DIFF
--- a/pkgs/development/libraries/libcec/platform.nix
+++ b/pkgs/development/libraries/libcec/platform.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
 }:
 
@@ -13,10 +14,27 @@ stdenv.mkDerivation rec {
     owner = "Pulse-Eight";
     repo = "platform";
     rev = "p8-platform-${version}";
-    sha256 = "sha256-zAI/AOLJAunv+cCQ6bOXrgkW+wl5frj3ktzx2cDeCCk=";
+    hash = "sha256-zAI/AOLJAunv+cCQ6bOXrgkW+wl5frj3ktzx2cDeCCk=";
   };
 
   nativeBuildInputs = [ cmake ];
+
+  patches = [
+    # required for cmake 4 support
+    (fetchpatch {
+      name = "libcec-platform-fix-cmake4-1.patch";
+      url = "https://github.com/Pulse-Eight/platform/commit/7350df98980b4e7036812b15812e3cb3c9353816.patch";
+      includes = [ "CMakeLists.txt" ];
+      hash = "sha256-YbxQxmXF2Iv67SjX/kMD9Df2nggBFX0fBFMyNdXXZtI=";
+    })
+    # required for cmake 4 support
+    (fetchpatch {
+      name = "libcec-platform-fix-cmake4-5.patch";
+      url = "https://github.com/Pulse-Eight/platform/commit/d7faed1c696b1a6a67f114a63a0f4c085f0f9195.patch";
+      includes = [ "CMakeLists.txt" ];
+      hash = "sha256-T+quL5wxc1w+KyNGxW443Ud+r6FVPej6jN6oXQ5pkRs=";
+    })
+  ];
 
   cmakeFlags = lib.optional stdenv.hostPlatform.isDarwin "-DCMAKE_CXX_FLAGS='-std=c++11'";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add cmake 4 support by taking latest master commit

Found while building https://github.com/NixOS/nixpkgs/pull/445903.

Broken in https://github.com/NixOS/nixpkgs/pull/394444.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
