### PR TITLE
loki-tool: init at 0-unstable-2016-06-27

### DIFF
--- a/pkgs/by-name/lo/loki-tool/package.nix
+++ b/pkgs/by-name/lo/loki-tool/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "loki-tool";
+  version = "0-unstable-2016-06-27";
+
+  src = fetchFromGitHub {
+    owner = "djrbliss";
+    repo = "loki";
+    rev = "784e86f981b7b1c30bd0d6b401f071e47e738eb8";
+    hash = "sha256-yeLTQP8TYDkaMmynRxmATPi2/5VxkUZsYd44UQwz4PY=";
+  };
+
+  strictDeps = true;
+
+  # Static build does not work on darwin due to linker issues
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail \
+      "CFLAGS += -g -static -Wall" "CFLAGS += -g -Wall"
+  '';
+
+  # Default build target tries to compile binary for Android
+  buildPhase = ''
+    runHook preBuild
+    make CC=cc loki_tool
+    runHook postBuild
+  '';
+
+  # Upstream has no install target
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 loki_tool -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/djrbliss/loki";
+    description = "Tool for custom firmware on AT&T/Verizon Samsung and LG devices";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "loki_tool";
+  };
+}


### PR DESCRIPTION
Add loki-tool, a tool for modifying firmware for AT&T/Verizon Samsung and LG devices

The goal of this PR is to replace the prebuilt binaries in #449137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
