### PR TITLE
windowtolayer: 0-unstable-2025-01-26 -> 0.3.1

### DIFF
--- a/pkgs/by-name/wi/windowtolayer/package.nix
+++ b/pkgs/by-name/wi/windowtolayer/package.nix
@@ -3,37 +3,36 @@
   rustPlatform,
   fetchFromGitLab,
   python3,
-  unstableGitUpdater,
   rustfmt,
+  nix-update-script,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "windowtolayer";
-  version = "0-unstable-2025-01-26";
+  version = "0.3.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mstoeckl";
     repo = "windowtolayer";
-    rev = "5ddb3a2834c834af4ec412bb2ba2c77431953d51";
-    hash = "sha256-PzKx8lkWDJGVj1Azc/vfbSPYV7x5+ZnCGMAAK4o207Y=";
+    tag = "v${version}";
+    hash = "sha256-TUet9DqLMsY34Mb9t4IKr3Z/JxrPgvufzanHI4D9dZg=";
   };
 
-  cargoHash = "sha256-XuSlbBLWUkPsA0DYC4qemvAGyynkkuznA5FGBKRmNso=";
+  cargoHash = "sha256-MqcutNzorDeYoGKWFbCzIrNuo1w2vwnGEFOuooZwPgk=";
 
   nativeBuildInputs = [
     python3
     rustfmt
   ];
 
-  passthru.updateScript = unstableGitUpdater {
-    url = "https://gitlab.freedesktop.org/mstoeckl/windowtolayer.git";
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Display existing Wayland applications as a wallpaper instead";
     homepage = "https://gitlab.freedesktop.org/mstoeckl/windowtolayer";
     mainProgram = "windowtolayer";
     license = lib.licenses.gpl3Plus;
+    platforms = with lib.platforms; linux ++ freebsd;
     maintainers = with lib.maintainers; [ anomalocaris ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated `windowtolayer` to v0.3.1 and changed the update script to use stable versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
