### PR TITLE
skytemple, armips: fix compilation and remove indirectly vulnerable webkitgtk_4_0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15826,7 +15826,7 @@
     githubId = 13599169;
   };
   marius851000 = {
-    email = "mariusdavid@laposte.net";
+    email = "nix@mariusdavid.fr";
     name = "Marius David";
     github = "marius851000";
     githubId = 22586596;

--- a/pkgs/by-name/ar/armips/package.nix
+++ b/pkgs/by-name/ar/armips/package.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail c++11 c++17
+      --replace-fail c++11 c++17 \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.13)" # done by https://github.com/Kingcom/armips/commit/e1ed5bf0f4565250b98b0ddfb9112f15dc8e8e3b upstream, patch not directly compatible
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sk/skytemple/package.nix
+++ b/pkgs/by-name/sk/skytemple/package.nix
@@ -4,7 +4,6 @@
   gobject-introspection,
   gtk3,
   gtksourceview4,
-  webkitgtk_4_0,
   wrapGAppsHook3,
   python3Packages,
 }:
@@ -26,10 +25,11 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     gtk3
     gtksourceview4
-    # webkitgtk is used for rendering interactive statistics graph which
-    # can be seen by opening a ROM, entering Pokemon section, selecting
-    # any Pokemon, and clicking Stats and Moves tab.
-    webkitgtk_4_0
+    # SkyTemple uses webkitgtk 4.0 which is depend on libsoup2, an
+    # unmaintained library. Since it is optional, do not use it.
+    # It is only used to add interactive monster XP curver, that
+    # can alternatively be opened in the web browser (and is also
+    # rendered in-app as non-interactive image)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/explorerscript/default.nix
+++ b/pkgs/development/python-modules/explorerscript/default.nix
@@ -28,6 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
+      --replace-fail "pybind11>=2.13.6, < 2.14" "pybind11" \
       --replace-fail "scikit-build-core>=0.10.7, < 0.11" "scikit-build-core"
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Removed the webkit dependancy on SkyTemple. It use libsoup2, which is marked as vulnerable and outdated, and won’t compiled. SkyTemple work fine without it, only using it to display some graph, that are otherwised rendered as image in-app and offer the option to open them in the web browser.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I also noticed problem with an aiohttp update error in the portrait browser. I might fix that later, when I have more time to make a fix. (it is otherwise possible to manually download them from https://sprites.pmdcollab.org or https://nsc.pmdcollab.org and import them manually).

I tried to update to 4.1 which does use libsoup3, but it crash when it try to render the graph with some Wayland/X error (tested with both). I suspect it might also happen with 4.0, but I didn’t given I had trouble compiling it, as it doesn’t appear to respect the core limit I ask it (and otherwise eats up all the RAM). Might be an error on my side.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
