### PR TITLE
android-image-kitchen: init at 0-unstable-2025-10-17

### DIFF
--- a/pkgs/by-name/an/android-image-kitchen/0001-Use-PATH-to-find-programs.patch
+++ b/pkgs/by-name/an/android-image-kitchen/0001-Use-PATH-to-find-programs.patch
@@ -1,0 +1,224 @@
+From bb95a9794abc077ef29066ab6e769fee564c5592 Mon Sep 17 00:00:00 2001
+From: David Wronek <david.wronek@mainlining.org>
+Date: Thu, 12 Feb 2026 14:57:40 +0100
+Subject: [PATCH 1/2] Use $PATH to find programs
+
+Signed-off-by: David Wronek <david.wronek@mainlining.org>
+---
+ cleanup.sh   |  3 ---
+ repackimg.sh | 30 ++++++++++++++----------------
+ unpackimg.sh | 32 +++++++++++++++-----------------
+ 3 files changed, 29 insertions(+), 36 deletions(-)
+
+diff --git a/cleanup.sh b/cleanup.sh
+index 159d04c..b262c73 100755
+--- a/cleanup.sh
++++ b/cleanup.sh
+@@ -23,9 +23,6 @@ case $1 in
+   *) cd "$aik";;
+ esac;
+ 
+-chmod -R 755 "$bin" "$aik"/*.sh;
+-chmod 644 "$bin/magic" "$bin/androidbootimg.magic" "$bin/androidsign.magic" "$bin/boot_signer.jar" "$bin/avb/"* "$bin/chromeos/"*;
+-
+ if [ -d ramdisk ] && [ "$(stat $statarg ramdisk | head -n 1)" = "root" -o ! "$(find ramdisk 2>&1 | cpio -o >/dev/null 2>&1; echo $?)" -eq "0" ]; then
+   sudo=sudo;
+ fi;
+diff --git a/repackimg.sh b/repackimg.sh
+index 185a180..d5e7bc4 100755
+--- a/repackimg.sh
++++ b/repackimg.sh
+@@ -49,8 +49,6 @@ case $1 in
+   --local) shift;;
+   *) cd "$aik";;
+ esac;
+-chmod -R 755 "$bin" "$aik"/*.sh;
+-chmod 644 "$bin/magic" "$bin/androidbootimg.magic" "$bin/androidsign.magic" "$bin/boot_signer.jar" "$bin/avb/"* "$bin/chromeos/"*;
+ 
+ if [ -z "$(ls split_img/* 2>/dev/null)" -o ! -e ramdisk ]; then
+   echo "No files found to be packed/built.";
+@@ -135,8 +133,8 @@ else
+     xz) repackcmd="xz $level -Ccrc32";;
+     lzma) repackcmd="xz $level -Flzma";;
+     bzip2) compext=bz2;;
+-    lz4) repackcmd="$bin/$arch/lz4 $level";;
+-    lz4-l) repackcmd="$bin/$arch/lz4 $level -l"; compext=lz4;;
++    lz4) repackcmd="lz4 $level";;
++    lz4-l) repackcmd="lz4 $level -l"; compext=lz4;;
+     cpio) repackcmd="cat"; compext="";;
+     *) abort; exit 1;;
+   esac;
+@@ -263,7 +261,7 @@ if [ -f split_img/*-mtktype ]; then
+   echo "Generating MTK headers...";
+   echo " ";
+   echo "Using ramdisk type: $mtktype";
+-  "$bin/$arch/mkmtkhdr" --kernel "$kernel" --$mtktype "$ramdisk" >/dev/null;
++  mkmtkhdr --kernel "$kernel" --$mtktype "$ramdisk" >/dev/null;
+   if [ ! $? -eq "0" ]; then
+     abort;
+     exit 1;
+@@ -293,18 +291,18 @@ echo " ";
+ echo "Using format: $imgtype";
+ echo " ";
+ case $imgtype in
+-  AOSP_VNDR) "$bin/$arch/mkbootimg" --vendor_ramdisk "$ramdisk" "${dtb[@]}" --vendor_cmdline "$cmdline" --board "$board" --base $base --pagesize $pagesize --kernel_offset $kerneloff --ramdisk_offset $ramdiskoff --tags_offset $tagsoff --dtb_offset $dtboff --os_version "$osver" --os_patch_level "$oslvl" --header_version $hdrver --vendor_boot $outname;;
+-  AOSP) "$bin/$arch/mkbootimg" --kernel "$kernel" --ramdisk "$ramdisk" "${second[@]}" "${dtb[@]}" "${recoverydtbo[@]}" --cmdline "$cmdline" --board "$board" --base $base --pagesize $pagesize --kernel_offset $kerneloff --ramdisk_offset $ramdiskoff --second_offset "$secondoff" --tags_offset "$tagsoff" --dtb_offset "$dtboff" --os_version "$osver" --os_patch_level "$oslvl" --header_version "$hdrver" $hashtype "${dt[@]}" -o $outname;;
+-  AOSP-PXA) "$bin/$arch/pxa-mkbootimg" --kernel "$kernel" --ramdisk "$ramdisk" "${second[@]}" --cmdline "$cmdline" --board "$board" --base $base --pagesize $pagesize --kernel_offset $kerneloff --ramdisk_offset $ramdiskoff --second_offset "$secondoff" --tags_offset "$tagsoff" --unknown $unknown "${dt[@]}" -o $outname;;
+-  ELF) "$bin/$arch/elftool" pack -o $outname header="$header" "$kernel" "$ramdisk",ramdisk "${rpm[@]}" "${cmd[@]}" >/dev/null;;
+-  KRNL) "$bin/$arch/rkcrc" -k "$ramdisk" $outname;;
++  AOSP_VNDR) mkbootimg --vendor_ramdisk "$ramdisk" "${dtb[@]}" --vendor_cmdline "$cmdline" --board "$board" --base $base --pagesize $pagesize --kernel_offset $kerneloff --ramdisk_offset $ramdiskoff --tags_offset $tagsoff --dtb_offset $dtboff --os_version "$osver" --os_patch_level "$oslvl" --header_version $hdrver --vendor_boot $outname;;
++  AOSP) mkbootimg --kernel "$kernel" --ramdisk "$ramdisk" "${second[@]}" "${dtb[@]}" "${recoverydtbo[@]}" --cmdline "$cmdline" --board "$board" --base $base --pagesize $pagesize --kernel_offset $kerneloff --ramdisk_offset $ramdiskoff --second_offset "$secondoff" --tags_offset "$tagsoff" --dtb_offset "$dtboff" --os_version "$osver" --os_patch_level "$oslvl" --header_version "$hdrver" $hashtype "${dt[@]}" -o $outname;;
++  AOSP-PXA) pxa-mkbootimg --kernel "$kernel" --ramdisk "$ramdisk" "${second[@]}" --cmdline "$cmdline" --board "$board" --base $base --pagesize $pagesize --kernel_offset $kerneloff --ramdisk_offset $ramdiskoff --second_offset "$secondoff" --tags_offset "$tagsoff" --unknown $unknown "${dt[@]}" -o $outname;;
++  ELF) elftool pack -o $outname header="$header" "$kernel" "$ramdisk",ramdisk "${rpm[@]}" "${cmd[@]}" >/dev/null;;
++  KRNL) rkcrc -k "$ramdisk" $outname;;
+   OSIP)
+     mkdir split_img/.temp 2>/dev/null;
+     for i in bootstub cmdline.txt hdr kernel parameter sig; do
+       cp -f split_img/*-*$(basename $i .txt | sed -e 's/hdr/header/') split_img/.temp/$i 2>/dev/null;
+     done;
+     cp -f "$ramdisk" split_img/.temp/ramdisk.cpio.gz;
+-    "$bin/$arch/mboot" -d split_img/.temp -f $outname;
++    mboot -d split_img/.temp -f $outname;
+   ;;
+   U-Boot)
+     part0="$kernel";
+@@ -312,7 +310,7 @@ case $imgtype in
+       Multi) part1=(:"$ramdisk");;
+       RAMDisk) part0="$ramdisk";;
+     esac;
+-    "$bin/$arch/mkimage" -A $uarch -O $os -T $type -C $comp -a $addr -e $ep -n "$name" -d "$part0""${part1[@]}" $outname >/dev/null;
++    mkimage -A $uarch -O $os -T $type -C $comp -a $addr -e $ep -n "$name" -d "$part0""${part1[@]}" $outname >/dev/null;
+   ;;
+   *) echo " "; echo "Unsupported format."; abort; exit 1;;
+ esac;
+@@ -341,13 +339,13 @@ if [ -f split_img/*-sigtype ]; then
+     AVBv2) echo "AVBv2 detected, no need to sign.";;
+     BLOB)
+       awk 'BEGIN { printf "-SIGNED-BY-SIGNBLOB-\00\00\00\00\00\00\00\00" }' > image-new.img;
+-      "$bin/$arch/blobpack" blob.tmp $blobtype unsigned-new.img >/dev/null;
++      blobpack blob.tmp $blobtype unsigned-new.img >/dev/null;
+       cat blob.tmp >> image-new.img;
+       rm -f blob.tmp;
+     ;;
+-    CHROMEOS) "$bin/$arch/futility" vbutil_kernel --pack image-new.img --keyblock "$bin/chromeos/kernel.keyblock" --signprivate "$bin/chromeos/kernel_data_key.vbprivk" --version 1 --vmlinuz unsigned-new.img --bootloader "$bin/chromeos/empty" --config "$bin/chromeos/empty" --arch arm --flags 0x1;;
++    CHROMEOS) futility vbutil_kernel --pack image-new.img --keyblock "$bin/chromeos/kernel.keyblock" --signprivate "$bin/chromeos/kernel_data_key.vbprivk" --version 1 --vmlinuz unsigned-new.img --bootloader "$bin/chromeos/empty" --config "$bin/chromeos/empty" --arch arm --flags 0x1;;
+     DHTB)
+-      "$bin/$arch/dhtbsign" -i unsigned-new.img -o image-new.img >/dev/null;
++      dhtbsign -i unsigned-new.img -o image-new.img >/dev/null;
+       rm -f split_img/*-tailtype 2>/dev/null;
+     ;;
+     NOOK*) cat split_img/*-master_boot.key unsigned-new.img > image-new.img;;
+@@ -366,7 +364,7 @@ if [ -f split_img/*-lokitype ]; then
+   echo " ";
+   mv -f image-new.img unlokied-new.img;
+   if [ -f aboot.img ]; then
+-    "$bin/$arch/loki_tool" patch $lokitype aboot.img unlokied-new.img image-new.img >/dev/null;
++    loki_tool patch $lokitype aboot.img unlokied-new.img image-new.img >/dev/null;
+     if [ ! $? -eq "0" ]; then
+       echo "Patching failed.";
+       abort;
+diff --git a/unpackimg.sh b/unpackimg.sh
+index 9b74f3d..a81eaf0 100755
+--- a/unpackimg.sh
++++ b/unpackimg.sh
+@@ -53,8 +53,6 @@ esac;
+ if [ ! "$local" ]; then
+   cd "$aik";
+ fi;
+-chmod -R 755 "$bin" "$aik"/*.sh;
+-chmod 644 "$bin/magic" "$bin/androidbootimg.magic" "$bin/androidsign.magic" "$bin/boot_signer.jar" "$bin/avb/"* "$bin/chromeos/"*;
+ 
+ img="$1";
+ [ -f "$cur/$1" ] && img="$cur/$1";
+@@ -109,10 +107,10 @@ if [ "$(echo $imgtest | awk '{ print $2 }' | cut -d, -f1)" = "signing" ]; then
+   case $sigtype in
+     BLOB)
+       cp -f "$img" "$file";
+-      "$bin/$arch/blobunpack" "$file" | tail -n+5 | cut -d" " -f2 | dd bs=1 count=3 > "$file-blobtype" 2>/dev/null;
++      blobunpack "$file" | tail -n+5 | cut -d" " -f2 | dd bs=1 count=3 > "$file-blobtype" 2>/dev/null;
+       mv -f "$file."* "$file";
+     ;;
+-    CHROMEOS) "$bin/$arch/futility" vbutil_kernel --get-vmlinuz "$img" --vmlinuz-out "$file";;
++    CHROMEOS) futility vbutil_kernel --get-vmlinuz "$img" --vmlinuz-out "$file";;
+     DHTB) dd bs=4096 skip=512 iflag=skip_bytes conv=notrunc if="$img" of="$file" 2>/dev/null;;
+     NOOK)
+       dd bs=1048576 count=1 conv=notrunc if="$img" of="$file-master_boot.key" 2>/dev/null;
+@@ -123,7 +121,7 @@ if [ "$(echo $imgtest | awk '{ print $2 }' | cut -d, -f1)" = "signing" ]; then
+       dd bs=262144 skip=1 conv=notrunc if="$img" of="$file" 2>/dev/null;
+     ;;
+     SIN*)
+-      "$bin/$arch/sony_dump" . "$img" >/dev/null;
++      sony_dump . "$img" >/dev/null;
+       mv -f "$file."* "$file";
+       rm -f "$file-sigtype";
+     ;;
+@@ -165,7 +163,7 @@ case $(echo $imgtest | awk '{ print $3 }') in
+     echo " ";
+     echo "Warning: A dump of your device's aboot.img is required to re-Loki!";
+     echo " ";
+-    "$bin/$arch/loki_tool" unlok "$img" "$file" >/dev/null;
++    loki_tool unlok "$img" "$file" >/dev/null;
+     img="$file";
+   ;;
+   AMONET)
+@@ -220,26 +218,26 @@ case $imgtype in
+   AOSP_VNDR) vendor=vendor_;;
+ esac;
+ case $imgtype in
+-  AOSP|AOSP_VNDR) "$bin/$arch/unpackbootimg" -i "$img";;
+-  AOSP-PXA) "$bin/$arch/pxa-unpackbootimg" -i "$img";;
++  AOSP|AOSP_VNDR) unpackbootimg -i "$img";;
++  AOSP-PXA) pxa-unpackbootimg -i "$img";;
+   ELF)
+     mkdir elftool_out;
+-    "$bin/$arch/elftool" unpack -i "$img" -o elftool_out >/dev/null;
++    elftool unpack -i "$img" -o elftool_out >/dev/null;
+     mv -f elftool_out/header "$file-header" 2>/dev/null;
+     rm -rf elftool_out;
+-    "$bin/$arch/unpackelf" -i "$img";
++    unpackelf -i "$img";
+   ;;
+   KRNL) dd bs=4096 skip=8 iflag=skip_bytes conv=notrunc if="$img" of="$file-ramdisk" 2>&1 | tail -n+3 | cut -d" " -f1-2;;
+   OSIP)
+-    "$bin/$arch/mboot" -u -f "$img";
++    mboot -u -f "$img";
+     [ ! $? -eq "0" ] && error=1;
+     for i in bootstub cmdline.txt hdr kernel parameter ramdisk.cpio.gz sig; do
+       mv -f $i "$file-$(basename $i .txt | sed -e 's/hdr/header/' -e 's/ramdisk.cpio.gz/ramdisk/')" 2>/dev/null || true;
+     done;
+   ;;
+   U-Boot)
+-    "$bin/$arch/dumpimage" -l "$img";
+-    "$bin/$arch/dumpimage" -l "$img" > "$file-header";
++    dumpimage -l "$img";
++    dumpimage -l "$img" > "$file-header";
+     grep "Name:" "$file-header" | cut -c15- > "$file-name";
+     grep "Type:" "$file-header" | cut -c15- | cut -d" " -f1 > "$file-arch";
+     grep "Type:" "$file-header" | cut -c15- | cut -d" " -f2 > "$file-os";
+@@ -248,10 +246,10 @@ case $imgtype in
+     grep "Address:" "$file-header" | cut -c15- > "$file-addr";
+     grep "Point:" "$file-header" | cut -c15- > "$file-ep";
+     rm -f "$file-header";
+-    "$bin/$arch/dumpimage" -p 0 -o "$file-kernel" "$img";
++    dumpimage -p 0 -o "$file-kernel" "$img";
+     [ ! $? -eq "0" ] && error=1;
+     case $(cat "$file-type") in
+-      Multi) "$bin/$arch/dumpimage" -p 1 -o "$file-ramdisk" "$img";;
++      Multi) dumpimage -p 1 -o "$file-ramdisk" "$img";;
+       RAMDisk) mv -f "$file-kernel" "$file-ramdisk";;
+       *) touch "$file-ramdisk";;
+     esac;
+@@ -318,8 +316,8 @@ case $ramdiskcomp in
+   xz) ;;
+   lzma) ;;
+   bzip2) compext=bz2;;
+-  lz4) unpackcmd="$bin/$arch/lz4 -dcq";;
+-  lz4-l) unpackcmd="$bin/$arch/lz4 -dcq"; compext=lz4;;
++  lz4) unpackcmd="lz4 -dcq";;
++  lz4-l) unpackcmd="lz4 -dcq"; compext=lz4;;
+   cpio) unpackcmd="cat"; compext="";;
+   empty) compext=empty;;
+   *) compext="";;
+-- 
+2.52.0
+

--- a/pkgs/by-name/an/android-image-kitchen/0002-Do-not-change-directory.patch
+++ b/pkgs/by-name/an/android-image-kitchen/0002-Do-not-change-directory.patch
@@ -1,0 +1,85 @@
+From 6328bc3ddd491f0589e943deeabdfa4dda40f4c7 Mon Sep 17 00:00:00 2001
+From: David Wronek <david.wronek@mainlining.org>
+Date: Thu, 12 Feb 2026 18:11:37 +0100
+Subject: [PATCH 2/2] Do not change directory
+
+Signed-off-by: David Wronek <david.wronek@mainlining.org>
+---
+ cleanup.sh   | 4 ++--
+ repackimg.sh | 4 ++--
+ unpackimg.sh | 8 ++------
+ 3 files changed, 6 insertions(+), 10 deletions(-)
+
+diff --git a/cleanup.sh b/cleanup.sh
+index b262c73..d7a3188 100755
+--- a/cleanup.sh
++++ b/cleanup.sh
+@@ -3,7 +3,7 @@
+ # osm0sis @ xda-developers
+ 
+ case $1 in
+-  --help) echo "usage: cleanup.sh [--local] [--quiet]"; exit 1;
++  --help) echo "usage: cleanup.sh [--quiet]"; exit 1;
+ esac;
+ 
+ case $(uname -s) in
+@@ -20,7 +20,7 @@ bin="$aik/bin";
+ 
+ case $1 in
+   --local) shift;;
+-  *) cd "$aik";;
++  *) ;;
+ esac;
+ 
+ if [ -d ramdisk ] && [ "$(stat $statarg ramdisk | head -n 1)" = "root" -o ! "$(find ramdisk 2>&1 | cpio -o >/dev/null 2>&1; echo $?)" -eq "0" ]; then
+diff --git a/repackimg.sh b/repackimg.sh
+index d5e7bc4..15374c4 100755
+--- a/repackimg.sh
++++ b/repackimg.sh
+@@ -5,7 +5,7 @@
+ abort() { echo "Error!"; }
+ 
+ case $1 in
+-  --help) echo "usage: repackimg.sh [--local] [--original] [--origsize] [--level <0-9>] [--avbkey <name>] [--forceelf]"; exit 1;
++  --help) echo "usage: repackimg.sh [--original] [--origsize] [--level <0-9>] [--avbkey <name>] [--forceelf]"; exit 1;
+ esac;
+ 
+ case $(uname -s) in
+@@ -47,7 +47,7 @@ esac;
+ 
+ case $1 in
+   --local) shift;;
+-  *) cd "$aik";;
++  *) ;;
+ esac;
+ 
+ if [ -z "$(ls split_img/* 2>/dev/null)" -o ! -e ramdisk ]; then
+diff --git a/unpackimg.sh b/unpackimg.sh
+index a81eaf0..e330766 100755
+--- a/unpackimg.sh
++++ b/unpackimg.sh
+@@ -6,8 +6,8 @@ cleanup() { "$aik/cleanup.sh" $local --quiet; }
+ abort() { echo "Error!"; }
+ 
+ case $1 in
+-  --help) echo "usage: unpackimg.sh [--local] [--nosudo] <file>"; exit 1;;
+-  --local) local="--local"; shift;;
++  --help) echo "usage: unpackimg.sh [--nosudo] <file>"; exit 1;;
++  --local) shift;;
+ esac;
+ case $1 in
+   --nosudo) nosudo=1; shift;;
+@@ -50,10 +50,6 @@ case $plat in
+   ;;
+ esac;
+ 
+-if [ ! "$local" ]; then
+-  cd "$aik";
+-fi;
+-
+ img="$1";
+ [ -f "$cur/$1" ] && img="$cur/$1";
+ if [ ! "$img" ]; then
+-- 
+2.52.0
+

--- a/pkgs/by-name/an/android-image-kitchen/package.nix
+++ b/pkgs/by-name/an/android-image-kitchen/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  blobtools,
+  dhtbsign,
+  elftool,
+  futility,
+  loki-tool,
+  lz4,
+  mboot,
+  mkbootimg-osm0sis,
+  mkmtkhdr,
+  pxa-mkbootimg,
+  rkflashtool,
+  sony-dump,
+  ubootTools,
+  unpackelf,
+}:
+stdenv.mkDerivation {
+  pname = "android-image-kitchen";
+  version = "0-unstable-2025-10-17";
+
+  src = fetchFromGitHub {
+    owner = "SebaUbuntu";
+    repo = "AIK-Linux-mirror";
+    rev = "1c1411bd685bbc5fb4112484af2ad07cb6807f30";
+    hash = "sha256-auwAXWzUAFS8USTTH9h5nPzmoGOZf53GkLA+KNGl8uc=";
+  };
+
+  patches = [
+    ./0001-Use-PATH-to-find-programs.patch
+    ./0002-Do-not-change-directory.patch
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace {cleanup,repackimg,unpackimg}.sh \
+      --replace-fail "bin=\"\$aik/bin\";" "bin=$out/share"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for i in cleanup repackimg unpackimg; do
+      install -Dm 555 "$i.sh" "$out/bin/aik-$i"
+    done
+
+    # Remove prebuilt binaries
+    rm -rf bin/{linux,macos}
+
+    # Copy rest of the required files
+    mkdir -p $out/share
+    cp -rT bin $out/share
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for i in $out/bin/aik-{cleanup,repackimg,unpackimg}; do
+      wrapProgram $i --prefix PATH : ${
+        lib.makeBinPath [
+          blobtools
+          dhtbsign
+          elftool
+          futility
+          loki-tool
+          lz4
+          mboot
+          mkbootimg-osm0sis
+          mkmtkhdr
+          pxa-mkbootimg
+          rkflashtool
+          sony-dump
+          ubootTools
+          unpackelf
+        ]
+      }
+    done
+  '';
+
+  meta = {
+    description = "Unpack & repack Android boot files";
+    homepage = "https://github.com/SebaUbuntu/AIK-Linux-mirror";
+    # No license specified in the repository
+    license = lib.licenses.free;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "aik-unpackimg";
+  };
+}

--- a/pkgs/by-name/dh/dhtbsign/package.nix
+++ b/pkgs/by-name/dh/dhtbsign/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "dhtbsign";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "dhtbsign";
+    rev = "2b2711dff153485c549240423d9c908a2912f4b2";
+    hash = "sha256-51zmuQ817Mqx8Hwnx/t4fC9G5huiLGIv+99nRP16mSg=";
+  };
+
+  strictDeps = true;
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isGNU [
+      # Required with newer GCC
+      "-Wno-error=stringop-overflow"
+    ]
+  );
+
+  # Unstream has an install target, but installs dhtbsign as `$out/bin`
+  # instead of `$out/bin/dhtbsign`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 dhtbsign -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/dhtbsign";
+    description = "Tool to write the DHTB header for Samsung Spreadtrum devices";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "dhtbsign";
+  };
+}

--- a/pkgs/by-name/el/elftool/package.nix
+++ b/pkgs/by-name/el/elftool/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "elftool";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "elftool";
+    rev = "363653ee89d7b4e1cd5e1f2c878d71acd75fc072";
+    hash = "sha256-nMJhMzzvXtrezZbKdsBq24/El2n7ubiBd5XEYFg3C00=";
+  };
+
+  strictDeps = true;
+
+  # Needed to fix `collect2: error: ld returned 1 exit status`
+  env.NIX_LDFLAGS = if stdenv.hostPlatform.isDarwin then "-lc++" else "-lstdc++";
+
+  makeFlags = [ "CC=c++" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 elftool -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/elftool";
+    description = "Program for packing and unpacking boot images from Sony mobile devices";
+    # No license specified in the repository
+    license = lib.licenses.free;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "elftool";
+  };
+}

--- a/pkgs/by-name/fu/futility/package.nix
+++ b/pkgs/by-name/fu/futility/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  openssl,
+  pkg-config,
+  nss,
+}:
+let
+  url = "https://chromium.googlesource.com/chromiumos/platform/vboot_reference";
+  branch = "release-R145-16552.B";
+in
+stdenv.mkDerivation {
+  pname = "futility";
+  version = "0-${branch}";
+
+  src = fetchgit {
+    inherit url;
+    rev = "refs/heads/${branch}";
+    hash = "sha256-LctTKkf8nTVcrErMiAkvSCYkZnBoTYjqxWj0xADi0Q4=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    nss
+  ];
+
+  postPatch = ''
+    patchShebangs ./scripts
+    substituteInPlace ./scripts/getversion.sh \
+      --replace-fail "unknown" "${branch}"
+  '';
+
+  makeFlags = [
+    "UB_DIR=$(out)/bin"
+    "USE_FLASHROM=0"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "HAVE_MACOS=1" ];
+
+  buildFlags = "futil";
+
+  installTargets = "futil_install";
+
+  meta = {
+    homepage = url;
+    description = "ChromeOS firmware utility";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "futility";
+    badPlatforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/lo/loki-tool/package.nix
+++ b/pkgs/by-name/lo/loki-tool/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "loki-tool";
+  version = "0-unstable-2016-06-27";
+
+  src = fetchFromGitHub {
+    owner = "djrbliss";
+    repo = "loki";
+    rev = "784e86f981b7b1c30bd0d6b401f071e47e738eb8";
+    hash = "sha256-yeLTQP8TYDkaMmynRxmATPi2/5VxkUZsYd44UQwz4PY=";
+  };
+
+  strictDeps = true;
+
+  # Static build does not work on darwin due to linker issues
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail \
+      "CFLAGS += -g -static -Wall" "CFLAGS += -g -Wall"
+  '';
+
+  # Default build target tries to compile binary for Android
+  buildPhase = ''
+    runHook preBuild
+    make CC=cc loki_tool
+    runHook postBuild
+  '';
+
+  # Upstream has no install target
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 loki_tool -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/djrbliss/loki";
+    description = "Tool for custom firmware on AT&T/Verizon Samsung and LG devices";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "loki_tool";
+  };
+}

--- a/pkgs/by-name/mb/mboot/package.nix
+++ b/pkgs/by-name/mb/mboot/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mboot";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "mboot";
+    rev = "39f59a4f1b6a754c8953172fb80cb2ea1221ed20";
+    hash = "sha256-xpVokOb4cenrrlORNIl58NuOSnaVyCIxRbyunRpix1U=";
+  };
+
+  strictDeps = true;
+
+  # Unstream has an install target, but installs mboot as `$out/bin`
+  # instead of `$out/bin/mboot`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 mboot -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/mboot";
+    description = "Tool to pack and unpack Intel Android boot files";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "mboot";
+  };
+}

--- a/pkgs/by-name/mk/mkbootimg-osm0sis/package.nix
+++ b/pkgs/by-name/mk/mkbootimg-osm0sis/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mkbootimg-osm0sis";
+  version = "2022.11.09-unstable-2025-03-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "mkbootimg";
+    rev = "17cea80bd5af64e45cdf9e263cad7555030e0e86";
+    hash = "sha256-5ilpgQS5ctMpxTJRa8Wty1B0mNN+77/fS2FThNfAKZk=";
+  };
+
+  strictDeps = true;
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isGNU [
+      # Required with newer GCC
+      "-Wstringop-overflow=0"
+    ]
+  );
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 {mk,unpack}bootimg -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/mkbootimg";
+    description = "C rewrite of Android's boot image tools";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "mkbootimg";
+  };
+}

--- a/pkgs/by-name/mk/mkmtkhdr/package.nix
+++ b/pkgs/by-name/mk/mkmtkhdr/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mkmtkhdr";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "mkmtkhdr";
+    rev = "be292c5295feb8158603c8575850208ea6218a78";
+    hash = "sha256-eXC4OpjDCziahhhH73cOUkTsm1VFJE6wTtSk6RD5tqA=";
+  };
+
+  strictDeps = true;
+
+  # Unstream has an install target, but installs mkmtkhdr as `$out/bin`
+  # instead of `$out/bin/mkmtkhdr`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 mkmtkhdr -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/mkmtkhdr";
+    description = "Tool to write MTK headers for split zImages and ramdisks";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "mkmtkhdr";
+  };
+}

--- a/pkgs/by-name/so/sony-dump/0001-Fix-makefile.patch
+++ b/pkgs/by-name/so/sony-dump/0001-Fix-makefile.patch
@@ -1,0 +1,143 @@
+From 1f7c72d18298d1bdbd25fb51754bdcc54f700a1d Mon Sep 17 00:00:00 2001
+From: David Wronek <david.wronek@mainlining.org>
+Date: Wed, 8 Oct 2025 20:25:19 +0200
+Subject: [PATCH] Fix makefile
+
+Signed-off-by: David Wronek <david.wronek@mainlining.org>
+---
+ makefile | 116 ++++++++++---------------------------------------------
+ 1 file changed, 20 insertions(+), 96 deletions(-)
+
+diff --git a/makefile b/makefile
+index 9cbf7c9..00e756f 100644
+--- a/makefile
++++ b/makefile
+@@ -1,105 +1,29 @@
+-CFLAGS= -Wall -O2 -Iinclude -Izlib-1.2.11 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1
++CFLAGS= -Wall -O2 -Iinclude -Izlib -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1
+ 
+-CC=gcc
++CC=cc
+ STRIP=strip
+ 
+-CCWIN=i686-w64-mingw32-gcc
+-CCWINSTRIP=i686-w64-mingw32-strip
+-
+-CCARM=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabi/bin/arm-linux-gnueabi-gcc
+-CCARMSTRIP=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabi/bin/arm-linux-gnueabi-strip
+-
+-CCARM64=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+-CCARM64STRIP=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-strip
+-
+-CCAPPLE64=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/x86_64-apple-darwin11-cc
+-CCAPPLESTRIP64=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/x86_64-apple-darwin11-strip
+-
+-CCAPPLE=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/i386-apple-darwin11-cc
+-CCAPPLESTRIP=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/i386-apple-darwin11-strip
+-
+-CCMIPS64=/home/savan/Desktop/buildroot-2017.02.8/output/host/usr/bin/mips64-buildroot-linux-uclibc-gcc
+-CCMIPS64STRIP=/home/savan/Desktop/buildroot-2017.02.8/output/host/usr/bin/mips64-buildroot-linux-uclibc-strip
+-
+-CCMIPS=/home/savan/Desktop/buildroot-2018.02.2/output/host/usr/bin/mips-buildroot-linux-uclibc-gcc
+-CCMIPSSTRIP=/home/savan/Desktop/buildroot-2018.02.2/output/host/usr/bin/mips-buildroot-linux-uclibc-strip
+-
+ SOURCE=   \
+-     zlib-1.2.11/adler32.c \
+-     zlib-1.2.11/crc32.c \
+-     zlib-1.2.11/deflate.c \
+-     zlib-1.2.11/infback.c \
+-     zlib-1.2.11/inffast.c \
+-     zlib-1.2.11/inflate.c \
+-     zlib-1.2.11/inftrees.c \
+-     zlib-1.2.11/trees.c \
+-     zlib-1.2.11/zutil.c \
+-     zlib-1.2.11/compress.c \
+-     zlib-1.2.11/uncompr.c \
+-     zlib-1.2.11/gzclose.c \
+-     zlib-1.2.11/gzlib.c \
+-     zlib-1.2.11/gzread.c \
+-     zlib-1.2.11/gzwrite.c \
++     zlib/adler32.c \
++     zlib/crc32.c \
++     zlib/deflate.c \
++     zlib/infback.c \
++     zlib/inffast.c \
++     zlib/inflate.c \
++     zlib/inftrees.c \
++     zlib/trees.c \
++     zlib/zutil.c \
++     zlib/compress.c \
++     zlib/uncompr.c \
++     zlib/gzclose.c \
++     zlib/gzlib.c \
++     zlib/gzread.c \
++     zlib/gzwrite.c \
+      lz4.c \
+      unpackbootimg.c \
+      untar.c \
+      sony_dump.c
+ 
+-default:download sony_dump.exe sony_dump.i386 sony_dump.x86_64 sony_dump.arm32 sony_dump.arm32_pie sony_dump.arm64 sony_dump.arm64_pie sony_dump.x86_64-apple-darwin11 sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.mips32 archive
+-
+-download:
+-	@if [ ! -d "zlib-1.2.11" ]; then wget https://zlib.net/zlib-1.2.11.tar.gz ; tar xzf zlib-1.2.11.tar.gz ; rm -rf zlib-1.2.11.tar.gz ; fi
+-
+-sony_dump.exe:
+-	${CCWIN} ${CFLAGS} -static ${SOURCE} -o sony_dump.exe
+-	${CCWINSTRIP} sony_dump.exe
+-
+-sony_dump.i386:
+-	${CC} -m32 ${CFLAGS} -static ${SOURCE} -o sony_dump.i386
+-	${STRIP} sony_dump.i386
+-
+-sony_dump.x86_64:
+-	${CC} ${CFLAGS} -static ${SOURCE} -o sony_dump.x86_64
+-	${STRIP} sony_dump.x86_64
+-
+-sony_dump.arm32:
+-	${CCARM} ${CFLAGS} -static ${SOURCE} -o sony_dump.arm32
+-	${CCARMSTRIP} sony_dump.arm32
+-
+-sony_dump.arm32_pie:
+-	@cp -fr sony_dump.arm32 sony_dump.arm32_pie
+-	@dd if=pie of=sony_dump.arm32_pie bs=1 count=1 seek=16 conv=notrunc
+-
+-sony_dump.arm64:
+-	${CCARM64} ${CFLAGS} -static ${SOURCE} -o sony_dump.arm64
+-	${CCARM64STRIP} sony_dump.arm64
+-
+-sony_dump.arm64_pie:
+-	@cp -fr sony_dump.arm64 sony_dump.arm64_pie
+-	@dd if=pie of=sony_dump.arm64_pie bs=1 count=1 seek=16 conv=notrunc
+-
+-sony_dump.i386-apple-darwin11:
+-	${CCAPPLE} ${CFLAGS} ${SOURCE} -o sony_dump.i386-apple-darwin11
+-	${CCAPPLESTRIP} sony_dump.i386-apple-darwin11
+-
+-sony_dump.x86_64-apple-darwin11:
+-	${CCAPPLE64} ${CFLAGS} ${SOURCE} -o sony_dump.x86_64-apple-darwin11
+-	${CCAPPLESTRIP64} sony_dump.x86_64-apple-darwin11
+-
+-sony_dump.mips64:
+-	${CCMIPS64} ${CFLAGS} -static ${SOURCE} -o sony_dump.mips64
+-	${CCMIPS64STRIP} sony_dump.mips64
+-
+-sony_dump.mips32:
+-	${CCMIPS} ${CFLAGS} -static ${SOURCE} -o sony_dump.mips32
+-	${CCMIPSSTRIP} sony_dump.mips32
+-
+-archive:
+-	@zip -9 sony_dump_tool.zip sony_dump.arm32_pie sony_dump.arm64_pie sony_dump.exe sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.x86_64-apple-darwin11 sony_dump.arm32 sony_dump.arm64 sony_dump.i386 sony_dump.mips32 sony_dump.x86_64
+-
+-clean:
+-	rm -rf sony_dump_tool.zip sony_dump.exe sony_dump.i386 sony_dump.x86_64 sony_dump.arm32 sony_dump.arm32_pie sony_dump.arm64 sony_dump.arm64_pie sony_dump.x86_64-apple-darwin11 sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.mips32
+-
+-distclean:
+-	rm -rf sony_dump_tool.zip zlib-1.2.11 sony_dump.exe sony_dump.i386 sony_dump.x86_64 sony_dump.arm32 sony_dump.arm32_pie sony_dump.arm64 sony_dump.arm64_pie sony_dump.x86_64-apple-darwin11 sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.mips32
+-
++default:
++	${CC} ${CFLAGS} ${SOURCE} -o sony_dump
++	${STRIP} sony_dump
+-- 
+2.52.0
+

--- a/pkgs/by-name/so/sony-dump/package.nix
+++ b/pkgs/by-name/so/sony-dump/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zlib,
+}:
+stdenv.mkDerivation {
+  pname = "sony-dump";
+  version = "0-unstable-2019-11-3";
+
+  src = fetchFromGitHub {
+    owner = "munjeni";
+    repo = "anyxperia_dumper";
+    rev = "2171258c9df50aba139b4bd1aa93295cd14d2262";
+    hash = "sha256-kdHMDIX+ryx63A5TJMsqEZ4W36edC+dQrJKTeh5RFHA=";
+  };
+
+  strictDeps = true;
+
+  prePatch = ''
+    tar -xzf ${zlib.src}
+    mv ${zlib.name} zlib
+  '';
+
+  patches = [
+    ./0001-Fix-makefile.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 sony_dump -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/munjeni/anyxperia_dumper";
+    description = "Tool to dump Sony Xperia boot images";
+    # No license specified in the repository
+    license = lib.licenses.free;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "sony_dump";
+  };
+}

--- a/pkgs/by-name/un/unpackelf/package.nix
+++ b/pkgs/by-name/un/unpackelf/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unpackelf";
+  version = "2022.11.09";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "unpackelf";
+    tag = finalAttrs.version;
+    hash = "sha256-uAt4qpctQPGyXFLtRqTBiCXahoA+/b5rYZCjIh8N+QU=";
+  };
+
+  strictDeps = true;
+
+  # Unstream has an install target, but installs unpackelf as `$out/bin`
+  # instead of `$out/bin/unpackelf`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 unpackelf -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/unpackelf";
+    description = "Tool to unpack Sony ELF kernel format image variants";
+    # No license specified in the repository
+    license = lib.licenses.free;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    teams = [ lib.teams.android ];
+    mainProgram = "unpackelf";
+  };
+})


### PR DESCRIPTION
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
