### PR TITLE
nixos/crashdump: implement automatic kernel panic log dumps

### DIFF
--- a/nixos/modules/misc/crashdump.nix
+++ b/nixos/modules/misc/crashdump.nix
@@ -5,66 +5,126 @@
   ...
 }:
 let
-  crashdump = config.boot.crashDump;
-
-  kernelParams = lib.concatStringsSep " " crashdump.kernelParams;
-
+  cfg = config.boot.crashDump;
 in
-###### interface
 {
-  options = {
-    boot = {
-      crashDump = {
-        enable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = ''
-            If enabled, NixOS will set up a kernel that will
-            boot on crash, and leave the user in systemd rescue
-            to be able to save the crashed kernel dump at
-            /proc/vmcore.
-            It also activates the NMI watchdog.
-          '';
-        };
-        reservedMemory = lib.mkOption {
-          default = "128M";
-          type = lib.types.str;
-          description = ''
-            The amount of memory reserved for the crashdump kernel.
-            If you choose a too high value, dmesg will mention
-            "crashkernel reservation failed".
-          '';
-        };
-        kernelParams = lib.mkOption {
-          type = lib.types.listOf lib.types.str;
-          default = [
-            "1"
-            "boot.shell_on_fail"
-          ];
-          description = ''
-            Parameters that will be passed to the kernel kexec-ed on crash.
-          '';
-        };
-      };
+  meta.maintainers = with lib.maintainers; [ Scrumplex ];
+
+  options.boot.crashDump = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        If enabled, NixOS will set up a kernel that will
+        boot on crash, and leave the user in systemd rescue
+        to be able to save the crashed kernel dump at
+        /proc/vmcore.
+        It also activates the NMI watchdog.
+      '';
+    };
+
+    automatic = lib.mkEnableOption "automatic dumping of kernel logs after a panic";
+
+    reservedMemory = lib.mkOption {
+      default = "256M";
+      type = lib.types.str;
+      description = ''
+        The amount of memory reserved for the crashdump kernel.
+        If you choose a too high value, dmesg will mention
+        "crashkernel reservation failed".
+      '';
+    };
+
+    kernelParams = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Parameters that will be passed to the kernel kexec-ed on crash.
+      '';
     };
   };
 
-  ###### implementation
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.automatic -> config.boot.initrd.systemd.enable;
+        message = "Automatic crash dumps are only supported on systemd-based initrd. Enable the option boot.initrd.systemd.enable";
+      }
+    ];
 
