### PR TITLE
mkbootimg-osm0sis: init at 2022.11.09-unstable-2025-03-10

### DIFF
--- a/pkgs/by-name/mk/mkbootimg-osm0sis/package.nix
+++ b/pkgs/by-name/mk/mkbootimg-osm0sis/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mkbootimg-osm0sis";
+  version = "2022.11.09-unstable-2025-03-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "mkbootimg";
+    rev = "17cea80bd5af64e45cdf9e263cad7555030e0e86";
+    hash = "sha256-5ilpgQS5ctMpxTJRa8Wty1B0mNN+77/fS2FThNfAKZk=";
+  };
+
+  strictDeps = true;
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isGNU [
+      # Required with newer GCC
+      "-Wstringop-overflow=0"
+    ]
+  );
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 {mk,unpack}bootimg -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/mkbootimg";
+    description = "C rewrite of Android's boot image tools";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "mkbootimg";
+  };
+}


### PR DESCRIPTION
Add mkbooting-osm0sis, a C rewrite of mkbootimg from AOSP

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
