### PR TITLE
python3Packages.pyzstd: 0.17.0 → 0.18.0

### DIFF
--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "pyzstd";
-  version = "0.17.0";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Rogdham";
     repo = "pyzstd";
     tag = version;
-    hash = "sha256-PICYdB/xu/q2wjbkF2nziZt8z8PmzJ5eM+Yq0rpLfEU=";
+    hash = "sha256-15+GqJ/AMYs1R9ywo+muNVVbPkkzTMj//Zn/PPI+MCI=";
   };
 
   postPatch = ''
@@ -26,6 +26,9 @@ buildPythonPackage rec {
     # required for Python 3.9 under Windows
     substituteInPlace pyproject.toml \
         --replace-fail '"setuptools>=64,<74"' '"setuptools"'
+
+    # pyzst needs a copy of upstream zstd's license
+    ln -s ${zstd-c.src}/LICENSE zstd
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
[Changelog](https://github.com/Rogdham/pyzstd/blob/0.18.0/CHANGELOG.md):
- Support for Python 3.14
- Deprecate the `read_size` and `write_size` parameters of `ZstdFile` and `SeekableZstdFile`
- Deprecate `richmem_compress` and `RichMemZstdCompressor`
- Rework documentation to suggest using `compression.zstd` from Python stdlib, and provide a migration guide
- Include the `zstd` library license in package distributions

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
