### PR TITLE
cmake-language-server: skip failing tests

### DIFF
--- a/pkgs/by-name/cm/cmake-language-server/package.nix
+++ b/pkgs/by-name/cm/cmake-language-server/package.nix
@@ -45,11 +45,11 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = [
     cmake
     cmake-format
+    versionCheckHook
   ]
   ++ (with python3Packages; [
     pytest-datadir
     pytestCheckHook
-    versionCheckHook
   ]);
   versionCheckProgramArg = "--version";
 
@@ -58,6 +58,17 @@ python3Packages.buildPythonApplication rec {
   preCheck = ''
     echo "__version__ = \"$PDM_BUILD_SCM_VERSION\"" > cmake_language_server/version.py
   '';
+
+  disabledTests = [
+    # AssertionError: CTEST_SCP_COMMAND not found
+    "test_parse_variables"
+
+    # AssertionError: AddFileDependencies not found
+    "test_parse_modules"
+
+    # AssertionError: assert 'Boost' in [...
+    "test_completions_triggercharacter"
+  ];
 
   meta = {
     description = "CMake LSP Implementation";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @kira-bruneau

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
