### PR TITLE
systemd-openbaod: init at 0.0.0-unstable-2025-10-06

### DIFF
--- a/pkgs/by-name/sy/systemd-openbaod/package.nix
+++ b/pkgs/by-name/sy/systemd-openbaod/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+}:
+buildGoModule {
+  pname = "systemd-openbaod";
+  version = "0.0.0-unstable-2025-10-06";
+  src = fetchFromGitea {
+    domain = "git.lix.systems";
+    owner = "the-distro";
+    repo = "systemd-openbao";
+    rev = "93fa80b0687ffb9c4507694be06b0148ba8966c2";
+    hash = "sha256-8Us8WbEC9L7VdHT3gd7OYqJdGi7WWyV6gLMXR6n2TMg=";
+  };
+  vendorHash = null;
+  meta = {
+    description = "Proxy for secrets between systemd services and openbao";
+    homepage = "https://git.lix.systems/the-distro/systemd-openbao.git";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiara ];
+    platforms = lib.platforms.unix;
+    mainProgram = "systemd-openbaod";
+  };
+}


### PR DESCRIPTION
Add [systemd-openbaod](https://git.lix.systems/the-distro/systemd-openbao.git), a tool for loading credentials into systemd's `LoadCredential` from [OpenBao](https://openbao.org/).

/cc @RaitoBezarius

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
