### PR TITLE
wpewebkit: init at 2.50.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8180,6 +8180,12 @@
     github = "pacien";
     githubId = 1449319;
   };
+  eval-exec = {
+    email = "execvy@gmail.com";
+    name = "Eval Exec";
+    github = "eval-exec";
+    githubId = 46400566;
+  };
   evalexpr = {
     name = "Jonathan Wilkins";
     email = "nixos@wilkins.tech";

--- a/pkgs/by-name/wp/wpewebkit/package.nix
+++ b/pkgs/by-name/wp/wpewebkit/package.nix
@@ -121,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
     libjxl
     libpng
+    libinput
     libseccomp
     libsoup_3
     libtasn1

--- a/pkgs/by-name/wp/wpewebkit/package.nix
+++ b/pkgs/by-name/wp/wpewebkit/package.nix
@@ -1,0 +1,206 @@
+{
+  at-spi2-core,
+  bison,
+  bubblewrap,
+  cairo,
+  cctools,
+  cmake,
+  fetchurl,
+  flex,
+  fontconfig,
+  freetype,
+  gettext,
+  gi-docgen,
+  glib,
+  gobject-introspection,
+  gperf,
+  gst_all_1,
+  harfbuzz,
+  icu,
+  lcms2,
+  lib,
+  libavif,
+  libdrm,
+  libedit,
+  libepoxy,
+  libinput,
+  libgbm,
+  libgcrypt,
+  libgpg-error,
+  libjpeg,
+  libjxl,
+  libpng,
+  libseccomp,
+  libsoup_3,
+  libsysprof-capture,
+  libtasn1,
+  libwebp,
+  libwpe,
+  libwpe-fdo,
+  libxkbcommon,
+  libxml2,
+  libxslt,
+  mesa,
+  ninja,
+  p11-kit,
+  perl,
+  pkg-config,
+  python3,
+  ruby,
+  sqlite,
+  stdenv,
+  systemd,
+  unifdef,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  woff2,
+  xdg-dbus-proxy,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wpewebkit";
+  version = "2.50.4";
+
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  outputBin = "dev";
+
+  src = fetchurl {
+    url = "https://wpewebkit.org/releases/wpewebkit-${finalAttrs.version}.tar.xz";
+    hash = "sha256-0gTkBbCXVQh0jAJzwYCQMEqXnhFw/6KgpSj62QGR74c=";
+  };
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    flex
+    gettext
+    gi-docgen
+    gobject-introspection
+    gperf
+    libsysprof-capture
+    ninja
+    perl
+    pkg-config
+    python3
+    ruby
+    unifdef
+    wayland-protocols
+    wayland-scanner
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+  ];
+
+  buildInputs = [
+    at-spi2-core
+    bubblewrap
+    cairo
+    fontconfig
+    freetype
+    glib
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    icu
+    (harfbuzz.override { withIcu = true; })
+    lcms2
+    libavif
+    libdrm
+    libedit
+    libepoxy
+    libgbm
+    libgcrypt
+    libgpg-error
+    libjpeg
+    libjxl
+    libpng
+    libseccomp
+    libsoup_3
+    libtasn1
+    libwebp
+    libwpe
+    libwpe-fdo
+    libxkbcommon
+    libxml2
+    libxslt
+    mesa
+    p11-kit
+    sqlite
+    systemd
+    wayland
+    woff2
+    xdg-dbus-proxy
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "PORT" "WPE")
+    (lib.cmakeBool "ENABLE_DOCUMENTATION" true)
+    (lib.cmakeBool "ENABLE_INTROSPECTION" true)
+    (lib.cmakeBool "ENABLE_MINIBROWSER" true)
+    (lib.cmakeBool "ENABLE_SPEECH_SYNTHESIS" false)
+    (lib.cmakeBool "ENABLE_WPE_PLATFORM" true)
+    (lib.cmakeBool "USE_LIBBACKTRACE" false)
+  ];
+  
+  postFixup = ''
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+
+    simple-compilation = stdenv.mkDerivation {
+      name = "wpewebkit-test-simple-compilation";
+
+      nativeBuildInputs = [ pkg-config ];
+      buildInputs = [
+        finalAttrs.finalPackage
+        glib
+        libwpe
+        libsoup_3
+      ];
+
+      dontUnpack = true;
+
+      buildPhase = ''
+        cat > test.c <<EOF
+        #include <wpe/webkit.h>
+        #include <stdio.h>
+
+        int main(void) {
+            printf("WPE WebKit version: %d.%d.%d\n",
+                   webkit_get_major_version(),
+                   webkit_get_minor_version(),
+                   webkit_get_micro_version());
+            return 0;
+        }
+        EOF
+
+        $CC test.c -o test $(pkg-config --cflags --libs wpe-webkit-2.0)
+      '';
+
+      installPhase = ''
+        mkdir -p $out/bin
+        install -m755 test $out/bin/wpewebkit-test
+      '';
+    };
+  };
+
+  meta = {
+    description = "WPE WebKit port optimized for embedded devices";
+    homepage = "https://wpewebkit.org";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ eval-exec ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})

--- a/pkgs/by-name/wp/wpewebkit/package.nix
+++ b/pkgs/by-name/wp/wpewebkit/package.nix
@@ -50,6 +50,7 @@
   sqlite,
   stdenv,
   systemd,
+  testers,
   unifdef,
   wayland,
   wayland-protocols,
@@ -150,7 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_WPE_PLATFORM" true)
     (lib.cmakeBool "USE_LIBBACKTRACE" false)
   ];
-  
+
   postFixup = ''
     moveToOutput "share/doc" "$devdoc"
   '';
@@ -203,5 +204,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ eval-exec ];
     platforms = with lib.platforms; linux ++ darwin;
+    pkgConfigModules = [ "wpe-webkit-2.0" ];
   };
 })


### PR DESCRIPTION
WPE WebKit is a WebKit port optimized for embedded devices. This package provides the WPE port with support for Wayland, hardware acceleration, and multimedia through GStreamer.


We already have [libwpe](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/development/libraries/libwpe/default.nix#L35), [libwpe-fdo](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/development/libraries/libwpe/fdo.nix#L49), [webkitgtk](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/development/libraries/webkitgtk/default.nix#L264), but missing wpewebkit, so this PR add it. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
