### PR TITLE
nixd: fix cross compilation

### DIFF
--- a/pkgs/development/tools/language-servers/nixd/default.nix
+++ b/pkgs/development/tools/language-servers/nixd/default.nix
@@ -17,6 +17,7 @@
   pkg-config,
   testers,
   python3,
+  writeText,
 }:
 
 let
@@ -37,6 +38,14 @@ let
       python3
       pkg-config
       llvmPackages.llvm # workaround for a meson bug, where llvm-config is not found, making the build fail
+    ];
+
+    # meson still wouldn't find llvm-config when cross compiling, unless we tell it to use the `-native` one.
+    mesonFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--cross-file=${writeText "crossfile.ini" ''
+        [binaries]
+        llvm-config = '${lib.getExe' llvmPackages.llvm.dev "llvm-config-native"}'
+      ''}"
     ];
 
     mesonBuildType = "release";


### PR DESCRIPTION
- fixes `nix-build -A pkgsCross.aarch64-multiplatform.nixd`
- follow-up to https://github.com/NixOS/nixpkgs/pull/448474

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
