### PR TITLE
ghostty{,-bin}: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/by-name/gh/ghostty-bin/package.nix
+++ b/pkgs/by-name/gh/ghostty-bin/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ghostty-bin";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchurl {
     url = "https://release.files.ghostty.org/${finalAttrs.version}/Ghostty.dmg";
-    hash = "sha256-QyHKQ00iRxWS6GwPfRAi9RDSlgX/50N0+MASmnPGAo4=";
+    hash = "sha256-rFXYJxz6UPE8KKhrPLvksLLvxUdlZzvoxLGhIF3hTGM=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/gh/ghostty/deps.nix
+++ b/pkgs/by-name/gh/ghostty/deps.nix
@@ -169,11 +169,11 @@ linkFarm name [
     };
   }
   {
-    name = "N-V-__8AANodAwDnyHwhlOv5cVRn2rx_dTvija-wy5YtTw1B";
+    name = "N-V-__8AALIsAwDyo88G5mGJGN2lSVmmFMx4YePfUvp_2o3Y";
     path = fetchZigArtifact {
       name = "iterm2_themes";
-      url = "https://deps.files.ghostty.org/ghostty-themes-20250915-162204-b1fe546.tgz";
-      hash = "sha256-6rKNFpaUvSbvNZ0/+u0h4I/RRaV5V7xIPQ9y7eNVbCA=";
+      url = "https://github.com/mbadolato/iTerm2-Color-Schemes/releases/download/release-20251002-142451-4a5043e/ghostty-themes.tgz";
+      hash = "sha256-GsEWVt4wMzp6+7N5I+QVuhCVJ70cFrdADwUds59AKnw=";
     };
   }
   {

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -20,10 +20,8 @@
   pandoc,
   pkg-config,
   removeReferencesTo,
-  util-linux,
   versionCheckHook,
   wrapGAppsHook4,
-  writeShellApplication,
   zig_0_14,
 
   # Usually you would override `zig.hook` with this, but we do that internally
@@ -34,49 +32,13 @@
 let
   zig = zig_0_14;
 
-  # HACK:
-  # Work around a Zig bug where embedding a large enough file could crash
-  # the compiler when too many cores are used, which causes Hydra builds to
-  # reliably fail. See these links for more info:
-  #
-  #  * https://github.com/ziglang/zig/issues/25297
-  #  * https://github.com/ziglang/zig/issues/22867
-  #  * https://github.com/ghostty-org/ghostty/discussions/8676
-  #
-  # Note that the `-j` parameter does NOT fix this. It seems like the faulty
-  # intern pool logic always depends on the full amount of available cores
-  # instead of the value of `-j`, so we have to use `taskset` to trick Zig
-  # into thinking it only has access to a limited amount of cores.
-  zigWithLimitedCores = writeShellApplication {
-    name = "zig";
-    passthru = {
-      inherit (zig) version meta;
-    };
-    runtimeInputs = [
-      zig
-      util-linux
-    ];
-    text = ''
-      maxCores=$(nproc)
-      # 32 cores seem to be the upper limit through empiric testing
-      coreLimit=$((maxCores < 32 ? maxCores : 32))
-      # Also take NIX_BUILD_CORES into account so the build respects the `--cores` argument
-      effectiveCores=$((NIX_BUILD_CORES > coreLimit ? coreLimit : NIX_BUILD_CORES))
-      taskset -c "0-$((effectiveCores - 1))" zig "$@"
-    '';
+  zig_hook = zig.hook.overrideAttrs {
+    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
   };
-
-  zig_hook =
-    (zig.hook.override {
-      zig = zigWithLimitedCores;
-    }).overrideAttrs
-      {
-        zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
-      };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ghostty";
-  version = "1.2.0";
+  version = "1.2.1";
 
   outputs = [
     "out"
@@ -90,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ghostty-org";
     repo = "ghostty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Z6lndpkEqBwgsjIeZhmVIQ5D7YdQSH/fG6NCY+YWEAo=";
+    hash = "sha256-LIJ8ZzOzpZMwgJOlOE/n6yiJ/mVKHI4pt/1Bm93gbG8=";
   };
 
   deps = callPackage ./deps.nix {


### PR DESCRIPTION
Changelog: https://ghostty.org/docs/install/release-notes/1-2-1

Also removed the `taskset` hack now that a fix has been merged upstream (see https://github.com/ghostty-org/ghostty/pull/8925)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
