### PR TITLE
thunderbird-bin: support darwin platforms

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/darwin.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/darwin.nix
@@ -1,0 +1,36 @@
+{
+  pname,
+  version,
+  src,
+  nativeBuildInputs,
+  passthru,
+  meta,
+  stdenv,
+  undmg,
+}:
+
+stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    ;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = nativeBuildInputs ++ [ undmg ];
+
+  # don't break code signing
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    mv Thunderbird*.app "$out/Applications/${passthru.applicationName}.app"
+
+    runHook postInstall
+  '';
+
+  inherit passthru meta;
+}

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -10,12 +10,9 @@
   fetchurl,
   config,
   wrapGAppsHook3,
-  autoPatchelfHook,
-  alsa-lib,
   curl,
   gtk3,
   writeScript,
-  writeText,
   xidel,
   coreutils,
   gnused,
@@ -23,18 +20,29 @@
   gnupg,
   runtimeShell,
   systemLocale ? config.i18n.defaultLocale or "en_US",
-  patchelfUnstable, # have to use patchelfUnstable to support --no-clobber-old-sections
   generated,
   versionSuffix ? "",
   applicationName ? "Thunderbird",
+  # linux dependencies
+  writeText,
+  autoPatchelfHook,
+  patchelfUnstable,
+  alsa-lib,
+  # darwin dependencies
+  undmg,
 }:
 
 let
   inherit (generated) version sources;
 
+  pname = "thunderbird-bin";
+
   mozillaPlatforms = {
     i686-linux = "linux-i686";
     x86_64-linux = "linux-x86_64";
+    # bundles are universal and can be re-used for both darwin architectures
+    aarch64-darwin = "mac";
+    x86_64-darwin = "mac";
   };
 
   arch = mozillaPlatforms.${stdenv.hostPlatform.system};
@@ -42,12 +50,6 @@ let
   isPrefixOf = prefix: string: builtins.substring 0 (builtins.stringLength prefix) string == prefix;
 
   sourceMatches = locale: source: (isPrefixOf source.locale locale) && source.arch == arch;
-
-  policies = {
-    DisableAppUpdate = true;
-  }
-  // config.thunderbird.policies or { };
-  policiesJson = writeText "thunderbird-policies.json" (builtins.toJSON { inherit policies; });
 
   defaultSource = lib.findFirst (sourceMatches "en-US") { } sources;
 
@@ -59,50 +61,23 @@ let
 
   source = lib.findFirst (sourceMatches mozLocale) defaultSource sources;
 
-  pname = "thunderbird-bin";
-in
-
-stdenv.mkDerivation {
-  inherit pname version;
-
   src = fetchurl {
     inherit (source) url sha256;
   };
 
-  nativeBuildInputs = [
-    wrapGAppsHook3
-    autoPatchelfHook
-    patchelfUnstable
-  ];
-  buildInputs = [
-    alsa-lib
-  ];
-  # Thunderbird uses "relrhack" to manually process relocations from a fixed offset
-  patchelfFlags = [ "--no-clobber-old-sections" ];
+  meta = {
+    changelog = "https://www.thunderbird.net/en-US/thunderbird/${version}/releasenotes/";
+    description = "Mozilla Thunderbird, a full-featured email client (binary package)";
+    homepage = "http://www.mozilla.org/thunderbird/";
+    mainProgram = "thunderbird";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ lovesegfault ];
+    platforms = builtins.attrNames mozillaPlatforms;
+    hydraPlatforms = [ ];
+  };
 
