### PR TITLE
innoextract: 1.9 -> 1.9-unstable-2025-02-06 (cmake-4 compatible)

### DIFF
--- a/pkgs/by-name/in/innoextract/package.nix
+++ b/pkgs/by-name/in/innoextract/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
   cmake,
   makeWrapper,
   boost,
@@ -10,26 +9,19 @@
   libiconv,
   withGog ? false,
   unar ? null,
+  unstableGitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "innoextract";
-  version = "1.9";
+  version = "1.9-unstable-2025-02-06";
 
-  src = fetchurl {
-    url = "https://constexpr.org/innoextract/files/innoextract-${version}.tar.gz";
-    sha256 = "09l1z1nbl6ijqqwszdwch9mqr54qb7df0wp2sd77v17dq6gsci33";
+  src = fetchFromGitHub {
+    owner = "dscharrer";
+    repo = "innoextract";
+    rev = "6e9e34ed0876014fdb46e684103ef8c3605e382e";
+    hash = "sha256-bgACPDo1phjIiwi336JEB1UAJKyL2NmCVOhyZxBFLJo=";
   };
-
-  patches = [
-    # Fix boost-1.86 build:
-    #   https://github.com/dscharrer/innoextract/pull/169
-    (fetchpatch {
-      name = "boost-1.86.patch";
-      url = "https://github.com/dscharrer/innoextract/commit/264c2fe6b84f90f6290c670e5f676660ec7b2387.patch";
-      hash = "sha256-QYwrqLXC7FE4oYi6G1erpX/RUUtS5zNBv7/fO7AdZQg=";
-    })
-  ];
 
   buildInputs = [
     xz
@@ -52,6 +44,9 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/innoextract \
       --prefix PATH : ${lib.makeBinPath [ unar ]}
   '';
+
+  # use unstable as latest release does not yet support cmake-4
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "Tool to unpack installers created by Inno Setup";


### PR DESCRIPTION
Without the change the build fails on` master as:

    innoextract> CMake Error at /build/innoextract-1.9/cmake/VersionScript.cmake:20 (cmake_minimum_required):
    innoextract>   Compatibility with CMake < 3.5 has been removed from CMake.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
