### PR TITLE
nixos/cosmic: add missing dependencies

### DIFF
--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -89,10 +89,13 @@ in
           cosmic-screenshot
           cosmic-term
           cosmic-wallpapers
+          glib
           hicolor-icon-theme
+          networkmanagerapplet
           playerctl
           pop-icon-theme
           pop-launcher
+          pulseaudio
           xdg-user-dirs
         ]
         ++ lib.optionals config.services.flatpak.enable [

--- a/pkgs/by-name/ne/networkmanagerapplet/package.nix
+++ b/pkgs/by-name/ne/networkmanagerapplet/package.nix
@@ -73,6 +73,10 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file
     patchShebangs meson_post_install.py
+
+    # Prevent applet from autostarting in COSMIC, which has its own built-in network applet
+    substituteInPlace nm-applet.desktop.in \
+      --replace-fail "NotShowIn=KDE;GNOME;" "NotShowIn=KDE;GNOME;COSMIC;"
   '';
 
   passthru = {


### PR DESCRIPTION
#### Added missing dependencies for some cosmic tools

-  cosmic-settings network page
   - **_networkmanagerapplet_** for `nm-connection-editor`
   https://github.com/pop-os/cosmic-settings/blob/ae5f151932f936f3dd11a8467b8733d0fd260cdb/cosmic-settings/src/pages/networking/mod.rs#L375
- cosmic-settings-daemon
   - **_pulseaudio_** for `pactl`
   https://github.com/pop-os/cosmic-settings-daemon/blob/8616c40d235164779cd3f2ceec1fe9b2b4aceb40/src/pulse.rs#L16
   - **_glib_** for `gsettings`
   https://github.com/pop-os/cosmic-settings-daemon/blob/8616c40d235164779cd3f2ceec1fe9b2b4aceb40/src/theme.rs#L494

#### Patched **networkmanagerapplet**

- Added a small patch to disable autostart in COSMIC, following the [behavior of Pop_OS](https://github.com/pop-os/network-manager-applet/) (thanks @michaelBelsanti, @Pandapip1)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
