### PR TITLE
libretro.pcsx2: 0-unstable-2025-09-14 -> 0-unstable-2025-09-29; fix build

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/pcsx2.nix
+++ b/pkgs/applications/emulators/libretro/cores/pcsx2.nix
@@ -11,13 +11,13 @@
 }:
 mkLibretroCore {
   core = "pcsx2";
-  version = "0-unstable-2025-09-14";
+  version = "0-unstable-2025-09-29";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "ps2";
-    rev = "bb03c99fa968b50309bd80d74598f053fe9168ce";
-    hash = "sha256-qIdrsLQWH29PGL0TNcUtFw6aSFUJKJccKrhMoi/vYCA=";
+    rev = "9485a53fa5aa2bff17e04518116107f81a8c82e3";
+    hash = "sha256-xkRPESbLNX9AFOIdEA9iW4Xn7hdJXfdi+TEbegC8KXA=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/emulators/libretro/cores/pcsx2.nix
+++ b/pkgs/applications/emulators/libretro/cores/pcsx2.nix
@@ -33,26 +33,20 @@ mkLibretroCore {
     xz
   ];
 
-  # CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
-  # Compatibility with CMake < 3.5 has been removed from CMake.
-  #
-  # Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
-  # to tell CMake that the project requires at least <min> but has been updated
-  # to work with policies introduced by <max> or earlier.
-  #
-  # Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
-  cmakeFlags = [
-    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-  ];
-
-  # libretro/ps2 needs at least those flags to compile, and probably doesn't
-  # work on x86_64-v1
-  # https://github.com/libretro/ps2/blob/397b8f54b92aeffd2dd502c2c9b601305fb1de9d/cmake/BuildParameters.cmake#L101
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-msse"
-    "-msse2"
-    "-msse4.1"
-    "-mfxsr"
+  cmakeFlags = with lib.strings; [
+    # Workaround the following error:
+    # > CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
+    # > Compatibility with CMake < 3.5 has been removed from CMake.
+    #
+    # > Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+    # > to tell CMake that the project requires at least <min> but has been updated
+    # > to work with policies introduced by <max> or earlier.
+    #
+    # > Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+    (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+    # Explicitly set ARCH_FLAG to avoid -march=native
+    # https://github.com/libretro/ps2/blob/9485a53fa5aa2bff17e04518116107f81a8c82e3/cmake/BuildParameters.cmake#L106-L117
+    (cmakeFeature "ARCH_FLAG" "-msse4.1")
   ];
 
   makefile = "Makefile";

--- a/pkgs/applications/emulators/libretro/cores/pcsx2.nix
+++ b/pkgs/applications/emulators/libretro/cores/pcsx2.nix
@@ -33,6 +33,18 @@ mkLibretroCore {
     xz
   ];
 
+  # CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
+  # Compatibility with CMake < 3.5 has been removed from CMake.
+  #
+  # Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+  # to tell CMake that the project requires at least <min> but has been updated
+  # to work with policies introduced by <max> or earlier.
+  #
+  # Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+  cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
   # libretro/ps2 needs at least those flags to compile, and probably doesn't
   # work on x86_64-v1
   # https://github.com/libretro/ps2/blob/397b8f54b92aeffd2dd502c2c9b601305fb1de9d/cmake/BuildParameters.cmake#L101


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #449393.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
