### PR TITLE
raspi-utils: init at 0-unstable-2025-10-02

### DIFF
--- a/pkgs/by-name/ra/raspi-utils/package.nix
+++ b/pkgs/by-name/ra/raspi-utils/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  bashNonInteractive,
+  dtc,
+  gnutls,
+  python3,
+  perl,
+}:
+
+stdenv.mkDerivation {
+  pname = "raspi-utils";
+  version = "0-unstable-2025-10-02";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "utils";
+    rev = "9f61b87db715fe9729305e242de8412d8db4153c";
+    hash = "sha256-LAEAjxb6+lQKo2VUknkuZa5sK37k6SjF+imj/7qyOe4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    bashNonInteractive
+    dtc
+    gnutls
+    python3
+    perl
+  ];
+
+  meta = {
+    description = "Collection of scripts and simple applications for interfacing with Raspberry Pi hardware";
+    homepage = "https://github.com/raspberrypi/utils";
+    license = lib.licenses.bsd3;
+    platforms = [
+      "armv6l-linux"
+      "armv7l-linux"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with lib.maintainers; [
+      gigglesquid
+      sfrijters
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #449772

Adds `raspi-utils`, a replacement for `libraspberrypi`.

The rpi userland repo was archived 2025-07-27: https://github.com/raspberrypi/userland
This contained mostly proprietary VideoCore APIs (alongside rpi hardware tools).

Other rpi hardware tools were moved to the utils repo: https://github.com/raspberrypi/utils

After 25.11 `libraspberrypi` will be deprecated in favor of `raspi-utils`

@dezgeg @tkerber Please let me know if you wish to be maintainers for this package as your were both maintainers for `libraspberrypi`.

@SFrijters Please let me know if you wish to be a maintainer as well, as this was mostly your idea.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
