### PR TITLE
superTuxKart: fix build against cmake 4

### DIFF
--- a/pkgs/by-name/su/superTuxKart/package.nix
+++ b/pkgs/by-name/su/superTuxKart/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchsvn,
+  fetchpatch,
   cmake,
   pkg-config,
   makeWrapper,
@@ -75,6 +76,20 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-gqdaVvgNfCN40ZO/9y8+vTeIJPSq6udKxYZ/MAi4ZMM=";
   };
+
+  patches = [
+    # upstreamed patches required to build against cmake 4.0; remove with next release update.
+    (fetchpatch {
+      name = "Require-Cmake-3.6-or-higher";
+      url = "https://github.com/supertuxkart/stk-code/commit/7d4e8433c124c08c62f5335e2a884aeea71cf184.patch?full_index=1";
+      hash = "sha256-5q/Gf1I/maFPQ83NDIa7Sn6gtLfErwxP16fup4SZ+gc=";
+    })
+    (fetchpatch {
+      name = "Fixed-cmake-4.0-warnings";
+      url = "https://github.com/supertuxkart/stk-code/commit/184c80138faf5232c33ff99ffe7706e821be70c2.patch?full_index=1";
+      hash = "sha256-5zoDmKBRBC2rAUjgpmyc0ZCObGofjuImqk07Tr5K7Og=";
+    })
+  ];
 
   postPatch = ''
     # Deletes all bundled libs in stk-code/lib except those


### PR DESCRIPTION
this plus https://github.com/NixOS/nixpkgs/pull/449352 fix the `superTuxKart` build on master; can be merged in either order.

cmake4 tracking issue: https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
