### PR TITLE
superTux: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/su/superTux/package.nix
+++ b/pkgs/by-name/su/superTux/package.nix
@@ -32,6 +32,29 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed '1i#include <memory>' -i external/partio_zip/zip_manager.hpp # gcc12
+    # Fix build with cmake 4. Remove for version >= 0.6.4.
+    # See <https://github.com/SuperTux/supertux/pull/3093>
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.1)' \
+      'cmake_minimum_required(VERSION 4.0)'
+    substituteInPlace external/physfs/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 2.8.12)' \
+      'cmake_minimum_required(VERSION 4.0)'
+    substituteInPlace external/sexp-cpp/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.0)' \
+      'cmake_minimum_required(VERSION 4.0)'
+    substituteInPlace external/squirrel/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 2.8)' \
+      'cmake_minimum_required(VERSION 4.0)'
+    substituteInPlace external/tinygettext/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 2.4)' \
+      'cmake_minimum_required(VERSION 4.0)'
+    substituteInPlace external/SDL_ttf/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.0)' \
+      'cmake_minimum_required(VERSION 4.0)'
+    substituteInPlace external/discord-sdk/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required (VERSION 3.2.0)' \
+      'cmake_minimum_required (VERSION 4.0)'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
tracking issue for cmake 4 build failures: https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
