### PR TITLE
libxml2: fix attribute normalization regression

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -58,6 +58,15 @@ let
         tag = "v${packages.libxml2.version}";
         hash = "sha256-jumHSiIMDzqG2hvPUdcBP8LsszcU+loOY+vqEh/0Yqo=";
       };
+      extraPatches = [
+        # Fixes a regression in attribute normalization.
+        # Also see https://www.postgresql.org/message-id/flat/0756AC61-FBA3-46E2-B3C2-19B58B65EBDC%2540yesql.se
+        # To be removed with 2.15.1.
+        (fetchpatch2 {
+          url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/da45a190f718e8e2f0e3d2a6325ffa23abc8b90c.patch";
+          hash = "sha256-dE5DxkP+LBZ8N5V3x02Q1xOU9IXDvvr64xzcln0QH0E=";
+        })
+      ];
       extraMeta = {
         maintainers = with lib.maintainers; [
           jtojnar

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -2,7 +2,7 @@
   lib,
   callPackage,
   fetchFromGitLab,
-  fetchpatch2,
+  fetchpatch,
 }:
 
 let
@@ -20,15 +20,15 @@ let
         # same as upstream patch but fixed conflict and added required import:
         # https://gitlab.gnome.org/GNOME/libxml2/-/commit/acbbeef9f5dcdcc901c5f3fa14d583ef8cfd22f0.diff
         ./CVE-2025-6021.patch
-        (fetchpatch2 {
+        (fetchpatch {
           name = "CVE-2025-49794-49796.patch";
           url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/f7ebc65f05bffded58d1e1b2138eb124c2e44f21.patch";
-          hash = "sha256-k+IGq6pbv9EA7o+uDocEAUqIammEjLj27Z+2RF5EMrs=";
+          hash = "sha256-p5Vc/lkakHKsxuFNnCQtFczjqFJBeLnCwIwv2GnrQco=";
         })
-        (fetchpatch2 {
+        (fetchpatch {
           name = "CVE-2025-49795.patch";
           url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/c24909ba2601848825b49a60f988222da3019667.patch";
-          hash = "sha256-r7PYKr5cDDNNMtM3ogNLsucPFTwP/uoC7McijyLl4kU=";
+          hash = "sha256-vICVSb+X89TTE4QY92/v/6fRk77Hy9vzEWWsADHqMlk=";
           excludes = [ "runtest.c" ]; # tests were rewritten in C and are on schematron for 2.13.x, meaning this does not apply
         })
         # same as upstream, fixed conflicts
@@ -62,9 +62,9 @@ let
         # Fixes a regression in attribute normalization.
         # Also see https://www.postgresql.org/message-id/flat/0756AC61-FBA3-46E2-B3C2-19B58B65EBDC%2540yesql.se
         # To be removed with 2.15.1.
-        (fetchpatch2 {
+        (fetchpatch {
           url = "https://gitlab.gnome.org/GNOME/libxml2/-/commit/da45a190f718e8e2f0e3d2a6325ffa23abc8b90c.patch";
-          hash = "sha256-dE5DxkP+LBZ8N5V3x02Q1xOU9IXDvvr64xzcln0QH0E=";
+          hash = "sha256-wqmFszr7w1Lte12YR6Ug7Ng7fXABzizwUsJU1EhylgU=";
         })
       ];
       extraMeta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/pull/444599#issuecomment-3376020863

2.15.0 introduced a regression in attribute normalization that affected PostgreSQL among others. PostgreSQL fixed the issue on their side by manually normalizing the failing attributes, which has already been merged to staging. As we aren't sure what other packages are possibly affected, we're pulling in the fix for the regression from upstream early, which will be included in 2.15.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
