### PR TITLE
catimg: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/ca/catimg/package.nix
+++ b/pkgs/by-name/ca/catimg/package.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  # Fix build with CMake 4: https://github.com/NixOS/nixpkgs/issues/449801
+  # CMake 4 removed support for CMake < 3.5, so we set the minimum policy version
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+
   env = lib.optionalAttrs (stdenv.hostPlatform.libc == "glibc") {
     CFLAGS = "-D_DEFAULT_SOURCE";
   };


### PR DESCRIPTION
## Summary
- Fixes catimg build failure with CMake 4
- CMake 4 removed compatibility with versions < 3.5, causing build to fail
- Sets `CMAKE_POLICY_VERSION_MINIMUM` to 3.5 to restore compatibility

## Test plan
- [x] Built catimg successfully with `nix-build -A catimg`
- [x] Build completed without errors

Fixes #449801