### PR TITLE
openmolcas: fix cmake4 compatibility

### DIFF
--- a/pkgs/by-name/op/openmolcas/qcmaquis.patch
+++ b/pkgs/by-name/op/openmolcas/qcmaquis.patch
@@ -2,16 +2,17 @@ diff --git a/cmake/custom/nevpt2.cmake b/cmake/custom/nevpt2.cmake
 index 789739ec8..6c86a7b8c 100644
 --- a/cmake/custom/nevpt2.cmake
 +++ b/cmake/custom/nevpt2.cmake
-@@ -67,6 +67,7 @@ list(APPEND NEVPT2CMakeArgs
+@@ -67,6 +67,8 @@ list(APPEND NEVPT2CMakeArgs
    "-DMOLCAS_BUILD_DIR=${PROJECT_BINARY_DIR}"
    "-DCMAKE_Fortran_MODULE_DIRECTORY=${mod_dir}"
    "-DDMRG_INCLUDE=${HDF5_QCM_INCLUDE}"
 +  "-DCMAKE_SKIP_BUILD_RPATH=ON"
++      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
    )
- 
+
  if(HDF5_ROOT)
 @@ -118,9 +119,7 @@ endif ()
- 
+
  ExternalProject_Add(${EP_PROJECT}
                      PREFIX ${CUSTOM_NEVPT2_LOCATION}
 -                    GIT_REPOSITORY ${reference_git_repo}
@@ -25,16 +26,17 @@ diff --git a/cmake/custom/qcmaquis.cmake b/cmake/custom/qcmaquis.cmake
 index 5fd1ef207..8d2957c6e 100644
 --- a/cmake/custom/qcmaquis.cmake
 +++ b/cmake/custom/qcmaquis.cmake
-@@ -77,6 +77,7 @@ list (APPEND QCMaquisCMakeArgs
+@@ -77,6 +77,8 @@ list (APPEND QCMaquisCMakeArgs
        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
        -DCMAKE_CXX_FLAGS=${QCM_CMake_CXX_FLAGS}
        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
 +      -DCMAKE_SKIP_BUILD_RPATH=ON
++      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
  )
  if (HDF5_ROOT)
    list (APPEND QCMaquisCMakeArgs
 @@ -274,10 +275,7 @@ if (NOT MAQUIS_DMRG_FOUND) # Does the opposite work?
- 
+
    ExternalProject_Add (${EP_PROJECT}
                         PREFIX ${extprojpath}
 -                       GIT_REPOSITORY ${reference_git_repo}


### PR DESCRIPTION
Fix build
- #445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
