### PR TITLE
discord-rpc: fix build with CMake 4; various: disable discord-rpc

### DIFF
--- a/pkgs/by-name/di/discord-rpc/package.nix
+++ b/pkgs/by-name/di/discord-rpc/package.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required (VERSION 3.2.0)" \
+      "cmake_minimum_required (VERSION 3.10.0)"
+  '';
+
   meta = with lib; {
     description = "Official library to interface with the Discord client";
     homepage = "https://github.com/discordapp/discord-rpc";

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -30,6 +30,7 @@
   pkg-config,
   speexdsp,
   zlib,
+  withDiscordRpc ? false,
 }:
 
 let
@@ -79,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     curl
-    discord-rpc
     duktape
     expat
     flac
@@ -100,13 +100,15 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     speexdsp
     zlib
-  ];
+  ]
+  ++ lib.optional withDiscordRpc discord-rpc;
 
   cmakeFlags = [
     (lib.cmakeBool "DOWNLOAD_OBJECTS" false)
     (lib.cmakeBool "DOWNLOAD_OPENMSX" false)
     (lib.cmakeBool "DOWNLOAD_OPENSFX" false)
     (lib.cmakeBool "DOWNLOAD_TITLE_SEQUENCES" false)
+    (lib.cmakeBool "DISABLE_DISCORD_RPC" (!withDiscordRpc))
   ];
 
   postUnpack = ''

--- a/pkgs/by-name/pa/parallel-launcher/package.nix
+++ b/pkgs/by-name/pa/parallel-launcher/package.nix
@@ -20,6 +20,7 @@
   # Allow overrides for the RetroArch core and declarative settings
   parallel-n64-core ? parallel-launcher.passthru.parallel-n64-core,
   extraRetroArchSettings ? { },
+  withDiscordRpc ? false,
 }:
 let
   # Converts a version string like x.y.z to vx.y-z
@@ -88,12 +89,12 @@ stdenv.mkDerivation (
 
     buildInputs = [
       SDL2
-      discord-rpc
       libgcrypt
       sqlite
       qt5.qtbase
       qt5.qtsvg
-    ];
+    ]
+    ++ lib.optional withDiscordRpc discord-rpc;
 
     qtWrapperArgs = [
       "--prefix PATH : ${

--- a/pkgs/by-name/rm/rmg/package.nix
+++ b/pkgs/by-name/rm/rmg/package.nix
@@ -25,6 +25,7 @@
   withWayland ? false,
   # Affects final license
   withAngrylionRdpPlus ? false,
+  withDiscordRpc ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -48,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     boost
-    discord-rpc
     freetype
     hidapi
     libpng
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     xdg-user-dirs
     zlib
   ]
+  ++ lib.optional withDiscordRpc discord-rpc
   ++ (
     with qt6Packages;
     [
@@ -78,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     # everything else.
     (lib.cmakeBool "NO_RUST" true)
     (lib.cmakeBool "USE_ANGRYLION" withAngrylionRdpPlus)
+    (lib.cmakeBool "DISCORD_RPC" withDiscordRpc) # Remove with 0.8.4 update
   ];
 
   qtWrapperArgs =

--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -22,6 +22,7 @@
   qtmultimedia,
   discord-rpc,
   yajl,
+  withDiscordRpc ? false,
 }:
 
 let
@@ -98,8 +99,8 @@ stdenv.mkDerivation rec {
     qtbase
     qtmultimedia
     yajl
-    discord-rpc
-  ];
+  ]
+  ++ lib.optional withDiscordRpc discord-rpc;
 
   cmakeFlags = [
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
@@ -131,10 +132,12 @@ stdenv.mkDerivation rec {
       --set LUA_CPATH "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \
       --prefix LUA_PATH : "$NIX_LUA_PATH" \
       --prefix DYLD_LIBRARY_PATH : "${
-        lib.makeLibraryPath [
-          libsForQt5.qtkeychain
-          discord-rpc
-        ]
+        lib.makeLibraryPath (
+          [
+            libsForQt5.qtkeychain
+          ]
+          ++ lib.optional withDiscordRpc discord-rpc
+        )
       }:$out/lib" \
       --chdir "$out";
 
@@ -146,10 +149,12 @@ stdenv.mkDerivation rec {
       --set LUA_CPATH "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \
       --prefix LUA_PATH : "$NIX_LUA_PATH" \
       --prefix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath [
-          libsForQt5.qtkeychain
-          discord-rpc
-        ]
+        lib.makeLibraryPath (
+          [
+            libsForQt5.qtkeychain
+          ]
+          ++ lib.optional withDiscordRpc discord-rpc
+        )
       }" \
       --chdir "$out";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`discord-rpc` is unmaintained upstream.

- Related to: https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
