### PR TITLE
mkmtkhdr: init at 0-unstable-2022-11-10

### DIFF
--- a/pkgs/by-name/mk/mkmtkhdr/package.nix
+++ b/pkgs/by-name/mk/mkmtkhdr/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "mkmtkhdr";
+  version = "0-unstable-2022-11-10";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "mkmtkhdr";
+    rev = "be292c5295feb8158603c8575850208ea6218a78";
+    hash = "sha256-eXC4OpjDCziahhhH73cOUkTsm1VFJE6wTtSk6RD5tqA=";
+  };
+
+  strictDeps = true;
+
+  # Unstream has an install target, but installs mkmtkhdr as `$out/bin`
+  # instead of `$out/bin/mkmtkhdr`
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 mkmtkhdr -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/mkmtkhdr";
+    description = "Tool to write MTK headers for split zImages and ramdisks";
+    license = lib.licenses.free;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "mkmtkhdr";
+  };
+}


### PR DESCRIPTION
Add mkmtkhdr, a tool to write MTK headers for split zImages and ramdisks

The goal of this PR is to replace the prebuilt binaries in #449137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
