### PR TITLE
allegro5: fix build with cmake 4

### DIFF
--- a/pkgs/development/libraries/allegro/5.nix
+++ b/pkgs/development/libraries/allegro/5.nix
@@ -4,6 +4,7 @@
   cmake,
   enet,
   fetchFromGitHub,
+  fetchpatch2,
   fixDarwinDylibNames,
   flac,
   freetype,
@@ -52,6 +53,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-agE3K+6VhhG/LO52fiesCsOq1fNYVRhdW7aKdPCbTOo=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "Bump CMake minimum version to 3.5";
+      url = "https://github.com/liballeg/allegro5/commit/6e93fcaabaafd81701f4cd1b74f4b69dd598bc9b.patch?full_index=1";
+      hash = "sha256-IEnn66bS2m6MVFCNf341yLtd7jTl2gflL5EFJFmbEt4=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/allegro/5.nix
+++ b/pkgs/development/libraries/allegro/5.nix
@@ -8,6 +8,7 @@
   fixDarwinDylibNames,
   flac,
   freetype,
+  gitUpdater,
   gtk3,
   libGL,
   libGLU,
@@ -56,7 +57,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch2 {
-      name = "Bump CMake minimum version to 3.5";
+      name = "Bump-CMake-minimum-version-to-3.5";
       url = "https://github.com/liballeg/allegro5/commit/6e93fcaabaafd81701f4cd1b74f4b69dd598bc9b.patch?full_index=1";
       hash = "sha256-IEnn66bS2m6MVFCNf341yLtd7jTl2gflL5EFJFmbEt4=";
     })
@@ -125,6 +126,10 @@ stdenv.mkDerivation rec {
     "out"
     "dev"
   ];
+
+  strictDeps = true;
+
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     description = "Game programming library";


### PR DESCRIPTION
tracking issue for cmake 4 build failures: https://github.com/NixOS/nixpkgs/issues/445447

also enabled strictDeps. diffed the package with and without it -- looks the same. i've been using `pkgsCross.aarch64-multiplatform.allegro5` where `strictDeps` is implicitly set true, and that's been fine. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
