### PR TITLE
elftool: init at 0-unstable-2022-11-10

### DIFF
--- a/pkgs/by-name/el/elftool/package.nix
+++ b/pkgs/by-name/el/elftool/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "elftool";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "elftool";
+    rev = "363653ee89d7b4e1cd5e1f2c878d71acd75fc072";
+    hash = "sha256-nMJhMzzvXtrezZbKdsBq24/El2n7ubiBd5XEYFg3C00=";
+  };
+
+  strictDeps = true;
+
+  # Needed to fix `collect2: error: ld returned 1 exit status`
+  env.NIX_LDFLAGS = if stdenv.hostPlatform.isDarwin then "-lc++" else "-lstdc++";
+
+  makeFlags = [ "CC=c++" ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 elftool -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/elftool";
+    description = "Program for packing and unpacking boot images from Sony mobile devices";
+    license = lib.licenses.free;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "elftool";
+  };
+}


### PR DESCRIPTION
Add elftool, a tool for modifiying firmware for Sony devices

The goal of this PR is to replace the prebuilt binaries in #449137 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