-  patchPhase = ''
-    # Don't download updates from Mozilla directly
-    echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
-  '';
-
-  installPhase = ''
-    mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
-    cp -r * "$prefix/usr/lib/thunderbird-bin-${version}"
-
-    mkdir -p "$out/bin"
-    ln -s "$prefix/usr/lib/thunderbird-bin-${version}/thunderbird" "$out/bin/"
-
-    # wrapThunderbird expects "$out/lib" instead of "$out/usr/lib"
-    ln -s "$out/usr/lib" "$out/lib"
-
-    gappsWrapperArgs+=(--argv0 "$out/bin/.thunderbird-wrapped")
-
-    # See: https://github.com/mozilla/policy-templates/blob/master/README.md
-    mkdir -p "$out/lib/thunderbird-bin-${version}/distribution";
-    ln -s ${policiesJson} "$out/lib/thunderbird-bin-${version}/distribution/policies.json";
-  '';
-
-  passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {
+  updateScript = import ./../../browsers/firefox-bin/update.nix {
     inherit
       pname
       writeScript
@@ -120,22 +95,48 @@ stdenv.mkDerivation {
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
   };
 
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
+
   passthru = {
-    inherit applicationName;
+    inherit
+      applicationName
+      updateScript
+      gtk3
+      ;
     binaryName = "thunderbird";
     gssSupport = true;
-    gtk3 = gtk3;
   };
 
-  meta = {
-    changelog = "https://www.thunderbird.net/en-US/thunderbird/${version}/releasenotes/";
-    description = "Mozilla Thunderbird, a full-featured email client (binary package)";
-    homepage = "http://www.mozilla.org/thunderbird/";
-    mainProgram = "thunderbird";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ lovesegfault ];
-    platforms = builtins.attrNames mozillaPlatforms;
-    hydraPlatforms = [ ];
-  };
-}
+in
+if stdenv.hostPlatform.isDarwin then
+  import ./darwin.nix {
+    inherit
+      pname
+      version
+      src
+      nativeBuildInputs
+      passthru
+      meta
+      stdenv
+      undmg
+      ;
+  }
+else
+  import ./linux.nix {
+    inherit
+      pname
+      version
+      src
+      nativeBuildInputs
+      passthru
+      meta
+      stdenv
+      config
+      writeText
+      autoPatchelfHook
+      patchelfUnstable
+      alsa-lib
+      ;
+  }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/linux.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/linux.nix
@@ -1,0 +1,70 @@
+{
+  pname,
+  version,
+  src,
+  nativeBuildInputs,
+  passthru,
+  meta,
+  stdenv,
+  config,
+  writeText,
+  autoPatchelfHook,
+  patchelfUnstable,
+  alsa-lib,
+}:
+
+let
+  policies = {
+    DisableAppUpdate = true;
+  }
+  // config.thunderbird.policies or { };
+
+  policiesJson = writeText "thunderbird-policies.json" (builtins.toJSON { inherit policies; });
+in
+stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    ;
+
+  nativeBuildInputs = nativeBuildInputs ++ [
+    autoPatchelfHook
+    patchelfUnstable
+  ];
+
+  buildInputs = [
+    alsa-lib
+  ];
+
+  # Thunderbird uses "relrhack" to manually process relocations from a fixed offset
+  patchelfFlags = [ "--no-clobber-old-sections" ];
+
+  postPatch = ''
+    # Don't download updates from Mozilla directly
+    echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$prefix/usr/lib/thunderbird-bin-${version}"
+    cp -r * "$prefix/usr/lib/thunderbird-bin-${version}"
+
+    mkdir -p "$out/bin"
+    ln -s "$prefix/usr/lib/thunderbird-bin-${version}/thunderbird" "$out/bin/"
+
+    # wrapThunderbird expects "$out/lib" instead of "$out/usr/lib"
+    ln -s "$out/usr/lib" "$out/lib"
+
+    gappsWrapperArgs+=(--argv0 "$out/bin/.thunderbird-wrapped")
+
+    # See: https://github.com/mozilla/policy-templates/blob/master/README.md
+    mkdir -p "$out/lib/thunderbird-bin-${version}/distribution";
+    ln -s ${policiesJson} "$out/lib/thunderbird-bin-${version}/distribution/policies.json";
+
+    runHook postInstall
+  '';
+
+  inherit passthru meta;
+}


### PR DESCRIPTION
This patch makes `thunderbird-bin` available on `aarch64-darwin` and `x86_64-darwin`.

## Things done

Mostly just copied `firefox-bin`.

The mac sources were already being fetched so the changes are very minimal.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
