### PR TITLE
chromium,chromedriver: 141.0.7390.54 -> 141.0.7390.65

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "141.0.7390.54",
+    "version": "141.0.7390.65",
     "chromedriver": {
-      "version": "141.0.7390.55",
-      "hash_darwin": "sha256-wo68N1aftGGyZR4rYI+96lXKJqPAYro3g4s/OL/CUco=",
-      "hash_darwin_aarch64": "sha256-5uUklsYRFhpLIAKoPl5EU5dQJcxwXVpJp0lyQ4SkspY="
+      "version": "141.0.7390.66",
+      "hash_darwin": "sha256-0LLARLPwlZ3KB5xCq4Yx5S6vtnhVddJ62IdgEy0vp7o=",
+      "hash_darwin_aarch64": "sha256-rLW5FOMNyFEn1Du2VN2sGfWri2erjN7SENa01vA2Vp8="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "b95610d5c4a562d9cd834bc0a098d3316e2f533f",
-        "hash": "sha256-jraDPodJBdyFFHS30BcQTZOEUD+h9SFHQrO0GoMhtk8=",
+        "rev": "b2ec783d2b51a396804a4e3e33f6586be09a4e2d",
+        "hash": "sha256-9jZ7411NThelyL0R5yoLXB0lOkydOI3v6K5ORhjqfF4=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -252,8 +252,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "65f160d43dc97a2e8eb5e1c2814179a519313884",
-        "hash": "sha256-VLMJ/WWCIzk92mmuBdx+P6Gi0ouiXuMGkiR0KVK5GWI="
+        "rev": "9c2c4cc7cf6c82ad460e1f3b49f34bb702d5fe11",
+        "hash": "sha256-qj1vR0FW2jiR2v18Nv8RqYgy/UEw2rgGUsQ68EhdHos="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/10/stable-channel-update-for-desktop.html

This update includes 3 security fixes.

CVEs:
CVE-2025-11458 CVE-2025-11460 CVE-2025-11211

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
