### PR TITLE
luaPackages.lgi, awesome: Backport fix for GLib 2.86

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -70,6 +70,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/awesomeWM/awesome/commit/d256d9055095f27a33696e0aeda4ee20ed4fb1a0.patch";
       sha256 = "1n3y4wnjra8blss7642jgpxnm9n92zhhjj541bb9i60m4b7bgfzz";
     })
+
+    # lib, tests: use GioUnix to use platform-specific Gio classes
+    # https://github.com/awesomeWM/awesome/pull/4022
+    (fetchpatch {
+      name = "glib-2.86.0.patch";
+      url = "https://github.com/void-linux/void-packages/raw/933b305b313a2c7d971d746835deb9f49b652204/srcpkgs/awesome/patches/glib-2.86.0.patch";
+      hash = "sha256-qVzD8O34sULcV6S4daDUBPnxVDd8T6ZyLOE+gYxCmf0=";
+    })
   ];
 
   # Fix build with CMake 4

--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -72,6 +72,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # Fix build with CMake 4
+  # https://github.com/awesomeWM/awesome/pull/4030#issuecomment-3370822668
+  postPatch = ''
+    substituteInPlace {,tests/examples/}CMakeLists.txt \
+      --replace-fail 'cmake_minimum_required(VERSION 3.0.0)' 'cmake_minimum_required(VERSION 3.10)' \
+      --replace-warn 'cmake_policy(VERSION 2.6)' 'cmake_policy(VERSION 3.10)'
+  '';
+
   nativeBuildInputs = [
     cmake
     doxygen

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -298,6 +298,14 @@ in
         url = "https://github.com/psychon/lgi/commit/46a163d9925e7877faf8a4f73996a20d7cf9202a.patch";
         sha256 = "0gfvvbri9kyzhvq3bvdbj2l6mwvlz040dk4mrd5m9gz79f7w109c";
       })
+
+      # https://github.com/lgi-devs/lgi/issues/346
+      # https://gitlab.archlinux.org/archlinux/packaging/packages/lgi/-/issues/1
+      (fetchpatch {
+        name = "glib-2.86.0.patch";
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/lgi/-/raw/05a0c9df75883da235bacd4379b769e7d7713fb9/0001-Use-TypeClass.get-instead-of-.ref.patch";
+        hash = "sha256-Z1rNv0VzVrK41rV73KiPXq9yLaNxbTOFiSd6eLZyrbY=";
+      })
     ];
 
     # https://github.com/lgi-devs/lgi/pull/300


### PR DESCRIPTION
cc https://github.com/NixOS/nixpkgs/pull/440720

Background:

https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4792#note_2550562
https://gitlab.gnome.org/GNOME/glib/-/issues/3744

Test:

https://github.com/bobby285271/test-awesome-wm-glib-2-86

This should work with old (2.84) and new (2.86) glib so master should be fine.

- To test with glib 2.86: `nix run github:bobby285271/test-awesome-wm-glib-2-86 --override-input nixpkgs 'github:bobby285271/nixpkgs/upd/awesome'`
- To test with glib 2.84: `nix run github:bobby285271/test-awesome-wm-glib-2-86/glib-2-84 --override-input nixpkgs 'github:bobby285271/nixpkgs/upd/awesome'`

... and it will start a VM, login with username and password `test`. As long as you can start awesome the testing is done.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

