### PR TITLE
cxxopts: fix broken pkgconfig dependency on icu-cu

### DIFF
--- a/pkgs/by-name/cx/cxxopts/package.nix
+++ b/pkgs/by-name/cx/cxxopts/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   icu74,
   pkg-config,
@@ -19,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-baM6EX9D0yfrKxuPXyUUV9RqdrVLyygeG6x57xN8lc4=";
   };
 
-  buildInputs = lib.optionals enableUnicodeHelp [ icu74.dev ];
+  propagatedBuildInputs = lib.optionals enableUnicodeHelp [ icu74.dev ];
   cmakeFlags = [
     "-DCXXOPTS_BUILD_EXAMPLES=OFF"
   ]
@@ -36,6 +37,14 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace packaging/pkgconfig.pc.in \
       --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/jarro2783/cxxopts/commit/e98c73d665915b292a0592bf34fcbe8522035bc1.patch?full_index=1";
+      name = "fix-icu-uc-typo-in-pkgconfig.patch";
+      hash = "sha256-bqd3H66Op1/EkN2HLd84Obky4Y2ndPPY8MGZ5fqtdk4=";
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/jarro2783/cxxopts";

--- a/pkgs/by-name/cx/cxxopts/package.nix
+++ b/pkgs/by-name/cx/cxxopts/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/jarro2783/cxxopts/issues/332
   postPatch = ''
     substituteInPlace packaging/pkgconfig.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+      --replace-fail '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   patches = [

--- a/pkgs/by-name/cx/cxxopts/package.nix
+++ b/pkgs/by-name/cx/cxxopts/package.nix
@@ -6,6 +6,8 @@
   cmake,
   icu74,
   pkg-config,
+  testers,
+  validatePkgConfig,
   enableUnicodeHelp ? true,
 }:
 
@@ -25,7 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCXXOPTS_BUILD_EXAMPLES=OFF"
   ]
   ++ lib.optional enableUnicodeHelp "-DCXXOPTS_USE_UNICODE_HELP=TRUE";
-  nativeBuildInputs = [ cmake ] ++ lib.optionals enableUnicodeHelp [ pkg-config ];
+  nativeBuildInputs = [
+    cmake
+  ]
+  ++ lib.optionals enableUnicodeHelp [
+    pkg-config
+    validatePkgConfig
+  ];
 
   doCheck = true;
 
@@ -46,11 +54,19 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+  };
+
   meta = with lib; {
     homepage = "https://github.com/jarro2783/cxxopts";
     description = "Lightweight C++ GNU-style option parser library";
     license = licenses.mit;
     maintainers = [ maintainers.spease ];
+    pkgConfigModules = [ "cxxopts" ];
     platforms = platforms.all;
   };
 })


### PR DESCRIPTION
1. the .pc file typo'd this as `icu-cu` instead of `icu-uc`.
2. the package was not propagating icu, so consumers couldn't locate icu-uc's own .pc file.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
