### PR TITLE
ltrace: fix test failure with PIE

### DIFF
--- a/pkgs/by-name/lt/ltrace/package.nix
+++ b/pkgs/by-name/lt/ltrace/package.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation {
     ./testsuite-newfstatat.patch
     # https://gitlab.com/cespedes/ltrace/-/merge_requests/15
     ./sysdeps-x86.patch
+    # print-instruction-pointer.exp doesn't expect ASLR
+    (fetchurl {
+      url = "https://github.com/gentoo/gentoo/raw/a2eb7e103ec985ff90f59e722e0a8a43373972a2/dev-debug/ltrace/files/ltrace-0.7.3-print-test-pie.patch";
+      hash = "sha256-QRsUoN3WLzfiY5GDPwVYXtJPFMJt6rcc6eE96SAtI6Q=";
+    })
   ];
 
   doCheck = true;


### PR DESCRIPTION
Fixes #439314

> Bisect says this change broke `ltrace` testsuite in `master`:
> 
> ```
> $ nix build --no-link -f. -L ltrace
> ...
> ltrace> Running /build/ltrace-0.7.91/testsuite/ltrace.minor/print-instruction-pointer.exp ...
> ltrace> FAIL: 1161.*printf in /build/ltrace-0.7.91/testsuite/ltrace.minor/print-instruction-pointer.ltrace for 0 times, should be 1
> ltrace> FAIL: 1181.*printf in /build/ltrace-0.7.91/testsuite/ltrace.minor/print-instruction-pointer.ltrace for 0 times, should be 1
> ltrace>                 ===  Summary ===
> ltrace>
> ltrace> # of expected passes            242
> ltrace> # of unexpected failures        2
> ltrace> # of unsupported tests          1
> ltrace> make[4]: *** [Makefile:498: check-DEJAGNU] Error 1
> ```
> 
> _Originally posted by @trofi in https://github.com/NixOS/nixpkgs/issues/439314#issuecomment-3373483053_
> 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
