### PR TITLE
oxker: add a desktop file

### DIFF
--- a/pkgs/by-name/ox/oxker/package.nix
+++ b/pkgs/by-name/ox/oxker/package.nix
@@ -4,6 +4,8 @@
   fetchCrate,
   rustPlatform,
   nix-update-script,
+  makeDesktopItem,
+  copyDesktopItems,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -24,6 +26,36 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      desktopName = "oxker";
+      comment = finalAttrs.meta.description;
+      exec = finalAttrs.meta.mainProgram;
+      icon = "oxker";
+      terminal = true;
+      categories = [
+        "System"
+        "Utility"
+        "Monitor"
+        "ConsoleOnly"
+      ];
+      keywords = [
+        "docker"
+        "container"
+      ];
+    })
+  ];
+
+  postInstall = ''
+    mkdir --parents $out/share/icons/hicolor/scalable/apps
+    cp .github/logo.svg $out/share/icons/hicolor/scalable/apps/oxker.svg
+  '';
 
   meta = {
     description = "Simple TUI to view & control docker containers";


### PR DESCRIPTION
Makes it possible to run oxker from gnome-shell or such. Upstream has a nice little logo in the repo that can serve as an icon :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
