### PR TITLE
futility: init at 0-release-R144-16503.B

### DIFF
--- a/pkgs/by-name/fu/futility/package.nix
+++ b/pkgs/by-name/fu/futility/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  openssl,
+  pkg-config,
+  nss,
+}:
+let
+  url = "https://chromium.googlesource.com/chromiumos/platform/vboot_reference";
+  branch = "release-R144-16503.B";
+in
+stdenv.mkDerivation {
+  pname = "futility";
+  version = "0-${branch}";
+
+  src = fetchgit {
+    inherit url;
+    rev = "refs/heads/${branch}";
+    hash = "sha256-mij5cDezMYXAIdMlDACfGbck72UhtF4oLY7YWNQS2f8=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    nss
+  ];
+
+  postPatch = ''
+    patchShebangs ./scripts
+    substituteInPlace ./scripts/getversion.sh \
+      --replace-fail "unknown" "${branch}"
+  '';
+
+  makeFlags = [
+    "UB_DIR=$(out)/bin"
+    "USE_FLASHROM=0"
+  ];
+
+  buildFlags = "futil";
+
+  installTargets = "futil_install";
+
+  meta = {
+    homepage = url;
+    description = "ChromeOS firmware utility";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "futility";
+  };
+}


### PR DESCRIPTION
Add futility, a firmware utility for signing ChromeOS images.

The goal of this PR is to replace the prebuilt binaries in #449137 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