-  config = lib.mkIf crashdump.enable {
     boot = {
-      postBootCommands = ''
-        echo "loading crashdump kernel...";
-        ${pkgs.kexec-tools}/sbin/kexec -p /run/current-system/kernel \
-        --initrd=/run/current-system/initrd \
-        --reset-vga --console-vga \
-        --command-line="init=$(readlink -f /run/current-system/init) irqpoll maxcpus=1 reset_devices ${kernelParams}"
-      '';
-      kernelParams = [
-        "crashkernel=${crashdump.reservedMemory}"
-        "nmi_watchdog=panic"
-        "softlockup_panic=1"
+      kernel.sysctl = {
+        "kernel.panic" = -1;
+        "kernel.panic_on_oops" = 1;
+        "kernel.hardlockup_panic" = 1;
+        "kernel.softlockup_panic" = 1;
+      };
+
+      initrd.systemd.services."dump-dmesg" = lib.mkIf cfg.automatic {
+        script = ''
+          if [ ! -f /proc/vmcore ]; then
+            echo "No /proc/vmcore. Bailing out" >&2
+            reboot -f
+            exit 0
+          fi
+
+          mkdir -p /sysroot/var/log/crashdump
+
+          timestamp=$(date "+%Y-%m-%d-%H-%M-%S")
+          boot_id=$(systemd-id128 boot-id)
+
+          ${lib.getExe pkgs.makedumpfile} --dump-dmesg /proc/vmcore "/sysroot/var/log/crashdump/dmesg-$timestamp-$boot_id.txt"
+          reboot -f
+        '';
+        unitConfig = {
+          RequiresMountsFor = "/sysroot";
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+      };
+
+      initrd.systemd.storePaths = lib.mkIf cfg.automatic [
+        (lib.getExe pkgs.makedumpfile)
       ];
+
+      kernelParams = [
+        "crashkernel=${cfg.reservedMemory}"
+        "nmi_watchdog=panic"
+      ];
+    };
+
+    systemd.services."load-crashkernel" = {
+      script =
+        let
+          kernelParams = [
+            "init=$(readlink -f /run/current-system/init)"
+            "irqpoll"
+            "maxcpus=1"
+            "reset_devices"
+          ]
+          ++ lib.optionals cfg.automatic [
+            "rd.systemd.unit=dump-dmesg.service"
+          ]
+          ++ cfg.kernelParams;
+        in
+        ''
+          ${lib.getExe pkgs.kexec-tools} -p /run/current-system/kernel \
+            --initrd=/run/current-system/initrd \
+            --reset-vga --console-vga \
+            --command-line="${lib.concatStringsSep " " kernelParams}" # TODO: deal with escaping strings
+        '';
+      before = [
+        "shutdown.target"
+      ];
+      conflicts = [ "shutdown.target" ];
+      requiredBy = [ "sysinit.target" ];
+      unitConfig.ConditionKernelCommandLine = [ "crashkernel" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
     };
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -437,6 +437,7 @@ in
   };
   coturn = runTest ./coturn.nix;
   couchdb = runTest ./couchdb.nix;
+  crashdump = runTest ./crashdump.nix;
   cri-o = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./cri-o.nix;
   croc = runTest ./croc.nix;
   cross-seed = runTest ./cross-seed.nix;

--- a/nixos/tests/crashdump.nix
+++ b/nixos/tests/crashdump.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+{
+  name = "crashdump";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ Scrumplex ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      boot.initrd.systemd.enable = true;
+      boot.kernel.sysctl."kernel.sysrq" = 1;
+      boot.crashDump = {
+        enable = true;
+        automatic = true;
+      };
+    };
+
+  testScript = ''
+    machine.start(allow_reboot=True)
+
+    machine.wait_for_unit("load-crashkernel.service")
+    machine.execute("echo c > /proc/sysrq-trigger", check_output=False, check_return=False)
+    machine.connected = False # We need to reconnect after the panic
+
+    machine.succeed("grep 'Kernel panic - not syncing: sysrq triggered crash' /var/log/crashdump/dmesg-*.txt")
+  '';
+}

--- a/pkgs/by-name/ma/makedumpfile/package.nix
+++ b/pkgs/by-name/ma/makedumpfile/package.nix
@@ -1,0 +1,57 @@
+{
+  bzip2,
+  elfutils,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  zlib,
+  zstd,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "makedumpfile";
+  version = "1.7.8";
+
+  src = fetchFromGitHub {
+    owner = "makedumpfile";
+    repo = "makedumpfile";
+    tag = finalAttrs.version;
+    hash = "sha256-xUYIvNf7Td/PJreuadMTUwy0XaSQVes/9ltrJNiAwVw=";
+  };
+
+  buildInputs = [
+    bzip2
+    zstd
+    elfutils
+    zlib
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '/usr/share' "/share"
+  '';
+
+  makeFlags = [
+    "USEZSTD=on"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+    "LINKTYPE=dynamic"
+  ];
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "SBINDIR=bin"
+  ];
+
+  postInstall = ''
+    ln -s bin $out/sbin
+  '';
+
+  meta = {
+    homepage = "https://github.com/makedumpfile/makedumpfile";
+    description = "Make Linux crash dump small by filtering and compressing pages";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ Scrumplex ];
+    mainProgram = "makedumpfile";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This is my initial implementation of automatic kernel panic dumping. There are multiple way to achieve this. Some distros choose to use `pstore` instead of crashkernel. Perhaps we can do the same.

Some other to-dos include making the log path configurable and allowing additional parameters to makedumpfile.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
