### PR TITLE
simple-dftd3 and dftd4 fixes and python bindings

### DIFF
--- a/pkgs/by-name/df/dftd4/python.nix
+++ b/pkgs/by-name/df/dftd4/python.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  meson-python,
+  ninja,
+  setuptools,
+  pkg-config,
+  dftd4,
+  cffi,
+  numpy,
+}:
+
+buildPythonPackage {
+  inherit (dftd4)
+    pname
+    version
+    src
+    meta
+    ;
+
+  pyproject = true;
+
+  buildInputs = [ dftd4 ];
+
+  nativeBuildInputs = [
+    pkg-config
+    ninja
+  ];
+
+  build-system = [
+    meson-python
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+    numpy
+  ];
+
+  preConfigure = ''
+    cd python
+  '';
+
+  pythonImportsCheck = [ "dftd4" ];
+  doCheck = true;
+}

--- a/pkgs/by-name/li/libxc/package.nix
+++ b/pkgs/by-name/li/libxc/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     "-DENABLE_FORTRAN=ON"
     "-DBUILD_SHARED_LIBS=ON"
     "-DENABLE_XHOST=OFF"

--- a/pkgs/by-name/pc/pcmsolver/package.nix
+++ b/pkgs/by-name/pc/pcmsolver/package.nix
@@ -45,7 +45,10 @@ stdenv.mkDerivation rec {
   # Required for build with gcc-14
   env.NIX_CFLAGS_COMPILE = "-std=c++14";
 
-  cmakeFlags = [ "-DENABLE_OPENMP=ON" ];
+  cmakeFlags = [
+    "-DENABLE_OPENMP=ON"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/libraries/science/chemistry/simple-dftd3/python.nix
+++ b/pkgs/development/libraries/science/chemistry/simple-dftd3/python.nix
@@ -1,5 +1,6 @@
 {
   buildPythonPackage,
+  python,
   simple-dftd3,
   cffi,
   numpy,
@@ -43,5 +44,15 @@ buildPythonPackage {
   # The compiled CFFI is not placed correctly before pytest invocation
   preCheck = ''
     find . -name "_libdftd3*" -exec cp {} ./dftd3/. \;
+  '';
+
+  pythonImportsCheck = [ "dftd3" ];
+  doCheck = true;
+
+  # Parameters need to be present in the python site packages directory, but they
+  # are originally only present in the fortran package. This is a consequence of
+  # building the python bindings separately from the fortran library.
+  postInstall = ''
+    ln -s ${simple-dftd3}/share/s-dftd3/parameters.toml $out/${python.sitePackages}/dftd3/.
   '';
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3653,6 +3653,10 @@ self: super: with self; {
 
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };
 
+  dftd4 = callPackage ../by-name/df/dftd4/python.nix {
+    inherit (pkgs) dftd4;
+  };
+
   diagrams = callPackage ../development/python-modules/diagrams { };
 
   diceware = callPackage ../development/python-modules/diceware { };


### PR DESCRIPTION
This PR

  * fixes a subtle bug in the Python bindings of simple-dftd3: the D3 parameter file is not installed in the python site packages directory, but only in the original fortran library. The Python module assumes it's existence in the siute packages directory, however, and crashes on import otherwise.
  * Enables the Simple-DFTD3 test suite
  * Adds the DFTD4 python bindings
  * Adds a Cmake policy argument to LibXC to allow building with the new CMake versions. This is required to make Simple-DFTD3 tests working, as they require PySCF and PySCF requires LibXC.
  * Adds the CMake policy argument to PCMSolver to allow building with newer CMake versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
