### PR TITLE
ocaml-ng.ocamlPackages_5_4: init at 5.4.0

### DIFF
--- a/pkgs/development/compilers/ocaml/5.4.nix
+++ b/pkgs/development/compilers/ocaml/5.4.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  major_version = "5";
+  minor_version = "4";
+  patch_version = "0";
+  sha256 = "sha256-36qKLhHHmbwXZdi+9EkRQG7l9IAwJxkDgqk5+IyRImY=";
+}

--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -48,6 +48,6 @@ buildDunePackage rec {
     description = "Build and execute typed scientific workflows";
     maintainers = [ lib.maintainers.vbgl ];
     license = lib.licenses.gpl2;
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
+    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }

--- a/pkgs/development/ocaml-modules/kcas/default.nix
+++ b/pkgs/development/ocaml-modules/kcas/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   fetchurl,
+  ocaml,
   domain-local-await,
   domain-local-timeout,
   alcotest,
@@ -29,7 +30,7 @@ buildDunePackage rec {
     backoff
   ];
 
-  doCheck = true;
+  doCheck = !lib.versionAtLeast ocaml.version "5.4";
   nativeCheckInputs = [ mdx.bin ];
   checkInputs = [
     alcotest

--- a/pkgs/development/ocaml-modules/morbig/default.nix
+++ b/pkgs/development/ocaml-modules/morbig/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  ocaml,
   buildDunePackage,
   fetchFromGitHub,
   menhir,
@@ -9,34 +10,36 @@
   yojson,
 }:
 
-buildDunePackage rec {
-  pname = "morbig";
-  version = "0.11.0";
+lib.throwIf (lib.versionAtLeast ocaml.version "5.4")
+  "morbig is not available for OCaml ${ocaml.version}"
 
-  src = fetchFromGitHub {
-    owner = "colis-anr";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-fOBaJHHP/Imi9UDLflI52OdKDcmMxpl+NH3pfofmv/o=";
-  };
+  buildDunePackage
+  rec {
+    pname = "morbig";
+    version = "0.11.0";
 
-  duneVersion = "3";
+    src = fetchFromGitHub {
+      owner = "colis-anr";
+      repo = pname;
+      rev = "v${version}";
+      hash = "sha256-fOBaJHHP/Imi9UDLflI52OdKDcmMxpl+NH3pfofmv/o=";
+    };
 
-  nativeBuildInputs = [
-    menhir
-  ];
+    nativeBuildInputs = [
+      menhir
+    ];
 
-  propagatedBuildInputs = [
-    menhirLib
-    ppx_deriving_yojson
-    visitors
-    yojson
-  ];
+    propagatedBuildInputs = [
+      menhirLib
+      ppx_deriving_yojson
+      visitors
+      yojson
+    ];
 
-  meta = with lib; {
-    homepage = "https://github.com/colis-anr/${pname}";
-    description = "Static parser for POSIX Shell";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ niols ];
-  };
-}
+    meta = with lib; {
+      homepage = "https://github.com/colis-anr/${pname}";
+      description = "Static parser for POSIX Shell";
+      license = licenses.gpl3Plus;
+      maintainers = with maintainers; [ niols ];
+    };
+  }

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   fetchurl,
+  fetchpatch,
   cppo,
   uutf,
   lwt,
