### PR TITLE
calibre: fix build for aarch64

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -233,6 +233,7 @@ stdenv.mkDerivation (finalAttrs: {
       $ETN 'test_recipe_browser_webengine'
 
       ${lib.optionalString stdenv.hostPlatform.isAarch64 "$ETN 'test_piper'"} # https://github.com/microsoft/onnxruntime/issues/10038
+      ${lib.optionalString stdenv.hostPlatform.isAarch64 "$ETN 'test_plugins'"} # loading onnxruntime on aarch64 tries to access /sys
       ${lib.optionalString (!unrarSupport) "$ETN 'test_unrar'"}
     )
 


### PR DESCRIPTION
This PR addresses an issue related to #448801, with additional background available in #351917.

## Problem

On aarch64, running something involving the onnxruntime library fail during the Nix build because they attempt to access /sys, which is not permitted inside the Nix build sandbox.

The build succeeds when explicitly allowing access:

```bash
nix build .#calibre --system aarch64-linux --option extra-sandbox-paths /sys
```

## Solution

Disable the `test_plugins` test, which relies on piper-tts (and thus onnxruntime).
By skipping this test, we avoid the `/sys` access and prevent the onnxruntime error, allowing the package to run the tests successfully in the sandboxed environment.


## Important info

The build may still fail until https://github.com/kovidgoyal/calibre/pull/2885 is merged and included in a new Calibre release.
If that patch isn’t yet available, you may encounter a failure similar to:

```
> test_winutil (calibre.test_build.BuildTest.test_winutil) ... skipped 'winutil is windows only' [0.0 s]
> test_wpd (calibre.test_build.BuildTest.test_wpd) ... skipped 'WPD is windows only' [0.0 s]
> test_zeroconf (calibre.test_build.BuildTest.test_zeroconf) ... ok [3.6 s]
> test_forked_map (calibre.utils.forked_map.find_tests.<locals>.TestForkedMap.test_forked_map) ... ok [1.2 s]
>
> ======================================================================
> FAIL: test_fts_search (calibre.db.tests.fts_api.FTSAPITest.test_fts_search)
> ----------------------------------------------------------------------
> Traceback (most recent call last):
>   File "/build/calibre-8.12.0/src/calibre/db/tests/fts_api.py", line 149, in test_fts_search
>     self.assertFalse(fts.all_currently_dirty())
>     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
> AssertionError: [(2, 'MD')] is not false
>
> ----------------------------------------------------------------------
> Ran 342 tests in 476.872s
>
> FAILED (failures=1, skipped=10)

```
This failure can occur depending on whether `Hydra` has sufficient power to complete the database check within a 10 ms timeout. Unfortunately, this behavior is known and somewhat nondeterministic (it failed on my nix build using crossCompiling, and the calibre PR fixes this).

**This patch is independent of the upstream Calibre PR, so it can be merged without waiting for the next Calibre release.**


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
