### PR TITLE
sony-dump: init at 0-unstable-2019-11-03

### DIFF
--- a/pkgs/by-name/so/sony-dump/0001-Fix-makefile.patch
+++ b/pkgs/by-name/so/sony-dump/0001-Fix-makefile.patch
@@ -1,0 +1,112 @@
+From 0c9e13dc773fd7048891686ffbfe29fd6f218050 Mon Sep 17 00:00:00 2001
+From: David Wronek <david.wronek@mainlining.org>
+Date: Wed, 8 Oct 2025 20:25:19 +0200
+Subject: [PATCH] Fix makefile
+
+---
+ makefile | 84 +++-----------------------------------------------------
+ 1 file changed, 4 insertions(+), 80 deletions(-)
+
+diff --git a/makefile b/makefile
+index 9cbf7c9..6184d05 100644
+--- a/makefile
++++ b/makefile
+@@ -1,29 +1,8 @@
+ CFLAGS= -Wall -O2 -Iinclude -Izlib-1.2.11 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1
+ 
+-CC=gcc
++CC=cc
+ STRIP=strip
+ 
+-CCWIN=i686-w64-mingw32-gcc
+-CCWINSTRIP=i686-w64-mingw32-strip
+-
+-CCARM=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabi/bin/arm-linux-gnueabi-gcc
+-CCARMSTRIP=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_arm-linux-gnueabi/bin/arm-linux-gnueabi-strip
+-
+-CCARM64=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+-CCARM64STRIP=/home/savan/Desktop/gcc-linaro-5.3.1-2016.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-strip
+-
+-CCAPPLE64=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/x86_64-apple-darwin11-cc
+-CCAPPLESTRIP64=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/x86_64-apple-darwin11-strip
+-
+-CCAPPLE=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/i386-apple-darwin11-cc
+-CCAPPLESTRIP=/home/savan/Desktop/osxtoolchain/osxcross/target/bin/i386-apple-darwin11-strip
+-
+-CCMIPS64=/home/savan/Desktop/buildroot-2017.02.8/output/host/usr/bin/mips64-buildroot-linux-uclibc-gcc
+-CCMIPS64STRIP=/home/savan/Desktop/buildroot-2017.02.8/output/host/usr/bin/mips64-buildroot-linux-uclibc-strip
+-
+-CCMIPS=/home/savan/Desktop/buildroot-2018.02.2/output/host/usr/bin/mips-buildroot-linux-uclibc-gcc
+-CCMIPSSTRIP=/home/savan/Desktop/buildroot-2018.02.2/output/host/usr/bin/mips-buildroot-linux-uclibc-strip
+-
+ SOURCE=   \
+      zlib-1.2.11/adler32.c \
+      zlib-1.2.11/crc32.c \
+@@ -45,61 +24,6 @@ SOURCE=   \
+      untar.c \
+      sony_dump.c
+ 
+-default:download sony_dump.exe sony_dump.i386 sony_dump.x86_64 sony_dump.arm32 sony_dump.arm32_pie sony_dump.arm64 sony_dump.arm64_pie sony_dump.x86_64-apple-darwin11 sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.mips32 archive
+-
+-download:
+-	@if [ ! -d "zlib-1.2.11" ]; then wget https://zlib.net/zlib-1.2.11.tar.gz ; tar xzf zlib-1.2.11.tar.gz ; rm -rf zlib-1.2.11.tar.gz ; fi
+-
+-sony_dump.exe:
+-	${CCWIN} ${CFLAGS} -static ${SOURCE} -o sony_dump.exe
+-	${CCWINSTRIP} sony_dump.exe
+-
+-sony_dump.i386:
+-	${CC} -m32 ${CFLAGS} -static ${SOURCE} -o sony_dump.i386
+-	${STRIP} sony_dump.i386
+-
+-sony_dump.x86_64:
+-	${CC} ${CFLAGS} -static ${SOURCE} -o sony_dump.x86_64
+-	${STRIP} sony_dump.x86_64
+-
+-sony_dump.arm32:
+-	${CCARM} ${CFLAGS} -static ${SOURCE} -o sony_dump.arm32
+-	${CCARMSTRIP} sony_dump.arm32
+-
+-sony_dump.arm32_pie:
+-	@cp -fr sony_dump.arm32 sony_dump.arm32_pie
+-	@dd if=pie of=sony_dump.arm32_pie bs=1 count=1 seek=16 conv=notrunc
+-
+-sony_dump.arm64:
+-	${CCARM64} ${CFLAGS} -static ${SOURCE} -o sony_dump.arm64
+-	${CCARM64STRIP} sony_dump.arm64
+-
+-sony_dump.arm64_pie:
+-	@cp -fr sony_dump.arm64 sony_dump.arm64_pie
+-	@dd if=pie of=sony_dump.arm64_pie bs=1 count=1 seek=16 conv=notrunc
+-
+-sony_dump.i386-apple-darwin11:
+-	${CCAPPLE} ${CFLAGS} ${SOURCE} -o sony_dump.i386-apple-darwin11
+-	${CCAPPLESTRIP} sony_dump.i386-apple-darwin11
+-
+-sony_dump.x86_64-apple-darwin11:
+-	${CCAPPLE64} ${CFLAGS} ${SOURCE} -o sony_dump.x86_64-apple-darwin11
+-	${CCAPPLESTRIP64} sony_dump.x86_64-apple-darwin11
+-
+-sony_dump.mips64:
+-	${CCMIPS64} ${CFLAGS} -static ${SOURCE} -o sony_dump.mips64
+-	${CCMIPS64STRIP} sony_dump.mips64
+-
+-sony_dump.mips32:
+-	${CCMIPS} ${CFLAGS} -static ${SOURCE} -o sony_dump.mips32
+-	${CCMIPSSTRIP} sony_dump.mips32
+-
+-archive:
+-	@zip -9 sony_dump_tool.zip sony_dump.arm32_pie sony_dump.arm64_pie sony_dump.exe sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.x86_64-apple-darwin11 sony_dump.arm32 sony_dump.arm64 sony_dump.i386 sony_dump.mips32 sony_dump.x86_64
+-
+-clean:
+-	rm -rf sony_dump_tool.zip sony_dump.exe sony_dump.i386 sony_dump.x86_64 sony_dump.arm32 sony_dump.arm32_pie sony_dump.arm64 sony_dump.arm64_pie sony_dump.x86_64-apple-darwin11 sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.mips32
+-
+-distclean:
+-	rm -rf sony_dump_tool.zip zlib-1.2.11 sony_dump.exe sony_dump.i386 sony_dump.x86_64 sony_dump.arm32 sony_dump.arm32_pie sony_dump.arm64 sony_dump.arm64_pie sony_dump.x86_64-apple-darwin11 sony_dump.i386-apple-darwin11 sony_dump.mips64 sony_dump.mips32
+-
++default:
++	${CC} ${CFLAGS} ${SOURCE} -o sony_dump
++	${STRIP} sony_dump
+-- 
+2.51.0
+