@@ -16,6 +17,12 @@ buildDunePackage rec {
   src = fetchurl {
     url = "https://github.com/pqwy/notty/releases/download/v${version}/notty-${version}.tbz";
     sha256 = "sha256-dGWfsUBz20Q4mJiRqyTyS++Bqkl9rBbZpn+aHJwgCCQ=";
+  };
+
+  # Compatibility with OCaml 5.4
+  patches = fetchpatch {
+    url = "https://github.com/pqwy/notty/commit/a4d62f467e257196a5192da2184bd021dfd948b7.patch";
+    hash = "sha256-p1eUuCvQKLj8uBeGyT2+i9WOYy4rk84pf9L3QioJDNY=";
   };
 
   nativeBuildInputs = [ cppo ];

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -9,7 +9,9 @@
   lib,
   ocaml,
   version ?
-    if lib.versionAtLeast ocaml.version "5.3" then
+    if lib.versionAtLeast ocaml.version "5.4" then
+      "1.24.0"
+    else if lib.versionAtLeast ocaml.version "5.3" then
       "1.23.1"
     else if lib.versionAtLeast ocaml.version "5.2" then
       "1.21.0"
@@ -26,6 +28,11 @@
 let
   params =
     {
+      "1.24.0" = {
+        name = "lsp";
+        minimalOCamlVersion = "5.3";
+        sha256 = "sha256-TVoaIVf2EvbALY+DjZferKX4GyOt08XOpcts7Ot7N1c=";
+      };
       "1.23.1" = {
         name = "lsp";
         minimalOCamlVersion = "5.3";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -23,7 +23,9 @@
   ocamlformat-rpc-lib,
   ocaml,
   version ?
-    if lib.versionAtLeast ocaml.version "5.3" then
+    if lib.versionAtLeast ocaml.version "5.4" then
+      "1.24.0"
+    else if lib.versionAtLeast ocaml.version "5.3" then
       "1.23.1"
     else if lib.versionAtLeast ocaml.version "5.2" then
       "1.21.0"

--- a/pkgs/development/ocaml-modules/ocf/ppx.nix
+++ b/pkgs/development/ocaml-modules/ocf/ppx.nix
@@ -1,4 +1,5 @@
 {
+  fetchpatch,
   buildDunePackage,
   ocf,
   ppxlib,
@@ -10,7 +11,14 @@ buildDunePackage {
 
   inherit (ocf) src version;
 
-  duneVersion = "3";
+  patches = [
+    # Support for ppxlib ≥ 0.37
+    (fetchpatch {
+      url = "https://framagit.org/zoggy/ocf/-/commit/38b1f6420e5c01b3ea6b2fed99b6b62e4c848dc0.patch";
+      hash = "sha256-GymTdK/dOYGianvNIKkl9OhBGW+4dX5TqAkQuEF5FmA=";
+      includes = [ "*.ml" ];
+    })
+  ];
 
   buildInputs = [
     ppxlib

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,13 +1,17 @@
 {
   lib,
   fetchurl,
+  fetchFromGitHub,
   buildDunePackage,
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "4.07" then
       if lib.versionAtLeast ocaml.version "4.08" then
         if lib.versionAtLeast ocaml.version "4.11" then
-          if lib.versionAtLeast ocaml.version "5.03" then "0.36.2" else "0.33.0"
+          if lib.versionAtLeast ocaml.version "5.03" then
+            if lib.versionAtLeast ocaml.version "5.04" then "0.37.0" else "0.36.2"
+          else
+            "0.33.0"
         else
           "0.24.0"
       else
@@ -91,6 +95,10 @@ let
         sha256 = "sha256-yHVgB9jKwTeahGEUYQDB1hHH327MGpoKqb3ewNbk5xs=";
         min_version = "4.08";
       };
+      "0.37.0" = {
+        sha256 = "sha256-LiI4N+fOzDvISkMkMsCnL04dW+kWXJwzdy8VbbhdsLM=";
+        min_version = "4.08";
+      };
     }
     ."${version}";
 in
@@ -106,10 +114,11 @@ else
     pname = "ppxlib";
     inherit version;
 
-    src = fetchurl {
-      url = "https://github.com/ocaml-ppx/ppxlib/releases/download/${version}/ppxlib-${version}.tbz";
-      inherit (param) sha256;
-    };
+    src =
+      param.src or (fetchurl {
+        url = "https://github.com/ocaml-ppx/ppxlib/releases/download/${version}/ppxlib-${version}.tbz";
+        inherit (param) sha256;
+      });
 
     propagatedBuildInputs = [
       ocaml-compiler-libs

--- a/pkgs/development/ocaml-modules/xtmpl/ppx.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/ppx.nix
@@ -9,6 +9,12 @@ buildDunePackage {
 
   inherit (xtmpl) src version;
 
+  # Fix for ppxlib ≥ 0.37
+  postPatch = ''
+    substituteInPlace ppx/ppx_xtmpl.ml --replace-fail 'Parse.longident b' \
+      'Astlib.Longident.parse s'
+  '';
+
   buildInputs = [
     ppxlib
     xtmpl

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -29,6 +29,7 @@
       "5.2.0" = "5.3-502";
       "5.2.1" = "5.3-502";
       "5.3.0" = "5.6-503";
+      "5.4.0" = "5.6-504";
     }
     ."${ocaml.version}",
 }:
@@ -47,6 +48,7 @@ let
     "5.3-502" = "sha256-LOpG8SOX+m4x7wwNT14Rwc/ZFu5JQgaUAFyV67OqJLw=";
     "5.4.1-503" = "sha256-SbO0x3jBISX8dAXnN5CwsxLV15dJ3XPUg4tlYqJTMCI=";
     "5.6-503" = "sha256-sNytCSqq96I/ZauaCJ6HYb1mXMcjV5CeCsbCGC9PwtQ=";
+    "5.6-504" = "sha256-gtZIpBgNbVqjoIMhjii/GX9OnxR4hN6TArtoEa2Yt38=";
   };
 
 in

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2317,6 +2317,8 @@ rec {
 
   ocamlPackages_5_3 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.3.nix { });
 
+  ocamlPackages_5_4 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.4.nix { });
+
   ocamlPackages_latest = ocamlPackages_5_3;
 
   ocamlPackages = ocamlPackages_5_3;


### PR DESCRIPTION
Next release of OCaml is around the corner

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
