### PR TITLE
nixos/users-groups: move home directory creation to systemd-tmpfiles

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -400,3 +400,5 @@
 - The `open-webui` package's postgres support have been moved to optional dependencies to comply with upstream changes in 0.6.26.
 
 - `prl-tools` has been moved out of `linuxPackages` because Parallels Guest Tools become driverless since 26.1.0.
+
+- The creation of user home directories is now handled by `systemd-tmpfiles` for the perl based user management. This resolves a race condition where home directories could be created before the `/home` filesystem was mounted (see [#6481](https://github.com/NixOS/nixpkgs/issues/6481) for details).

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -231,13 +231,6 @@ foreach my $u (@{$spec->{users}}) {
         }
     }
 
-    # Ensure home directory incl. ownership and permissions.
-    if ($u->{createHome} and !$is_dry) {
-        make_path($u->{home}, { mode => 0755 }) if ! -e $u->{home};
-        chown $u->{uid}, $u->{gid}, $u->{home};
-        chmod oct($u->{homeMode}), $u->{home};
-    }
-
     if (defined $u->{hashedPasswordFile}) {
         if (-e $u->{hashedPasswordFile}) {
             $u->{hashedPassword} = read_file($u->{hashedPasswordFile});

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -637,8 +637,6 @@ let
           group
           description
           home
-          homeMode
-          createHome
           isSystemUser
           password
           hashedPasswordFile
@@ -892,6 +890,10 @@ in
           }
         else
           ""; # keep around for backwards compatibility
+
+      systemd.tmpfiles.rules = lib.mapAttrsToList (
+        _: user: "d '${user.home}' ${user.homeMode} ${user.name} ${user.group} - -"
+      ) (lib.filterAttrs (_: user: user.createHome && user.enable) cfg.users);
 
       systemd.services.linger-users = lib.mkIf ((length lingeringUsers) > 0) {
         wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/system/userborn.nix
+++ b/nixos/modules/services/system/userborn.nix
@@ -93,26 +93,6 @@ in
 
     systemd = {
 
-      # Create home directories, do not create /var/empty even if that's a user's
-      # home.
-      tmpfiles.settings.home-directories =
-        lib.mapAttrs'
-          (
-            username: opts:
-            lib.nameValuePair (toString opts.home) {
-              d = {
-                mode = opts.homeMode;
-                user = opts.name;
-                inherit (opts) group;
-              };
-            }
-          )
-          (
-            lib.filterAttrs (
-              _username: opts: opts.enable && opts.createHome && opts.home != "/var/empty"
-            ) userCfg.users
-          );
-
       services.userborn = {
         wantedBy = [ "sysinit.target" ];
         requiredBy = [ "sysinit-reactivation.target" ];

--- a/nixos/modules/system/boot/systemd/sysusers.nix
+++ b/nixos/modules/system/boot/systemd/sysusers.nix
@@ -99,20 +99,6 @@ in
     }) systemUsers;
 
     systemd = {
-
-      # Create home directories, do not create /var/empty even if that's a user's
-      # home.
-      tmpfiles.settings.home-directories = lib.mapAttrs' (
-        username: opts:
-        lib.nameValuePair opts.home {
-          d = {
-            mode = opts.homeMode;
-            user = username;
-            group = opts.group;
-          };
-        }
-      ) (lib.filterAttrs (_username: opts: opts.home != "/var/empty") systemUsers);
-
       # Create uid/gid marker files for those without an explicit id
       tmpfiles.settings.nixos-uid = lib.mapAttrs' (
         username: opts:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #6481
Based on the original work done in #223932 with some improvements

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
