### PR TITLE
ledger: fix cmake 4 compatibility

### DIFF
--- a/pkgs/by-name/le/ledger-autosync/package.nix
+++ b/pkgs/by-name/le/ledger-autosync/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3Packages,
   fetchFromGitHub,
   ledger,
@@ -11,11 +12,10 @@ python3Packages.buildPythonApplication rec {
   version = "1.2.0";
   pyproject = true;
 
-  # no tests included in PyPI tarball
   src = fetchFromGitHub {
     owner = "egh";
     repo = "ledger-autosync";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-bbFjDdxYr85OPjdvY3JYtCe/8Epwi+8JN60PKVKbqe0=";
   };
 
@@ -31,6 +31,13 @@ python3Packages.buildPythonApplication rec {
     ledger
     python3Packages.ledger
     python3Packages.pytestCheckHook
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # keyring.errors.KeyringError: Can't get password from keychain: (-50, 'Unknown Error')
+    # keyring.backends.macOS.api.Error: (-50, 'Unknown Error')
+    "tests/test_cli.py"
+    "tests/test_weird_ofx.py"
   ];
 
   meta = {

--- a/pkgs/by-name/le/ledger/package.nix
+++ b/pkgs/by-name/le/ledger/package.nix
@@ -99,6 +99,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_DOCS" true)
     (lib.cmakeBool "USE_PYTHON" usePython)
     (lib.cmakeBool "USE_GPGME" gpgmeSupport)
+
+    # CMake 4 dropped support of versions lower than 3.5, and versions
+    # lower than 3.10 are deprecated.
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.10")
   ];
 
   installTargets = [

--- a/pkgs/by-name/le/ledger/package.nix
+++ b/pkgs/by-name/le/ledger/package.nix
@@ -13,20 +13,29 @@
   installShellFiles,
   texinfo,
   gnused,
+  versionCheckHook,
+  nix-update-script,
   usePython ? false,
   gpgmeSupport ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ledger";
   version = "3.3.2";
 
   src = fetchFromGitHub {
     owner = "ledger";
     repo = "ledger";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Uym4s8EyzXHlISZqThcb6P1H5bdgD9vmdIOLkk5ikG0=";
   };
+
+  # by default, it will query the python interpreter for it's sitepackages location
+  # however, that would write to a different nixstore path, pass our own sitePackages location
+  prePatch = lib.optionalString usePython ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail 'DESTINATION ''${Python_SITEARCH}' 'DESTINATION "${placeholder "py"}/${python3.sitePackages}"'
+  '';
 
   patches = [
     (fetchpatch2 {
@@ -86,18 +95,11 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DBUILD_DOCS:BOOL=ON"
-    "-DUSE_PYTHON:BOOL=${if usePython then "ON" else "OFF"}"
-    "-DUSE_GPGME:BOOL=${if gpgmeSupport then "ON" else "OFF"}"
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeBool "BUILD_DOCS" true)
+    (lib.cmakeBool "USE_PYTHON" usePython)
+    (lib.cmakeBool "USE_GPGME" gpgmeSupport)
   ];
-
-  # by default, it will query the python interpreter for it's sitepackages location
-  # however, that would write to a different nixstore path, pass our own sitePackages location
-  prePatch = lib.optionalString usePython ''
-    substituteInPlace src/CMakeLists.txt \
-      --replace 'DESTINATION ''${Python_SITEARCH}' 'DESTINATION "${placeholder "py"}/${python3.sitePackages}"'
-  '';
 
   installTargets = [
     "doc"
@@ -108,11 +110,19 @@ stdenv.mkDerivation rec {
     installShellCompletion --cmd ledger --bash $src/contrib/ledger-completion.bash
   '';
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Double-entry accounting system with a command-line reporting interface";
     mainProgram = "ledger";
     homepage = "https://www.ledger-cli.org/";
-    changelog = "https://github.com/ledger/ledger/raw/v${version}/NEWS.md";
+    changelog = "https://github.com/ledger/ledger/raw/v${finalAttrs.version}/NEWS.md";
     license = lib.licenses.bsd3;
     longDescription = ''
       Ledger is a powerful, double-entry accounting system that is accessed
@@ -123,4 +133,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ jwiegley ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **ledger: modernize**
- **ledger: fix cmake 4 compatibility**
- **ledger-autosync: skip failing tests on darwin**

cc @jwiegley

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
