### PR TITLE
CONTRIBUTING: establish builtins prefix convention for prelude

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -661,6 +661,15 @@ If you have any problems with formatting, please ping the [formatting team](http
   As an exception, an explicit conditional expression with null can be used when fixing a important bug without triggering a mass rebuild.
   If this is done a follow up pull request _should_ be created to change the code to `lib.optional(s)`.
 
+- Certain [prelude
+  attributes](https://nix.dev/manual/nix/latest/language/builtins.html) should
+  explicitly use the `builtins` prefix, while others should conveniently omit
+  it:
+
+  | Use `builtins` | Omit `builtins` |
+  |----------------|-----------------|
+  | <li>`builtins.abort`</li><li>`builtins.baseNameOf`</li><li>`builtins.break`</li><li>`builtins.derivation`</li><li>`builtins.derivationStrict`</li><li>`builtins.dirOf`</li><li>`builtins.false`</li><li>`builtins.fetchGit`</li><li>`builtins.fetchMercurial`</li><li>`builtins.fetchTarball`</li><li>`builtins.fetchTree`</li><li>`builtins.fromTOML`</li><li>`builtins.import`</li><li>`builtins.isNull`</li><li>`builtins.map`</li><li>`builtins.null`</li><li>`builtins.placeholder`</li><li>`builtins.removeAttrs`</li><li>`builtins.scopedImport`</li><li>`builtins.throw`</li><li>`builtins.toString`</li><li>`builtins.true`</li> | <li>`abort`</li><li>`baseNameOf`</li><li>`break`</li><li>`derivation`</li><li>`derivationStrict`</li><li>`dirOf`</li><li>`false`</li><li>`fetchGit`</li><li>`fetchMercurial`</li><li>`fetchTarball`</li><li>`fetchTree`</li><li>`fromTOML`</li><li>`import`</li><li>`isNull`</li><li>`map`</li><li>`null`</li><li>`placeholder`</li><li>`removeAttrs`</li><li>`scopedImport`</li><li>`throw`</li><li>`toString`</li><li>`true`</li> |
+
 - Any style choices not covered here but that can be expressed as general rules should be left at the discretion of the authors of changes and _not_ commented in reviews.
   The purpose of this is:
    - to avoid churn as contributors with different style preferences undo each other's changes,


### PR DESCRIPTION
```
Establish the builtins prefix convention for prelude attributes to
progress [1] ("Unwritten style guides should be written"), following the
treewide removal of the builtins prefix for prelude attributes [2] [3]
[4] [5] [6].

[1]: https://github.com/NixOS/nixpkgs/issues/387072
[2]: https://github.com/NixOS/nixpkgs/pull/444432
[3]: https://github.com/NixOS/nixpkgs/pull/447401
[4]: https://github.com/NixOS/nixpkgs/pull/447402
[5]: https://github.com/NixOS/nixpkgs/pull/447403
[6]: https://github.com/NixOS/nixpkgs/pull/447404
```

Unlike removing builtins prefixes, adding them back in a follow-up PR should be fully automatable, including updates to code comments and documentation.

As pointed out in https://github.com/NixOS/nixpkgs/pull/447402#discussion_r2392119145, it seems inconsistent that `builtins.fromTOML` is in the prelude while `builtins.toJSON` is not. I suppose this stems from historical reasons to avoid breaking language changes.

Beyond establishing builtins prefix conventions, this proposal should decide whether to add more attributes to the prelude or discourage existing ones. For example, should `builtins.fromJSON` be added, or should `fromTOML` be discouraged in favor of `builtins.fromTOML`? Since expanding the prelude increases language complexity, this requires careful consideration.

Although this proposal is a non-functional change, it has far-reaching consequences for the Nix style guide. I am pinging several people to raise awareness:

- @NixOS/nix-team
- @NixOS/nixpkgs-vet
- [`statix`](https://github.com/oppiliappan/statix): @mightyiam, @oppiliappan

Considering the far-reaching consequences of this proposal, should this be elevated to an RFC, or is a PR discussion fine?

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
