### PR TITLE
lib.filesystem.listFilesRecursive: only flatten once

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -239,16 +239,15 @@ in
     ```
   */
   listFilesRecursive =
-    dir:
-    lib.flatten (
-      lib.mapAttrsToList (
-        name: type:
-        if type == "directory" then
-          lib.filesystem.listFilesRecursive (dir + "/${name}")
-        else
-          dir + "/${name}"
-      ) (builtins.readDir dir)
-    );
+    let
+      # We only flatten at the very end, as flatten is recursive.
+      internalFunc =
+        dir:
+        (lib.mapAttrsToList (
+          name: type: if type == "directory" then internalFunc (dir + "/${name}") else dir + "/${name}"
+        ) (builtins.readDir dir));
+    in
+    dir: lib.flatten (internalFunc dir);
 
   /**
     Transform a directory tree containing package files suitable for


### PR DESCRIPTION
Was doing some performance testing on my recursive importing function, and I noticed that `listFilesRecursive` calls `flatten` on every single recursive call. However, `flatten` is recursive - so we can just call it once at the very end.

I listed all the files in nixpkgs (85 thousand!) as a benchmark. This is the performance measured before this patch:
```
❯ hyperfine --warmup 25 --runs 25 'nix-instantiate --eval --expr "with import ./. {}; lib.filesystem.listFilesRecursive ./."'
Benchmark 1: nix-instantiate --eval --expr "with import ./. {}; lib.filesystem.listFilesRecursive ./."
  Time (mean ± σ):     708.6 ms ±   6.2 ms    [User: 397.7 ms, System: 306.0 ms]
  Range (min … max):   699.2 ms … 722.3 ms    25 runs
```
And this is after this patch:
```
❯ hyperfine --warmup 25 --runs 25 'nix-instantiate --eval --expr "with import ./. {}; lib.filesystem.listFilesRecursive ./."'
Benchmark 1: nix-instantiate --eval --expr "with import ./. {}; lib.filesystem.listFilesRecursive ./."
  Time (mean ± σ):     665.2 ms ±   5.9 ms    [User: 361.4 ms, System: 299.8 ms]
  Range (min … max):   654.1 ms … 679.1 ms    25 runs
```

Feel free to test performance yourself. Readability does suffer a little - let me know if there's a more ubiquitous variable name than `internalFunc` here.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
