### PR TITLE
hol: update to kananaskis-14 -> trindemossen-2

### DIFF
--- a/pkgs/by-name/ho/hol/package.nix
+++ b/pkgs/by-name/ho/hol/package.nix
@@ -11,10 +11,10 @@
 
 let
   pname = "hol4";
-  vnum = "14";
+  vnum = "2";
 
-  version = "k.${vnum}";
-  longVersion = "kananaskis-${vnum}";
+  version = "t.${vnum}";
+  longVersion = "trindemossen-${vnum}";
   holsubdir = "hol-${longVersion}";
   kernelFlag = if experimentalKernel then "--expk" else "--stdknl";
 
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/hol/hol/${longVersion}/${holsubdir}.tar.gz";
-    sha256 = "6Mc/qsEjzxGqzt6yP6x/1Tmqpwc1UDGlwV1Gl+4pMsY=";
+    url = "https://github.com/HOL-Theorem-Prover/HOL/releases/download/trindemossen-2/hol-trindemossen-2.tar.gz";
+    sha256 = "sha256-Ciy6IaB7LqwKlZOnEw1H1IcVoSL/bfbQxoWPcZD3H3w=";
   };
 
   buildInputs = [
@@ -57,8 +57,10 @@ stdenv.mkDerivation {
     cd ${holsubdir}
 
     substituteInPlace tools/Holmake/Holmake_types.sml \
-      --replace "\"/bin/" "\"" \
+      --replace "\"/bin/unquote" "\"unquote"
 
+    substituteInPlace tools/editor-modes/emacs/hol-mode.src \
+      --replace "/tools/yasnippets" "/tools/editor-modes/emacs/yasnippets"
 
     for f in tools/buildutils.sml help/src-sml/DOT;
     do

--- a/pkgs/by-name/ho/hol/package.nix
+++ b/pkgs/by-name/ho/hol/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://github.com/HOL-Theorem-Prover/HOL/releases/download/trindemossen-2/hol-trindemossen-2.tar.gz";
-    sha256 = "sha256-Ciy6IaB7LqwKlZOnEw1H1IcVoSL/bfbQxoWPcZD3H3w=";
+    url = "https://github.com/HOL-Theorem-Prover/HOL/releases/download/${longVersion}/${holsubdir}.tar.gz";
+    hash = "sha256-Ciy6IaB7LqwKlZOnEw1H1IcVoSL/bfbQxoWPcZD3H3w=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Updated the `hol` package, and changed some part of the compilation script.

The `smart-configure.sml` script is subtly changed and the old substitution causes the failure to find the `bin/linkToSigobj` file.

The emacs plugins have been moved from `tools` to `tools/editor-modes/emacs`, which moved the yasnippet part along and broke `hol-mode.el`, so an additional substitution is made to compensate for the upstream error.

Closes #447875

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
