### PR TITLE
mboot: init at 0-unstable-2022-11-10

### DIFF
--- a/pkgs/by-name/mb/mboot/package.nix
+++ b/pkgs/by-name/mb/mboot/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mboot";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "mboot";
+    rev = "39f59a4f1b6a754c8953172fb80cb2ea1221ed20";
+    hash = "sha256-xpVokOb4cenrrlORNIl58NuOSnaVyCIxRbyunRpix1U=";
+  };
+
+  strictDeps = true;
+
+  # Unstream has an install target, but installs mboot as `$out/bin`
+  # instead of `$out/bin/mboot`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 mboot -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/mboot";
+    description = "Tool to pack and unpack Intel Android boot files";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "mboot";
+  };
+}


### PR DESCRIPTION
Add mboot, a tool for creating and unpacking Intel Android boot images

The goal of this PR is to replace the prebuilt binaries in #449137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
