### PR TITLE
flare: backport upstream cmake-4 fixes

### DIFF
--- a/pkgs/by-name/fl/flare/engine.nix
+++ b/pkgs/by-name/fl/flare/engine.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   SDL2,
   SDL2_image,
@@ -20,7 +21,16 @@ stdenv.mkDerivation rec {
     hash = "sha256-DIzfTqwZJ8NAPB/TWzvPjepHb7hIbIr+Kk+doXJmpLc=";
   };
 
-  patches = [ ./desktop.patch ];
+  patches = [
+    ./desktop.patch
+
+    # cmake-4 compatibility patch
+    (fetchpatch {
+      name = "cmake-4.patch";
+      url = "https://github.com/flareteam/flare-engine/commit/9500379f886484382bba2f893faf49865de9f2c0.patch";
+      hash = "sha256-nUn54ZBEvvFkIhzE/UBbsvF0rFC9JAeQACTAPtsc1VI=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [

--- a/pkgs/by-name/fl/flare/game.nix
+++ b/pkgs/by-name/fl/flare/game.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
 }:
 
@@ -15,6 +16,15 @@ stdenv.mkDerivation rec {
     tag = "v${version}";
     hash = "sha256-tINIwxyQn8eeJCHwRmAMo2TYRgrgJlGaUrnrgbmM3Jo=";
   };
+
+  patches = [
+    # cmake-4 compatibility patch
+    (fetchpatch {
+      name = "cmake-4.patch";
+      url = "https://github.com/flareteam/flare-game/commit/5b61dfd69f4ecbaca6439caa9ae41b3168e4d21a.patch";
+      hash = "sha256-5Um6LWAWQyialzO3KSebmLju0VOuz1S5dzavO9EWlLE=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
Without the change the build fails on` master as:

    flare-game> CMake Error at /build/innoextract-1.9/cmake/VersionScript.cmake:20 (cmake_minimum_required):
    flare-game>   Compatibility with CMake < 3.5 has been removed from CMake.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
