### PR TITLE
fop: 2.8 -> 2.11

### DIFF
--- a/pkgs/by-name/fo/fop/package.nix
+++ b/pkgs/by-name/fo/fop/package.nix
@@ -1,61 +1,43 @@
 {
   lib,
-  stdenv,
   fetchurl,
-  fetchpatch,
-  ant,
-  jdk,
+  maven,
   jre,
   makeWrapper,
   stripJavaArchivesHook,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+maven.buildMavenPackage rec {
   pname = "fop";
-  version = "2.8";
+  version = "2.11";
 
   src = fetchurl {
-    url = "mirror://apache/xmlgraphics/fop/fop-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-b7Av17wu6Ar/npKOiwYqzlvBFSIuXTpqTacM1sxtBvc=";
+    url = "https://dlcdn.apache.org/xmlgraphics/fop/source/fop-${version}-src.tar.gz";
+    hash = "sha256-uY6cUjmyuenfK3jAWvugsYa5qg8rbnvRZZ6qA/g2fZM=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2024-28168.patch";
-      url = "https://github.com/apache/xmlgraphics-fop/commit/d96ba9a11710d02716b6f4f6107ebfa9ccec7134.patch";
-      hash = "sha256-zmUA1Tq6iZtvNECCiXebXodp6AikBn10NTZnVHpPMlw=";
-    })
-  ];
+  mvnHash = "sha256-EaOIAy0+YPrF+yGsFKKqcA4bt90bq1Z86V57P9rMatE=";
+
+  buildOffline = true;
+  doCheck = false;
 
   nativeBuildInputs = [
-    ant
-    jdk
     makeWrapper
     stripJavaArchivesHook
   ];
 
-  # Note: not sure if this is needed anymore
-  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";
-
-  buildPhase = ''
-    runHook preBuild
-
-    # build only the "package" target, which generates the fop command.
-    ant -f fop/build.xml package
-
-    runHook postBuild
-  '';
-
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib $out/share/doc/fop
-    cp fop/build/*.jar fop/lib/*.jar $out/lib/
-    cp -r README fop/examples/ $out/share/doc/fop/
+    install -Dm644 fop*/target/*.jar -t "$out/lib"
+    install -Dm644 fop*/lib/*.jar -t "$out/lib"
+
+    install -Dm644 README -t "$out/share/doc/fop"
+    cp -r fop/examples/ "$out/share/doc/fop"
 
     # There is a fop script in the source archive, but it has many impurities.
     # Instead of patching out 90 % of the script, we write our own.
-    makeWrapper ${jre}/bin/java $out/bin/fop \
+    makeWrapper ${lib.getExe jre} "$out/bin/fop" \
         --add-flags "-Djava.awt.headless=true" \
         --add-flags "-classpath $out/lib/\*" \
         --add-flags "org.apache.fop.cli.Main"
@@ -91,4 +73,4 @@ stdenv.mkDerivation (finalAttrs: {
       binaryBytecode # source bundles dependencies as jars
     ];
   };
-})
+}


### PR DESCRIPTION
Using the suggestions made by @afh in #348116. I did not see a reason to not include `stripJavaArchivesHook`, but I might be missing something.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
