### PR TITLE
server-box: fix build error: identifier 'xxx' preceded by whitespace in a literal operator declaration is deprecated

### DIFF
--- a/pkgs/by-name/se/server-box/package.nix
+++ b/pkgs/by-name/se/server-box/package.nix
@@ -34,6 +34,9 @@ flutter335.buildFlutterApplication {
     autoPatchelfHook
   ];
 
+  # https://github.com/juliansteenbakker/flutter_secure_storage/issues/965
+  CXXFLAGS = [ "-Wno-deprecated-literal-operator" ];
+
   desktopItems = [
     (makeDesktopItem {
       name = "server-box";


### PR DESCRIPTION
The build error was introduced by #444862:

<details><summary>Error log</summary>

```
[        ] In file included from /build/source/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_sto
rage_linux/linux/flutter_secure_storage_linux_plugin.cc:2:
[        ] In file included from /build/source/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_sto
rage_linux/linux/include/Secret.hpp:2:
[        ] /build/source/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux/linux/inclu
de/json.hpp:24392:35: error: identifier '_json' preceded by whitespace in a literal operator declaration i
s deprecated [-Werror,-Wdeprecated-literal-operator]
[   +1 ms]  24392 | inline nlohmann::json operator "" _json(const char* s, std::size_t n)
[        ]        |                       ~~~~~~~~~~~~^~~~~
[        ]        |                       operator""_json
[        ] /build/source/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux/linux/inclu
de/json.hpp:24400:49: error: identifier '_json_pointer' preceded by whitespace in a literal operator decla
ration is deprecated [-Werror,-Wdeprecated-literal-operator]
[        ]  24400 | inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size
_t n)
[        ]        |                                     ~~~~~~~~~~~~^~~~~~~~~~~~~
[        ]        |                                     operator""_json_pointer
[        ] /build/source/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux/linux/inclu
de/json.hpp:24464:58: error: identifier '_json' preceded by whitespace in a literal operator declaration i
s deprecated [-Werror,-Wdeprecated-literal-operator]
[        ]  24464 |     using nlohmann::literals::json_literals::operator "" _json; // NOLINT(misc-unused-
using-decls,google-global-names-in-headers)
[        ]        |                                              ~~~~~~~~~~~~^~~~~
[        ]        |                                              operator""_json
[        ] /build/source/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux/linux/inclu
de/json.hpp:24465:58: error: identifier '_json_pointer' preceded by whitespace in a literal operator decla
ration is deprecated [-Werror,-Wdeprecated-literal-operator]
[        ]  24465 |     using nlohmann::literals::json_literals::operator "" _json_pointer; //NOLINT(misc-
unused-using-decls,google-global-names-in-headers)
[        ]        |                                              ~~~~~~~~~~~~^~~~~~~~~~~~~
[        ]        |                                              operator""_json_pointer
[        ] 4 errors generated.
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
