### PR TITLE
gforth: 0.7.9_20230518 -> 0.7.9_20251001

### DIFF
--- a/pkgs/by-name/gf/gforth/boot-forth.nix
+++ b/pkgs/by-name/gf/gforth/boot-forth.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Forth implementation of the GNU project (outdated version used to bootstrap)";
     homepage = "https://www.gnu.org/software/gforth/";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/gf/gforth/package.nix
+++ b/pkgs/by-name/gf/gforth/package.nix
@@ -14,15 +14,14 @@ let
   bootForth = callPackage ./boot-forth.nix { };
   lispDir = "${placeholder "out"}/share/emacs/site-lisp";
 in
-stdenv.mkDerivation rec {
-
+stdenv.mkDerivation (finalAttrs: {
   pname = "gforth";
   version = "0.7.9_20251001";
 
   src = fetchFromGitHub {
     owner = "forthy42";
     repo = "gforth";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-u9snXcFa/YYvITgMBY8FRYyyLFhHCP6hWA5ljwdKGLk=";
   };
 
@@ -35,6 +34,7 @@ stdenv.mkDerivation rec {
     bootForth
     swig
   ];
+
   buildInputs = [
     libffi
   ];
@@ -54,9 +54,11 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Forth implementation of the GNU project";
-    homepage = "https://github.com/forthy42/gforth";
-    license = lib.licenses.gpl3;
+    homepage = "https://www.gnu.org/software/gforth";
+    downloadPage = "https://github.com/forthy42/gforth";
+    license = lib.licenses.gpl3Plus;
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64; # segfault when running ./gforthmi
     platforms = lib.platforms.all;
+    mainProgram = "gforth";
   };
-}
+})

--- a/pkgs/by-name/gf/gforth/package.nix
+++ b/pkgs/by-name/gf/gforth/package.nix
@@ -6,6 +6,7 @@
   autoreconfHook,
   texinfo,
   libffi,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -16,16 +17,19 @@ in
 stdenv.mkDerivation rec {
 
   pname = "gforth";
-  version = "0.7.9_20230518";
+  version = "0.7.9_20251001";
 
   src = fetchFromGitHub {
     owner = "forthy42";
     repo = "gforth";
     rev = version;
-    hash = "sha256-rXtmmENBt9RMdLPq8GDyndh4+CYnCmz6NYpe3kH5OwU=";
+    hash = "sha256-u9snXcFa/YYvITgMBY8FRYyyLFhHCP6hWA5ljwdKGLk=";
   };
 
+  patches = [ ./use-nproc-instead-of-fhs.patch ];
+
   nativeBuildInputs = [
+    writableTmpDirAsHomeHook
     autoreconfHook
     texinfo
     bootForth

--- a/pkgs/by-name/gf/gforth/package.nix
+++ b/pkgs/by-name/gf/gforth/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   callPackage,
   autoreconfHook,
+  gitUpdater,
   texinfo,
   libffi,
   writableTmpDirAsHomeHook,
@@ -51,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     mkdir -p ${lispDir}
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Forth implementation of the GNU project";

--- a/pkgs/by-name/gf/gforth/use-nproc-instead-of-fhs.patch
+++ b/pkgs/by-name/gf/gforth/use-nproc-instead-of-fhs.patch
@@ -1,0 +1,16 @@
+diff --git i/cilk.fs w/cilk.fs
+index 9c675d06..df858f3d 100644
+--- i/cilk.fs
++++ w/cilk.fs
+@@ -25,9 +25,8 @@ e? os-type 2dup s" darwin" string-prefix? -rot s" openbsd" string-prefix? or [IF
+     s>number drop
+     r> free throw
+ [ELSE] e? os-type s" linux" search nip nip [IF]
+-	s" /sys/devices/system/cpu/present" slurp-file over >r
+-	#lf -scan '-' $split 2nip
+-	s>number drop 1+
++	s" nproc" r/o open-pipe throw slurp-fid over >r
++	s>number drop
+ 	r> free throw
+     [ELSE]
+ 	1 \ we don't know


### PR DESCRIPTION
Since the last update, the gforth code executed during build started to use inaccessible directories during the nix build sandbox. Thus, I patched the code to use working alternatives:

- Instead of using `/sys/devices/system/cpu/present` to get the number of cores, now it uses `nproc`
- Instead of creating a temporary dir in `~/.cache` it creates it on the current build directory

Closes #419775 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
