### PR TITLE
treewide: remove usages of obsolete pie hardening flag

### DIFF
--- a/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
@@ -32,10 +32,6 @@ stdenv.mkDerivation rec {
     faust2lv2
   ];
 
-  # ld: crtbegin.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a PIE object
-  # ld: failed to set dynamic section sizes: bad value
-  hardeningDisable = [ "pie" ];
-
   enableParallelBuilding = true;
 
   dontWrapQtApps = true;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -158,8 +158,6 @@ stdenv.mkDerivation rec {
   ++ lib.concatMap (p: p.buildInputs) enabledPlugins
   ++ extraBuildInputs;
 
-  hardeningEnable = [ "pie" ];
-
   env.NIX_CFLAGS_COMPILE =
     "-I${python}/include/${python.libPrefix}"
     # Fix '_res_9_init: undefined symbol' error

--- a/pkgs/by-name/_2/_2ship2harkinian/package.nix
+++ b/pkgs/by-name/_2/_2ship2harkinian/package.nix
@@ -150,9 +150,6 @@ stdenv.mkDerivation (finalAttrs: {
   # Linking fails without this
   hardeningDisable = [ "format" ];
 
-  # Pie needs to be enabled or else it segfaults
-  hardeningEnable = [ "pie" ];
-
   preConfigure = ''
     # mirror 2ship's stb
     mkdir stb

--- a/pkgs/by-name/ba/bakelite/package.nix
+++ b/pkgs/by-name/ba/bakelite/package.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation {
     hash = "sha256-rRJrtCcgfbqC/4qQiTVeUUcPqoJlNfitYRqIO58AmpA=";
   };
 
-  hardeningEnable = [ "pie" ];
   preBuild = ''
     # pipe2() is only exposed with _GNU_SOURCE
     # Upstream makefile explicitly uses -O3 to improve SHA-3 performance

--- a/pkgs/by-name/ch/chrony/package.nix
+++ b/pkgs/by-name/ch/chrony/package.nix
@@ -62,8 +62,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   doCheck = true;
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   passthru.tests = {
     inherit (nixosTests) chrony chrony-ptp;
   };

--- a/pkgs/by-name/dn/dnsmasq/package.nix
+++ b/pkgs/by-name/dn/dnsmasq/package.nix
@@ -53,8 +53,6 @@ stdenv.mkDerivation rec {
     "PKG_CONFIG=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
   ];
 
-  hardeningEnable = [ "pie" ];
-
   postBuild = lib.optionalString stdenv.hostPlatform.isLinux ''
     make -C contrib/lease-tools
   '';

--- a/pkgs/by-name/fa/faustPhysicalModeling/package.nix
+++ b/pkgs/by-name/fa/faustPhysicalModeling/package.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
     bash
   ];
 
-  # ld: /nix/store/*-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14.2.1/crtbegin.o:
-  #  relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a PIE object
-  hardeningDisable = [ "pie" ];
-
   dontWrapQtApps = true;
 
   buildPhase = ''

--- a/pkgs/by-name/ic/icecast/package.nix
+++ b/pkgs/by-name/ic/icecast/package.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation rec {
     libopus
   ];
 
-  hardeningEnable = [ "pie" ];
-
   meta = {
     description = "Server software for streaming multimedia";
     mainProgram = "icecast";

--- a/pkgs/by-name/is/isc-cron/package.nix
+++ b/pkgs/by-name/is/isc-cron/package.nix
@@ -35,8 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
     "DESTROOT=$(out)"
   ];
 
-  hardeningEnable = [ "pie" ];
-
   unpackCmd = ''
     mkdir cron
     pushd cron

--- a/pkgs/by-name/ke/kexec-tools/package.nix
+++ b/pkgs/by-name/ke/kexec-tools/package.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
     "format"
     "pic"
     "relro"
-    "pie"
   ];
 
   # Prevent kexec-tools from using uname to detect target, which is wrong in

--- a/pkgs/by-name/ke/keydb/package.nix
+++ b/pkgs/by-name/ke/keydb/package.nix
@@ -57,8 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   # darwin currently lacks a pure `pgrep` which is extensively used here
   doCheck = !stdenv.hostPlatform.isDarwin;
   nativeCheckInputs = [

--- a/pkgs/by-name/lw/lwan/package.nix
+++ b/pkgs/by-name/lw/lwan/package.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation rec {
   # Note: tcmalloc and mimalloc are also supported (and normal malloc)
   cmakeFlags = lib.optional enableJemalloc "-DUSE_ALTERNATIVE_MALLOC=jemalloc";
 
-  hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "pie";
-
   meta = with lib; {
     description = "Lightweight high-performance multi-threaded web server";
     mainProgram = "lwan";

--- a/pkgs/by-name/ly/lynx/package.nix
+++ b/pkgs/by-name/ly/lynx/package.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = [ "pie" ];
-
   configureFlags = [
     "--enable-default-colors"
     "--enable-widec"

--- a/pkgs/by-name/me/memcached/package.nix
+++ b/pkgs/by-name/me/memcached/package.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
     libevent
   ];
 
-  hardeningEnable = [ "pie" ];
-
   env.NIX_CFLAGS_COMPILE = toString (
     [ "-Wno-error=deprecated-declarations" ] ++ lib.optional stdenv.hostPlatform.isDarwin "-Wno-error"
   );

--- a/pkgs/by-name/ne/netclient/package.nix
+++ b/pkgs/by-name/ne/netclient/package.nix
@@ -21,8 +21,6 @@ buildGoModule rec {
 
   buildInputs = lib.optional stdenv.hostPlatform.isLinux libX11;
 
-  hardeningEnabled = [ "pie" ];
-
   meta = {
     description = "Automated WireGuard® Management Client";
     mainProgram = "netclient";

--- a/pkgs/by-name/nt/ntp/package.nix
+++ b/pkgs/by-name/nt/ntp/package.nix
@@ -45,8 +45,6 @@ stdenv.mkDerivation rec {
     libcap
   ];
 
-  hardeningEnable = [ "pie" ];
-
   postInstall = ''
     rm -rf $out/share/doc
   '';

--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -100,7 +100,6 @@ stdenv.mkDerivation rec {
   ++ lib.optional withTLSRPT libtlsrpt;
 
   hardeningDisable = [ "format" ];
-  hardeningEnable = [ "pie" ];
 
   patches = [
     ./postfix-script-shell.patch

--- a/pkgs/by-name/pr/prismlauncher-unwrapped/package.nix
+++ b/pkgs/by-name/pr/prismlauncher-unwrapped/package.nix
@@ -74,8 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional gamemodeSupport gamemode;
 
-  hardeningEnable = lib.optionals stdenv.hostPlatform.isLinux [ "pie" ];
-
   cmakeFlags = [
     # downstream branding
     (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")

--- a/pkgs/by-name/re/redict/package.nix
+++ b/pkgs/by-name/re/redict/package.nix
@@ -68,8 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isClang [ "-std=c11" ]);
 
   # darwin currently lacks a pure `pgrep` which is extensively used here

--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -66,8 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isFreeBSD "-lexecinfo";
 
   # darwin currently lacks a pure `pgrep` which is extensively used here

--- a/pkgs/by-name/rs/rspamd/package.nix
+++ b/pkgs/by-name/rs/rspamd/package.nix
@@ -56,8 +56,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  hardeningEnable = [ "pie" ];
-
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/by-name/sd/sdcc/package.nix
+++ b/pkgs/by-name/sd/sdcc/package.nix
@@ -104,10 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
     fi
   '';
 
-  # ${src}/support/cpp/gcc/Makefile.in states:
-  # We don't want to compile the compilers with -fPIE, it make PCH fail.
-  hardeningDisable = [ "pie" ];
-
   meta = {
     homepage = "https://sdcc.sourceforge.net/";
     description = "Small Device C Compiler";

--- a/pkgs/by-name/se/seabios/package.nix
+++ b/pkgs/by-name/se/seabios/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [
     "fortify"
     "pic"
-    "pie" # ld: warning: creating DT_TEXTREL in a PIE (and more)
     "stackprotector"
   ];
 

--- a/pkgs/by-name/sh/shncpd/package.nix
+++ b/pkgs/by-name/sh/shncpd/package.nix
@@ -15,8 +15,6 @@ stdenv.mkDerivation {
     sha256 = "1sj7a77isc2jmh7gw2naw9l9366kjx6jb909h7spj7daxdwvji8f";
   };
 
-  hardeningEnable = [ "pie" ];
-
   preConfigure = ''
     makeFlags=( "PREFIX=$out" )
   '';

--- a/pkgs/by-name/so/socat/package.nix
+++ b/pkgs/by-name/so/socat/package.nix
@@ -38,8 +38,6 @@ stdenv.mkDerivation rec {
     readline
   ];
 
-  hardeningEnable = [ "pie" ];
-
   enableParallelBuilding = true;
 
   nativeCheckInputs = [

--- a/pkgs/by-name/so/solo5/package.nix
+++ b/pkgs/by-name/so/solo5/package.nix
@@ -40,8 +40,6 @@ stdenv.mkDerivation {
     hash = "sha256-KbeY667Y/ZPUuRIGYOZMMAuVEVJ7Kn9UDUSThX5zfII=";
   };
 
-  hardeningEnable = [ "pie" ];
-
   configurePhase = ''
     runHook preConfigure
     sh configure.sh --prefix=/

--- a/pkgs/by-name/ss/sshesame/package.nix
+++ b/pkgs/by-name/ss/sshesame/package.nix
@@ -24,8 +24,6 @@ buildGoModule rec {
     "-w"
   ];
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/sy/syslinux/package.nix
+++ b/pkgs/by-name/sy/syslinux/package.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [
     "pic"
-    "pie" # MBR gets too big with PIE
     "stackprotector"
     "fortify"
   ];

--- a/pkgs/by-name/va/valgrind/package.nix
+++ b/pkgs/by-name/va/valgrind/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
   ];
 
   hardeningDisable = [
-    "pie"
     "stackprotector"
   ];
 

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -64,8 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isClang [ "-std=c11" ]);
 
   # darwin currently lacks a pure `pgrep` which is extensively used here

--- a/pkgs/development/compilers/fpc/default.nix
+++ b/pkgs/development/compilers/fpc/default.nix
@@ -80,9 +80,6 @@ stdenv.mkDerivation rec {
     "FPC=${startFPC}/bin/fpc"
   ];
 
-  # disabled by default in fpcsrc/compiler/llvm/agllvm.pas
-  hardeningDisable = [ "pie" ];
-
   installFlags = [ "INSTALL_PREFIX=\${out}" ];
 
   postInstall = ''

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -234,7 +234,6 @@ pipe
 
       hardeningDisable = [
         "format"
-        "pie"
         "stackclashprotection"
       ];
 

--- a/pkgs/development/compilers/ghc/9.0.2-binary.nix
+++ b/pkgs/development/compilers/ghc/9.0.2-binary.nix
@@ -474,13 +474,6 @@ stdenv.mkDerivation {
       "$out/bin/ghc-pkg" --package-db="$package_db" recache
     '';
 
-  # GHC cannot currently produce outputs that are ready for `-pie` linking.
-  # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
-  # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
-  # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
-  hardeningDisable = [ "pie" ];
-
   doInstallCheck = true;
   installCheckPhase = ''
     # Sanity check, can ghc create executables?

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -438,13 +438,6 @@ stdenv.mkDerivation {
       "$out/bin/ghc-pkg" --package-db="$package_db" recache
     '';
 
-  # GHC cannot currently produce outputs that are ready for `-pie` linking.
-  # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
-  # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
-  # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
-  hardeningDisable = [ "pie" ];
-
   doInstallCheck = true;
   installCheckPhase = ''
     # Sanity check, can ghc create executables?

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -417,13 +417,6 @@ stdenv.mkDerivation {
       "$out/bin/ghc-pkg" --package-db="$package_db" recache
     '';
 
-  # GHC cannot currently produce outputs that are ready for `-pie` linking.
-  # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
-  # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
-  # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
-  hardeningDisable = [ "pie" ];
-
   doInstallCheck = true;
   installCheckPhase = ''
     # Sanity check, can ghc create executables?

--- a/pkgs/development/compilers/ghc/9.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.8.4-binary.nix
@@ -432,13 +432,6 @@ stdenv.mkDerivation {
       "$out/bin/ghc-pkg" --package-db="$package_db" recache
     '';
 
-  # GHC cannot currently produce outputs that are ready for `-pie` linking.
-  # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
-  # See:
-  # * https://github.com/NixOS/nixpkgs/issues/129247
-  # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
-  hardeningDisable = [ "pie" ];
-
   doInstallCheck = true;
   installCheckPhase = ''
     # Sanity check, can ghc create executables?

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -780,14 +780,8 @@ stdenv.mkDerivation (
 
     checkTarget = "test";
 
-    # GHC cannot currently produce outputs that are ready for `-pie` linking.
-    # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
-    # See:
-    # * https://github.com/NixOS/nixpkgs/issues/129247
-    # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
     hardeningDisable = [
       "format"
-      "pie"
     ];
 
     # big-parallel allows us to build with more than 2 cores on

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -600,14 +600,8 @@ stdenv.mkDerivation (
 
     checkTarget = "test";
 
-    # GHC cannot currently produce outputs that are ready for `-pie` linking.
-    # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
-    # See:
-    # * https://github.com/NixOS/nixpkgs/issues/129247
-    # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
     hardeningDisable = [
       "format"
-      "pie"
     ];
 
     # big-parallel allows us to build with more than 2 cores on

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -134,8 +134,7 @@ stdenv.mkDerivation (
         ];
     # x86_64-unknown-linux-musl-ld: -r and -pie may not be used together
     hardeningDisable =
-      lib.optional (lib.versionAtLeast version "4.09" && stdenv.hostPlatform.isMusl) "pie"
-      ++ lib.optional (lib.versionAtLeast version "5.0" && stdenv.cc.isClang) "strictoverflow"
+      lib.optional (lib.versionAtLeast version "5.0" && stdenv.cc.isClang) "strictoverflow"
       ++ lib.optionals (args ? hardeningDisable) args.hardeningDisable;
 
     # Older versions have some race:

--- a/pkgs/development/compilers/yosys/plugins/symbiflow.nix
+++ b/pkgs/development/compilers/yosys/plugins/symbiflow.nix
@@ -39,7 +39,6 @@ let
 
   static_gtest = gtest.overrideAttrs (old: {
     dontDisableStatic = true;
-    disableHardening = [ "pie" ];
     cmakeFlags = old.cmakeFlags ++ [ "-DBUILD_SHARED_LIBS=OFF" ];
   });
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -730,13 +730,7 @@ lib.fix (
       # package specifies `hardeningDisable`.
       hardeningDisable =
         lib.optionals (args ? hardeningDisable) hardeningDisable
-        ++ lib.optional (ghc.isHaLVM or false) "all"
-        # Static libraries (ie. all of pkgsStatic.haskellPackages) fail to build
-        # because by default Nix adds `-pie` to the linker flags: this
-        # conflicts with the `-r` and `-no-pie` flags added by GHC (see
-        # https://gitlab.haskell.org/ghc/ghc/-/issues/19580). hardeningDisable
-        # changes the default Nix behavior regarding adding "hardening" flags.
-        ++ lib.optional enableStaticLibraries "pie";
+        ++ lib.optional (ghc.isHaLVM or false) "all";
 
       configurePhase = ''
         runHook preConfigure

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -122,11 +122,6 @@ stdenv.mkDerivation {
     cd builddir
   '';
 
-  # ;; Loading file ../src/defmacro.lisp ...
-  # *** - handle_fault error2 ! address = 0x8 not in [0x1000000c0000,0x1000000c0000) !
-  # SIGSEGV cannot be cured. Fault address = 0x8.
-  hardeningDisable = [ "pie" ];
-
   doCheck = true;
 
   postInstall = lib.optionalString (withModules != [ ]) ''

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -584,9 +584,6 @@ stdenv.mkDerivation (finalAttrs: {
       export CFLAGS_NODIST="-fno-semantic-interposition"
     '';
 
-  # Our aarch64-linux bootstrap files lack Scrt1.o, which fails the config test
-  hardeningEnable = lib.optionals (!withMinimalDeps && !stdenv.hostPlatform.isAarch64) [ "pie" ];
-
   setupHook = python-setup-hook sitePackages;
 
   postInstall =

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -48,8 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     sourceRoot=$(readlink -e "./libgcc")
   '';
 
-  hardeningDisable = [ "pie" ];
-
   preConfigure = ''
     # Drop in libiberty, as external builds are not expected
     cd "$buildRoot"

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -58,12 +58,11 @@ in
       makeFlagsArray+=("bindir=$bin/bin" "sbindir=$bin/sbin" "rootsbindir=$bin/sbin")
     '';
 
-    # The pie, stackprotector and fortify hardening flags are autodetected by
+    # The stackprotector and fortify hardening flags are autodetected by
     # glibc and enabled by default if supported. Setting it for every gcc
     # invocation does not work.
     hardeningDisable = [
       "fortify"
-      "pie"
       "stackprotector"
       "strictflexarrays3"
     ];

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -24,9 +24,6 @@ buildDunePackage rec {
     export sourceRoot=$PWD
   '';
 
-  # x86_64-unknown-linux-musl-ld: -r and -pie may not be used together
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
-
   nativeBuildInputs = [
     menhir
     odoc

--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -35,9 +35,6 @@ buildGoModule (finalAttrs: {
 
   doCheck = false;
 
-  # /nix/store/.../bin/ld: internal/mkcw/embed/entrypoint_amd64.o: relocation R_X86_64_32S against `.rodata.1' can not be used when making a PIE object; recompile with -fPIE
-  hardeningDisable = [ "pie" ];
-
   nativeBuildInputs = [
     go-md2man
     installShellFiles

--- a/pkgs/development/tools/misc/binutils/2.38/default.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/default.nix
@@ -179,7 +179,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [
     "format"
-    "pie"
   ];
 
   configurePlatforms = [

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -209,7 +209,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   hardeningDisable = [
     "format"
-    "pie"
   ];
 
   configurePlatforms = [

--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -31,9 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   strictDeps = true;
 
-  # x86_64-unknown-linux-musl-ld: -r and -pie may not be used together
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
-
   configurePhase = ''
     runHook preConfigure
 

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [
     "format"
-    "pie"
   ]
   ++ lib.optionals enableStatic [ "fortify" ];
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -573,7 +573,6 @@ lib.makeOverridable (
           "fortify"
           "stackprotector"
           "pic"
-          "pie"
         ];
 
         makeFlags = [

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -254,8 +254,6 @@ stdenv.mkDerivation {
       --replace-fail '@nixStoreDirLen@' "''${#NIX_STORE}"
   '' postPatch;
 
-  hardeningEnable = lib.optional (!stdenv.hostPlatform.isDarwin) "pie";
-
   enableParallelBuilding = true;
 
   preInstall = ''

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -137,8 +137,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = (lib.concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
 
-  hardeningEnable = optional (!stdenv.hostPlatform.isDarwin) "pie";
-
   enableParallelBuilding = true;
 
   postInstall = ''

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -178,8 +178,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = [ "pie" ];
-
   meta = with lib; {
     description = "Scalable, high-performance, open source NoSQL database";
     homepage = "http://www.mongodb.org";

--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -52,8 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   __structuredAttrs = true;
 
-  hardeningEnable = lib.optionals (!stdenv.cc.isClang) [ "pie" ];
-
   outputs = [
     "out"
     "dev"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -151,7 +151,6 @@ let
     "nostrictaliasing"
     "pacret"
     "pic"
-    "pie"
     "relro"
     "stackprotector"
     "glibcxxassertions"
@@ -439,7 +438,7 @@ let
         else
           subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
       # hardeningDisable additionally supports "all".
-      erroneousHardeningFlags = subtractLists knownHardeningFlags (
+      erroneousHardeningFlags = subtractLists (knownHardeningFlags ++ [ "pie" ]) (
         hardeningEnable ++ remove "all" hardeningDisable
       );
 
@@ -637,7 +636,9 @@ let
               else
                 null
             } =
-              builtins.concatStringsSep " " enabledHardeningOptions;
+              lib.warnIf ((builtins.elem "pie" hardeningEnable) || (builtins.elem "pie" hardeningDisable))
+                "The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future."
+                (builtins.concatStringsSep " " enabledHardeningOptions);
 
             # TODO: remove platform condition
             # Enabling this check could be a breaking change as it requires to edit nix.conf

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -696,7 +696,6 @@ nameDrvAfterAttrName (
     relROExplicitDisabled = brokenIf true (
       checkTestBin
         (f2exampleWithStdEnv stdenv {
-          hardeningDisable = [ "pie" ];
         })
         {
           ignoreRelRO = false;
@@ -1202,7 +1201,6 @@ nameDrvAfterAttrName (
         hardeningDisable = [ "all" ];
         hardeningEnable = [
           "fortify"
-          "pie"
         ];
       };
     in

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -136,8 +136,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  hardeningEnable = [ "pie" ];
-
   doCheck = false;
   enableParallelChecking = false;
   nativeCheckInputs = [

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  hardeningEnable = [ "pie" ];
-
   nativeBuildInputs = [
     autoreconfHook
     w3m

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -373,7 +373,6 @@ stdenv.mkDerivation (finalAttrs: {
   # fortify breaks the build with lto and musl for some reason
   ++ lib.optional stdenv.hostPlatform.isMusl "fortify";
 
-  # hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
   separateDebugInfo = stdenv.hostPlatform.isLinux && !enableStatic;
   enableParallelBuilding = true;
 

--- a/pkgs/tools/package-management/nix/common-meson.nix
+++ b/pkgs/tools/package-management/nix/common-meson.nix
@@ -101,8 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  hardeningEnable = lib.optionals (!stdenv.hostPlatform.isDarwin) [ "pie" ];
-
   hardeningDisable = [
     "shadowstack"
   ]

--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -150,7 +150,6 @@ let
       pkg-config
     ];
     separateDebugInfo = !stdenv.hostPlatform.isStatic;
-    hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
   };
 
   mesonLibraryLayer = finalAttrs: prevAttrs: {

--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -32,12 +32,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-+MNIZQnecFGSE4sA7ywAu73Q6Eww1cB9I/xzqdxMycw=";
   };
 
-  # PIE is incompatible with the "persistent malloc" ("pma") feature.
-  # While build system attempts to pass -no-pie to gcc. nixpkgs' `ld`
-  # wrapped still passes `-pie` flag to linker and breaks linkage.
-  # Let's disable "pie" until `ld` is fixed to do the right thing.
-  hardeningDisable = [ "pie" ];
-
   # When we do build separate interactive version, it makes sense to always include man.
   outputs = [
     "out"


### PR DESCRIPTION
Closes #205031

In #439314 gcc was configured to enable PIE by default, matching our LLVM toolchains and how most distros have configured GCC for the last decade.  
In #442510 the pie hardening flag was removed from wrappers.

This PR is the last remaining step which removes treewide usage of the nonoperational flag.

Testing that packages setting `hardeningDisable = pie` continue to build now that pie is on by default in gcc was performed earlier, see https://github.com/NixOS/nixpkgs/pull/439314#issuecomment-3246814721 and [this testing log](https://gist.github.com/LunNova/00645ba8a7890a5b59b7519611847adc).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
     - This is a large rebuild, arbitrarily tested `nixosTests.boot.biosCdrom`
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - Ran with specific packages due to size 
- Nixpkgs Release Notes
  - [x] Release note for PIE flag removal was added in #442510
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
