### PR TITLE
uv: 0.8.23 -> 0.9.0

### DIFF
--- a/pkgs/by-name/jj/jj-pre-push/package.nix
+++ b/pkgs/by-name/jj/jj-pre-push/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  fetchpatch2,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -15,6 +16,15 @@ python3Packages.buildPythonApplication rec {
     tag = "v${version}";
     hash = "sha256-9HyVWxYmemF/K3ttQ0L1lZF/XFkSeqwli/Mm+FFI8lQ=";
   };
+
+  patches = [
+    # https://github.com/acarapetis/jj-pre-push/pull/2
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Prince213/jj-pre-push/commit/aa2d917ec9560318178fbc1040281228db7b7ec1.patch?full_index=1";
+      hash = "sha256-uNqOO0yVHShcXxYMPFcPCDM5YlL4IcmpUAfClmDlJ4Q=";
+    })
+  ];
 
   build-system = [
     python3Packages.uv-build

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.8.24";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-BxgVdPh9R+Oiu4kl8fe01mIZche4qy3FsERaMSImA6o=";
+    hash = "sha256-YDpaDArhw0QmJ7fmoNZAewOQx+cMnxW+xhdCL3zQ9GI=";
   };
 
-  cargoHash = "sha256-KQ+YjVmlfDdvUN1Gmmu0duIYZE0+BXirf9ZQH/hGpRI=";
+  cargoHash = "sha256-eHkEUG2Er6qN8JcUaEyJSec6L9cMI4EebNrdv4UJIUk=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.8.23";
+  version = "0.8.24";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-5L/FipR5MPsscpWfpDURbC5qwn6XB5KoOrjedk1HzDo=";
+    hash = "sha256-BxgVdPh9R+Oiu4kl8fe01mIZche4qy3FsERaMSImA6o=";
   };
 
-  cargoHash = "sha256-JHfqsT/W7RvoHx9WbA4fdQZw2/+BOSRuGV3mcMx1FN4=";
+  cargoHash = "sha256-KQ+YjVmlfDdvUN1Gmmu0duIYZE0+BXirf9ZQH/hGpRI=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/development/python-modules/construct-classes/default.nix
+++ b/pkgs/development/python-modules/construct-classes/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   construct,
   fetchFromGitHub,
+  fetchpatch2,
   pytestCheckHook,
   uv-build,
 }:
@@ -18,6 +19,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-goOQMt/nVjWXYltpnKHtJaLOhR+gRTmtoUh7zVb7go4=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/matejcik/construct-classes/commit/d1ecacc0cf5cb332ffe6ed85ce9dfc552f77231f.patch?full_index=1";
+      hash = "sha256-VeifL8bER0mIRNXKTA+/cje8AxWJKg/q8ipmf3gTeiw=";
+    })
+  ];
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/django-bootstrap3/default.nix
+++ b/pkgs/development/python-modules/django-bootstrap3/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   uv-build,
@@ -25,6 +26,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-TaB2PeBjmCNFuEZ+To2Q3C6zlFCaaTB70LxQWWb5AEo=";
   };
+
+  patches = [
+    # https://github.com/zostera/django-bootstrap3/pull/1085
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Prince213/django-bootstrap3/commit/d3285ad9c3de87aa763bb49b9666baed514f7c87.patch?full_index=1";
+      hash = "sha256-VcRC7ehyVTl0KuovD8tNCbZnKXKCOGpux1XXUOoDaTw=";
+    })
+  ];
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/django-bootstrap4/default.nix
+++ b/pkgs/development/python-modules/django-bootstrap4/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   uv-build,
@@ -28,6 +29,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-+G9UHW4eUGl00A/kDj+iTP7ehjj/dwUENKffvGxE6/4=";
   };
+
+  patches = [
+    # https://github.com/zostera/django-bootstrap4/pull/826
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Prince213/django-bootstrap4/commit/e3e6b7cc6720568177d37ff0998007c84c294c5a.patch?full_index=1";
+      hash = "sha256-ZW9y8n0ZCOP37EoP32e7ue6h93KgGw1pW8Q1Q8IuNk8=";
+    })
+  ];
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/django-bootstrap5/default.nix
+++ b/pkgs/development/python-modules/django-bootstrap5/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   django,
   fetchFromGitHub,
