### PR TITLE
openhd: init at 2.6.0-unstable

### DIFF
--- a/pkgs/by-name/op/openhd/CMakeLists.patch
+++ b/pkgs/by-name/op/openhd/CMakeLists.patch
@@ -1,0 +1,215 @@
+diff --git a/ohd_common/CMakeLists.txt b/ohd_common/CMakeLists.txt
+index 1bb7de06..0437485d 100644
+--- a/ohd_common/CMakeLists.txt
++++ b/ohd_common/CMakeLists.txt
+@@ -28,23 +28,9 @@ endif()
+ #----------------------------------------------------------------------------------------------------------------------
+ # Dependencies: spdlog and nlohmann::json
+ #----------------------------------------------------------------------------------------------------------------------
+-set(SPDLOG_MASTER_PROJECT OFF)
+-set(SPDLOG_PROJECT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/spdlog)
+-set(SPDLOG_SOURCES_DIRECTORY ${SPDLOG_PROJECT_DIRECTORY}/src)
+-
+-set(spdlog_sources
+-    "${SPDLOG_SOURCES_DIRECTORY}/bundled_fmtlib_format.cpp"
+-)
+-
+-target_precompile_headers(OHDCommonLib PRIVATE ${SPDLOG_PROJECT_DIRECTORY}/include/spdlog/spdlog.h)
+-target_include_directories(OHDCommonLib PUBLIC ${SPDLOG_PROJECT_DIRECTORY}/include)
+-
+-# Add nlohmann::json
+-add_subdirectory(lib/json)
+-target_link_libraries(OHDCommonLib PUBLIC nlohmann_json::nlohmann_json)
+-
+-# Add pthread support
+-find_package(Threads REQUIRED)
++find_package(spdlog CONFIG REQUIRED)
++find_package(nlohmann_json CONFIG REQUIRED)
++target_link_libraries(OHDCommonLib PUBLIC spdlog::spdlog nlohmann_json::nlohmann_json)
+ target_link_libraries(OHDCommonLib PUBLIC Threads::Threads)
+ 
+ #----------------------------------------------------------------------------------------------------------------------
+diff --git a/ohd_common/inc/openhd_tcp.h b/ohd_common/inc/openhd_tcp.h
+index bb8e556b..b3e5bd11 100644
+--- a/ohd_common/inc/openhd_tcp.h
++++ b/ohd_common/inc/openhd_tcp.h
+@@ -26,6 +26,7 @@
+ 
+ #include <deque>
+ #include <thread>
++#include <string>
+ 
+ #include "openhd_spdlog.h"
+ 
+diff --git a/ohd_common/src/openhd_action_handler.cpp b/ohd_common/src/openhd_action_handler.cpp
+index 46e02c3e..c2f014c9 100644
+--- a/ohd_common/src/openhd_action_handler.cpp
++++ b/ohd_common/src/openhd_action_handler.cpp
+@@ -25,6 +25,10 @@
+ 
+ #include "openhd_util_time.h"
+ 
++#include <spdlog/spdlog.h>
++
++#include <cassert>
++
+ openhd::ArmingStateHelper &openhd::ArmingStateHelper::instance() {
+   static openhd::ArmingStateHelper instance;
+   return instance;
+diff --git a/ohd_common/src/openhd_bitrate.cpp b/ohd_common/src/openhd_bitrate.cpp
+index c411c5f6..d980c64a 100644
+--- a/ohd_common/src/openhd_bitrate.cpp
++++ b/ohd_common/src/openhd_bitrate.cpp
+@@ -23,6 +23,10 @@
+ 
+ #include "openhd_bitrate.h"
+ 
++#include <spdlog/spdlog.h>
++
++#include <cassert>
++
+ openhd::BitrateDebugger::BitrateDebugger(std::string tag, bool debug_pps)
+     : m_debug_pps(debug_pps) {
+   m_console = openhd::log::create_or_get(tag);
+diff --git a/ohd_common/src/openhd_buttons.cpp b/ohd_common/src/openhd_buttons.cpp
+index 6eeb1812..3b9e887e 100644
+--- a/ohd_common/src/openhd_buttons.cpp
++++ b/ohd_common/src/openhd_buttons.cpp
+@@ -25,6 +25,8 @@
+ 
+ #include <thread>
+ 
++#include <spdlog/spdlog.h>
++
+ #include "openhd_platform.h"
+ #include "openhd_spdlog.h"
+ #include "openhd_util.h"
+diff --git a/ohd_common/src/openhd_external_device.cpp b/ohd_common/src/openhd_external_device.cpp
+index 8b8855eb..4a6e8b87 100644
+--- a/ohd_common/src/openhd_external_device.cpp
++++ b/ohd_common/src/openhd_external_device.cpp
+@@ -28,6 +28,10 @@
+ #include "openhd_spdlog.h"
+ #include "openhd_util.h"
+ 
++#include <spdlog/spdlog.h>
++
++#include <cassert>
++
+ openhd::ExternalDeviceManager::ExternalDeviceManager() {
+   // Here one can manually declare any IP addresses openhd should forward video
+   // / telemetry to
+diff --git a/ohd_common/src/openhd_platform.cpp b/ohd_common/src/openhd_platform.cpp
+index 785345d5..c3e2ce67 100644
+--- a/ohd_common/src/openhd_platform.cpp
++++ b/ohd_common/src/openhd_platform.cpp
+@@ -28,6 +28,8 @@
+ #include <regex>
+ #include <set>
+ 
++#include <spdlog/spdlog.h>
++
+ #include "openhd_spdlog.h"
+ #include "openhd_util.h"
+ #include "openhd_util_filesystem.h"
+diff --git a/ohd_common/src/openhd_settings_imp.cpp b/ohd_common/src/openhd_settings_imp.cpp
+index 27a4e7a0..370cb9a3 100644
+--- a/ohd_common/src/openhd_settings_imp.cpp
++++ b/ohd_common/src/openhd_settings_imp.cpp
+@@ -28,6 +28,8 @@
+ #include <map>
+ #include <sstream>
+ 
++#include <spdlog/spdlog.h>
++
+ #include "openhd_spdlog.h"
+ 
+ std::vector<openhd::Setting> openhd::testing::create_dummy_camera_settings() {
+diff --git a/ohd_common/src/openhd_tcp.cpp b/ohd_common/src/openhd_tcp.cpp
+index 5072c27a..2cbe5746 100644
+--- a/ohd_common/src/openhd_tcp.cpp
++++ b/ohd_common/src/openhd_tcp.cpp
+@@ -24,8 +24,11 @@
+ #include "openhd_tcp.h"
+ 
+ #include <arpa/inet.h>
++#include <errno.h>
++#include <spdlog/spdlog.h>
+ #include <unistd.h>
+ 
++#include <cassert>
+ #include <csignal>
+ #include <queue>
+ #include <utility>
+diff --git a/ohd_common/src/openhd_udp.cpp b/ohd_common/src/openhd_udp.cpp
+index 0a1c5d6c..110e0340 100644
+--- a/ohd_common/src/openhd_udp.cpp
++++ b/ohd_common/src/openhd_udp.cpp
+@@ -24,6 +24,7 @@
+ #include "openhd_udp.h"
+ 
+ #include <arpa/inet.h>
++#include <spdlog/spdlog.h>
+ #include <unistd.h>
+ 
+ #include <algorithm>
+diff --git a/ohd_common/src/openhd_util.cpp b/ohd_common/src/openhd_util.cpp
+index 30ef3c13..c9282c13 100644
+--- a/ohd_common/src/openhd_util.cpp
++++ b/ohd_common/src/openhd_util.cpp
+@@ -24,10 +24,12 @@
+ #include "openhd_util.h"
+ 
+ #include <arpa/inet.h>
++#include <spdlog/spdlog.h>
+ #include <unistd.h>
+ 
+ #include <cctype>
+ #include <chrono>
++#include <cmath>
+ #include <csignal>
+ #include <cstdlib>
+ #include <optional>
+diff --git a/ohd_common/src/openhd_util_async.cpp b/ohd_common/src/openhd_util_async.cpp
+index ac6f8d71..16ac86df 100644
+--- a/ohd_common/src/openhd_util_async.cpp
++++ b/ohd_common/src/openhd_util_async.cpp
+@@ -23,11 +23,14 @@
+ 
+ #include "openhd_util_async.h"
+ 
++#include <algorithm>
+ #include <utility>
+ 
+ #include "openhd_spdlog.h"
+ #include "openhd_util.h"
+ 
++#include <spdlog/spdlog.h>
++
+ openhd::AsyncHandle::AsyncHandle() {
+   m_watchdog_run = true;
+   m_watchdog_thread =
+diff --git a/ohd_common/src/openhd_util_filesystem.cpp b/ohd_common/src/openhd_util_filesystem.cpp
+index 76b6fabd..b3422c6b 100644
+--- a/ohd_common/src/openhd_util_filesystem.cpp
++++ b/ohd_common/src/openhd_util_filesystem.cpp
+@@ -25,6 +25,7 @@
+ 
+ #include <openhd_spdlog.h>
+ #include <openhd_util.h>
++#include <spdlog/spdlog.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ 
+diff --git a/ohd_common/src/openhd_util_time.cpp b/ohd_common/src/openhd_util_time.cpp
+index 02fe9fc5..a344a1fb 100644
+--- a/ohd_common/src/openhd_util_time.cpp
++++ b/ohd_common/src/openhd_util_time.cpp
+@@ -23,6 +23,7 @@
+ 
+ #include "openhd_util_time.h"
+ 
++#include <mutex>
+ #include <sstream>
+ 
+ std::string openhd::util::verbose_timespan(

--- a/pkgs/by-name/op/openhd/package.nix
+++ b/pkgs/by-name/op/openhd/package.nix
@@ -1,0 +1,88 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libv4l,
+  gst_all_1,
+  libpcap,
+  libsodium,
+  lib,
+  nlohmann_json,
+  spdlog,
+  poco,
+  withSDL2 ? true,
+  SDL2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "OpenHD";
+  version = "2.6.0-unstable-2025-10-22";
+
+  src = fetchFromGitHub {
+    owner = "OpenHD";
+    repo = "OpenHD";
+    rev = "7626570e24151624351bf8a700ee88e25908a609";
+    hash = "sha256-kVxvqPgQcEvsqcrjZ4mx7L0nCs1UFxppV5BH42/3ERw=";
+  };
+
+  wifibroadcastSrc = fetchFromGitHub {
+    owner = "OpenHD";
+    repo = "wifibroadcast";
+    rev = "99e53e7ea6dfafff85999504481d7cf26e3ee749";
+    hash = "sha256-rkpFCLWQ8VtINhq0ts5x6o1odpFFQ9RCKVJIrHkDGFk=";
+  };
+
+  mavlinkHeadersSrc = fetchFromGitHub {
+    owner = "OpenHD";
+    repo = "mavlink-headers";
+    rev = "a34e186e2ec6c6a2add840254691a6719606e189";
+    hash = "sha256-s4hIsLhXIaitIwQE6tgJEtHVYeqpP5LnuNNxVrrIJfY=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/OpenHD";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gst_all_1.gst-plugins-base
+    libpcap
+    libsodium
+    libv4l
+    nlohmann_json
+    poco
+    spdlog.dev
+  ]
+  ++ lib.optionals withSDL2 [ SDL2 ];
+
+  patches = [ ./CMakeLists.patch ];
+
+  postPatch = ''
+    echo "Injecting wifibroadcast source to the expected location ..."
+    ln -s ${finalAttrs.wifibroadcastSrc} ohd_common/lib/wifibroadcast
+    substituteInPlace "ohd_interface/CMakeLists.txt" \
+      --replace-fail \
+          'include(lib/wifibroadcast/wifibroadcast/WBLib.cmake)' \
+          'include("''${CMAKE_SOURCE_DIR}/ohd_common/lib/wifibroadcast/wifibroadcast/WBLib.cmake")'
+
+    echo "Injecting mavlink-headers source to the expected location ..."
+    # Doesn't like this to be a symlink
+    mkdir -p ohd_telemetry/lib/mavlink-headers
+    cp -r ${finalAttrs.mavlinkHeadersSrc}/* ohd_telemetry/lib/mavlink-headers/
+  '';
+
+  meta = {
+    mainProgram = "openhd";
+    longDescription = ''
+      OpenHD is a suite of software designed for long-range video transmission,
+      telemetry, and RC control.
+    '';
+    homepage = "https://openhdfpv.org/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ marijanp ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/qo/qopenhd/package.nix
+++ b/pkgs/by-name/qo/qopenhd/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt5,
+  pkg-config,
+  ffmpeg,
+  gst_all_1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "QOpenHD";
+  version = "2.6.0-unstable-2025-09-09";
+  gitRev = "821d6b9cfa7198e2ce582af10e4365685a8bb510";
+
+  src = fetchFromGitHub {
+    owner = "OpenHD";
+    repo = "QOpenHD";
+    rev = finalAttrs.gitRev;
+    hash = "sha256-IWg2S1Kl+FoUQ53sO24s7q9NfYMlEF/gnca2OAMhKpg=";
+  };
+
+  nativeBuildInputs = [
+    qt5.qmake
+    qt5.wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    ffmpeg
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    qt5.qtcharts
+    qt5.qtmultimedia
+    qt5.qtquickcontrols2
+    qt5.qtspeech
+  ];
+
+  mavlinkHeadersSrc = fetchFromGitHub {
+    owner = "OpenHD";
+    repo = "mavlink-headers";
+    rev = "a34e186e2ec6c6a2add840254691a6719606e189";
+    hash = "sha256-s4hIsLhXIaitIwQE6tgJEtHVYeqpP5LnuNNxVrrIJfY=";
+  };
+
+  postPatch = ''
+    echo "Injecting mavlink-headers source to the expected location ..."
+    # Doesn't like this to be a symlink
+    mkdir -p lib/mavlink-headers
+    cp -r ${finalAttrs.mavlinkHeadersSrc}/* lib/mavlink-headers/
+
+    substituteInPlace git.pri \
+      --replace-fail \
+        'QOPENHD_GIT_VERSION = $$system(git describe --always --tags --abbrev=0 --dirty)' \
+        'QOPENHD_GIT_VERSION = "${finalAttrs.version}"'
+
+    substituteInPlace git.pri \
+      --replace-fail \
+        'QOPENHD_GIT_COMMIT_HASH = $$system(git rev-parse HEAD)' \
+        'QOPENHD_GIT_COMMIT_HASH = "${finalAttrs.gitRev}"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    ls -lisa release/
+    cp release/QOpenHD $out/bin/
+    runHook postInstall
+  '';
+
+  meta = {
+    mainProgram = "QOpenHD";
+    longDescription = ''
+      QOpenHD is the default OpenHD companion app that runs on the OHD Ground station
+      or any other "external" devices connected to the ground station.
+    '';
+    homepage = "https://openhdfpv.org/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ marijanp ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packaged the two core components for https://openhdfpv.org/ i.e. https://github.com/OpenHD/OpenHD and https://github.com/OpenHD/QOpenHD

I have created two pull requests where I attempt to get parts of the patches (i.e. the missing includes) merged upstream:
- https://github.com/OpenHD/OpenHD/pull/1219
- https://github.com/OpenHD/OpenHD/pull/1220

I built and ran both packages on x86_64-linux and aarch64-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
