### PR TITLE
dislocker: fix build against CMake >= 4.0

### DIFF
--- a/pkgs/by-name/di/dislocker/package.nix
+++ b/pkgs/by-name/di/dislocker/package.nix
@@ -31,6 +31,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/Aorimn/dislocker/commit/7744f87c75fcfeeb414d0957771042b10fb64e62.diff";
       sha256 = "0bpyccbbfjsidsrd2q9qylb95nvi8g3glb3jss7xmhywj86bhzr5";
     })
+    # fix compatibility with CMake (https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html)
+    # https://github.com/Aorimn/dislocker/pull/346
+    (fetchpatch {
+      name = "cmake-raise-minimum-required-version-to-3.5.patch";
+      url = "https://github.com/Aorimn/dislocker/commit/337d05dc7447436539f2fb481eef0e528a000b66.patch";
+      hash = "sha256-6LTRjaZfyGS2BCdpcJy/qo0r8soXJSZqWjZRbaKvcQk=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/di/dislocker/package.nix
+++ b/pkgs/by-name/di/dislocker/package.nix
@@ -9,15 +9,15 @@
   fuse,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dislocker";
   version = "0.7.3";
 
   src = fetchFromGitHub {
-    owner = "aorimn";
+    owner = "Aorimn";
     repo = "dislocker";
-    rev = "v${version}";
-    sha256 = "1ak68s1v5dwh8y2dy5zjybmrh0pnqralmyqzis67y21m87g47h2k";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-U8BD3kE1CH+Mjh/7SlXG9gKY6/LyF9+ER5C3soNGZqo=";
   };
 
   patches = [
@@ -28,8 +28,9 @@ stdenv.mkDerivation rec {
     #
     # https://github.com/Aorimn/dislocker/pull/246
     (fetchpatch {
-      url = "https://github.com/Aorimn/dislocker/commit/7744f87c75fcfeeb414d0957771042b10fb64e62.diff";
-      sha256 = "0bpyccbbfjsidsrd2q9qylb95nvi8g3glb3jss7xmhywj86bhzr5";
+      name = "feat-support-the-latest-FUSE-on-macOS.patch";
+      url = "https://github.com/Aorimn/dislocker/commit/7744f87c75fcfeeb414d0957771042b10fb64e62.patch";
+      hash = "sha256-JX+4DJLcw9qP1nIs+sZDcduSFvU4YdGyblFLtxZj/i4=";
     })
     # fix compatibility with CMake (https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html)
     # https://github.com/Aorimn/dislocker/pull/346
@@ -44,16 +45,18 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
   ];
+
   buildInputs = [
     fuse
     mbedtls_2
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Read BitLocker encrypted partitions in Linux";
-    homepage = "https://github.com/aorimn/dislocker";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ elitak ];
-    platforms = platforms.unix;
+    homepage = "https://github.com/Aorimn/dislocker";
+    changelog = "https://github.com/Aorimn/dislocker/raw/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ elitak ];
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## `nixpkgs-review` result

- Related to: https://github.com/NixOS/nixpkgs/issues/445447

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `4ed1f23de3dea1e44d2c39cae3bd1b942c0b6821`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>dislocker</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc