### PR TITLE
libraspberrypi: 0-unstable-2022-06-16 -> 0-unstable-2024-12-23

### DIFF
--- a/pkgs/by-name/li/libraspberrypi/package.nix
+++ b/pkgs/by-name/li/libraspberrypi/package.nix
@@ -8,24 +8,26 @@
 
 stdenv.mkDerivation {
   pname = "libraspberrypi";
-  version = "0-unstable-2022-06-16";
+  version = "0-unstable-2024-12-23";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "userland";
-    rev = "54fd97ae4066a10b6b02089bc769ceed328737e0";
-    hash = "sha512-f7tBgIykcIdkwcFjBKk5ooD/5Bsyrd/0OFr7LNCwWFYeE4DH3XA7UR7YjArkwqUVCVBByr82EOaacw0g1blOkw==";
+    rev = "a54a0dbb2b8dcf9bafdddfc9a9374fb51d97e976";
+    hash = "sha256-Edca6nkykdXKFF5MGq6LeKirMLHTZBCbFWvHTNHMWJ4=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
+
   cmakeFlags = [
     # -DARM64=ON disables all targets that only build on 32-bit ARM; this allows
     # the package to build on aarch64 and other architectures
     "-DARM64=${if stdenv.hostPlatform.isAarch32 then "OFF" else "ON"}"
     "-DVMCS_INSTALL_PREFIX=${placeholder "out"}"
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.10")
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
~~The rpi userland repo was archived 2025-07-27: https://github.com/raspberrypi/userland
The userland repo contained mostly proprietary VideoCore APIs (alongside rpi hardware tools).~~

~~Other rpi hardware tools were moved to the utils repo: https://github.com/raspberrypi/utils~~

~~This package update targets the new utils repo.
I have not yet (and may not be able to) confirmed full parity with the previous version.~~

Updated to the latest commit of the archived rpi userland repo.
Added cmake flag to update min cmake version.

This change seems to now be required due to nixpkgs bumping `cmake` to `4.1.1` which removes support for `cmake` < `3.5` causing a build failure in the current version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
