### PR TITLE
jetbrains.jdk: 21.0.7 -> 21.0.8

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -45,27 +45,27 @@ let
 in
 jdk.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "21.0.7";
-  build = "1038.58";
+  javaVersion = "21.0.8";
+  build = "1140.54";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
   # git tag --points-at [revision]
   # Look for the line that starts with jbr-
-  openjdkTag = "jbr-release-21.0.7b1038.58";
+  openjdkTag = "jbr-release-21.0.8b1140.54";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-sGAMrE9gAt73jgLlNW8p5Lz37gFiK4ZvMQ8giE2Ia54=";
+    hash = "sha256-Iz5Sh9qRktFYsT7m90IG6LC5+tARtVnvqaiEEGLCAXc=";
   };
 
   env = {
     BOOT_JDK = jdk.home;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    SOURCE_DATE_EPOCH = 1745907200;
+    SOURCE_DATE_EPOCH = 1758959208;
   };
 
   patches = [ ];

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -117,11 +117,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "7a7b9383b3bf39c850feb0d103c6b829e2f48a6b";
+  rev = "bb9fb310ed7f3abf858faf248c53bbb707be21f7";
   # This is the commit number
   # Currently from the branch: https://github.com/JetBrains/jcef/tree/251
   # Run `git rev-list --count HEAD`
-  version = "1014";
+  version = "1083";
 
   nativeBuildInputs = [
     cmake
@@ -147,16 +147,16 @@ stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-ZMxx5mwmsBiUneULHFUDOrJQ8yKuK9bfPz89vN31ql4=";
+    hash = "sha256-BHmGEhfkrUWDfrUFR8d5AgIq8qkAr+blX9n7ZVg8mtc=";
   };
   cef-bin =
     let
       # `cef_binary_${CEF_VERSION}_linux64_minimal`, where CEF_VERSION is from $src/CMakeLists.txt
-      name = "cef_binary_122.1.9+gd14e051+chromium-122.0.6261.94_${platform}_minimal";
+      name = "cef_binary_137.0.17+gf354b0e+chromium-137.0.7151.104_${platform}_minimal";
       hash =
         {
-          "linuxarm64" = "sha256-wABtvz0JHitlkkB748I7yr02Oxs5lXvqDfrBAQiKWHU=";
-          "linux64" = "sha256-qlutM0IsE1emcMe/3p7kwMIK7ou1rZGvpUkrSMVPnCc=";
+          "linuxarm64" = "sha256-QKkJwLtYS3o7lf4T31jIww2LGuAJT3sNTeI3Jq0VEYQ=";
+          "linux64" = "sha256-qE5SOi0/6dPsewyemarTbWG9MbWCQUlng8TgqU+4Tak=";
         }
         .${platform};
       urlName = builtins.replaceStrings [ "+" ] [ "%2B" ] name;

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -99,6 +99,21 @@ let
     .${platform};
   inherit (arches) depsArch projectArch targetArch;
 
+  thrift20 = thrift.overrideAttrs (old: {
+    version = "0.20.0";
+
+    src = fetchFromGitHub {
+      owner = "apache";
+      repo = "thrift";
+      tag = "v0.20.0";
+      hash = "sha256-cwFTcaNHq8/JJcQxWSelwAGOLvZHoMmjGV3HBumgcWo=";
+    };
+
+    cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+      "-DCMAKE_POLICY_VERSION_MINIMUM=3.10"
+    ];
+  });
+
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
@@ -125,7 +140,7 @@ stdenv.mkDerivation rec {
     libXdamage
     nss
     nspr
-    thrift
+    thrift20
   ];
 
   src = fetchFromGitHub {
@@ -184,7 +199,7 @@ stdenv.mkDerivation rec {
       -e 's|vcpkg_install_package(boost-filesystem boost-interprocess thrift)||' \
       -i CMakeLists.txt
 
-    sed -e 's|vcpkg_bring_host_thrift()|set(THRIFT_COMPILER_HOST ${thrift}/bin/thrift)|' -i remote/CMakeLists.txt
+    sed -e 's|vcpkg_bring_host_thrift()|set(THRIFT_COMPILER_HOST ${lib.getExe thrift20})|' -i remote/CMakeLists.txt
 
     mkdir jcef_build
     cd jcef_build


### PR DESCRIPTION
Bump JetBrainsRuntime to the latest release ([21.0.8b1140.54](https://github.com/JetBrains/JetBrainsRuntime/releases/tag/jbr-release-21.0.8b1140.54) as of 2025-10-07), including updating JCEF to the same revision that is used by that particular release.

Additionally, JCEF currently fails to build on Thrift 0.21, so there’s a local override to use 0.20.

Supercedes #439557.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
