### PR TITLE
libvdpau-va-gl: update to latest git

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10060,6 +10060,13 @@
     githubId = 79340822;
     keys = [ { fingerprint = "3582 5B85 66C8 4F36 45C7  EC42 809F 7938 9CB1 8650"; } ];
   };
+  hater = {
+    name = "hater.dev";
+    github = "haterdotdev";
+    githubId = 101119701;
+    email = "hater@hater.dev";
+    keys = [ { fingerprint = "CC93 78E4 51B6 3490 8101  5260 3FB8 AFB5 95FA E565"; } ];
+  };
   havvy = {
     email = "ryan.havvy@gmail.com";
     github = "Havvy";

--- a/pkgs/by-name/li/libvdpau-va-gl/package.nix
+++ b/pkgs/by-name/li/libvdpau-va-gl/package.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation {
     description = "VDPAU driver with OpenGL/VAAPI backend";
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = [ maintainers.hater ];
   };
 }

--- a/pkgs/by-name/li/libvdpau-va-gl/package.nix
+++ b/pkgs/by-name/li/libvdpau-va-gl/package.nix
@@ -15,15 +15,15 @@
   libGLU,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "libvdpau-va-gl";
-  version = "0.4.2";
+  version = "0.4.2-unstable-2025-5-18";
 
   src = fetchFromGitHub {
     owner = "i-rinat";
     repo = "libvdpau-va-gl";
-    rev = "v${version}";
-    sha256 = "0asndybfv8xb0fx73sjjw5kydqrahqkm6n04lh589pbf18s5qlld";
+    rev = "a845e8720d900e4bcc89e7ee16106ce63b44af0d";
+    hash = "sha256-CtpyWod+blqC3u12MaQyqFOXurCP5Rb2PYq7PoaoASA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
The old version fails to build with modern CMake versions.  This update bumps the package to the latest upstream commit, which updates the CMakeFiles to fix the build.

Closes https://github.com/NixOS/nixpkgs/issues/448918

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
