### PR TITLE
pystring: 1.1.4-unstable-2025-06-23 -> 1.1.4-unstable-2025-10-07

### DIFF
--- a/pkgs/by-name/py/pystring/package.nix
+++ b/pkgs/by-name/py/pystring/package.nix
@@ -2,21 +2,27 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  cmake,
+  meson,
+  ninja,
+  pkg-config,
 }:
 
 stdenv.mkDerivation {
   pname = "pystring";
-  version = "1.1.4-unstable-2025-06-23";
+  version = "1.1.4-unstable-2025-10-07";
 
   src = fetchFromGitHub {
     owner = "imageworks";
     repo = "pystring";
-    rev = "02ef1186d6b77bc35f385bd4db2da75b4736adb7";
-    hash = "sha256-M0/nDxeRo8NBQ3/SvBc0i5O4ImIP/A8ry/jA27dLybg=";
+    rev = "a09708a4870db7862e1a1aa42658c8e6e36547e7";
+    hash = "sha256-S43OkXcOCzPds2iDLunqg9a1zOiODo2dB9ReuOfe7Bw=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
This PR also switch build system to meson since its meson build system supports pkg-config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
