### PR TITLE
usbtop: fix build against CMake >= 4.0

### DIFF
--- a/pkgs/by-name/us/usbtop/package.nix
+++ b/pkgs/by-name/us/usbtop/package.nix
@@ -18,6 +18,16 @@ stdenv.mkDerivation rec {
     sha256 = "0qbad0aq6j4jrh90l6a0akk71wdzhyzmy6q8wl138axyj2bp9kss";
   };
 
+  postPatch =
+    # fix compatibility with CMake (https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html)
+    # TODO: drop when https://github.com/aguinet/usbtop/pull/45 is merged
+    ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail \
+          'cmake_minimum_required(VERSION 2.8)' \
+          'cmake_minimum_required(VERSION 2.8...4.0)'
+    '';
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     libpcap

--- a/pkgs/by-name/us/usbtop/package.nix
+++ b/pkgs/by-name/us/usbtop/package.nix
@@ -7,15 +7,15 @@
   boost,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "usbtop";
   version = "1.0";
 
   src = fetchFromGitHub {
     owner = "aguinet";
     repo = "usbtop";
-    rev = "release-${version}";
-    sha256 = "0qbad0aq6j4jrh90l6a0akk71wdzhyzmy6q8wl138axyj2bp9kss";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-Ws90l5C+KzQC5QgbX7+Hv/Fw5lRAGQoSzJJIgxVoamE=";
   };
 
   postPatch =
@@ -29,17 +29,19 @@ stdenv.mkDerivation rec {
     '';
 
   nativeBuildInputs = [ cmake ];
+
   buildInputs = [
     libpcap
     boost
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/aguinet/usbtop";
+    changelog = "https://github.com/aguinet/usbtop/raw/${finalAttrs.src.rev}/CHANGELOG";
     description = "Top utility that shows an estimated instantaneous bandwidth on USB buses and devices";
     mainProgram = "usbtop";
     maintainers = [ ];
-    license = licenses.bsd3;
-    platforms = platforms.linux;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `dabf8f709e215305884c53211b461a72ca64b895`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>usbtop</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc