### PR TITLE
espeak-ng: fix build with ucdSupport against CMake >= 4.0

### DIFF
--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -47,6 +47,11 @@ let
 
     sourceRoot = "${src.name}/src/ucd-tools";
 
+    # fix compatibility with CMake (https://cmake.org/cmake/help/v4.0/policy/CMP0000.html)
+    postPatch = ''
+      echo 'cmake_minimum_required(VERSION 4.0)' >> CMakeLists.txt
+    '';
+
     nativeBuildInputs = [ cmake ];
 
     installPhase = ''


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e938b1e247f8ae9ba8aa214d680bfac056998deb`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>local-ai</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>calibre</li>
    <li>piper-tts</li>
    <li>piper-tts.dist</li>
    <li>unbook</li>
    <li>wyoming-piper</li>
    <li>wyoming-piper.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc