### PR TITLE
nixos/nextcloud: avoid duplicate X-Robots-Tag header, remove option nginx.recommendedHttpHeaders

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1547,6 +1547,8 @@ in
             client_max_body_size ${cfg.maxUploadSize};
             fastcgi_buffers 64 4K;
             fastcgi_hide_header X-Powered-By;
+            # mirror upstream htaccess file https://github.com/nextcloud/server/blob/v32.0.0/.htaccess#L40-L41
+            fastcgi_hide_header X-Robots-Tag;
             gzip on;
             gzip_vary on;
             gzip_comp_level 4;

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -320,6 +320,9 @@ in
     (lib.mkRemovedOptionModule [ "services" "nextcloud" "config" "dbport" ] ''
       Add port to services.nextcloud.config.dbhost instead.
     '')
+    (lib.mkRemovedOptionModule [ "services" "nextcloud" "nginx" "recommendedHttpHeaders" ] ''
+      This option has been removed to always follow upstream's security recommendation.
+    '')
     (lib.mkRenamedOptionModule
       [ "services" "nextcloud" "logLevel" ]
       [ "services" "nextcloud" "settings" "loglevel" ]
@@ -979,11 +982,6 @@ in
     };
 
     nginx = {
-      recommendedHttpHeaders = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Enable additional recommended HTTP response headers";
-      };
       hstsMaxAge = lib.mkOption {
         type = lib.types.ints.positive;
         default = 15552000;
@@ -1534,13 +1532,11 @@ in
           };
           extraConfig = ''
             index index.php index.html /index.php$request_uri;
-            ${lib.optionalString (cfg.nginx.recommendedHttpHeaders) ''
-              add_header X-Content-Type-Options nosniff;
-              add_header X-Robots-Tag "noindex, nofollow";
-              add_header X-Permitted-Cross-Domain-Policies none;
-              add_header X-Frame-Options sameorigin;
-              add_header Referrer-Policy no-referrer;
-            ''}
+            add_header X-Content-Type-Options nosniff;
+            add_header X-Robots-Tag "noindex, nofollow";
+            add_header X-Permitted-Cross-Domain-Policies none;
+            add_header X-Frame-Options sameorigin;
+            add_header Referrer-Policy no-referrer;
             ${lib.optionalString (cfg.https) ''
               add_header Strict-Transport-Security "max-age=${toString cfg.nginx.hstsMaxAge}; includeSubDomains" always;
             ''}
@@ -1548,6 +1544,10 @@ in
             fastcgi_buffers 64 4K;
             fastcgi_hide_header X-Powered-By;
             # mirror upstream htaccess file https://github.com/nextcloud/server/blob/v32.0.0/.htaccess#L40-L41
+            fastcgi_hide_header Referrer-Policy;
+            fastcgi_hide_header X-Content-Type-Options;
+            fastcgi_hide_header X-Frame-Options;
+            fastcgi_hide_header X-Permitted-Cross-Domain-Policies;
             fastcgi_hide_header X-Robots-Tag;
             gzip on;
             gzip_vary on;


### PR DESCRIPTION
We already set this header in `nginx` https://github.com/NixOS/nixpkgs/blob/f8b7dbc46d330984bb52722a4e5df70fd364ab1d/nixos/modules/services/web-apps/nextcloud.nix#L1539 and a duplicate header can lead to issues, like: https://github.com/nextcloud/notes-android/issues/2848.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
