### PR TITLE
python3.pkgs.icalendar: build offline documentation

### DIFF
--- a/pkgs/development/python-modules/icalendar/default.nix
+++ b/pkgs/development/python-modules/icalendar/default.nix
@@ -9,12 +9,19 @@
   tzdata,
   hypothesis,
   pytestCheckHook,
+  sphinxHook,
+  sphinx-copybutton,
+  pydata-sphinx-theme,
 }:
 
 buildPythonPackage rec {
   version = "6.3.1";
   pname = "icalendar";
   pyproject = true;
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   src = fetchFromGitHub {
     owner = "collective";
@@ -37,6 +44,12 @@ buildPythonPackage rec {
   dependencies = [
     python-dateutil
     tzdata
+  ];
+
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-copybutton
+    pydata-sphinx-theme
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
# python3.pkgs.icalendar: build offline documentation

```
python3.pkgs.icalendar: build offline documentation
```

## Build info of packages affected directly
### python3.pkgs.icalendar

<details><summary>content of python3.pkgs.icalendar.dist</summary>

```
/nix/store/r0j8kps3jynggclvg0fk18rf1gdc9782-python3.13-icalendar-6.3.1-dist
└── icalendar-6.3.1-py3-none-any.whl

1 directory, 1 file
```
</details>

<details><summary>content of python3.pkgs.icalendar.doc</summary>

```
/nix/store/4am3jjl7pix7l3k7v3cv34szxn4zpmkk-python3.13-icalendar-6.3.1-doc
└── share
    └── doc
        └── python3.13-icalendar-6.3.1
            └── html
                ├── _modules
                │   ├── icalendar
                │   │   ├── alarms.html
                │   │   ├── attr.html
                │   │   ├── cal.html
                │   │   ├── caselessdict.html
                │   │   ├── cli.html
                │   │   ├── enums.html
                │   │   ├── error.html
                │   │   ├── param.html
                │   │   ├── parser.html
                │   │   ├── parser_tools.html
                │   │   ├── prop.html
                │   │   ├── timezone
                │   │   │   ├── tzid.html
                │   │   │   └── tzp.html
                │   │   ├── timezone.html
                │   │   └── tools.html
                │   └── index.html
                ├── _static
                │   ├── basic.css
                │   ├── check-solid.svg
                │   ├── clipboard.min.js
                │   ├── copy-button.svg
                │   ├── copybutton.css
                │   ├── copybutton.js
                │   ├── copybutton_funcs.js
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── language_data.js
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── scripts
                │   │   ├── bootstrap.js
                │   │   ├── bootstrap.js.LICENSE.txt
                │   │   ├── bootstrap.js.map
                │   │   ├── fontawesome.js
                │   │   ├── fontawesome.js.LICENSE.txt
                │   │   ├── fontawesome.js.map
                │   │   ├── pydata-sphinx-theme.js
                │   │   └── pydata-sphinx-theme.js.map
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── styles
                │   │   ├── pydata-sphinx-theme.css
                │   │   ├── pydata-sphinx-theme.css.map
                │   │   └── theme.css
                │   ├── vendor
                │   │   └── fontawesome
                │   │       └── webfonts
                │   │           ├── fa-brands-400.ttf
                │   │           ├── fa-brands-400.woff2
                │   │           ├── fa-regular-400.ttf
                │   │           ├── fa-regular-400.woff2
                │   │           ├── fa-solid-900.ttf
                │   │           └── fa-solid-900.woff2
                │   └── webpack-macros.html
                ├── about.html
                ├── api.html
                ├── changelog.html
                ├── cli.html
                ├── contributing.html
                ├── credits.html
                ├── genindex.html
                ├── index.html
                ├── install.html
                ├── license.html
                ├── maintenance.html
                ├── objects.inv
                ├── py-modindex.html
                ├── search.html
                ├── searchindex.js
                ├── security.html
                └── usage.html

14 directories, 67 files
```
</details>

<details><summary>content of python3.pkgs.icalendar.out</summary>

```
/nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1
├── bin
│   └── icalendar
├── lib
│   └── python3.13
│       └── site-packages
│           ├── icalendar
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   ├── __init__.cpython-313.pyc
│           │   │   ├── _version.cpython-313.opt-1.pyc
│           │   │   ├── _version.cpython-313.pyc
│           │   │   ├── alarms.cpython-313.opt-1.pyc
│           │   │   ├── alarms.cpython-313.pyc
│           │   │   ├── attr.cpython-313.opt-1.pyc
│           │   │   ├── attr.cpython-313.pyc
│           │   │   ├── cal.cpython-313.opt-1.pyc
│           │   │   ├── cal.cpython-313.pyc
│           │   │   ├── caselessdict.cpython-313.opt-1.pyc
│           │   │   ├── caselessdict.cpython-313.pyc
│           │   │   ├── cli.cpython-313.opt-1.pyc
│           │   │   ├── cli.cpython-313.pyc
│           │   │   ├── enums.cpython-313.opt-1.pyc
│           │   │   ├── enums.cpython-313.pyc
│           │   │   ├── error.cpython-313.opt-1.pyc
│           │   │   ├── error.cpython-313.pyc
│           │   │   ├── param.cpython-313.opt-1.pyc
│           │   │   ├── param.cpython-313.pyc
│           │   │   ├── parser.cpython-313.opt-1.pyc
│           │   │   ├── parser.cpython-313.pyc
│           │   │   ├── parser_tools.cpython-313.opt-1.pyc
│           │   │   ├── parser_tools.cpython-313.pyc
│           │   │   ├── prop.cpython-313.opt-1.pyc
│           │   │   ├── prop.cpython-313.pyc
│           │   │   ├── tools.cpython-313.opt-1.pyc
│           │   │   ├── tools.cpython-313.pyc
│           │   │   ├── version.cpython-313.opt-1.pyc
│           │   │   └── version.cpython-313.pyc
│           │   ├── _version.py
│           │   ├── alarms.py
│           │   ├── attr.py
│           │   ├── cal.py
│           │   ├── caselessdict.py
│           │   ├── cli.py
│           │   ├── enums.py
│           │   ├── error.py
│           │   ├── param.py
│           │   ├── parser.py
│           │   ├── parser_tools.py
│           │   ├── prop.py
│           │   ├── tests
│           │   │   ├── __init__.py
│           │   │   ├── __pycache__
│           │   │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   │   ├── __init__.cpython-313.pyc
│           │   │   │   ├── conftest.cpython-313.opt-1.pyc
│           │   │   │   ├── conftest.cpython-313.pyc
│           │   │   │   ├── test_bom_calendar.cpython-313.opt-1.pyc
│           │   │   │   ├── test_bom_calendar.cpython-313.pyc
│           │   │   │   ├── test_cli_tool.cpython-313.opt-1.pyc
│           │   │   │   ├── test_cli_tool.cpython-313.pyc
│           │   │   │   ├── test_components_break_on_bad_ics.cpython-313.opt-1.pyc
│           │   │   │   ├── test_components_break_on_bad_ics.cpython-313.pyc
│           │   │   │   ├── test_encoding.cpython-313.opt-1.pyc
│           │   │   │   ├── test_encoding.cpython-313.pyc
│           │   │   │   ├── test_equality.cpython-313.opt-1.pyc
│           │   │   │   ├── test_equality.cpython-313.pyc
│           │   │   │   ├── test_examples.cpython-313.opt-1.pyc
│           │   │   │   ├── test_examples.cpython-313.pyc
│           │   │   │   ├── test_icalendar.cpython-313.opt-1.pyc
│           │   │   │   ├── test_icalendar.cpython-313.pyc
│           │   │   │   ├── test_issue_116.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_116.cpython-313.pyc
│           │   │   │   ├── test_issue_165_missing_event.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_165_missing_event.cpython-313.pyc
│           │   │   │   ├── test_issue_168_parsing_invalid_calendars_no_warning.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_168_parsing_invalid_calendars_no_warning.cpython-313.pyc
│           │   │   │   ├── test_issue_218_parse_calendar.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_218_parse_calendar.cpython-313.pyc
│           │   │   │   ├── test_issue_27_period.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_27_period.cpython-313.pyc
│           │   │   │   ├── test_issue_301_add_rrule_as_string.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_301_add_rrule_as_string.cpython-313.pyc
│           │   │   │   ├── test_issue_318_skip_default_parameters.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_318_skip_default_parameters.cpython-313.pyc
│           │   │   │   ├── test_issue_322_single_strings_characters_split_into_multiple_categories.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_322_single_strings_characters_split_into_multiple_categories.cpython-313.pyc
│           │   │   │   ├── test_issue_336_dateutil_timezone.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_336_dateutil_timezone.cpython-313.pyc
│           │   │   │   ├── test_issue_348_exception_parsing_value.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_348_exception_parsing_value.cpython-313.pyc
│           │   │   │   ├── test_issue_350.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_350.cpython-313.pyc
│           │   │   │   ├── test_issue_500_vboolean_for_parameter.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_500_vboolean_for_parameter.cpython-313.pyc
│           │   │   │   ├── test_issue_557_encode_native_parameters.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_557_encode_native_parameters.cpython-313.pyc
│           │   │   │   ├── test_issue_662_component_properties.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_662_component_properties.cpython-313.pyc
│           │   │   │   ├── test_issue_716_alarm_time_computation.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_716_alarm_time_computation.cpython-313.pyc
│           │   │   │   ├── test_issue_720_uid_property.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_720_uid_property.cpython-313.pyc
│           │   │   │   ├── test_issue_722_generate_vtimezone.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_722_generate_vtimezone.cpython-313.pyc
│           │   │   │   ├── test_issue_798_property_parameters.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_798_property_parameters.cpython-313.pyc
│           │   │   │   ├── test_issue_802.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_802.cpython-313.pyc
│           │   │   │   ├── test_issue_828.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_828.cpython-313.pyc
│           │   │   │   ├── test_issue_836_do_not_quote_tzid.cpython-313.opt-1.pyc
│           │   │   │   ├── test_issue_836_do_not_quote_tzid.cpython-313.pyc
│           │   │   │   ├── test_multiple.cpython-313.opt-1.pyc
│           │   │   │   ├── test_multiple.cpython-313.pyc
│           │   │   │   ├── test_oss_fuzz_errors.cpython-313.opt-1.pyc
│           │   │   │   ├── test_oss_fuzz_errors.cpython-313.pyc
│           │   │   │   ├── test_parsing.cpython-313.opt-1.pyc
│           │   │   │   ├── test_parsing.cpython-313.pyc
│           │   │   │   ├── test_period.cpython-313.opt-1.pyc
│           │   │   │   ├── test_period.cpython-313.pyc
│           │   │   │   ├── test_property_params.cpython-313.opt-1.pyc
│           │   │   │   ├── test_property_params.cpython-313.pyc
│           │   │   │   ├── test_pytz_zoneinfo_integration.cpython-313.opt-1.pyc
│           │   │   │   ├── test_pytz_zoneinfo_integration.cpython-313.pyc
│           │   │   │   ├── test_recurrence.cpython-313.opt-1.pyc
│           │   │   │   ├── test_recurrence.cpython-313.pyc
│           │   │   │   ├── test_rfc_6868.cpython-313.opt-1.pyc
│           │   │   │   ├── test_rfc_6868.cpython-313.pyc
│           │   │   │   ├── test_rfc_7529.cpython-313.opt-1.pyc
│           │   │   │   ├── test_rfc_7529.cpython-313.pyc
│           │   │   │   ├── test_rfc_7986.cpython-313.opt-1.pyc
│           │   │   │   ├── test_rfc_7986.cpython-313.pyc
│           │   │   │   ├── test_rfc_7986_categories.cpython-313.opt-1.pyc
│           │   │   │   ├── test_rfc_7986_categories.cpython-313.pyc
│           │   │   │   ├── test_rfc_9074.cpython-313.opt-1.pyc
│           │   │   │   ├── test_rfc_9074.cpython-313.pyc
│           │   │   │   ├── test_time.cpython-313.opt-1.pyc
│           │   │   │   ├── test_time.cpython-313.pyc
│           │   │   │   ├── test_timezone_identification.cpython-313.opt-1.pyc
│           │   │   │   ├── test_timezone_identification.cpython-313.pyc
│           │   │   │   ├── test_timezoned.cpython-313.opt-1.pyc
│           │   │   │   ├── test_timezoned.cpython-313.pyc
│           │   │   │   ├── test_unit_cal.cpython-313.opt-1.pyc
│           │   │   │   ├── test_unit_cal.cpython-313.pyc
│           │   │   │   ├── test_unit_caselessdict.cpython-313.opt-1.pyc
│           │   │   │   ├── test_unit_caselessdict.cpython-313.pyc
│           │   │   │   ├── test_unit_parser_tools.cpython-313.opt-1.pyc
│           │   │   │   ├── test_unit_parser_tools.cpython-313.pyc
│           │   │   │   ├── test_unit_tools.cpython-313.opt-1.pyc
│           │   │   │   ├── test_unit_tools.cpython-313.pyc
│           │   │   │   ├── test_with_doctest.cpython-313.opt-1.pyc
│           │   │   │   ├── test_with_doctest.cpython-313.pyc
│           │   │   │   ├── timezone_ids.cpython-313.opt-1.pyc
│           │   │   │   └── timezone_ids.cpython-313.pyc
│           │   │   ├── alarms
│           │   │   │   ├── rfc_5545_absolute_alarm_example.ics
│           │   │   │   ├── rfc_5545_end.ics
│           │   │   │   └── start_date.ics
│           │   │   ├── attr
│           │   │   │   ├── __init__.py
│           │   │   │   ├── __pycache__
│           │   │   │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   │   │   ├── __init__.cpython-313.pyc
│           │   │   │   │   ├── test_alarm.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_alarm.cpython-313.pyc
│           │   │   │   │   ├── test_component.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_component.cpython-313.pyc
│           │   │   │   │   ├── test_exdates.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_exdates.cpython-313.pyc
│           │   │   │   │   ├── test_rdate.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_rdate.cpython-313.pyc
│           │   │   │   │   ├── test_rrule.cpython-313.opt-1.pyc
│           │   │   │   │   └── test_rrule.cpython-313.pyc
│           │   │   │   ├── test_alarm.py
│           │   │   │   ├── test_component.py
│           │   │   │   ├── test_exdates.py
│           │   │   │   ├── test_rdate.py
│           │   │   │   └── test_rrule.py
│           │   │   ├── calendars
│           │   │   │   ├── alarm_etar_future.ics
│           │   │   │   ├── alarm_etar_notification.ics
│           │   │   │   ├── alarm_etar_notification_clicked.ics
│           │   │   │   ├── alarm_google_acknowledged.ics
│           │   │   │   ├── alarm_google_future.ics
│           │   │   │   ├── alarm_thunderbird_2_future.ics
│           │   │   │   ├── alarm_thunderbird_2_notification_5_min_postponed.ics
│           │   │   │   ├── alarm_thunderbird_2_notification_5_min_postponed_and_closed.ics
│           │   │   │   ├── alarm_thunderbird_2_notification_5_min_postponed_and_popped_up.ics
│           │   │   │   ├── alarm_thunderbird_2_notification_popped_up.ics
│           │   │   │   ├── alarm_thunderbird_closed.ics
│           │   │   │   ├── alarm_thunderbird_future.ics
│           │   │   │   ├── alarm_thunderbird_snoozed_until_1457.ics
│           │   │   │   ├── america_new_york.ics
│           │   │   │   ├── america_new_york_forward_reference.ics
│           │   │   │   ├── big_bad_calendar.ics
│           │   │   │   ├── bom_calendar.ics
│           │   │   │   ├── broken_ical.ics
│           │   │   │   ├── calendar_with_unicode.ics
│           │   │   │   ├── created_calendar_with_unicode_fields.ics
│           │   │   │   ├── example.ics
│           │   │   │   ├── issue_104_broken_calendar.ics
│           │   │   │   ├── issue_156_RDATE_with_PERIOD_TZID_khal.ics
│           │   │   │   ├── issue_156_RDATE_with_PERIOD_TZID_khal_2.ics
│           │   │   │   ├── issue_165_missing_event.ics
│           │   │   │   ├── issue_168_expected_output.ics
│           │   │   │   ├── issue_168_input.ics
│           │   │   │   ├── issue_178_component_with_invalid_name_represented.ics
│           │   │   │   ├── issue_178_custom_component_contains_other.ics
│           │   │   │   ├── issue_178_custom_component_inside_other.ics
│           │   │   │   ├── issue_218_bad_tzid.ics
│           │   │   │   ├── issue_237_fail_to_parse_timezone_with_non_ascii_tzid.ics
│           │   │   │   ├── issue_27_multiple_periods_in_freebusy_multiple_freebusies.ics
│           │   │   │   ├── issue_27_multiple_periods_in_freebusy_one_freebusy.ics
│           │   │   │   ├── issue_322_expected_calendar.ics
│           │   │   │   ├── issue_348_exception_parsing_value.ics
│           │   │   │   ├── issue_350.ics
│           │   │   │   ├── issue_466_convert_tzid_with_slash.ics
│           │   │   │   ├── issue_466_respect_unique_timezone.ics
│           │   │   │   ├── issue_526_calendar_with_different_events.ics
│           │   │   │   ├── issue_526_calendar_with_event_subset.ics
│           │   │   │   ├── issue_526_calendar_with_events.ics
│           │   │   │   ├── issue_526_calendar_with_shuffeled_events.ics
│           │   │   │   ├── issue_722_missing_VTIMEZONE_custom.ics
│           │   │   │   ├── issue_722_missing_timezones.ics
│           │   │   │   ├── issue_722_timezone_transition_ambiguity.ics
│           │   │   │   ├── issue_798_freebusy.ics
│           │   │   │   ├── issue_798_related_to.ics
│           │   │   │   ├── issue_836_do_not_quote_tzid.ics
│           │   │   │   ├── multiple_calendar_components.ics
│           │   │   │   ├── pacific_fiji.ics
│           │   │   │   ├── parsing_error.ics
│           │   │   │   ├── parsing_error_in_UTC_offset.ics
│           │   │   │   ├── period_with_timezone.ics
│           │   │   │   ├── pr_480_summary_with_colon.ics
│           │   │   │   ├── property_params.ics
│           │   │   │   ├── rfc_5545_RDATE_example.ics
│           │   │   │   ├── rfc_6868.ics
│           │   │   │   ├── rfc_7529.ics
│           │   │   │   ├── small_bad_calendar.ics
│           │   │   │   ├── time.ics
│           │   │   │   ├── timezone_rdate.ics
│           │   │   │   ├── timezone_same_start.ics
│           │   │   │   ├── timezone_same_start_and_offset.ics
│           │   │   │   ├── timezoned.ics
│           │   │   │   └── x_location.ics
│           │   │   ├── conftest.py
│           │   │   ├── events
│           │   │   │   ├── event_with_escaped_character1.ics
│           │   │   │   ├── event_with_escaped_character2.ics
│           │   │   │   ├── event_with_escaped_character3.ics
│           │   │   │   ├── event_with_escaped_character4.ics
│           │   │   │   ├── event_with_escaped_characters.ics
│           │   │   │   ├── event_with_recurrence.ics
│           │   │   │   ├── event_with_recurrence_exdates_on_different_lines.ics
│           │   │   │   ├── event_with_rsvp.ics
│           │   │   │   ├── event_with_unicode_fields.ics
│           │   │   │   ├── event_with_unicode_organizer.ics
│           │   │   │   ├── issue_100_transformed_doctests_into_unittests.ics
│           │   │   │   ├── issue_101_icalendar_chokes_on_umlauts_in_organizer.ics
│           │   │   │   ├── issue_104_mark_events_broken.ics
│           │   │   │   ├── issue_112_missing_tzinfo_on_exdate.ics
│           │   │   │   ├── issue_156_RDATE_with_PERIOD.ics
│           │   │   │   ├── issue_156_RDATE_with_PERIOD_list.ics
│           │   │   │   ├── issue_157_removes_trailing_semicolon.ics
│           │   │   │   ├── issue_184_broken_representation_of_period.ics
│           │   │   │   ├── issue_464_invalid_rdate.ics
│           │   │   │   ├── issue_53_description_parsed_properly.ics
│           │   │   │   ├── issue_64_event_with_ascii_summary.ics
│           │   │   │   ├── issue_64_event_with_non_ascii_summary.ics
│           │   │   │   ├── issue_70_rrule_causes_attribute_error.ics
│           │   │   │   ├── issue_82_expected_output.ics
│           │   │   │   ├── rfc_9074_example_1.ics
│           │   │   │   ├── rfc_9074_example_2.ics
│           │   │   │   ├── rfc_9074_example_3.ics
│           │   │   │   ├── rfc_9074_example_4.ics
│           │   │   │   └── rfc_9074_example_proximity.ics
│           │   │   ├── fuzzed
│           │   │   │   ├── __init__.py
│           │   │   │   ├── __pycache__
│           │   │   │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   │   │   ├── __init__.cpython-313.pyc
│           │   │   │   │   ├── test_fuzzed_calendars.cpython-313.opt-1.pyc
│           │   │   │   │   └── test_fuzzed_calendars.cpython-313.pyc
│           │   │   │   ├── generate_python_test_cases_from_downloaded_clusterfuzz_test_cases.sh
│           │   │   │   └── test_fuzzed_calendars.py
│           │   │   ├── hypothesis
│           │   │   │   ├── __pycache__
│           │   │   │   │   ├── test_fuzzing.cpython-313.opt-1.pyc
│           │   │   │   │   └── test_fuzzing.cpython-313.pyc
│           │   │   │   └── test_fuzzing.py
│           │   │   ├── prop
│           │   │   │   ├── __init__.py
│           │   │   │   ├── __pycache__
│           │   │   │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   │   │   ├── __init__.cpython-313.pyc
│           │   │   │   │   ├── test_constructors.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_constructors.cpython-313.pyc
│           │   │   │   │   ├── test_identity_and_equality.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_identity_and_equality.cpython-313.pyc
│           │   │   │   │   ├── test_property_values.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_property_values.cpython-313.pyc
│           │   │   │   │   ├── test_unit.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_unit.cpython-313.pyc
│           │   │   │   │   ├── test_vBinary.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vBinary.cpython-313.pyc
│           │   │   │   │   ├── test_vBoolean.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vBoolean.cpython-313.pyc
│           │   │   │   │   ├── test_vCalAddress.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vCalAddress.cpython-313.pyc
│           │   │   │   │   ├── test_vDDDTypes.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vDDDTypes.cpython-313.pyc
│           │   │   │   │   ├── test_vDatetime.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vDatetime.cpython-313.pyc
│           │   │   │   │   ├── test_vPeriod.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vPeriod.cpython-313.pyc
│           │   │   │   │   ├── test_vWeekday.cpython-313.opt-1.pyc
│           │   │   │   │   ├── test_vWeekday.cpython-313.pyc
│           │   │   │   │   ├── test_windows_to_olson_mapping.cpython-313.opt-1.pyc
│           │   │   │   │   └── test_windows_to_olson_mapping.cpython-313.pyc
│           │   │   │   ├── test_constructors.py
│           │   │   │   ├── test_identity_and_equality.py
│           │   │   │   ├── test_property_values.py
│           │   │   │   ├── test_unit.py
│           │   │   │   ├── test_vBinary.py
│           │   │   │   ├── test_vBoolean.py
│           │   │   │   ├── test_vCalAddress.py
│           │   │   │   ├── test_vDDDTypes.py
│           │   │   │   ├── test_vDatetime.py
│           │   │   │   ├── test_vPeriod.py
│           │   │   │   ├── test_vWeekday.py
│           │   │   │   └── test_windows_to_olson_mapping.py
│           │   │   ├── test_bom_calendar.py
│           │   │   ├── test_cli_tool.py
│           │   │   ├── test_components_break_on_bad_ics.py
│           │   │   ├── test_create_release.sh
│           │   │   ├── test_encoding.py
│           │   │   ├── test_equality.py
│           │   │   ├── test_examples.py
│           │   │   ├── test_icalendar.py
│           │   │   ├── test_issue_116.py
│           │   │   ├── test_issue_165_missing_event.py
│           │   │   ├── test_issue_168_parsing_invalid_calendars_no_warning.py
│           │   │   ├── test_issue_218_parse_calendar.py
│           │   │   ├── test_issue_27_period.py
│           │   │   ├── test_issue_301_add_rrule_as_string.py
│           │   │   ├── test_issue_318_skip_default_parameters.py
│           │   │   ├── test_issue_322_single_strings_characters_split_into_multiple_categories.py
│           │   │   ├── test_issue_336_dateutil_timezone.py
│           │   │   ├── test_issue_348_exception_parsing_value.py
│           │   │   ├── test_issue_350.py
│           │   │   ├── test_issue_500_vboolean_for_parameter.py
│           │   │   ├── test_issue_557_encode_native_parameters.py
│           │   │   ├── test_issue_662_component_properties.py
│           │   │   ├── test_issue_716_alarm_time_computation.py
│           │   │   ├── test_issue_720_uid_property.py
│           │   │   ├── test_issue_722_generate_vtimezone.py
│           │   │   ├── test_issue_798_property_parameters.py
│           │   │   ├── test_issue_802.py
│           │   │   ├── test_issue_828.py
│           │   │   ├── test_issue_836_do_not_quote_tzid.py
│           │   │   ├── test_multiple.py
│           │   │   ├── test_oss_fuzz_errors.py
│           │   │   ├── test_parsing.py
│           │   │   ├── test_period.py
│           │   │   ├── test_property_params.py
│           │   │   ├── test_pytz_zoneinfo_integration.py
│           │   │   ├── test_recurrence.py
│           │   │   ├── test_rfc_6868.py
│           │   │   ├── test_rfc_7529.py
│           │   │   ├── test_rfc_7986.py
│           │   │   ├── test_rfc_7986_categories.py
│           │   │   ├── test_rfc_9074.py
│           │   │   ├── test_time.py
│           │   │   ├── test_timezone_identification.py
│           │   │   ├── test_timezoned.py
│           │   │   ├── test_unit_cal.py
│           │   │   ├── test_unit_caselessdict.py
│           │   │   ├── test_unit_parser_tools.py
│           │   │   ├── test_unit_tools.py
│           │   │   ├── test_with_doctest.py
│           │   │   ├── timezone_ids.py
│           │   │   └── timezones
│           │   │       ├── issue_237_brazilia_standard.ics
│           │   │       ├── issue_53_tzid_parsed_properly.ics
│           │   │       ├── issue_55_parse_error_on_utc_offset_with_seconds.ics
│           │   │       └── pacific_fiji.ics
│           │   ├── timezone
│           │   │   ├── __init__.py
│           │   │   ├── __pycache__
│           │   │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   │   ├── __init__.cpython-313.pyc
│           │   │   │   ├── equivalent_timezone_ids.cpython-313.opt-1.pyc
│           │   │   │   ├── equivalent_timezone_ids.cpython-313.pyc
│           │   │   │   ├── equivalent_timezone_ids_result.cpython-313.opt-1.pyc
│           │   │   │   ├── equivalent_timezone_ids_result.cpython-313.pyc
│           │   │   │   ├── provider.cpython-313.opt-1.pyc
│           │   │   │   ├── provider.cpython-313.pyc
│           │   │   │   ├── pytz.cpython-313.opt-1.pyc
│           │   │   │   ├── pytz.cpython-313.pyc
│           │   │   │   ├── tzid.cpython-313.opt-1.pyc
│           │   │   │   ├── tzid.cpython-313.pyc
│           │   │   │   ├── tzp.cpython-313.opt-1.pyc
│           │   │   │   ├── tzp.cpython-313.pyc
│           │   │   │   ├── windows_to_olson.cpython-313.opt-1.pyc
│           │   │   │   ├── windows_to_olson.cpython-313.pyc
│           │   │   │   ├── zoneinfo.cpython-313.opt-1.pyc
│           │   │   │   └── zoneinfo.cpython-313.pyc
│           │   │   ├── equivalent_timezone_ids.py
│           │   │   ├── equivalent_timezone_ids_result.py
│           │   │   ├── provider.py
│           │   │   ├── pytz.py
│           │   │   ├── tzid.py
│           │   │   ├── tzp.py
│           │   │   ├── windows_to_olson.py
│           │   │   └── zoneinfo.py
│           │   ├── tools.py
│           │   └── version.py
│           └── icalendar-6.3.1.dist-info
│               ├── METADATA
│               ├── RECORD
│               ├── WHEEL
│               ├── entry_points.txt
│               └── licenses
│                   └── LICENSE.rst
└── nix-support
    └── propagated-build-inputs

26 directories, 402 files
```
</details>

<details><summary>build log of python3.pkgs.icalendar</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
Sourcing sphinx-hook
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/hyx9fklhq5mg2wyjld4sx7qi55w5hsz2-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tox.ini"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
applying patch /nix/store/0ah511w64m97pcsmgfzmh08qq4s7mvrv-no-dynamic-version.patch
patching file pyproject.toml
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing pypaBuildPhase
Setting SETUPTOOLS_SCM_PRETEND_VERSION to 6.3.1
Including all tracked files automatically
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
Successfully built icalendar-6.3.1-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for icalendar-6.3.1-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing pypaInstallPhase
Successfully installed icalendar-6.3.1-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: buildSphinxPhase
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
Executing buildSphinxPhase
Sphinx documentation found in docs
Executing sphinx-build with html builder
Running Sphinx v8.2.3
loading translations [en]... locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
done
Adding copy buttons to code blocks...
making output directory... done
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
loading intersphinx inventory 'python' from https://docs.python.org/3/objects.inv ...
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.python.org/3/objects.inv' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='docs.python.org', port=443): Max retries exceeded with url: /3/objects.inv (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7ffff4789be0>: Failed to resolve 'docs.python.org' ([Errno -3] Temporary failure in name resolution)"))
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 12 source files that are out of date
updating environment: locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[new config] 12 added, 0 changed, 0 removed
reading sources... [  8%] about
reading sources... [ 17%] api
reading sources... [ 25%] changelog
reading sources... [ 33%] cli
reading sources... [ 42%] contributing
reading sources... [ 50%] credits
reading sources... [ 58%] index
reading sources... [ 67%] install
reading sources... [ 75%] license
reading sources... [ 83%] maintenance
reading sources... [ 92%] security
reading sources... [100%] usage

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /build/source/.sphinx/html/html/_static/language_data.js
Writing evaluated template result to /build/source/.sphinx/html/html/_static/basic.css
Writing evaluated template result to /build/source/.sphinx/html/html/_static/documentation_options.js
Writing evaluated template result to /build/source/.sphinx/html/html/_static/copybutton.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [  8%] about
writing output... [ 17%] api
writing output... [ 25%] changelog
writing output... [ 33%] cli
writing output... [ 42%] contributing
writing output... [ 50%] credits
writing output... [ 58%] index
writing output... [ 67%] install
writing output... [ 75%] license
writing output... [ 83%] maintenance
writing output... [ 92%] security
writing output... [100%] usage

generating indices... genindex py-modindex done
highlighting module code... [  7%] icalendar.alarms
highlighting module code... [ 13%] icalendar.attr
highlighting module code... [ 20%] icalendar.cal
highlighting module code... [ 27%] icalendar.caselessdict
highlighting module code... [ 33%] icalendar.cli
highlighting module code... [ 40%] icalendar.enums
highlighting module code... [ 47%] icalendar.error
highlighting module code... [ 53%] icalendar.param
highlighting module code... [ 60%] icalendar.parser
highlighting module code... [ 67%] icalendar.parser_tools
highlighting module code... [ 73%] icalendar.prop
highlighting module code... [ 80%] icalendar.timezone
highlighting module code... [ 87%] icalendar.timezone.tzid
highlighting module code... [ 93%] icalendar.timezone.tzp
highlighting module code... [100%] icalendar.tools

writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in .sphinx/html/html.
Running phase: installSphinxPhase
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
Executing installSphinxPhase
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1
checking for references to /build/ in /nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1...
patching script interpreter paths in /nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1
/nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1/lib/python3.13/site-packages/icalendar/cli.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/829wb290i87wngxlh404klwxql5v18p4-python3-3.13.7/bin/python3"
stripping (with command strip and flags -S -p) in  /nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1/lib /nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1/bin
shrinking RPATHs of ELF executables and libraries in /nix/store/4am3jjl7pix7l3k7v3cv34szxn4zpmkk-python3.13-icalendar-6.3.1-doc
checking for references to /build/ in /nix/store/4am3jjl7pix7l3k7v3cv34szxn4zpmkk-python3.13-icalendar-6.3.1-doc...
patching script interpreter paths in /nix/store/4am3jjl7pix7l3k7v3cv34szxn4zpmkk-python3.13-icalendar-6.3.1-doc
shrinking RPATHs of ELF executables and libraries in /nix/store/r0j8kps3jynggclvg0fk18rf1gdc9782-python3.13-icalendar-6.3.1-dist
checking for references to /build/ in /nix/store/r0j8kps3jynggclvg0fk18rf1gdc9782-python3.13-icalendar-6.3.1-dist...
patching script interpreter paths in /nix/store/r0j8kps3jynggclvg0fk18rf1gdc9782-python3.13-icalendar-6.3.1-dist
Rewriting #!/nix/store/829wb290i87wngxlh404klwxql5v18p4-python3-3.13.7/bin/python3.13 to #!/nix/store/829wb290i87wngxlh404klwxql5v18p4-python3-3.13.7
wrapping `/nix/store/52ribz5vc0fmv5fx9rlhyw9i57rn30wh-python3.13-icalendar-6.3.1/bin/icalendar'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
@nix { "action": "setPhase", "phase": "installCheckPhase" }
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonImportsCheckPhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Executing pythonImportsCheckPhase
Running phase: pytestCheckPhase
@nix { "action": "setPhase", "phase": "pytestCheckPhase" }
Executing pytestCheckPhase
pytest flags: -m pytest src/icalendar -k not\ \(test_dateutil_timezone_is_matched_with_tzname\)\ and\ not\ \(test_docstring_of_python_file\)\ and\ not\ \(test_add_missing_timezones_to_example\)
============================= test session starts ==============================
platform linux -- Python 3.13.7, pytest-8.4.1, pluggy-1.6.0
rootdir: /build/source
configfile: pyproject.toml
plugins: hypothesis-6.136.9
collecting ... 
collected 6114 items / 106 deselected / 6008 selected                          

src/icalendar/tests/attr/test_alarm.py .......                           [  0%]
src/icalendar/tests/attr/test_component.py ............................. [  0%]
...............................................                          [  1%]
src/icalendar/tests/attr/test_exdates.py ............................... [  1%]
..................................                                       [  2%]
src/icalendar/tests/attr/test_rdate.py ................................. [  3%]
.......                                                                  [  3%]
src/icalendar/tests/attr/test_rrule.py ................................. [  3%]
......................                                                   [  4%]
src/icalendar/tests/fuzzed/test_fuzzed_calendars.py s                    [  4%]
src/icalendar/tests/prop/test_constructors.py ................           [  4%]
src/icalendar/tests/prop/test_identity_and_equality.py ................. [  4%]
........................................................................ [  5%]
.........................                                                [  6%]
src/icalendar/tests/prop/test_property_values.py .                       [  6%]
src/icalendar/tests/prop/test_unit.py ................                   [  6%]
src/icalendar/tests/prop/test_vBinary.py ......                          [  6%]
src/icalendar/tests/prop/test_vBoolean.py ....                           [  6%]
src/icalendar/tests/prop/test_vCalAddress.py .........                   [  6%]
src/icalendar/tests/prop/test_vDDDTypes.py ......                        [  6%]
src/icalendar/tests/prop/test_vDatetime.py .......                       [  7%]
src/icalendar/tests/prop/test_vPeriod.py ..........                      [  7%]
src/icalendar/tests/prop/test_vWeekday.py ....                           [  7%]
src/icalendar/tests/prop/test_windows_to_olson_mapping.py .............. [  7%]
........................................................................ [  8%]
.....................                                                    [  9%]
src/icalendar/tests/test_bom_calendar.py .                               [  9%]
src/icalendar/tests/test_cli_tool.py .                                   [  9%]
src/icalendar/tests/test_components_break_on_bad_ics.py .......          [  9%]
src/icalendar/tests/test_encoding.py ................                    [  9%]
src/icalendar/tests/test_equality.py ................................... [ 10%]
.............................s.......................................... [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
.............................                                            [ 17%]
src/icalendar/tests/test_examples.py ...........                         [ 17%]
src/icalendar/tests/test_icalendar.py .......                            [ 18%]
src/icalendar/tests/test_issue_116.py .                                  [ 18%]
src/icalendar/tests/test_issue_165_missing_event.py .                    [ 18%]
src/icalendar/tests/test_issue_168_parsing_invalid_calendars_no_warning.py . [ 18%]
                                                                         [ 18%]
src/icalendar/tests/test_issue_218_parse_calendar.py ..                  [ 18%]
src/icalendar/tests/test_issue_27_period.py .                            [ 18%]
src/icalendar/tests/test_issue_301_add_rrule_as_string.py .              [ 18%]
src/icalendar/tests/test_issue_318_skip_default_parameters.py ...        [ 18%]
src/icalendar/tests/test_issue_322_single_strings_characters_split_into_multiple_categories.py . [ 18%]
                                                                         [ 18%]
src/icalendar/tests/test_issue_336_dateutil_timezone.py ..               [ 18%]
src/icalendar/tests/test_issue_348_exception_parsing_value.py ..         [ 18%]
src/icalendar/tests/test_issue_350.py .                                  [ 18%]
src/icalendar/tests/test_issue_500_vboolean_for_parameter.py .           [ 18%]
src/icalendar/tests/test_issue_557_encode_native_parameters.py ........  [ 18%]
src/icalendar/tests/test_issue_662_component_properties.py ............. [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 33%]
..........                                                               [ 33%]
src/icalendar/tests/test_issue_716_alarm_time_computation.py ........... [ 33%]
...................................................                      [ 34%]
src/icalendar/tests/test_issue_720_uid_property.py .                     [ 34%]
src/icalendar/tests/test_issue_722_generate_vtimezone.py ............... [ 34%]
......................................................s................. [ 35%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 39%]
........................................................................ [ 40%]
........................................................................ [ 41%]
........................................................................ [ 42%]
........................................................................ [ 44%]
........................................................................ [ 45%]
....                                                                     [ 45%]
src/icalendar/tests/test_issue_798_property_parameters.py .............. [ 45%]
................                                                         [ 45%]
src/icalendar/tests/test_issue_802.py ..............................     [ 46%]
src/icalendar/tests/test_issue_828.py .................................. [ 46%]
........................................................................ [ 48%]
...........................ssssss.........................               [ 49%]
src/icalendar/tests/test_issue_836_do_not_quote_tzid.py ................ [ 49%]
........................................................................ [ 50%]
........................................................................ [ 51%]
.......................................................................  [ 52%]
src/icalendar/tests/test_multiple.py ...                                 [ 52%]
src/icalendar/tests/test_oss_fuzz_errors.py ..                           [ 53%]
src/icalendar/tests/test_parsing.py .................................... [ 53%]
....                                                                     [ 53%]
src/icalendar/tests/test_period.py ...........................           [ 54%]
src/icalendar/tests/test_property_params.py ....................         [ 54%]
src/icalendar/tests/test_pytz_zoneinfo_integration.py .................. [ 54%]
........................................................................ [ 55%]
........................................................................ [ 57%]
........................................................................ [ 58%]
........................................................................ [ 59%]
..............s......................................................... [ 60%]
........................................................................ [ 61%]
........................................................................ [ 63%]
........................................................................ [ 64%]
......s.........                                                         [ 64%]
src/icalendar/tests/test_recurrence.py ............................      [ 65%]
src/icalendar/tests/test_rfc_6868.py .................................   [ 65%]
src/icalendar/tests/test_rfc_7529.py ....................                [ 65%]
src/icalendar/tests/test_rfc_7986.py ................................... [ 66%]
..........................................                               [ 67%]
src/icalendar/tests/test_rfc_7986_categories.py ........................ [ 67%]
....                                                                     [ 67%]
src/icalendar/tests/test_rfc_9074.py ......                              [ 67%]
src/icalendar/tests/test_time.py ....                                    [ 67%]
src/icalendar/tests/test_timezone_identification.py .s..s..s..s.s.s.s.s. [ 68%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 69%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 70%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 71%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 73%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 74%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 75%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 76%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 77%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 78%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 80%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 81%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 82%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 83%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 84%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 86%]
s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s. [ 87%]
s.s.s.s.s.s.s.s.s.s.s................................................... [ 88%]
........................................................................ [ 89%]
........................................................................ [ 90%]
........................................................................ [ 92%]
........................................................................ [ 93%]
........................................................................ [ 94%]
........................................................................ [ 95%]
........................................................................ [ 96%]
........................................                                 [ 97%]
src/icalendar/tests/test_timezoned.py ....ss....s.                       [ 97%]
src/icalendar/tests/test_unit_cal.py ................................... [ 98%]
.........................................................                [ 99%]
src/icalendar/tests/test_unit_caselessdict.py ....                       [ 99%]
src/icalendar/tests/test_unit_parser_tools.py ...                        [ 99%]
src/icalendar/tests/test_unit_tools.py ...........                       [ 99%]
src/icalendar/tests/test_with_doctest.py ...ssssssssssssssss.            [100%]

============== 5383 passed, 625 skipped, 106 deselected in 5.59s ===============
Finished executing pytestCheckPhase
Running phase: pytestcachePhase
@nix { "action": "setPhase", "phase": "pytestcachePhase" }
Running phase: pytestRemoveBytecodePhase
@nix { "action": "setPhase", "phase": "pytestRemoveBytecodePhase" }
```
</details>
