### PR TITLE
services.xray: add settingsExtension option for YAML and TOML config support

### DIFF
--- a/nixos/modules/services/networking/xray.nix
+++ b/nixos/modules/services/networking/xray.nix
@@ -23,6 +23,24 @@ with lib;
 
       package = mkPackageOption pkgs "xray" { };
 
+      settingsExtension = mkOption {
+        type = types.enum [
+          "json"
+          "yaml"
+          "toml"
+        ];
+        default = "json";
+        description = ''
+          The config file format, and therefore the parser xray uses to read it.
+
+          This controls how `settings` is serialised. When `settingsFile` is
+          used instead, its contents must be written in this format, as xray
+          selects the parser from the config file extension.
+
+          Note that TOML cannot represent null values.
+        '';
+      };
+
       settingsFile = mkOption {
         type = types.nullOr types.path;
         default = null;
@@ -68,17 +86,16 @@ with lib;
   config =
     let
       cfg = config.services.xray;
-      settingsFile =
-        if cfg.settingsFile != null then
-          cfg.settingsFile
-        else
-          pkgs.writeTextFile {
-            name = "xray.json";
-            text = builtins.toJSON cfg.settings;
-            checkPhase = ''
-              ${cfg.package}/bin/xray -test -config $out
-            '';
-          };
+      extension = cfg.settingsExtension;
+
+      settingsFormat = pkgs.formats.${extension} { };
+
+      generatedSettingsFile = pkgs.runCommandLocal "xray-config.${extension}" { } ''
+        ln -s ${settingsFormat.generate "xray.${extension}" cfg.settings} "$out"
+        ${cfg.package}/bin/xray -test -config "$out"
+      '';
+
+      settingsFile = if cfg.settingsFile != null then cfg.settingsFile else generatedSettingsFile;
 
     in
     mkIf cfg.enable {
@@ -94,9 +111,9 @@ with lib;
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          ExecStart = "${cfg.package}/bin/xray -config \"\${CREDENTIALS_DIRECTORY}\"/config.json";
+          ExecStart = "${cfg.package}/bin/xray -config \"\${CREDENTIALS_DIRECTORY}\"/config.${extension}";
           DynamicUser = true;
-          LoadCredential = "config.json:${settingsFile}";
+          LoadCredential = "config.${extension}:${settingsFile}";
           CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";
           AmbientCapabilities = "CAP_NET_ADMIN CAP_NET_BIND_SERVICE";
           NoNewPrivileges = true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1619,7 +1619,7 @@ in
   xmonad = runTest ./xmonad.nix;
   xmonad-xdg-autostart = runTest ./xmonad-xdg-autostart.nix;
   xpadneo = runTest ./xpadneo.nix;
-  xray = runTest ./xray.nix;
+  xray = import ./xray.nix { inherit runTest; };
   xrdp = runTest ./xrdp.nix;
   xrdp-with-audio-pulseaudio = runTest ./xrdp-with-audio-pulseaudio.nix;
   xscreensaver = runTest ./xscreensaver.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1619,6 +1619,7 @@ in
   xmonad = runTest ./xmonad.nix;
   xmonad-xdg-autostart = runTest ./xmonad-xdg-autostart.nix;
   xpadneo = runTest ./xpadneo.nix;
+  xray = runTest ./xray.nix;
   xrdp = runTest ./xrdp.nix;
   xrdp-with-audio-pulseaudio = runTest ./xrdp-with-audio-pulseaudio.nix;
   xscreensaver = runTest ./xscreensaver.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -2038,6 +2038,7 @@ in
   xmonad = runTest ./xmonad.nix;
   xmonad-xdg-autostart = runTest ./xmonad-xdg-autostart.nix;
   xpadneo = runTest ./xpadneo.nix;
+  xray = import ./xray.nix { inherit runTest; };
   xrdp = runTest ./xrdp.nix;
   xrdp-with-audio-pulseaudio = runTest ./xrdp-with-audio-pulseaudio.nix;
   xscreensaver = runTest ./xscreensaver.nix;

--- a/nixos/tests/xray.nix
+++ b/nixos/tests/xray.nix
@@ -1,0 +1,95 @@
+{ ... }:
+let
+
+  xrayUser = {
+    # A random UUID.
+    id = "a6a46834-2150-45f8-8364-0f6f6ab32384";
+  };
+
+  # 1080 [http proxy] -> 1081 [vless] -> direct
+  xraysettings = {
+    inbounds = [
+      {
+        tag = "http_in";
+        port = 1080;
+        listen = "127.0.0.1";
+        protocol = "http";
+      }
+      {
+        tag = "vless_in";
+        port = 1081;
+        listen = "127.0.0.1";
+        protocol = "vless";
+        settings.decryption = "none";
+        settings.clients = [ xrayUser ];
+      }
+    ];
+    outbounds = [
+      {
+        tag = "vless_out";
+        protocol = "vless";
+        settings.decryption = "none";
+        settings.vnext = [
+          {
+            address = "127.0.0.1";
+            port = 1081;
+            users = [ (xrayUser // { encryption = "none"; }) ];
+          }
+        ];
+      }
+      {
+        tag = "direct";
+        protocol = "freedom";
+      }
+    ];
+    routing.rules = [
+      {
+        type = "field";
+        inboundTag = "http_in";
+        outboundTag = "vless_out";
+      }
+      {
+        type = "field";
+        inboundTag = "vless_in";
+        outboundTag = "direct";
+      }
+
+      # Assert assets "geoip" and "geosite" are accessible.
+      {
+        type = "field";
+        ip = [ "geoip:private" ];
+        domain = [ "geosite:category-ads" ];
+        outboundTag = "direct";
+      }
+    ];
+  };
+
+in
+{
+  name = "xray";
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.curl ];
+      services.xray = {
+        enable = true;
+        settings = xraysettings;
+      };
+      services.httpd = {
+        enable = true;
+        adminAddr = "foo@example.org";
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("httpd.service")
+    machine.wait_for_unit("xray.service")
+    machine.wait_for_open_port(80)
+    machine.wait_for_open_port(1080)
+    machine.succeed(
+        "curl --fail --max-time 10 --proxy http://localhost:1080 http://localhost"
+    )
+  '';
+}

--- a/nixos/tests/xray.nix
+++ b/nixos/tests/xray.nix
@@ -1,0 +1,100 @@
+{ runTest }:
+let
+  xrayUser.id = "a6a46834-2150-45f8-8364-0f6f6ab32384";
+
+  # 1080 [http proxy] -> 1081 [vless] -> direct
+  xraySettings = {
+    inbounds = [
+      {
+        tag = "http_in";
+        port = 1080;
+        listen = "127.0.0.1";
+        protocol = "http";
+      }
+      {
+        tag = "vless_in";
+        port = 1081;
+        listen = "127.0.0.1";
+        protocol = "vless";
+        settings.decryption = "none";
+        settings.clients = [ xrayUser ];
+      }
+    ];
+    outbounds = [
+      {
+        tag = "vless_out";
+        protocol = "vless";
+        settings.decryption = "none";
+        settings.vnext = [
+          {
+            address = "127.0.0.1";
+            port = 1081;
+            users = [ (xrayUser // { encryption = "none"; }) ];
+          }
+        ];
+      }
+      {
+        tag = "direct";
+        protocol = "freedom";
+      }
+    ];
+    routing.rules = [
+      {
+        type = "field";
+        inboundTag = "http_in";
+        outboundTag = "vless_out";
+      }
+      {
+        type = "field";
+        inboundTag = "vless_in";
+        outboundTag = "direct";
+      }
+
+      # Assert assets "geoip" and "geosite" are accessible.
+      {
+        type = "field";
+        ip = [ "geoip:private" ];
+        domain = [ "geosite:category-ads" ];
+        outboundTag = "direct";
+      }
+    ];
+  };
+
+  makeTest =
+    settingsExtension:
+    runTest {
+      name = "xray-${settingsExtension}";
+
+      nodes.machine =
+        { pkgs, ... }:
+        {
+          environment.systemPackages = [ pkgs.curl ];
+          services.xray = {
+            enable = true;
+            inherit settingsExtension;
+            settings = xraySettings;
+          };
+          services.httpd = {
+            enable = true;
+            adminAddr = "foo@example.org";
+          };
+        };
+
+      testScript = ''
+        start_all()
+
+        machine.wait_for_unit("httpd.service")
+        machine.wait_for_unit("xray.service")
+        machine.wait_for_open_port(80)
+        machine.wait_for_open_port(1080)
+        machine.succeed(
+            "curl --fail --max-time 10 --proxy http://localhost:1080 http://localhost"
+        )
+      '';
+    };
+in
+{
+  json = makeTest "json";
+  yaml = makeTest "yaml";
+  toml = makeTest "toml";
+}

--- a/pkgs/by-name/xr/xray/package.nix
+++ b/pkgs/by-name/xr/xray/package.nix
@@ -5,6 +5,7 @@
   buildGo126Module,
   makeWrapper,
   nix-update-script,
+  nixosTests,
   v2ray-rules-dat,
   assets ? [
     v2ray-rules-dat
@@ -53,6 +54,7 @@ buildGo126Module (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+    tests = nixosTests.xray;
   };
 
   meta = {


### PR DESCRIPTION
Adds `services.xray.settingsExtension` (`json` | `yaml` | `toml`, default `json`).
xray detects the config format from the file extension, so this also lets a
YAML/TOML `settingsFile` be loaded correctly instead of always as JSON.

`settings` is serialised with `pkgs.formats`; the generated file is still
validated at build time with `xray -test` (via `runCommandLocal`). Includes a
NixOS test per format and `passthru.tests`.

cc @iopq @h7x4 @HigherOrderLogic

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
