### PR TITLE
oggvideotools: fix build against CMake >= 4.0

### DIFF
--- a/pkgs/by-name/og/oggvideotools/package.nix
+++ b/pkgs/by-name/og/oggvideotools/package.nix
@@ -12,13 +12,13 @@
   libvorbis,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "oggvideotools";
   version = "0.9.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/oggvideotools/oggvideotools/oggvideotools-${version}/oggvideotools-${version}.tar.bz2";
-    sha256 = "sha256-2dv3iXt86phhIgnYC5EnRzyX1u5ssNzPwrOP4+jilSM=";
+    url = "mirror://sourceforge/oggvideotools/oggvideotools/oggvideotools-${finalAttrs.version}/oggvideotools-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-2dv3iXt86phhIgnYC5EnRzyX1u5ssNzPwrOP4+jilSM=";
   };
 
   patches = [
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "gcc-10.patch";
       url = "https://sourceforge.net/p/oggvideotools/bugs/12/attachment/fix-compile.patch";
-      sha256 = "sha256-mJttoC3jCLM3vmPhlyqh+W0ryp2RjJGIBXd6sJfLJA4=";
+      hash = "sha256-mJttoC3jCLM3vmPhlyqh+W0ryp2RjJGIBXd6sJfLJA4=";
     })
 
     # Fix pending upstream inclusion for build failure on gcc-12:
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "gcc-12.patch";
       url = "https://sourceforge.net/p/oggvideotools/bugs/13/attachment/fix-gcc-12.patch";
-      sha256 = "sha256-zuDXe86djWkR8SgYZHkuAJJ7Lf2VYsVRBrlEaODtMKE=";
+      hash = "sha256-zuDXe86djWkR8SgYZHkuAJJ7Lf2VYsVRBrlEaODtMKE=";
       # svn patch, rely on prefix added by fetchpatch:
       extraPrefix = "";
     })
@@ -64,14 +64,14 @@ stdenv.mkDerivation rec {
     (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "4.0")
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Toolbox for manipulating and creating Ogg video files";
-    homepage = "http://www.streamnik.de/oggvideotools.html";
-    license = licenses.gpl2Only;
+    homepage = "https://sourceforge.net/projects/oggvideotools/";
+    license = lib.licenses.gpl2Only;
     maintainers = [ ];
     # Compilation error on Darwin:
     # error: invalid argument '--std=c++0x' not allowed with 'C'
     # make[2]: *** [src/libresample/CMakeFiles/resample.dir/build.make:76: src/libresample/CMakeFiles/resample.dir/filterkit.c.o] Error 1
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/og/oggvideotools/package.nix
+++ b/pkgs/by-name/og/oggvideotools/package.nix
@@ -59,6 +59,11 @@ stdenv.mkDerivation rec {
     libvorbis
   ];
 
+  cmakeFlags = [
+    # fix compatibility with CMake (https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html)
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "4.0")
+  ];
+
   meta = with lib; {
     description = "Toolbox for manipulating and creating Ogg video files";
     homepage = "http://www.streamnik.de/oggvideotools.html";


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `ef4c045c0353cd25487e95525547816bb30374e1`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>oggvideotools</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc