### PR TITLE
python3Packages.mpi4py: follow upstream checkPhase

### DIFF
--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -8,6 +8,8 @@
   toPythonModule,
   pytestCheckHook,
   mpiCheckPhaseHook,
+  mpi4py,
+  mpich,
 }:
 
 buildPythonPackage rec {
@@ -60,6 +62,10 @@ buildPythonPackage rec {
 
   passthru = {
     inherit mpi;
+
+    tests = {
+      mpich = mpi4py.override { mpi = mpich; };
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -6,7 +6,7 @@
   setuptools,
   mpi,
   toPythonModule,
-  pytestCheckHook,
+  pytest,
   mpiCheckPhaseHook,
   mpi4py,
   mpich,
@@ -42,16 +42,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "mpi4py" ];
 
   nativeCheckInputs = [
-    pytestCheckHook
+    pytest
     mpiCheckPhaseHook
-  ];
-  disabledTestPaths = lib.optionals (mpi.pname == "mpich") [
-    # These tests from some reason cause pytest to crash, and therefor it is
-    # hard to debug them. Upstream mentions these tests to raise issues in
-    # https://github.com/mpi4py/mpi4py/issues/418  but the workaround suggested
-    # there (setting MPI4PY_RC_RECV_MPROBE=0) doesn't work.
-    "test/test_util_pool.py"
-    "demo/futures/test_futures.py"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -59,6 +51,19 @@ buildPythonPackage rec {
   # skip spawn related tests for openmpi implemention
   # see https://github.com/mpi4py/mpi4py/issues/545#issuecomment-2343011460
   env.MPI4PY_TEST_SPAWN = if mpi.pname == "openmpi" then 0 else 1;
+
+  # follow upstream's checkPhase
+  # see https://github.com/mpi4py/mpi4py/blob/4.1.0/.github/workflows/ci-test.yml#L92-L95
+  checkPhase = ''
+    runHook preCheck
+
+    echo 'Testing mpi4py (np=1)'
+    mpiexec -n 1 python test/main.py -v
+    echo 'Testing mpi4py (np=2)'
+    mpiexec -n 2 python test/main.py -v -f -e spawn
+
+    runHook postCheck
+  '';
 
   passthru = {
     inherit mpi;


### PR DESCRIPTION
# The issue
mpi4py build with mpich has been broken

# The cause
some tests hang when doing check with mpich e.g. test/test_envrion.py
one can reproduce the hang via
```
pytest test/test_envrion.py
```
the test will complain missing the mpiexec procedure name and hangs

# The solution
prefixing pytest with mpiexec
```
mpiexec -n 1 pytest test/test_envrion.py
```
moreover, we follow upstream's checkPhase in https://github.com/mpi4py/mpi4py/blob/4.1.0/.github/workflows/ci-test.yml#L92-L95. 
```
runHook preCheck

echo 'Testing mpi4py (np=1)'
mpiexec -n 1 python test/main.py -v
echo 'Testing mpi4py (np=2)'
mpiexec -n 2 python test/main.py -v -f -e spawn

runHook postCheck
```
This is also exactly how archlinux do they check https://gitlab.archlinux.org/archlinux/packaging/packages/python-mpi4py/-/blob/main/PKGBUILD?ref_type=heads#L46. 

# pros and cons
## pros: 
1. now mpi4py build with mpich
2. allow doing check with nproc >1
3. make it easier maintaining the checkPhase in python3Packages.mpi4py

## cons
1. unless we really need to disable some tests specifically on nixos, we need follow the pytestCheckHook framework, but 
before that we should allow prefixing exec command in pytestCheckHook. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
