### PR TITLE
postgresqlPackages.pg_graphql: init at 1.5.12-unstable-2025-09-01

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_graphql.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_graphql.nix
@@ -1,0 +1,50 @@
+{
+  buildPgrxExtension,
+  cargo-pgrx_0_16_0,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  postgresql,
+}:
+buildPgrxExtension (finalAttrs: {
+  inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_16_0;
+
+  pname = "pg_graphql";
+  version = "1.5.12-unstable-2025-09-01";
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "pg_graphql";
+    # ToDo: 1.5.12 has not been tagged in Git yet, hence `rev` is used instead for now
+    #tag = "v${finalAttrs.version}";
+    rev = "bae1cb506d48d14ccf2b05f6a42331f3c9c71a76";
+    hash = "sha256-aJPstwzizWzVIo1N/4CHKgJBJ7DJpRkrwYrzNL+z7zQ=";
+  };
+
+  cargoHash = "sha256-Gfvu6YY+pRGrcAXAgEIa1iZKLJlbkvMv0F3pg3X/CXQ=";
+
+  # pgrx tests try to install the extension into postgresql nix store
+  doCheck = false;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "GraphQL support for PostgreSQL";
+    homepage = "https://supabase.github.io/pg_graphql";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ julm ];
+    broken =
+      lib.versionOlder postgresql.version "14"
+      || (
+        # ToDo: check after next package update.
+        lib.versionAtLeast postgresql.version "18"
+        && (
+          finalAttrs.version == "1.5.12-unstable-2025-09-01"
+          || lib.warn "Is postgresql18Packages.pg_graphql still broken?" false
+        )
+      );
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- [X] Init [`pg_graphql`](https://supabase.github.io/pg_graphql/) at 1.5.12

This PR can be tested (from a `pkgs` pinned to it) with:
```nix
{
services.postgresql.package = pkgs.postgresql_16.withPackages (ps: [ps.pg_graphql]);
}
```

And then:
```console
$ psql -At some_db <<<'create extension pg_graphql;'
$ psql -At some_db <<<'select jsonb_pretty(graphql.resolve($$ query { __schema {types {name}}} $$));'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Ping @happysalada who may be interested, as seen on https://github.com/supabase/pg_graphql/issues/369