### PR TITLE
openmvg: move to by-name, cleanup, fix cmake compatibility

### DIFF
--- a/pkgs/by-name/op/openmvg/package.nix
+++ b/pkgs/by-name/op/openmvg/package.nix
@@ -67,6 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "COINUTILS_INCLUDE_DIR_HINTS" "${lib.getDev coin-utils}/include")
     (lib.cmakeFeature "LEMON_INCLUDE_DIR_HINTS" "${lib.getDev lemon-graph}/include")
     (lib.cmakeFeature "OSI_INCLUDE_DIR_HINTS" "${lib.getDev osi}/include")
+
+    # Compatibility with CMake < 3.5 has been removed from CMake.
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ]
   ++ lib.optionals enableShared [
     (lib.cmakeBool "OpenMVG_BUILD_SHARED" true)

--- a/pkgs/by-name/op/openmvg/package.nix
+++ b/pkgs/by-name/op/openmvg/package.nix
@@ -14,7 +14,7 @@
   libpng,
   libtiff,
   nix-update-script,
-  openmp,
+  llvmPackages,
   osi,
   zlib,
   enableShared ? !stdenv.hostPlatform.isStatic,
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     libjpeg
     libpng
     libtiff
-    openmp
+    llvmPackages.openmp
     osi
     zlib
   ];

--- a/pkgs/by-name/op/openmvg/package.nix
+++ b/pkgs/by-name/op/openmvg/package.nix
@@ -22,14 +22,14 @@
   enableDocs ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "2.1";
   pname = "openmvg";
 
   src = fetchFromGitHub {
     owner = "openmvg";
     repo = "openmvg";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vG+tW9Gl/DAUL8DeY+rJVDJH/oMPH3XyZMUgzjtwFv0=";
   };
 
@@ -60,15 +60,17 @@ stdenv.mkDerivation rec {
 
   # flann is missing because the lz4 dependency isn't propagated: https://github.com/openMVG/openMVG/issues/1265
   cmakeFlags = [
-    "-DOpenMVG_BUILD_EXAMPLES=${if enableExamples then "ON" else "OFF"}"
-    "-DOpenMVG_BUILD_DOC=${if enableDocs then "ON" else "OFF"}"
-    "-DTARGET_ARCHITECTURE=generic"
-    "-DCLP_INCLUDE_DIR_HINTS=${lib.getDev clp}/include"
-    "-DCOINUTILS_INCLUDE_DIR_HINTS=${lib.getDev coin-utils}/include"
-    "-DLEMON_INCLUDE_DIR_HINTS=${lib.getDev lemon-graph}/include"
-    "-DOSI_INCLUDE_DIR_HINTS=${lib.getDev osi}/include"
+    (lib.cmakeBool "OpenMVG_BUILD_EXAMPLES" enableExamples)
+    (lib.cmakeBool "OpenMVG_BUILD_DOC" enableDocs)
+    (lib.cmakeFeature "TARGET_ARCHITECTURE" "generic")
+    (lib.cmakeFeature "CLP_INCLUDE_DIR_HINTS" "${lib.getDev clp}/include")
+    (lib.cmakeFeature "COINUTILS_INCLUDE_DIR_HINTS" "${lib.getDev coin-utils}/include")
+    (lib.cmakeFeature "LEMON_INCLUDE_DIR_HINTS" "${lib.getDev lemon-graph}/include")
+    (lib.cmakeFeature "OSI_INCLUDE_DIR_HINTS" "${lib.getDev osi}/include")
   ]
-  ++ lib.optional enableShared "-DOpenMVG_BUILD_SHARED=ON";
+  ++ lib.optionals enableShared [
+    (lib.cmakeBool "OpenMVG_BUILD_SHARED" true)
+  ];
 
   cmakeDir = "./src";
 
@@ -83,14 +85,18 @@ stdenv.mkDerivation rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
     description = "Library for computer-vision scientists and targeted for the Multiple View Geometry community";
     homepage = "https://openmvg.readthedocs.io/en/latest/";
+    downloadPage = "https://github.com/openMVG/openMVG";
+    changelog = "https://github.com/openMVG/openMVG/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.unix;
+    badPlatforms = [
+      "x86_64-darwin"
+    ];
     maintainers = with lib.maintainers; [
       mdaiter
       bouk
     ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3636,10 +3636,6 @@ with pkgs;
 
   openhantek6022 = libsForQt5.callPackage ../applications/science/electronics/openhantek6022 { };
 
-  openmvg = callPackage ../applications/science/misc/openmvg {
-    inherit (llvmPackages) openmp;
-  };
-
   openmvs = callPackage ../applications/science/misc/openmvs {
     inherit (llvmPackages) openmp;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **openmvg: move to by-name**
- **openmvg: cleanup**
- **openmvg: fix cmake compatibility**

cc @mdaiter @bouk @flokli

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
