### PR TITLE
wb32-dfu-updater: fix broken CMake 4 build

### DIFF
--- a/pkgs/by-name/wb/wb32-dfu-updater/fix-cmake4-build.patch
+++ b/pkgs/by-name/wb/wb32-dfu-updater/fix-cmake4-build.patch
@@ -1,0 +1,7 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.10)
+ 
+ set(CMAKE_C_STANDARD 99)

--- a/pkgs/by-name/wb/wb32-dfu-updater/package.nix
+++ b/pkgs/by-name/wb/wb32-dfu-updater/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-DKsDVO00JFhR9hIZksFVJLRwC6PF9LCRpf++QywFO2w=";
   };
 
+  patches = [
+    ./fix-cmake4-build.patch # Temporary fix for https://github.com/WestberryTech/wb32-dfu-updater/pull/19
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libusb1 ];
 


### PR DESCRIPTION
Related to: https://github.com/NixOS/nixpkgs/issues/445447
Temporary fix for: https://github.com/WestberryTech/wb32-dfu-updater/pull/19

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
