### PR TITLE
fuzzylite: 6.0 -> 6.0-unstable-2025-08-30 (cmake-4 compatible)

### DIFF
--- a/pkgs/by-name/fu/fuzzylite/package.nix
+++ b/pkgs/by-name/fu/fuzzylite/package.nix
@@ -5,19 +5,19 @@
   cmake,
   ninja,
   useFloat ? false,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation rec {
   pname = "fuzzylite";
-  version = "6.0";
+  version = "6.0-unstable-2025-08-30";
 
   src = fetchFromGitHub {
     owner = "fuzzylite";
     repo = "fuzzylite";
-    rev = "v${version}";
-    hash = "sha256-i1txeUE/ZSRggwLDtpS8dd4uuZfHX9w3zRH0gBgGXnk=";
+    rev = "fe62b61ad0e301fbd8868d5fc3d76d7590c59636";
+    hash = "sha256-p3ikdY3kfC8N7XsHHa3HzWI0blciWoxCHiEOOUt2yLY=";
   };
-  sourceRoot = "${src.name}/fuzzylite";
 
   outputs = [
     "out"
@@ -38,6 +38,9 @@ stdenv.mkDerivation rec {
     "-DFL_BUILD_TESTS:BOOL=OFF"
     "-DFL_USE_FLOAT:BOOL=${if useFloat then "ON" else "OFF"}"
   ];
+
+  # use unstable as latest release does not yet support cmake-4
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = with lib; {
     description = "Fuzzy logic control library in C++";


### PR DESCRIPTION
Without the change the build fails on` master as:

    fuzzylite> CMake Error at /build/innoextract-1.9/cmake/VersionScript.cmake:20 (cmake_minimum_required):
    fuzzylite>   Compatibility with CMake < 3.5 has been removed from CMake.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
