### PR TITLE
dhtbsign: init at 0-unstable-2022-11-10

### DIFF
--- a/pkgs/by-name/dh/dhtbsign/package.nix
+++ b/pkgs/by-name/dh/dhtbsign/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "dhtbsign";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "dhtbsign";
+    rev = "2b2711dff153485c549240423d9c908a2912f4b2";
+    hash = "sha256-51zmuQ817Mqx8Hwnx/t4fC9G5huiLGIv+99nRP16mSg=";
+  };
+
+  strictDeps = true;
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isGNU [
+      # Required with newer GCC
+      "-Wno-error=stringop-overflow"
+    ]
+  );
+
+  # Unstream has an install target, but installs dhtbsign as `$out/bin`
+  # instead of `$out/bin/dhtbsign`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 dhtbsign -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/dhtbsign";
+    description = "Tool to write the DHTB header for Samsung Spreadtrum devices";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "dhtbsign";
+  };
+}


### PR DESCRIPTION
Add dhtbsign, a tool for signing firmware for Spreadtrum-based Samsung devices.

The goal of this PR is to replace the prebuilt binaries in #449137 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
