### PR TITLE
ankiAddons.anki-connect: 24.7.25.0 -> 25.9.6.0

### DIFF
--- a/pkgs/games/anki/addons/anki-connect/default.nix
+++ b/pkgs/games/anki/addons/anki-connect/default.nix
@@ -6,12 +6,12 @@
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "anki-connect";
-  version = "24.7.25.0";
+  version = "25.9.6.0";
   src = fetchFromSourcehut {
     owner = "~foosoft";
     repo = "anki-connect";
     rev = finalAttrs.version;
-    hash = "sha256-N98EoCE/Bx+9QUQVeU64FXHXSek7ASBVv1b9ltJ4G1U=";
+    hash = "sha256-ZPjGqyxTyLg5DtOUPJWCBC/IMfDVxtWt86VeFrsE41k=";
   };
   sourceRoot = "${finalAttrs.src.name}/plugin";
   passthru.updateScript = nix-update-script { };
@@ -20,7 +20,7 @@ anki-utils.buildAnkiAddon (finalAttrs: {
       Enable external applications such as Yomichan to communicate
       with Anki over a simple HTTP API
     '';
-    homepage = "https://foosoft.net/projects/anki-connect/";
+    homepage = "https://git.sr.ht/~foosoft/anki-connect";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ junestepp ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Had a bug in the addon and noticed it's due to an outdated version,
the update script for ryantm doesnt seem to work for these types of tagged versions? I'm not sure how to make sure this updates automatically properly though

https://r.ryantm.com/log/ankiAddons.anki-connect/2025-10-07.log



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
