### PR TITLE
pxa-mkbootimg: init at 2022.11.09

### DIFF
--- a/pkgs/by-name/px/pxa-mkbootimg/package.nix
+++ b/pkgs/by-name/px/pxa-mkbootimg/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pxa-mkbootimg";
+  version = "2022.11.09";
+
+  src = fetchFromGitHub {
+    owner = "osm0sis";
+    repo = "pxa-mkbootimg";
+    rev = finalAttrs.version;
+    hash = "sha256-CZxtTPUlbUNsYTdNK0UYhlU45rYy4ToODE00MGlOPb0=";
+  };
+
+  strictDeps = true;
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isGNU [
+      # Required with newer GCC
+      "-Wno-error=stringop-overflow"
+    ]
+  );
+
+  # Upstream has an install target, but doesn't install all required binaries
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 -t $out/bin {pxa-mkbootimg,pxa-unpackbootimg,pxa1088-dtbtool,pxa1908-dtbtool}
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/osm0sis/pxa-mkbootimg";
+    description = "Boot image tool variants for the Marvell PXA1088 and PXA1908 boards";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "pxa-mkbootimg";
+  };
+})


### PR DESCRIPTION
Add pxa-mkbootimg, a collection of tools to create and modify firmware for Marvell-based Android devices

The goal of this PR is to replace the prebuilt binaries in #449137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
