### PR TITLE
[25.05] civetweb: 1.15 -> 1.16, apply patch for CVE-2025-55763

### DIFF
--- a/pkgs/by-name/ci/civetweb/fix-pkg-config-files.patch
+++ b/pkgs/by-name/ci/civetweb/fix-pkg-config-files.patch
@@ -1,0 +1,43 @@
+From 69b825ef5daebdb6e3b51ce23663003807028634 Mon Sep 17 00:00:00 2001
+From: Thomas Gerbet <thomas@gerbet.me>
+Date: Sun, 28 Sep 2025 21:45:34 +0200
+Subject: [PATCH] Use `@CMAKE_INSTALL_FULL_*DIR@` in pkg-config files
+
+This make possible to install to absolute paths and not only to relative
+paths.
+---
+ cmake/civetweb-cpp.pc.in | 4 ++--
+ cmake/civetweb.pc.in     | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/civetweb-cpp.pc.in b/cmake/civetweb-cpp.pc.in
+index ca1232c5..dc2d99e3 100644
+--- a/cmake/civetweb-cpp.pc.in
++++ b/cmake/civetweb-cpp.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @PROJECT_NAME@-cpp
+ Description: generic graph library
+diff --git a/cmake/civetweb.pc.in b/cmake/civetweb.pc.in
+index 27cea8f1..dd669c5f 100644
+--- a/cmake/civetweb.pc.in
++++ b/cmake/civetweb.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ 
+ Name: @PROJECT_NAME@
+ Description: generic graph library
+-- 
+2.51.0
+

--- a/pkgs/by-name/ci/civetweb/package.nix
+++ b/pkgs/by-name/ci/civetweb/package.nix
@@ -5,16 +5,20 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "civetweb";
-  version = "1.15";
+  version = "1.16";
 
   src = fetchFromGitHub {
     owner = "civetweb";
     repo = "civetweb";
-    rev = "v${version}";
-    sha256 = "sha256-Qh6BGPk7a01YzCeX42+Og9M+fjXRs7kzNUCyT4mYab4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eXb5f2jhtfxDORG+JniSy17kzB7A4vM0UnUQAfKTquU=";
   };
+
+  patches = [
+    ./fix-pkg-config-files.patch
+  ];
 
   outputs = [
     "out"
@@ -48,4 +52,4 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/civetweb/civetweb";
     license = [ lib.licenses.mit ];
   };
-}
+})

--- a/pkgs/by-name/ci/civetweb/package.nix
+++ b/pkgs/by-name/ci/civetweb/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
 }:
 
@@ -18,6 +19,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./fix-pkg-config-files.patch
+    (fetchpatch {
+      name = "CVE-2025-55763.patch";
+      url = "https://github.com/civetweb/civetweb/commit/76e222bcb77ba8452e5da4e82ae6cecd499c25e0.patch";
+      hash = "sha256-gv2FR53SxmRCCTRjj17RhIjoHkgOz5ENs9oHmcfFmw8=";
+    })
   ];
 
   outputs = [


### PR DESCRIPTION
Backport of #446986 without the CMake 4 related changes.

Changes:  
https://github.com/civetweb/civetweb/releases/tag/v1.16

A public POC exists for CVE-2025-55763:
https://github.com/krispybyte/CVE-2025-55763

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
