### PR TITLE
intel-graphics-compiler: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/in/intel-graphics-compiler/bump-cmake.patch
+++ b/pkgs/by-name/in/intel-graphics-compiler/bump-cmake.patch
@@ -1,0 +1,77 @@
+From bc76a7087e4621269bdf9080581088a6c8f6b3a6 Mon Sep 17 00:00:00 2001
+From: Chris Mayo <aklhfex@gmail.com>
+Date: Tue, 20 May 2025 19:27:57 +0100
+Subject: [PATCH] Raise minimum CMake version to 3.5
+
+For compatibility with CMake 4.0, which also removes CMP0043 OLD - there
+are no uses of COMPILE_DEFINITIONS_<CONFIG>.
+
+Signed-off-by: Chris Mayo <aklhfex@gmail.com>
+---
+ IGC/MDAutogen/CMakeLists.txt                    | 2 +-
+ external/SPIRV-Tools/CMakeLists.txt             | 2 +-
+ visa/CMakeLists.txt                             | 7 +------
+ visa/iga/GEDLibrary/GED_external/CMakeLists.txt | 6 +-----
+ 4 files changed, 4 insertions(+), 13 deletions(-)
+
+diff --git a/IGC/MDAutogen/CMakeLists.txt b/IGC/MDAutogen/CMakeLists.txt
+index c9522feea29d..0a79b3c8e32b 100644
+--- a/igc/IGC/MDAutogen/CMakeLists.txt
++++ b/igc/IGC/MDAutogen/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ #
+ #============================ end_copyright_notice =============================
+ 
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.5)
+ 
+ set(_autogenScript "${IGC_SOURCE_DIR}/common/autogen.py")
+ set(_autogenSource "${IGC_SOURCE_DIR}/common/MDFrameWork.h")
+diff --git a/external/SPIRV-Tools/CMakeLists.txt b/external/SPIRV-Tools/CMakeLists.txt
+index d2e3f63fb0d3..75f013409990 100644
+--- a/igc/external/SPIRV-Tools/CMakeLists.txt
++++ b/igc/external/SPIRV-Tools/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ #
+ #============================ end_copyright_notice =============================
+ 
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.5)
+ 
+ message(STATUS "============================ SPIRV-Tools project ============================")
+ 
+diff --git a/visa/CMakeLists.txt b/visa/CMakeLists.txt
+index a96924e907c5..1e4b57516ce8 100644
+--- a/igc/visa/CMakeLists.txt
++++ b/igc/visa/CMakeLists.txt
+@@ -74,12 +74,7 @@ if (WIN32 OR UNIX)
+   add_subdirectory(iga/IGAExe)
+ endif (WIN32 OR UNIX)
+ 
+-if(WIN32)
+-  cmake_minimum_required(VERSION 3.1)
+-  cmake_policy(SET CMP0043 OLD)
+-else()
+-  cmake_minimum_required(VERSION 2.8.12)
+-endif(WIN32)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # In the case where this is the IGC build we need to add a dummy custom target check_headers
+ add_custom_target(check_headers)
+diff --git a/visa/iga/GEDLibrary/GED_external/CMakeLists.txt b/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
+index e40313fc1944..275fff1114a6 100644
+--- a/igc/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
++++ b/igc/visa/iga/GEDLibrary/GED_external/CMakeLists.txt
+@@ -7,11 +7,7 @@
+ #============================ end_copyright_notice =============================
+ 
+ # GEDLibrary/GED
+-if(WIN32)
+-    cmake_minimum_required(VERSION 3.1)
+-else()
+-    cmake_minimum_required(VERSION 2.8.12)
+-endif(WIN32)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(GEDLibrary)
+ 

--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   ninja,
   git,
@@ -56,6 +57,13 @@ stdenv.mkDerivation rec {
       tag = "v15.0.15";
       hash = "sha256-kFVDS+qwoG1AXrZ8LytoiLVbZkTGR9sO+Wrq3VGgWNQ=";
     })
+  ];
+
+  patches = [
+    # Raise minimum CMake version to 3.5
+    # https://github.com/intel/intel-graphics-compiler/commit/4f0123a7d67fb716b647f0ba5c1ab550abf2f97d
+    # https://github.com/intel/intel-graphics-compiler/pull/364
+    ./bump-cmake.patch
   ];
 
   sourceRoot = ".";


### PR DESCRIPTION
Closes #448304

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
