### PR TITLE
unpackelf: init at 2022.11.09

### DIFF
--- a/pkgs/by-name/un/unpackelf/package.nix
+++ b/pkgs/by-name/un/unpackelf/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unpackelf";
+  version = "2022.11.09";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "unpackelf";
+    tag = finalAttrs.version;
+    hash = "sha256-uAt4qpctQPGyXFLtRqTBiCXahoA+/b5rYZCjIh8N+QU=";
+  };
+
+  strictDeps = true;
+
+  # Unstream has an install target, but installs unpackelf as `$out/bin`
+  # instead of `$out/bin/unpackelf`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 unpackelf -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/unpackelf";
+    description = "Tool to unpack Sony ELF kernel format image variants";
+    # No license specified in the repository
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "unpackelf";
+  };
+})


### PR DESCRIPTION
Add unpackelf, a tool to unpack kernels from Sony devices.

The goal of this PR is to replace the prebuilt binaries in #449137 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
