### PR TITLE
dash: 0.5.12 -> 0.5.13

### DIFF
--- a/pkgs/by-name/da/dash/package.nix
+++ b/pkgs/by-name/da/dash/package.nix
@@ -4,6 +4,7 @@
   buildPackages,
   pkg-config,
   fetchurl,
+  fetchpatch,
   libedit,
   runCommand,
   dash,
@@ -11,12 +12,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dash";
-  version = "0.5.12";
+  version = "0.5.13";
 
   src = fetchurl {
     url = "http://gondor.apana.org.au/~herbert/dash/files/dash-${finalAttrs.version}.tar.gz";
-    hash = "sha256-akdKxG6LCzKRbExg32lMggWNMpfYs4W3RQgDDKSo8oo=";
+    hash = "sha256-/Y2hIeMGsn9ZMwYTQXsYK4hE8R4mlTHMRyC/Uj4+Btc=";
   };
+
+  patches = [
+    # Inverted if typo
+    (fetchpatch {
+      url = "https://git.kernel.org/pub/scm/utils/dash/dash.git/patch/?id=6dcc007a72f13c3e518a65bffef571795ad6678c";
+      hash = "sha256-lOL/MaDHk1D/1387Exaa31mVOf3e70zRzluiFGEtUz4=";
+    })
+    # Missing NUL byte due to off-by-one
+    (fetchpatch {
+      url = "https://git.kernel.org/pub/scm/utils/dash/dash.git/patch/?id=85ae9ea3b7a9d5bc4e95d1bacf3446c545b6ed8b";
+      hash = "sha256-crsE64oC/LebzggijMHBnGHSmeAy4LB57LHcL62+zBw=";
+    })
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
Updates the dash shell to 0.5.13 and fetches two patches which fix two regressions introduced in that version, both typographical errors. The first one was an improperly-inverted if condition and the second one was caused by forgetting to make space for a NUL byte leading to autotools `./configure` script seeing corrupted filenames.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There is a changelog at [dash.git/tree/ChangeLog](https://git.kernel.org/pub/scm/utils/dash/dash.git/tree/ChangeLog), but it is from 2014, and I could not find an up-to-date one. Also, I could not find any unit tests for dash. There are probably lots of packages that depend on dash as it is a popular shell.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
I ran `nixpkgs-review rev HEAD` on this branch. nixpkgs-review, or more precisely nix-env, was using 13.8 gigs of memory doing... _something?_ ... and then WSL crashed.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
The shell seems to work, I created a new git worktree in my local copy of the dash repository and then ran dash's own configure script using the newly-built dash.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
