### PR TITLE
audit: disable asan test for auparse

### DIFF
--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-NX0TWA+LtcZgbM9aQfokWv2rGNAAb3ksGqAH8URAkYM=";
   };
 
+  patches = [
+    # builds with pie+asan on a hardened linux kernel fail for some reason, so don't test asan
+    ./test-auparse-without-asan.patch
+  ];
+
   postPatch = ''
     substituteInPlace bindings/swig/src/auditswig.i \
       --replace-fail "/usr/include/linux/audit.h" \

--- a/pkgs/by-name/au/audit/test-auparse-without-asan.patch
+++ b/pkgs/by-name/au/audit/test-auparse-without-asan.patch
@@ -1,0 +1,17 @@
+diff --git a/auparse/test/Makefile.am b/auparse/test/Makefile.am
+index f8fd453f..2079f6cc 100644
+--- a/auparse/test/Makefile.am
++++ b/auparse/test/Makefile.am
+@@ -32,12 +32,7 @@ DISTCLEANFILES = $(CLEANFILES)
+ AM_CPPFLAGS = -I${top_srcdir}/auparse -I${top_srcdir}/lib -I${top_srcdir}/common \
+ 	-I${top_srcdir}/src
+ 
+-if HAVE_ASAN
+-AM_CFLAGS = -D_GNU_SOURCE -Wno-pointer-sign ${WFLAGS} ${ASAN_FLAGS}
+-AM_LDFLAGS = ${ASAN_FLAGS}
+-else
+ AM_CFLAGS = -D_GNU_SOURCE -Wno-pointer-sign ${WFLAGS}
+-endif
+ 
+ if BUILD_STATIC
+ STATIC_LINK = -static


### PR DESCRIPTION
Pings:
@vcunat (staging)
@LunNova (pie)
@WilliButz @nikstur (both reproduced this issue)

The auparse test fails for inexplicable reasons when doing pie+asan on a hardend linux kernel


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