--- a/pkgs/by-name/so/sony-dump/0002-Fix-darwin-build.patch
+++ b/pkgs/by-name/so/sony-dump/0002-Fix-darwin-build.patch
@@ -1,0 +1,35 @@
+From 2b019a92faf0a35bb953dc3dcb1c2e48a05a55b3 Mon Sep 17 00:00:00 2001
+From: David Wronek <david.wronek@mainlining.org>
+Date: Thu, 9 Oct 2025 09:44:39 +0200
+Subject: [PATCH] Fix darwin build
+
+---
+ zlib-1.2.11/zutil.h | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/zlib-1.2.11/zutil.h b/zlib-1.2.11/zutil.h
+index b079ea6..4e94f2f 100644
+--- a/zlib-1.2.11/zutil.h
++++ b/zlib-1.2.11/zutil.h
+@@ -130,17 +130,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
+ #endif
+ 
+ #ifdef __acorn
+-- 
+2.51.0
+

--- a/pkgs/by-name/so/sony-dump/package.nix
+++ b/pkgs/by-name/so/sony-dump/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+let
+  sony-dump = fetchFromGitHub {
+    name = "sony-dump";
+    owner = "munjeni";
+    repo = "anyxperia_dumper";
+    rev = "2171258c9df50aba139b4bd1aa93295cd14d2262";
+    hash = "sha256-kdHMDIX+ryx63A5TJMsqEZ4W36edC+dQrJKTeh5RFHA=";
+  };
+  zlib = fetchFromGitHub {
+    name = "zlib-1.2.11";
+    owner = "madler";
+    repo = "zlib";
+    tag = "v1.2.11";
+    hash = "sha256-j5b6aki1ztrzfCqu8y729sPar8GpyQWIrajdzpJC+ww=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "sony-dump";
+  version = "0-unstable-2019-11-3";
+
+  srcs = [
+    sony-dump
+    zlib
+  ];
+
+  sourceRoot = sony-dump.name;
+
+  strictDeps = true;
+
+  patches = [
+    ./0001-Fix-makefile.patch
+    ./0002-Fix-darwin-build.patch
+  ];
+
+  prePatch = ''
+    cp -r ${zlib} ${zlib.name}
+    chmod -R a+rwX ${zlib.name}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 sony_dump -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/munjeni/anyxperia_dumper";
+    description = "Tool to dump Sony Xperia boot images";
+    license = lib.licenses.free;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "sony_dump";
+  };
+}


### PR DESCRIPTION
Add sony-dump, a tool to dump Sony Xperia boot images. 

The goal of this PR is to replace the prebuilt binaries in #449137

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
