### PR TITLE
v4l-utils: 1.30.1 -> 1.32.0

### DIFF
--- a/pkgs/by-name/v4/v4l-utils/package.nix
+++ b/pkgs/by-name/v4/v4l-utils/package.nix
@@ -34,11 +34,11 @@ in
 # we need to use stdenv.mkDerivation in order not to pollute the libv4l’s closure with Qt
 stdenv.mkDerivation (finalAttrs: {
   pname = "v4l-utils";
-  version = "1.30.1";
+  version = "1.32.0";
 
   src = fetchurl {
     url = "https://linuxtv.org/downloads/v4l-utils/v4l-utils-${finalAttrs.version}.tar.xz";
-    hash = "sha256-wc9UnC7DzznrXse/FXMTSeYbJqIbXpY5IttCIzO64Zc=";
+    hash = "sha256-aCiCihd3VSbrk/slipKU0dEHPWM8NE3XHs1Oeh/7ffw=";
   };
 
   patches = [
@@ -106,17 +106,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [ libjpeg ];
 
-  # these two `substituteInPlace` have been sent upstream as patches
-  # https://lore.kernel.org/linux-media/867c4d2e-7871-4280-8c89-d4b654597f32@public-files.de/T/
-  # they might fail and have to be removed once the patches get accepted
   postPatch = ''
     patchShebangs utils/
-    substituteInPlace \
-      lib/libdvbv5/meson.build \
-      --replace-fail "install_dir: 'include/libdvbv5'" "install_dir: get_option('includedir') / 'libdvbv5'"
-    substituteInPlace \
-      meson.build \
-      --replace-fail "get_option('datadir') / 'locale'" "get_option('localedir')"
   '';
 
   # Meson unable to find moc/uic/rcc in case of cross-compilation


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More:

- [x] `nix build v4l-utils libv4l` build.
- [x] `nix build dtv-scan-tables` builds (it uses `${v4l-utils}/bin/dvb-format-convert` during the build).
- [x] The output of `v4l2-ctl --list-formats-ext -d /dev/video0` seems alright.
- [x] `qv4l2` starts up and looks nice.
- [x] `dvbv5-zap --adapter=0 --channel=channels.dvbv5 --pat --output=/tmp/output.ts $CHANNEL` records some TV into the output file as expected (tested with dvb-t2 and dvb-s2).
- [x] `dvbv5-scan --get_frontend --nit ${dtv-scan-tables}/share/dvbv5/dvb-t/${SOME_TRANSPONDER_FILE}` finds a lot of dvb-t2 channels, as it should.
- [x] `mpv dvb://$CHANNEL` works (tested with dvb-s channel)

`pkgsMusl.v4l-utils` not tested due to too many builds.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc