### PR TITLE
msedit: fix build on x86_64-darwin

### DIFF
--- a/pkgs/by-name/ms/msedit/package.nix
+++ b/pkgs/by-name/ms/msedit/package.nix
@@ -22,6 +22,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Requires nightly features
   env.RUSTC_BOOTSTRAP = 1;
 
+  # Without -headerpad, the following error occurs on x86_64-darwin
+  # error: install_name_tool: changing install names or rpaths can't be redone for: ... because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
+  NIX_LDFLAGS = lib.optionals (with stdenv.hostPlatform; isDarwin && isx86_64) [
+    "-headerpad_max_install_names"
+  ];
+
   buildInputs = [
     icu
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```console
> hydra-check msedit --arch x86_64-darwin --channel nixpkgs-unstable
Build Status for msedit.x86_64-darwin on jobset nixpkgs/trunk
https://hydra.nixos.org/job/nixpkgs/trunk/msedit.x86_64-darwin
✖ (Failed)  msedit-1.2.0  2025-10-07  https://hydra.nixos.org/build/309045632
✔           msedit-1.2.0  2025-09-11  https://hydra.nixos.org/build/307159990
✔           msedit-1.2.0  2025-08-24  https://hydra.nixos.org/build/305823210
✔           msedit-1.2.0  2025-07-28  https://hydra.nixos.org/build/303591706
✔           msedit-1.2.0  2025-07-15  https://hydra.nixos.org/build/302608222

> hydra-check msedit --arch aarch64-darwin --channel nixpkgs-unstable
Build Status for msedit.aarch64-darwin on jobset nixpkgs/trunk
https://hydra.nixos.org/job/nixpkgs/trunk/msedit.aarch64-darwin
✔  msedit-1.2.0  2025-10-07  https://hydra.nixos.org/build/309045630
✔  msedit-1.2.0  2025-09-11  https://hydra.nixos.org/build/307159991
✔  msedit-1.2.0  2025-08-24  https://hydra.nixos.org/build/305823207
✔  msedit-1.2.0  2025-07-28  https://hydra.nixos.org/build/303591705
✔  msedit-1.2.0  2025-07-15  https://hydra.nixos.org/build/302608220

> hydra-check msedit --arch x86_64-linux --channel nixpkgs-unstable
Build Status for msedit.x86_64-linux on jobset nixpkgs/trunk
https://hydra.nixos.org/job/nixpkgs/trunk/msedit.x86_64-linux
✔  msedit-1.2.0  2025-10-07  https://hydra.nixos.org/build/309045633
✔  msedit-1.2.0  2025-09-11  https://hydra.nixos.org/build/307159993
✔  msedit-1.2.0  2025-08-24  https://hydra.nixos.org/build/305823209
✔  msedit-1.2.0  2025-07-28  https://hydra.nixos.org/build/303591707
✔  msedit-1.2.0  2025-07-15  https://hydra.nixos.org/build/302608223
```


I am not sure why this error happens only on x86_64-darwin at [this time](https://hydra.nixos.org/build/309045632).
But the build is fixed by adding a patch, which is similar to the one the ghostscript package uses.

https://github.com/NixOS/nixpkgs/blob/3f4aeb684a6f381d2de5e9b6730dbdb8dfc6ff7b/pkgs/by-name/gh/ghostscript/package.nix#L186-L188

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
