### PR TITLE
libopenglrecorder: fix build against cmake 4

### DIFF
--- a/pkgs/by-name/li/libopenglrecorder/package.nix
+++ b/pkgs/by-name/li/libopenglrecorder/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   pkg-config,
   libjpeg,
@@ -22,6 +23,15 @@ stdenv.mkDerivation {
     rev = "c1b81ce26e62fae1aaa086b5cd337cb12361ea3d";
     sha256 = "13s2d7qs8z4w0gb3hx03n97xmwl07d4s473m4gw90qcvmz217kiz";
   };
+
+  patches = [
+    (fetchpatch2 {
+      # https://github.com/Benau/libopenglrecorder/pull/14
+      name = "support building against cmake 4";
+      url = "https://github.com/Benau/libopenglrecorder/commit/6101627e9952ec1a835dad38475f281878526052.patch?full_index=1";
+      hash = "sha256-EJIXiTPKLxwStHqQeWqjpv/9olqKOMse5lzCp/j0zJM=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
cmake4 tracking issue: <https://github.com/NixOS/nixpkgs/issues/445447>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] ~~[Package tests] at `passthru.tests`.~~ none present
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
