### PR TITLE
gtk3: fix clang builds

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -88,6 +88,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./patches/3.0-immodules.cache.patch
     ./patches/3.0-Xft-setting-fallback-compute-DPI-properly.patch
+    # Backport of MR 5531 to fix sincos detection with clang
+    # Adds proper headers and -D_GNU_SOURCE to function checks
+    # MR 5531 was only merged into GTK 4, never backported to gtk-3-24
+    # See: https://github.com/NixOS/nixpkgs/pull/449689
+    # Upstream: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5531
+    ./patches/3.0-mr5531-backport.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin

--- a/pkgs/development/libraries/gtk/patches/3.0-mr5531-backport.patch
+++ b/pkgs/development/libraries/gtk/patches/3.0-mr5531-backport.patch
@@ -1,0 +1,93 @@
+From f1fb82c739aebc6b37090f8ebf74d856129116d3 Mon Sep 17 00:00:00 2001
+From: Matteo Pacini <m+github@matteopacini.me>
+Date: Tue, 14 Oct 2025 22:03:27 +0100
+Subject: [PATCH] Backport MR 5531: Fix sincos detection with clang
+
+Add proper headers and -D_GNU_SOURCE to function checks to ensure
+functions like sincos are properly detected, especially with clang.
+
+Also fix gtkgears.c to avoid issues when sincos is in headers but
+not detected by the build system.
+
+Backport of https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5531
+adapted for GTK 3.24.49.
+---
+ meson.build      | 10 +++++++++-
+ tests/gtkgears.c | 22 ++++++++++++----------
+ 2 files changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 08337ec..92d7781 100644
+--- a/meson.build
++++ b/meson.build
+@@ -255,7 +255,15 @@ check_functions = [
+ ]
+ 
+ foreach func : check_functions
+-  if cc.has_function(func, dependencies: libm)
++  if cc.has_function(func,
++                     args: '-D_GNU_SOURCE',
++                     prefix:
++                       '#include <stdlib.h>\n' +
++                       '#include <unistd.h>\n' +
++                       '#include <sys/mman.h>\n' +
++                       '#include <fcntl.h>\n' +
++                       '#include <math.h>',
++                     dependencies: libm)
+     cdata.set('HAVE_' + func.underscorify().to_upper(), 1)
+   endif
+ endforeach
+diff --git a/tests/gtkgears.c b/tests/gtkgears.c
+index 062b611..ba7e196 100644
+--- a/tests/gtkgears.c
++++ b/tests/gtkgears.c
+@@ -48,14 +48,16 @@
+ #define VERTICES_PER_TOOTH 34
+ #define GEAR_VERTEX_STRIDE 6
+ 
+-#ifndef HAVE_SINCOS
+-static void
+-sincos (double x, double *_sin, double *_cos)
++static inline void
++_sincos (double x, double *_sin, double *_cos)
+ {
++#ifdef HAVE_SINCOS
++  sincos (x, _sin, _cos);
++#else
+   *_sin = sin (x);
+   *_cos = cos (x);
+-}
+ #endif
++}
+ 
+ /**
+  * Struct describing the vertices in triangle strip
+@@ -306,11 +308,11 @@ create_gear (GLfloat inner_radius,
+     struct point p[7];
+ 
+     /* Calculate needed sin/cos for varius angles */
+-    sincos(i * 2.0 * G_PI / teeth + da * 0, &s[0], &c[0]);
+-    sincos(i * 2.0 * M_PI / teeth + da * 1, &s[1], &c[1]);
+-    sincos(i * 2.0 * M_PI / teeth + da * 2, &s[2], &c[2]);
+-    sincos(i * 2.0 * M_PI / teeth + da * 3, &s[3], &c[3]);
+-    sincos(i * 2.0 * M_PI / teeth + da * 4, &s[4], &c[4]);
++    _sincos(i * 2.0 * G_PI / teeth + da * 0, &s[0], &c[0]);
++    _sincos(i * 2.0 * M_PI / teeth + da * 1, &s[1], &c[1]);
++    _sincos(i * 2.0 * M_PI / teeth + da * 2, &s[2], &c[2]);
++    _sincos(i * 2.0 * M_PI / teeth + da * 3, &s[3], &c[3]);
++    _sincos(i * 2.0 * M_PI / teeth + da * 4, &s[4], &c[4]);
+ 
+     GEAR_POINT(p[0], r2, 1);
+     GEAR_POINT(p[1], r2, 2);
+@@ -519,7 +521,7 @@ void perspective(GLfloat *m, GLfloat fovy, GLfloat aspect, GLfloat zNear, GLfloa
+    identity(tmp);
+ 
+    deltaZ = zFar - zNear;
+-   sincos(radians, &sine, &cosine);
++   _sincos(radians, &sine, &cosine);
+ 
+    if ((deltaZ == 0) || (sine == 0) || (aspect == 0))
+       return;
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## gtk3: fix sincos detection with clang

Backports [GTK MR 5531](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5531) to fix sincos detection with clang on all platforms.

### Problem

GTK 3's meson build system fails to properly detect the `sincos()` function when using clang because it doesn't include the necessary headers or `-D_GNU_SOURCE` flag during function detection. This causes build failures in `tests/gtkgears.c` which attempts to use `sincos()`:

```
../tests/gtkgears.c:309:5: error: call to undeclared library function 'sincos' with type 'void (double, double *, double *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
sincos (angle, &s, &c);
^
```


### Solution (thanks @jtojnar !)

This PR backports the fix from GTK 4's [MR 5531](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5531), which was merged in February 2023 but **never backported to the gtk-3-24 stable branch**.

The patch:
1. Adds proper headers (`stdlib.h`, `unistd.h`, `sys/mman.h`, `fcntl.h`, `math.h`) and `-D_GNU_SOURCE` to meson's function detection
2. Updates `tests/gtkgears.c` to use a `_sincos()` wrapper that conditionally uses the native `sincos()` only when `HAVE_SINCOS` is properly detected

This fixes build failures on Darwin platforms (https://hydra.nixos.org/build/308984944)

### References

- Upstream MR: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5531
- Closes #450132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
