### PR TITLE
mbedtls_2: fix build against Clang >= 20

### DIFF
--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -10,5 +10,20 @@ callPackage ./generic.nix {
       url = "https://github.com/Mbed-TLS/mbedtls/commit/be4af04fcffcfebe44fa12d39388817d9949a9f3.patch";
       hash = "sha256-CbDm6CchzoTia7Wbpbe3bo9CmHPOsxY2d055AfbCS0g=";
     })
+    # fix build against Clang >= 20 (https://github.com/Mbed-TLS/mbedtls-framework/pull/173)
+    (fetchpatch {
+      name = "Add-__attribute__-nonstring-to-remove-unterminated-s.patch";
+      url = "https://github.com/Mbed-TLS/mbedtls-framework/commit/e811994babf84e29e56ebf97265f5fefdf18050f.patch";
+      hash = "sha256-PGXh7tMnl7VqBOWVZP3UqT5pEd0yh4oszEJNMiVOcGo=";
+    })
+    # fix build against Clang >= 20 (https://github.com/Mbed-TLS/mbedtls/pull/10215)
+    (fetchpatch {
+      name = "Add-__attribute__-nonstring-to-remove-unterminated-s.patch";
+      url = "https://github.com/Mbed-TLS/mbedtls/commit/2e1399f1e1ed6fa1072cf9584f5771322b0d001b.patch";
+      includes = [ "tests/*" ];
+      # drop some context in order to apply the backported patch cleanly
+      decode = "interdiff -U1 /dev/null -";
+      hash = "sha256-OTRnYw7Og6eAsB9pue1jkxO1xnkR48efz5QKjN9H0I8=";
+    })
   ];
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

#457852

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc