### PR TITLE
ipfs-cluster: fix build

### DIFF
--- a/pkgs/by-name/ip/ipfs-cluster/package.nix
+++ b/pkgs/by-name/ip/ipfs-cluster/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo124Module (finalAttrs: {
   pname = "ipfs-cluster";
   version = "1.1.4";
 

--- a/pkgs/by-name/ip/ipfs-cluster/package.nix
+++ b/pkgs/by-name/ip/ipfs-cluster/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "ipfs-cluster";
   version = "1.1.4";
 
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "ipfs-cluster";
     repo = "ipfs-cluster";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-mdLrLiRNudpQ8i0lvwoNAqhSWJ8VMEC1ZRxXHWHpqLY=";
   };
 
@@ -26,4 +26,4 @@ buildGoModule rec {
       jglukasik
     ];
   };
-}
+})

--- a/pkgs/by-name/ip/ipfs-cluster/package.nix
+++ b/pkgs/by-name/ip/ipfs-cluster/package.nix
@@ -17,6 +17,8 @@ buildGoModule (finalAttrs: {
     hash = "sha256-mdLrLiRNudpQ8i0lvwoNAqhSWJ8VMEC1ZRxXHWHpqLY=";
   };
 
+  __darwinAllowLocalNetworking = true; # required for tests
+
   meta = with lib; {
     description = "Allocate, replicate, and track Pins across a cluster of IPFS daemons";
     homepage = "https://ipfscluster.io";

--- a/pkgs/by-name/ip/ipfs-cluster/package.nix
+++ b/pkgs/by-name/ip/ipfs-cluster/package.nix
@@ -17,6 +17,18 @@ buildGo124Module (finalAttrs: {
     hash = "sha256-mdLrLiRNudpQ8i0lvwoNAqhSWJ8VMEC1ZRxXHWHpqLY=";
   };
 
+  checkFlags =
+    let
+      skippedTests = [
+        # Flaky test, sometimes fails with:
+        # --- FAIL: TestClustersPeerAddInUnhealthyCluster (7.58s)
+        #     peer_manager_test.go:247: failed to dial: failed to dial QmSookyjcPhxchnHeo2jtssHqe8zdmhgEQiY61yUcWjWp5: all dials failed
+        #           * [/ip4/127.0.0.1/tcp/46571] dial backoff
+        "TestClustersPeerAddInUnhealthyCluster"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
   __darwinAllowLocalNetworking = true; # required for tests
 
   meta = with lib; {


### PR DESCRIPTION
Compile ipfs-cluster with Go 1.24 instead of Go 1.25 because:
- Their CI uses Go 1.24, see https://github.com/ipfs-cluster/ipfs-cluster/blob/v1.1.4/.github/workflows/tests.yml#L10
- ipfs-cluster fails to compile with Go 1.25:
  ```
  Building subPackage .
  Building subPackage ./adder
  Building subPackage ./adder/adderutils
  Building subPackage ./adder/ipfsadd
  Building subPackage ./adder/sharding
  Building subPackage ./adder/single
  Building subPackage ./allocator/balanced
  Building subPackage ./api
  Building subPackage ./api/common
  Building subPackage ./api/common/test
  Building subPackage ./api/ipfsproxy
  Building subPackage ./api/pb
  Building subPackage ./api/pinsvcapi
  Building subPackage ./api/pinsvcapi/pinsvc
  Building subPackage ./api/rest
  Building subPackage ./api/rest/client
  Building subPackage ./cmd/ipfs-cluster-ctl
  Building subPackage ./cmd/ipfs-cluster-follow
  # github.com/cockroachdb/swiss
  vendor/github.com/cockroachdb/swiss/map.go:286:7: undefined: hashFn
  vendor/github.com/cockroachdb/swiss/map.go:337:14: undefined: getRuntimeHasher
  vendor/github.com/cockroachdb/swiss/map.go:338:22: undefined: fastrand64
  vendor/github.com/cockroachdb/swiss/map.go:600:23: undefined: fastrand64
  vendor/github.com/cockroachdb/swiss/map.go:649:19: undefined: fastrand64
  vendor/github.com/cockroachdb/swiss/map.go:670:20: undefined: fastrand64
  vendor/github.com/cockroachdb/swiss/options.go:30:14: undefined: hashFn
  ```

Also use the `finalAttrs` pattern and skip a flaky test.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
