### PR TITLE
mupdf: fix build with enableCxx against Clang >= 20

### DIFF
--- a/pkgs/by-name/mu/mupdf/package.nix
+++ b/pkgs/by-name/mu/mupdf/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   fetchFromGitHub,
+  fetchpatch,
   copyDesktopItems,
   makeDesktopItem,
   desktopToDarwinBundle,
@@ -85,6 +86,19 @@ stdenv.mkDerivation rec {
     # Upstream C++ wrap script only defines fixed-sized integers on macOS but
     # this is required on aarch64-linux too.
     ./fix-cpp-build.patch
+  ]
+  # fix compatibility with Clang >= 20
+  ++ lib.optionals enableCxx [
+    (fetchpatch {
+      name = "scripts-wrap-parse.py-get_args-improve-caching-of-re.patch";
+      url = "https://github.com/ArtifexSoftware/mupdf/commit/559e45ac8c134712cd8eaee01536ea3841e3a449.patch";
+      hash = "sha256-gI3hzrNo6jj9eqQ9E/BJ3jxXi/sl1C5WRyYlkG3Gkfg=";
+    })
+    (fetchpatch {
+      name = "scripts-wrap-parse.py-get_args-fix-for-libclang-20.patch";
+      url = "https://github.com/ArtifexSoftware/mupdf/commit/4bbf411898341d3ba30f521a6c137a788793cd45.patch";
+      hash = "sha256-cxKNziAGjpDwEw/9ZQHslMeJbiqYo80899BDkUOIX8g=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -122,6 +122,7 @@ buildPythonPackage rec {
     # Requires downloads
     "test_4457"
     "test_4445"
+    "test_4533"
     # Not a git repository, so git ls-files fails
     "test_open2"
   ];


### PR DESCRIPTION
also fix `python3Packages.pymupdf` by disabling a test requiring network access

## `nixpkgs-review` result

build failures are due to unrelated failures in dependencies

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `a6dae01d158ffadfcec8f1c35420ee8a83f56dc9`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>khoj</li>
    <li>khoj.dist</li>
  </ul>
</details>
<details>
  <summary>:x: 11 packages failed to build:</summary>
  <ul>
    <li>kcc</li>
    <li>kcc.dist</li>
    <li>libretranslate (python313Packages.libretranslate)</li>
    <li>libretranslate.dist (python313Packages.libretranslate.dist)</li>
    <li>newelle</li>
    <li>python312Packages.argos-translate-files</li>
    <li>python312Packages.argos-translate-files.dist</li>
    <li>python312Packages.libretranslate</li>
    <li>python312Packages.libretranslate.dist</li>
    <li>python313Packages.argos-translate-files</li>
    <li>python313Packages.argos-translate-files.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 53 packages built:</summary>
  <ul>
    <li>browsr</li>
    <li>browsr.dist</li>
    <li>cardimpose (python313Packages.cardimpose)</li>
    <li>cardimpose.dist (python313Packages.cardimpose.dist)</li>
    <li>librum</li>
    <li>mcomix</li>
    <li>mcomix.dist</li>
    <li>plakativ</li>
    <li>plakativ.dist</li>
    <li>python312Packages.cardimpose</li>
    <li>python312Packages.cardimpose.dist</li>
    <li>python312Packages.llama-index</li>
    <li>python312Packages.llama-index-readers-file</li>
    <li>python312Packages.llama-index-readers-file.dist</li>
    <li>python312Packages.llama-index-readers-s3</li>
    <li>python312Packages.llama-index-readers-s3.dist</li>
    <li>python312Packages.llama-index.dist</li>
    <li>python312Packages.llm-pdf-to-images</li>
    <li>python312Packages.llm-pdf-to-images.dist</li>
    <li>python312Packages.paddleocr</li>
    <li>python312Packages.paddleocr.dist</li>
    <li>python312Packages.pdf2docx</li>
    <li>python312Packages.pdf2docx.dist</li>
    <li>python312Packages.pymupdf</li>
    <li>python312Packages.pymupdf.dist</li>
    <li>python312Packages.pymupdf4llm</li>
    <li>python312Packages.pymupdf4llm.dist</li>
    <li>python312Packages.pytikz-allefeld</li>
    <li>python312Packages.pytikz-allefeld.dist</li>
    <li>python312Packages.svgdigitizer</li>
    <li>python312Packages.svgdigitizer.dist</li>
    <li>python313Packages.llama-index</li>
    <li>python313Packages.llama-index-readers-file</li>
    <li>python313Packages.llama-index-readers-file.dist</li>
    <li>python313Packages.llama-index-readers-s3</li>
    <li>python313Packages.llama-index-readers-s3.dist</li>
    <li>python313Packages.llama-index.dist</li>
    <li>python313Packages.llm-pdf-to-images</li>
    <li>python313Packages.llm-pdf-to-images.dist</li>
    <li>python313Packages.paddleocr</li>
    <li>python313Packages.paddleocr.dist</li>
    <li>python313Packages.pdf2docx</li>
    <li>python313Packages.pdf2docx.dist</li>
    <li>python313Packages.pymupdf</li>
    <li>python313Packages.pymupdf.dist</li>
    <li>python313Packages.pymupdf4llm</li>
    <li>python313Packages.pymupdf4llm.dist</li>
    <li>python313Packages.pytikz-allefeld</li>
    <li>python313Packages.pytikz-allefeld.dist</li>
    <li>python313Packages.svgdigitizer</li>
    <li>python313Packages.svgdigitizer.dist</li>
    <li>termpdfpy</li>
    <li>termpdfpy.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc