### PR TITLE
[Backport release-25.05] consul: 1.21.4 -> 1.21.5; unmark vulnerable

### DIFF
--- a/pkgs/by-name/co/consul/package.nix
+++ b/pkgs/by-name/co/consul/package.nix
@@ -57,7 +57,6 @@ buildGo125Module rec {
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsl11;
     maintainers = with maintainers; [
-      adamcstephens
       vdemeester
       nh2
       techknowlogick

--- a/pkgs/by-name/co/consul/package.nix
+++ b/pkgs/by-name/co/consul/package.nix
@@ -62,14 +62,5 @@ buildGo125Module rec {
       techknowlogick
     ];
     mainProgram = "consul";
-    knownVulnerabilities = [
-      (lib.concatStringsSep " " [
-        "Note: These issues are fixed in the unstable nixpkgs releases."
-        "They cannot be fixed in the 25.05 release due to incompatible Go versions."
-      ])
-      "Remote authentication bypass (https://github.com/hashicorp/consul/pull/22612)"
-      "Local attacker can see TLS private key in some cases (https://github.com/hashicorp/consul/pull/22626)"
-      "Comparisons of sensitive values may be susceptible to timing attacks (https://github.com/hashicorp/consul/pull/22537)"
-    ];
   };
 }

--- a/pkgs/by-name/co/consul/package.nix
+++ b/pkgs/by-name/co/consul/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
   nixosTests,
   nix-update-script,
 }:
 
-buildGoModule rec {
+buildGo125Module rec {
   pname = "consul";
-  version = "1.21.4";
+  version = "1.21.5";
 
   # Note: Currently only release tags are supported, because they have the Consul UI
   # vendored. See
@@ -22,7 +22,7 @@ buildGoModule rec {
     owner = "hashicorp";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-z2hyEqC8SnIac01VjB2g2+RAaZEaLlVsqBzwedx5t4Q=";
+    hash = "sha256-x5e0DhJ3qMh51E+bEIzl0JmH7bvdicVgOa0l1Qix9vI=";
   };
 
   # This corresponds to paths with package main - normally unneeded but consul
@@ -32,7 +32,7 @@ buildGoModule rec {
     "connect/certgen"
   ];
 
-  vendorHash = "sha256-fWdzFyRtbTOgAapmVz1ScYEHCZUx7nfqw0y2v4aDuic=";
+  vendorHash = "sha256-PZtLz7jqtqYcBO/xrE/tE4vqNstLq9Iv20eWnW5xloQ=";
 
   doCheck = false;
 


### PR DESCRIPTION
Now with Go 1.25 on the release branch we can actually backport the fixes in #445535 instead of just marking as vulnerable.

Background:
* #448728
* #448731
* #448882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