+  fetchpatch2,
   jinja2,
   pillow,
   pytest-django,
@@ -22,6 +23,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-aqP2IkAkZsw5vbQxhiy9L3giSgb0seub9gsxPTajiXo=";
   };
+
+  patches = [
+    # https://github.com/zostera/django-bootstrap5/pull/769
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Prince213/django-bootstrap5/commit/e588b25e0c81d9133ca2b9391c125b41d485aefc.patch?full_index=1";
+      hash = "sha256-cFOY+pu2TAZXpAipSIQh1nPPC0ipfncvpObcH667+ac=";
+    })
+  ];
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pythonOlder,
   uv-build,
   pytestCheckHook,
@@ -23,6 +24,14 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-u//L2vxucFlWmk1+pdp+iCrpzzMZUonDAn1LELgX86E=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Ch00k/ffmpy/commit/11a053d11939b488ce7ac362589372904218a798.patch?full_index=1";
+      hash = "sha256-78D64uSX03zp2VM7h3hg493Vtow8fh+tQWXkzVgokDA=";
+    })
+  ];
 
   postPatch =
     # Default to store ffmpeg.

--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -3,6 +3,7 @@
   anyio,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   hishel,
   httpx,
   pydantic,
@@ -25,6 +26,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-4THc5BNQGSrpf3Y3OoFisywEdKp8ZgNjle4yvVLUy1A=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/yanyongyu/githubkit/commit/2817664d904541242d4cedf7aae85cd4c4b606e2.patch?full_index=1";
+      hash = "sha256-mmtjlebHZpHX457frSOe88tsUo7iNdSIUynGZjcjuw4=";
+    })
+  ];
 
   pythonRelaxDeps = [ "hishel" ];
 

--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  fetchpatch2,
   fetchPypi,
   pythonOlder,
 
@@ -41,6 +42,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-cmkz/ZyVYfpz4yOxghsXPF4PhRluwqSXo1CcwvwkXFg=";
   };
+
+  patches = [
+    # https://github.com/marimo-team/marimo/pull/6714
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Prince213/marimo/commit/b1c690e82e8117c451a74fdf172eb51a4861853d.patch?full_index=1";
+      hash = "sha256-iFS5NSGjaGdECRk0LCRSA8XzRb1/sVSZCTRLy6taHNU=";
+    })
+  ];
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/sigstore-models/default.nix
+++ b/pkgs/development/python-modules/sigstore-models/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pydantic,
   typing-extensions,
   uv-build,
@@ -19,6 +20,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-zlIZzfgHZPEuiZu3JNX74Cg1jPNaO1HUhMtpxoyOoqk=";
   };
+
+  patches = [
+    # https://github.com/astral-sh/sigstore-models/pull/4
+    (fetchpatch2 {
+      name = "uv-build.patch";
+      url = "https://github.com/Prince213/sigstore-models/commit/0cbd46ce7ebc8a5d2825b8fc98147a9ba4b3be70.patch?full_index=1";
+      hash = "sha256-6DLhhHkGW2Ok9xwKx6YT5BkCqQNH/Ja/KEO9FHl4NXo=";
+    })
+  ];
 
   build-system = [ uv-build ];
 


### PR DESCRIPTION
Changelog: https://github.com/astral-sh/uv/blob/0.9.0/CHANGELOG.md#090

Cherry picked the commit to master and built on x86_64-linux:
```
/nix/store/dcmkvpbp4dxz6l48nkiw80dzqpfigwx5-uv-0.9.0
/nix/store/3s711pki3ij3pyqvxmhnkp2pviypv9m5-python3.13-uv-0.9.0
/nix/store/y0k9bw1flqmggwny3pj8hkv7jmvqpsh2-python3.13-uv-build-0.9.0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
