### PR TITLE
binutils: patch 2.44 with backported 2.45 CVE fixes

### DIFF
--- a/pkgs/development/tools/misc/binutils/CVE-2025-5244.diff
+++ b/pkgs/development/tools/misc/binutils/CVE-2025-5244.diff
@@ -1,0 +1,13 @@
+Backported patch originally targeted against 2.45.
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -14356,5 +14356,6 @@ elf_gc_sweep (bfd *abfd, struct bfd_link_info *info)
+	  if (o->flags & SEC_GROUP)
+	    {
+	      asection *first = elf_next_in_group (o);
+-	      o->gc_mark = first->gc_mark;
++	      if (first != NULL)
++	        o->gc_mark = first->gc_mark;
+	    }
+
+	  if (o->gc_mark)

--- a/pkgs/development/tools/misc/binutils/CVE-2025-5245.diff
+++ b/pkgs/development/tools/misc/binutils/CVE-2025-5245.diff
@@ -1,0 +1,26 @@
+Backported patch originally targeted against 2.45.
+--- a/binutils/debug.c
++++ b/binutils/debug.c
+@@ -2554,9 +2554,6 @@ debug_write_type (struct debug_handle *info,
+     case DEBUG_KIND_UNION_CLASS:
+       return debug_write_class_type (info, fns, fhandle, type, tag);
+     case DEBUG_KIND_ENUM:
+-      if (type->u.kenum == NULL)
+-	return (*fns->enum_type) (fhandle, tag, (const char **) NULL,
+-				  (bfd_signed_vma *) NULL);
+       return (*fns->enum_type) (fhandle, tag, type->u.kenum->names,
+ 				type->u.kenum->values);
+     case DEBUG_KIND_POINTER:
+@@ -3097,9 +3094,9 @@ debug_type_samep (struct debug_handle *info, struct debug_type_s *t1,
+       break;
+
+     case DEBUG_KIND_ENUM:
+-      if (t1->u.kenum == NULL)
+-	ret = t2->u.kenum == NULL;
+-      else if (t2->u.kenum == NULL)
++      if (t1->u.kenum->names == NULL)
++	ret = t2->u.kenum->names == NULL;
++      else if (t2->u.kenum->names == NULL)
+ 	ret = false;
+       else
+ 	{

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -122,6 +122,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Backported against CVE patched in the 2.45 series. See:
     # https://nvd.nist.gov/vuln/detail/CVE-2025-5244
     ./CVE-2025-5244.diff
+
+    # Backported against CVE patched in the 2.45 series. See:
+    # https://nvd.nist.gov/vuln/detail/CVE-2025-5245
+    ./CVE-2025-5245.diff
   ];
 
   outputs = [

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -118,6 +118,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./avr-size.patch
 
     ./windres-locate-gcc.patch
+
+    # Backported against CVE patched in the 2.45 series. See:
+    # https://nvd.nist.gov/vuln/detail/CVE-2025-5244
+    ./CVE-2025-5244.diff
   ];
 
   outputs = [


### PR DESCRIPTION
Two outstanding CVEs are present in `binutils` 2.44:

- https://nvd.nist.gov/vuln/detail/CVE-2025-5244
- https://nvd.nist.gov/vuln/detail/CVE-2025-5245

Those links include direct references to the corrective commits, which is what these diffs are derived from.

Although 2.45 includes the fixes, as noted in #431912, the odd-numbered releases exclude `gold`, which would introduce a lot of breakage, and this should go in sooner than we could get a large breaking change in esp. before 25.11. As discussed in `#staging` on Matrix; we _should_ deprecate `gold` eventually but that's out of scope in the immediate-term so that we can just patch these CVEs.

I built this myself to confirm it's buildable but obviously something like `binutils` lives deep down in the dependency tree so it's branched off `staging` and will likely cause large rebuilds.

In addition to the listed maintainers, @fabianhjr was highlighted in Matrix so I'm doing so here as well in case additional eyes should be here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
