### PR TITLE
maintainers: drop CrazedProgrammer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5308,12 +5308,6 @@
     githubId = 1957293;
     name = "Casey Ransom";
   };
-  CrazedProgrammer = {
-    email = "crazedprogrammer@gmail.com";
-    github = "CrazedProgrammer";
-    githubId = 12202789;
-    name = "CrazedProgrammer";
-  };
   creator54 = {
     email = "hi.creator54@gmail.com";
     github = "Creator54";

--- a/pkgs/by-name/cc/ccemux/package.nix
+++ b/pkgs/by-name/cc/ccemux/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
     maintainers = with maintainers; [
-      CrazedProgrammer
       viluon
     ];
     mainProgram = "ccemux";

--- a/pkgs/by-name/co/compsize/package.nix
+++ b/pkgs/by-name/co/compsize/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     mainProgram = "compsize";
     homepage = "https://github.com/kilobyte/compsize";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ CrazedProgrammer ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/cu/curlpp/package.nix
+++ b/pkgs/by-name/cu/curlpp/package.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     description = "C++ wrapper around libcURL";
     mainProgram = "curlpp-config";
     license = licenses.mit;
-    maintainers = with maintainers; [ CrazedProgrammer ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ur/urn/package.nix
+++ b/pkgs/by-name/ur/urn/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
     description = "Yet another Lisp variant which compiles to Lua";
     mainProgram = "urn";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ CrazedProgrammer ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hasn't been active in Nixpkgs since 2019 ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3ACrazedProgrammer), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3ACrazedProgrammer)) and has not replied to pings since https://github.com/NixOS/nixpkgs/pull/61460, which is way longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs.

@CrazedProgrammer, you have 1 (one) week (Oct 16 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
