### PR TITLE
nixos/rke2: Fix CIS profile for version 1.30+

### DIFF
--- a/nixos/modules/services/cluster/rke2/default.nix
+++ b/nixos/modules/services/cluster/rke2/default.nix
@@ -258,6 +258,14 @@ in
       "kernel.panic_on_oops" = 1;
     };
 
+    users = lib.mkIf cfg.cisHardening {
+      users.etcd = {
+        group = "etcd";
+        isSystemUser = true;
+      };
+      groups.etcd = { };
+    };
+
     systemd.services."rke2-${cfg.role}" = {
       description = "Rancher Kubernetes Engine v2";
       documentation = [ "https://github.com/rancher/rke2#readme" ];
@@ -316,7 +324,7 @@ in
             ++ (lib.optional cfg.selinux "--selinux")
             ++ (lib.optional (cfg.role == "server" && cfg.cni != "canal") "--cni=${cfg.cni}")
             ++ (lib.optional cfg.cisHardening "--profile=${
-              if cfg.package.version >= "1.25" then "cis-1.23" else "cis-1.6"
+              if cfg.package.version >= "1.29" then "cis" else "cis-1.23"
             }")
             ++ cfg.extraFlags
           )

--- a/nixos/modules/services/cluster/rke2/default.nix
+++ b/nixos/modules/services/cluster/rke2/default.nix
@@ -258,14 +258,6 @@ in
       "kernel.panic_on_oops" = 1;
     };
 
-    users = lib.mkIf cfg.cisHardening {
-      users.etcd = {
-        group = "etcd";
-        isSystemUser = true;
-      };
-      groups.etcd = { };
-    };
-
     systemd.services."rke2-${cfg.role}" = {
       description = "Rancher Kubernetes Engine v2";
       documentation = [ "https://github.com/rancher/rke2#readme" ];

--- a/nixos/modules/services/cluster/rke2/default.nix
+++ b/nixos/modules/services/cluster/rke2/default.nix
@@ -258,6 +258,14 @@ in
       "kernel.panic_on_oops" = 1;
     };
 
+    users = lib.mkIf cfg.cisHardening {
+      users.etcd = {
+        group = "etcd";
+        isSystemUser = true;
+      };
+      groups.etcd = { };
+    };
+
     systemd.services."rke2-${cfg.role}" = {
       description = "Rancher Kubernetes Engine v2";
       documentation = [ "https://github.com/rancher/rke2#readme" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Per [RKE2 release notes](https://docs.rke2.io/release-notes/v1.30.X#changes-since-v1294rke2r1), the CIS profile `cis-1.23` was deprecated after v1.29. This is used in nixpkgs, giving a fatal error on startup (`time="2025-10-07T17:34:35Z" level=fatal msg="cis-1.23 profile is deprecated. Please use 'cis' instead."`). This PR updates the logic to use `--profile=cis-1.23` for RKE2 `v1.29`, and `--profile=cis` otherwise.

Additionally, when the CIS profile is enabled, [RKE2 will fail when the "etcd" user/group does not exist](https://docs.rke2.io/security/hardening_guide#etcd-is-configured-properly). This PR adds that system user.

Maybe it's worth adding `cisHardening = true` to one of the tests to catch this?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
