### PR TITLE
libvirt: replace lvm2 binary paths

### DIFF
--- a/pkgs/by-name/li/libvirt/0003-substitute-lvm2-commands.patch
+++ b/pkgs/by-name/li/libvirt/0003-substitute-lvm2-commands.patch
@@ -1,0 +1,100 @@
+diff --git a/src/storage/storage_backend_logical.c b/src/storage/storage_backend_logical.c
+index 51e9337820..dea1e9f166 100644
+--- a/src/storage/storage_backend_logical.c
++++ b/src/storage/storage_backend_logical.c
+@@ -49,7 +49,7 @@ virStorageBackendLogicalSetActive(virStoragePoolObj *pool,
+     g_autoptr(virCommand) cmd = NULL;
+     int ret;
+ 
+-    cmd = virStorageBackendLogicalChangeCmd("vgchange", def, on);
++    cmd = virStorageBackendLogicalChangeCmd("@vgchange@", def, on);
+ 
+     virObjectUnlock(pool);
+     ret = virCommandRun(cmd, NULL);
+@@ -70,7 +70,7 @@ virStorageBackendLogicalRemoveDevice(const char *path)
+ {
+     g_autoptr(virCommand) cmd = NULL;
+ 
+-    cmd = virCommandNewArgList("pvremove", path, NULL);
++    cmd = virCommandNewArgList("@pvremove@", path, NULL);
+     if (virCommandRun(cmd, NULL) < 0)
+         VIR_INFO("Failed to pvremove logical device '%s'", path);
+ }
+@@ -100,7 +100,7 @@ virStorageBackendLogicalInitializeDevice(const char *path)
+      * Initialize the physical volume because vgcreate is not
+      * clever enough todo this for us :-(
+      */
+-    pvcmd = virCommandNewArgList("pvcreate", path, NULL);
++    pvcmd = virCommandNewArgList("@pvcreate@", path, NULL);
+     return virCommandRun(pvcmd, NULL);
+ }
+ 
+@@ -380,7 +380,7 @@ virStorageBackendLogicalFindLVs(virStoragePoolObj *pool,
+     };
+     g_autoptr(virCommand) cmd = NULL;
+ 
+-    cmd = virCommandNewArgList("lvs",
++    cmd = virCommandNewArgList("@lvs@",
+                                "--separator", "#",
+                                "--noheadings",
+                                "--units", "b",
+@@ -487,7 +487,7 @@ virStorageBackendLogicalGetPoolSources(virStoragePoolSourceList *sourceList)
+     if (virCommandRun(vgcmd, NULL) < 0)
+         VIR_WARN("Failure when running vgscan to refresh physical volumes");
+ 
+-    pvcmd = virCommandNewArgList("pvs",
++    pvcmd = virCommandNewArgList("@pvs@",
+                                  "--noheadings",
+                                  "-o", "pv_name,vg_name",
+                                  NULL, NULL);
+@@ -658,7 +658,7 @@ virStorageBackendLogicalBuildPool(virStoragePoolObj *pool,
+                              VIR_STORAGE_POOL_BUILD_NO_OVERWRITE,
+                              cleanup);
+ 
+-    vgcmd = virCommandNewArgList("vgcreate", def->source.name, NULL);
++    vgcmd = virCommandNewArgList("@vgcreate@", def->source.name, NULL);
+ 
+     for (i = 0; i < def->source.ndevice; i++) {
+         const char *path = def->source.devices[i].path;
+@@ -720,7 +720,7 @@ virStorageBackendLogicalRefreshPool(virStoragePoolObj *pool)
+     if (virStorageBackendLogicalFindLVs(pool, NULL) < 0)
+         return -1;
+ 
+-    cmd = virCommandNewArgList("vgs",
++    cmd = virCommandNewArgList("@vgs@",
+                                "--separator", ":",
+                                "--noheadings",
+                                "--units", "b",
+@@ -769,7 +769,7 @@ virStorageBackendLogicalDeletePool(virStoragePoolObj *pool,
+     virCheckFlags(0, -1);
+ 
+     /* first remove the volume group */
+-    cmd = virCommandNewArgList("vgremove",
++    cmd = virCommandNewArgList("@vgremove@",
+                                "-f", def->source.name,
+                                NULL);
+     if (virCommandRun(cmd, NULL) < 0)
+@@ -795,8 +795,8 @@ virStorageBackendLogicalDeleteVol(virStoragePoolObj *pool G_GNUC_UNUSED,
+ 
+     virWaitForDevices();
+ 
+-    lvchange_cmd = virCommandNewArgList("lvchange", "-aln", vol->target.path, NULL);
+-    lvremove_cmd = virCommandNewArgList("lvremove", "-f", vol->target.path, NULL);
++    lvchange_cmd = virCommandNewArgList("@lvchange@", "-aln", vol->target.path, NULL);
++    lvremove_cmd = virCommandNewArgList("@lvremove@", "-f", vol->target.path, NULL);
+ 
+     if (virCommandRun(lvremove_cmd, NULL) < 0) {
+         if (virCommandRun(lvchange_cmd, NULL) < 0) {
+diff --git a/tests/storagepoolxml2argvtest.c b/tests/storagepoolxml2argvtest.c
+index d5c2531ab8..f24427666f 100644
+--- a/tests/storagepoolxml2argvtest.c
++++ b/tests/storagepoolxml2argvtest.c
+@@ -43,7 +43,7 @@ testCompareXMLToArgvFiles(bool shouldFail,
+         break;
+ 
+     case VIR_STORAGE_POOL_LOGICAL:
+-        cmd = virStorageBackendLogicalChangeCmd("vgchange", def, true);
++        cmd = virStorageBackendLogicalChangeCmd("@vgchange@", def, true);
+         break;
+ 
+     case VIR_STORAGE_POOL_DIR:

--- a/pkgs/by-name/li/libvirt/0003-substitute-lvm2-commands.patch
+++ b/pkgs/by-name/li/libvirt/0003-substitute-lvm2-commands.patch
@@ -1,5 +1,5 @@
 diff --git a/src/storage/storage_backend_logical.c b/src/storage/storage_backend_logical.c
-index 51e9337820..dea1e9f166 100644
+index 51e9337820..cff78a6e81 100644
 --- a/src/storage/storage_backend_logical.c
 +++ b/src/storage/storage_backend_logical.c
 @@ -49,7 +49,7 @@ virStorageBackendLogicalSetActive(virStoragePoolObj *pool,
@@ -38,7 +38,12 @@ index 51e9337820..dea1e9f166 100644
                                 "--separator", "#",
                                 "--noheadings",
                                 "--units", "b",
-@@ -487,7 +487,7 @@ virStorageBackendLogicalGetPoolSources(virStoragePoolSourceList *sourceList)
+@@ -483,11 +483,11 @@ virStorageBackendLogicalGetPoolSources(virStoragePoolSourceList *sourceList)
+      * that might be hanging around, so if this fails for some reason, the
+      * worst that happens is that scanning doesn't pick everything up
+      */
+-    vgcmd = virCommandNew("vgscan");
++    vgcmd = virCommandNew("@vgscan@");
      if (virCommandRun(vgcmd, NULL) < 0)
          VIR_WARN("Failure when running vgscan to refresh physical volumes");
  
@@ -85,6 +90,15 @@ index 51e9337820..dea1e9f166 100644
  
      if (virCommandRun(lvremove_cmd, NULL) < 0) {
          if (virCommandRun(lvchange_cmd, NULL) < 0) {
+@@ -825,7 +825,7 @@ virStorageBackendLogicalLVCreate(virStorageVolDef *vol,
+         return -1;
+     }
+ 
+-    cmd = virCommandNewArgList("lvcreate",
++    cmd = virCommandNewArgList("@lvcreate@",
+                                "--name", vol->name,
+                                NULL);
+     virCommandAddArg(cmd, "-L");
 diff --git a/tests/storagepoolxml2argvtest.c b/tests/storagepoolxml2argvtest.c
 index d5c2531ab8..f24427666f 100644
 --- a/tests/storagepoolxml2argvtest.c

--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -108,7 +108,7 @@ let
       zfs
     ]
     ++ lib.optionals enableLvm2 [
-      zfs
+      lvm2
     ]
   );
 in

--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -76,7 +76,7 @@
   enableZfs ? stdenv.hostPlatform.isLinux,
   zfs,
   enableLvm2 ? stdenv.hostPlatform.isLinux,
-  lvm2
+  lvm2,
 }:
 
 let


### PR DESCRIPTION
Similarly to the ZFS support, this patches the "logical" storage backend to have the right paths to the LVM2 user 
commands. 

## Things done

Package itself does not come with tests, but built and tested on my main machine, which runs NixOS 25.05.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
