### PR TITLE
oculante: Fix broken build

### DIFF
--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -17,21 +17,24 @@
   stdenv,
   gtk3,
   perl,
+  shaderc,
   wrapGAppsHook3,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "oculante";
-  version = "0.9.2";
+  version = "0.9.2.1-unstable-2025-10-08";
 
   src = fetchFromGitHub {
     owner = "woelper";
     repo = "oculante";
-    rev = version;
-    hash = "sha256-3kDrsD24/TNcA7NkwwCHN4ez1bC5MP7g28H3jaO/M7E=";
+    rev = "51b9f70b35e09850baee85971720b8d3ac49c80b";
+    hash = "sha256-YTrUucO1Fq2TgnV/HHkx2fcHvBupeoMpiBSwqIvyHaQ=";
   };
 
-  cargoHash = "sha256-lksAPT1nuwN5bh3x7+EN4B8ksGtvemt4tbm6/3gqdgE=";
+  cargoHash = "sha256-Bn2HxmFiqOeb3oUnUL/K0SahcFWRlY9RrbGU4orQz+Y=";
+
+  SHADERC_LIB_DIR = "${lib.getLib shaderc}/lib";
 
   nativeBuildInputs = [
     cmake
@@ -44,6 +47,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     openssl
     fontconfig
+    shaderc
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libGL


### PR DESCRIPTION
Build break was introduced by the move to Cmake4. However, the offending package (glsl-to-spriv) has been deprecated and replaced by shaderc. So use the HEAD of the master branch to pull in this latest version.

A issue has been raised upstream to see about tagging a new official release, https://github.com/woelper/oculante/issues/735


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
