### PR TITLE
python3Packages.sphinx-prompt: disable runtime deps check for requests version

### DIFF
--- a/pkgs/development/python-modules/sphinx-prompt/default.nix
+++ b/pkgs/development/python-modules/sphinx-prompt/default.nix
@@ -41,6 +41,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # Disable strict runtime dependency checking until upstream relaxes
+  # exact version pin on requests (requests==2.32.4 -> requests>=2.32.4)
+  # See: https://github.com/sbrunner/sphinx-prompt/pull/609
+  # See: https://github.com/NixOS/nixpkgs/issues/449603
+  dontCheckRuntimeDeps = true;
+
   meta = with lib; {
     description = "Sphinx extension for creating unselectable prompt";
     homepage = "https://github.com/sbrunner/sphinx-prompt";


### PR DESCRIPTION
## Description

Temporarily disable strict runtime dependency checking for `sphinx-prompt` to fix build failures caused by exact version pinning on the `requests` package.

## Problem

Upstream `sphinx-prompt` 1.10.0 has an exact version pin (`requests==2.32.4`) instead of a version range. This conflicts with nixpkgs' current `requests` version (2.32.5), causing build failures for packages depending on `sphinx-prompt`, including `incus-lts`.

## Solution

Add `dontCheckRuntimeDeps = true;` to skip the strict version check until upstream fixes the version constraint.

## Related Links

- Upstream fix in progress: https://github.com/sbrunner/sphinx-prompt/pull/609
- Related issue: #449603

## Testing

```bash
nix build nixpkgs#python3Packages.sphinx-prompt
nix build nixpkgs#incus-lts
```

Both builds succeed with this change.

## Notes

This workaround can be removed once:
1. Upstream merges the fix to relax the version constraint
2. A new sphinx-prompt release is published
3. nixpkgs updates to the fixed version