### PR TITLE
free42: 3.3.8 -> 3.3.10, plus42: init at 1.3.12

### DIFF
--- a/pkgs/by-name/fr/free42/package.nix
+++ b/pkgs/by-name/fr/free42/package.nix
@@ -1,24 +1,21 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchurl,
   alsa-lib,
   copyDesktopItems,
   wrapGAppsHook3,
   makeDesktopItem,
   pkg-config,
+  nix-update-script,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "free42";
-  version = "3.3.8";
+  version = "3.3.10";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
-    owner = "thomasokken";
-    repo = "free42";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-L6WZM5/+ujM6hv85ppt9YiqHLkd0vYFx3nFVcJwzEBM=";
+  src = fetchurl {
+    url = "https://thomasokken.com/free42/upstream/free42-nologo-${version}.tgz";
+    hash = "sha256-Vh+Sh3oX1ICy0R6R4zu9Df2+ba2mM33qHtifINNpn7Y=";
   };
 
   nativeBuildInputs = [
@@ -30,19 +27,20 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ alsa-lib ];
 
   postPatch = ''
-    sed -i -e "s|/bin/ls|ls|" gtk/Makefile
+    substituteInPlace gtk/Makefile \
+      --replace-fail /bin/ls ls
   '';
 
   dontConfigure = true;
 
   desktopItems = [
     (makeDesktopItem {
-      name = "com.thomasokken.free42bin";
+      name = "free42bin";
       desktopName = "Free42Bin";
       genericName = "Calculator";
       exec = "free42bin";
       type = "Application";
-      comment = "A software clone of HP-42S Calculator";
+      comment = "Software clone of the HP-42S calculator";
       icon = "free42";
       categories = [
         "Utility"
@@ -50,12 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     })
     (makeDesktopItem {
-      name = "com.thomasokken.free42dec";
+      name = "free42dec";
       desktopName = "Free42Dec";
       genericName = "Calculator";
       exec = "free42dec";
       type = "Application";
-      comment = "A software clone of HP-42S Calculator";
+      comment = "Software clone of the HP-42S calculator";
       icon = "free42";
       categories = [
         "Utility"
@@ -68,9 +66,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preBuild
 
     make -C gtk cleaner
-    make --jobs=$NIX_BUILD_CORES -C gtk
+    make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1
     make -C gtk clean
-    make --jobs=$NIX_BUILD_CORES -C gtk BCD_MATH=1
+    make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1 BCD_MATH=1
 
     runHook postBuild
   '';
@@ -87,20 +85,36 @@ stdenv.mkDerivation (finalAttrs: {
     install -m755 gtk/free42dec gtk/free42bin $out/bin
     install -m644 README $out/share/doc/free42/README
 
-    install -m644 gtk/icon-48x48.xpm $out/share/icons/hicolor/48x48/apps/free42.xpm
-    install -m644 gtk/icon-128x128.xpm $out/share/icons/hicolor/128x128/apps/free42.xpm
+    install -m644 gtk/icon-48x48.png $out/share/icons/hicolor/48x48/apps/free42.png
+    install -m644 gtk/icon-128x128.png $out/share/icons/hicolor/128x128/apps/free42.png
     install -m644 skins/* $out/share/free42/skins
 
     runHook postInstall
   '';
 
+  dontWrapGApps = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/free42dec \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \
+      "''${gappsWrapperArgs[@]}"
+
+    wrapProgram $out/bin/free42bin \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--url=https://codeberg.org/thomasokken/free42" ];
+  };
+
   meta = {
     homepage = "https://thomasokken.com/free42/";
     changelog = "https://thomasokken.com/free42/history.html";
-    description = "Software clone of HP-42S Calculator";
+    description = "Software clone of the HP-42S calculator";
     license = with lib.licenses; [ gpl2Only ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ elfenermarcell ];
     mainProgram = "free42dec";
     platforms = with lib.platforms; unix;
   };
-})
+}

--- a/pkgs/by-name/pl/plus42/package.nix
+++ b/pkgs/by-name/pl/plus42/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  alsa-lib,
+  copyDesktopItems,
+  wrapGAppsHook3,
+  makeDesktopItem,
+  pkg-config,
+  nix-update-script,
+}:
+stdenv.mkDerivation rec {
+  pname = "plus42";
+  version = "1.3.12";
+
+  src = fetchurl {
+    url = "https://thomasokken.com/plus42/upstream/plus42-upstream-${version}.tgz";
+    hash = "sha256-IBXQu1hI0bJZISL9wInAzf2z8zbynXXP15oG/od+MC8=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [ alsa-lib ];
+
+  postPatch = ''
+    substituteInPlace gtk/Makefile \
+      --replace-fail /bin/ls ls
+  '';
+
+  dontConfigure = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "plus42bin";
+      desktopName = "Plus42Bin";
+      genericName = "Calculator";
+      exec = "plus42bin";
+      type = "Application";
+      comment = "Software clone of the HP-42S calculator (enhanced version)";
+      icon = "plus42";
+      categories = [
+        "Utility"
+        "Calculator"
+      ];
+    })
+    (makeDesktopItem {
+      name = "plus42dec";
+      desktopName = "Plus42Dec";
+      genericName = "Calculator";
+      exec = "plus42dec";
+      type = "Application";
+      comment = "Software clone of the HP-42S calculator (enhanced version)";
+      icon = "plus42";
+      categories = [
+        "Utility"
+        "Calculator"
+      ];
+    })
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -C gtk cleaner
+    make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1
+    make -C gtk clean
+    make --jobs=$NIX_BUILD_CORES -C gtk AUDIO_ALSA=1 BCD_MATH=1
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install --directory $out/bin \
+                        $out/share/doc/plus42 \
+                        $out/share/plus42/skins \
+                        $out/share/icons/hicolor/48x48/apps \
+                        $out/share/icons/hicolor/128x128/apps
+
+    install -m755 gtk/plus42dec gtk/plus42bin $out/bin
+    install -m644 README $out/share/doc/plus42/README
+
+    install -m644 gtk/icon-48x48.png $out/share/icons/hicolor/48x48/apps/plus42.png
+    install -m644 gtk/icon-128x128.png $out/share/icons/hicolor/128x128/apps/plus42.png
+    install -m644 skins/* $out/share/plus42/skins
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/plus42dec \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \
+      "''${gappsWrapperArgs[@]}"
+
+    wrapProgram $out/bin/plus42bin \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--url=https://codeberg.org/thomasokken/plus42desktop" ];
+  };
+
+  meta = {
+    homepage = "https://thomasokken.com/plus42/";
+    changelog = "https://thomasokken.com/plus42/history.html";
+    description = "Software clone of the HP-42S calculator (enhanced version)";
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ elfenermarcell ];
+    mainProgram = "plus42dec";
+    platforms = with lib.platforms; unix;
+  };
+}


### PR DESCRIPTION
This changes free42 to use the release source tarballs, as it means 1) we only download the part needed for the linux build, 2) it doesn't contain the HP logo (potential legal issue, I think).
It also makes it so free42 actually uses alsa, it wasn't actually built with it despite having the dependency.

And this also adds plus42, an enhanced version of free42 by the same author. The build is basically the same.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
