### PR TITLE
imagemagick: 7.1.2-4 -> 7.1.2-5

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -85,13 +85,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "imagemagick";
-  version = "7.1.2-4";
+  version = "7.1.2-5";
 
   src = fetchFromGitHub {
     owner = "ImageMagick";
     repo = "ImageMagick";
     tag = finalAttrs.version;
-    hash = "sha256-FOai96rtDWFQZ8vest0pDl6m2swQwXp7hVO2sZa1U2A=";
+    hash = "sha256-THStvhNWu4OYotzxksGJ6l6VeTVRNoJeKoRG1LaJhNI=";
   };
 
   outputs = [


### PR DESCRIPTION
imagemagick 7.1.2-4 fails to fetch on master branch, it appears that upstream pulled this version and git tag down.

Diff: https://github.com/ImageMagick/ImageMagick/compare/7.1.2-3...7.1.2-5

Changelog: https://github.com/ImageMagick/Website/blob/main/ChangeLog.md

```
user@nixos ~/nixpkgs (master)> nix-build -A imagemagick
these 2 derivations will be built:
  /nix/store/v75j3kv8kwsyj4nsk03wrh5kfh249s06-source.drv
  /nix/store/lm1nps345jxp4585qjk85ajgl6ai60g8-imagemagick-7.1.2-4.drv
resolved derivation: '/nix/store/v75j3kv8kwsyj4nsk03wrh5kfh249s06-source.drv' -> '/nix/store/d6kqnqjjmb28q9bwiglq2f3s625pzbky-source.drv'...
building '/nix/store/d6kqnqjjmb28q9bwiglq2f3s625pzbky-source.drv'...

trying https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-4.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Will retry in 1 second. 2 retries left.
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Warning: Problem (retrying all errors). Will retry in 1 second. 1 retry left.
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
error: cannot download source from any mirror
error: Cannot build '/nix/store/d6kqnqjjmb28q9bwiglq2f3s625pzbky-source.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/rvd1aff6rr7h9knc6cd9r7q9zvz8h2sl-source
       Last 20 log lines:
       >
       > trying https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-4.tar.gz
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Will retry in 1 second. 2 retries left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Will retry in 1 second. 1 retry left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 404
       > error: cannot download source from any mirror
       For full logs, run:
         nix log /nix/store/d6kqnqjjmb28q9bwiglq2f3s625pzbky-source.drv
error: Cannot build '/nix/store/lm1nps345jxp4585qjk85ajgl6ai60g8-imagemagick-7.1.2-4.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/7jby4a6wgqfyzz9j8pjr9ii0x8lsk484-imagemagick-7.1.2-4-doc
         /nix/store/p9jhqfawbx01pl7fm4m0rzaj15xrlxp1-imagemagick-7.1.2-4-dev
         /nix/store/v09x022p6i1a6acnqqsnh526g5qp21pj-imagemagick-7.1.2-4
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
