### PR TITLE
sshwifty: update to 0.4.1 and fix updateScript

### DIFF
--- a/pkgs/by-name/ss/sshwifty/package.nix
+++ b/pkgs/by-name/ss/sshwifty/package.nix
@@ -10,20 +10,20 @@
 }:
 buildGo125Module (finalAttrs: {
   pname = "sshwifty";
-  version = "0.4.0-beta-release";
+  version = "0.4.1-beta-release";
 
   src = fetchFromGitHub {
     owner = "nirui";
     repo = "sshwifty";
     tag = finalAttrs.version;
-    hash = "sha256-7ZfS46+aflKIQ8S9T18JjCb7bY8mB6cJl/lgJi5Hukg=";
+    hash = "sha256-Kg5aE4lkzSedo+VJgdsfO5XTKupsPU2DhZNdNhEQ/Q4=";
   };
 
   sshwifty-ui = buildNpmPackage {
     pname = "sshwifty-ui";
     inherit (finalAttrs) version src;
 
-    npmDepsHash = "sha256-I96VixL21cF2kp9AK6q0ipjphjdWuSETKakbsprGek0=";
+    npmDepsHash = "sha256-vX3CtjwjzcxxIPYG6QXsPybyBRow1YdS9pHr961P1HA=";
 
     npmBuildScript = "generate";
 
@@ -39,7 +39,7 @@ buildGo125Module (finalAttrs: {
     cp -r ${finalAttrs.sshwifty-ui}/lib/node_modules/sshwifty-ui/* .
   '';
 
-  vendorHash = "sha256-kLKydjvZtFEY7vjqxK1cCwZSTbdqYWPRmxYSN0LYqsg=";
+  vendorHash = "sha256-/SLUC0xM195QfKgX9te8UP1bbzRbKF+Npyugi19JijY=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ss/sshwifty/package.nix
+++ b/pkgs/by-name/ss/sshwifty/package.nix
@@ -55,7 +55,14 @@ buildGo125Module (finalAttrs: {
 
   passthru = {
     tests = { inherit (nixosTests) sshwifty; };
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version=unstable"
+        "--version-regex=^([0-9.]+(?!.+-prebuild).+$)"
+        "--subpackage"
+        "sshwifty-ui"
+      ];
+    };
   };
 
   meta = {


### PR DESCRIPTION
Update sshwifty to 0.4.1-beta-release and fix `passthru.updateScript`.

Note: Depends on Go 1.25.2 to be merged from staging into master for a successful build.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
