### PR TITLE
cruise: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9675,6 +9675,12 @@
     name = "Greaka";
     keys = [ { fingerprint = "6275 FB5C C9AC 9D85 FF9E  44C5 EE92 A5CD C367 118C"; } ];
   };
+  greatnatedev = {
+    email = "Nate@pelmel.net";
+    github = "GreatNateDev";
+    githubId = 99703235;
+    name = "Nate";
+  };
   greg = {
     email = "greg.hellings@gmail.com";
     github = "greg-hellings";

--- a/pkgs/by-name/cr/cruise/package.nix
+++ b/pkgs/by-name/cr/cruise/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cruise";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "NucleoFusion";
+    repo = "cruise";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0xIugbLlKlMODbMvsFzQXjKNNGY61tF4P/0loPlfs6o=";
+  };
+
+  vendorHash = "sha256-Zx1rZl5ljlsBNV1eQKPtQ+SgJV9l5rS8hwBe8nX9dYQ=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI for managing Docker containers, images, volumes, networks, and more";
+    homepage = "https://github.com/NucleoFusion/cruise";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ greatnatedev ];
+    mainProgram = "cruise";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
# cruise: init at 1.1.0

Adds `cruise`, a powerful TUI for managing Docker containers, images, volumes, networks, and more. Built with Go and Bubbletea.

**Homepage:** https://github.com/NucleoFusion/cruise

This package uses the prebuilt binary from the official releases.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md] and [pkgs/README.md].

## Notes

Currently only supports x86_64-linux (prebuilt binary). Open to converting to `buildGoModule` for multi-platform support if preferred.

My first contribution to a project, open to all criticism!

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md