### PR TITLE
newsboat: fix build on darwin, use mkDerivation/cargoSetupHook

### DIFF
--- a/pkgs/by-name/ne/newsboat/package.nix
+++ b/pkgs/by-name/ne/newsboat/package.nix
@@ -36,6 +36,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CyhyzNw2LXwIVf/SX2rQRvEex5LmjZfZKgCe88jthz0=";
   };
 
+  # fix macOS build
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/newsboat/newsboat/commit/4139a0ba1ec87e442ef1408823b07fc739742f9d.patch";
+      hash = "sha256-zdtdpUQGATq/9w+hAY/Va9Ob95c8VT2D9aKFmAF+O0c=";
+    })
+    (fetchpatch {
+      url = "https://github.com/newsboat/newsboat/commit/4eb748b6b6b63acddb3582e012442e519e8704ea.patch";
+      hash = "sha256-A/0WbuMIapTsLoziUPr95ZctIr2hW7JOJSdMVaWayYI=";
+    })
+  ];
+
   # allow other ncurses versions on Darwin
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace config.sh --replace-fail "ncurses5.4" "ncurses"

--- a/pkgs/by-name/ne/newsboat/package.nix
+++ b/pkgs/by-name/ne/newsboat/package.nix
@@ -3,6 +3,9 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch,
+  cargo,
+  rustc,
   stfl,
   sqlite,
   curl,
@@ -17,7 +20,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "newsboat";
   version = "2.41";
 
@@ -28,19 +31,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-LhEhbK66OYwAD/pel81N7Hgh/xEvnFR8GlZzgqZIe5M=";
   };
 
-  cargoHash = "sha256-CyhyzNw2LXwIVf/SX2rQRvEex5LmjZfZKgCe88jthz0=";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-CyhyzNw2LXwIVf/SX2rQRvEex5LmjZfZKgCe88jthz0=";
+  };
 
-  # TODO: Check if that's still needed
+  # allow other ncurses versions on Darwin
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Allow other ncurses versions on Darwin
-    substituteInPlace config.sh \
-      --replace "ncurses5.4" "ncurses"
+    substituteInPlace config.sh --replace-fail "ncurses5.4" "ncurses"
   '';
 
   nativeBuildInputs = [
     pkg-config
     asciidoctor
     gettext
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     makeWrapper
@@ -60,12 +67,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gettext
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ];
-
-  postBuild = ''
-    make -j $NIX_BUILD_CORES prefix="$out"
-  '';
-
   # https://github.com/NixOS/nixpkgs/pull/98471#issuecomment-703100014 . We set
   # these for all platforms, since upstream's gettext crate behavior might
   # change in the future.
@@ -73,16 +74,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   GETTEXT_INCLUDE_DIR = "${lib.getDev gettext}/include";
   GETTEXT_BIN_DIR = "${lib.getBin gettext}/bin";
 
+  makeFlags = [ "prefix=$(out)" ];
+  enableParallelBuilding = true;
+
   doCheck = true;
+  checkTarget = "test";
 
-  preCheck = ''
-    make -j $NIX_BUILD_CORES test
-  '';
-
-  postInstall = ''
-    make -j $NIX_BUILD_CORES prefix="$out" install
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     for prog in $out/bin/*; do
       wrapProgram "$prog" --prefix DYLD_LIBRARY_PATH : "${stfl}/lib"
     done
@@ -91,13 +89,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
   };
-
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 newsboat $out/bin/newsboat
-    install -Dm755 podboat $out/bin/podboat
-    runHook postInstall
-  '';
 
   meta = {
     homepage = "https://newsboat.org/";


### PR DESCRIPTION
Fixes the build on darwin by pulling in one file of https://github.com/newsboat/newsboat/pull/3185 (the tests hadn't been changed on the tagged release yet).

Now uses `--replace-fail` instead of the TODO note so we notice when it fails.

Let the Makefile handle most things:
- `NIX_BUILD_CORES` is set/controlled through `enableParallelBuilding`
- the resulting output directories are 1:1 the same as before, we just don't need to run `install` ourselves.

And on my systems, it looked like we don't need `NIX_CFLAGS_COMPILE` anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
