### PR TITLE
lfe: 2.1.4 -> 2.2.0, simplify to single version

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -90,8 +90,7 @@ let
 
       elixir-ls = callPackage ./elixir-ls { inherit elixir; };
 
-      lfe = lfe_2_1;
-      lfe_2_1 = lib'.callLFE ../interpreters/lfe/2.1.nix { inherit erlang buildRebar3 buildHex; };
+      lfe = callPackage ../interpreters/lfe { inherit erlang buildRebar3 buildHex; };
 
       livebook = callPackage ./livebook { };
 

--- a/pkgs/development/interpreters/lfe/2.1.nix
+++ b/pkgs/development/interpreters/lfe/2.1.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation {
-  version = "2.1.4";
-  hash = "sha256-mDavRI2it0SrSR0iBItm2MfjI+F/zCy38YSd2KpE0Hs=";
-  maximumOTPVersion = "27";
-}

--- a/pkgs/development/interpreters/lfe/default.nix
+++ b/pkgs/development/interpreters/lfe/default.nix
@@ -19,8 +19,8 @@ let
     versions
     ;
 
-  version = "2.1.4";
-  hash = "sha256-mDavRI2it0SrSR0iBItm2MfjI+F/zCy38YSd2KpE0Hs=";
+  version = "2.2.0";
+  hash = "sha256-47lEUVU9Api1Yj1q+Ch8aIV8kaALhst1ty8RHTwMVcI=";
 
   maximumOTPVersion = "27";
   mainVersion = versions.major (getVersion erlang);

--- a/pkgs/development/interpreters/lfe/default.nix
+++ b/pkgs/development/interpreters/lfe/default.nix
@@ -1,43 +1,29 @@
 {
-  config,
-  lib,
-  fetchFromGitHub,
-  erlang,
-  makeWrapper,
-  coreutils,
   bash,
-  buildRebar3,
   buildHex,
-}:
-
-{
-  baseName ? "lfe",
-  version,
-  maximumOTPVersion,
-  sha256 ? "",
-  hash ? "",
-  rev ? version,
-  src ? fetchFromGitHub {
-    inherit hash rev sha256;
-    owner = "lfe";
-    repo = "lfe";
-  },
-  patches ? [ ],
+  buildRebar3,
+  config,
+  coreutils,
+  erlang,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
 }:
 
 let
   inherit (lib)
     assertMsg
     makeBinPath
-    optionalString
     getVersion
     versionAtLeast
-    versionOlder
     versions
     ;
 
-  mainVersion = versions.major (getVersion erlang);
+  version = "2.1.4";
+  hash = "sha256-mDavRI2it0SrSR0iBItm2MfjI+F/zCy38YSd2KpE0Hs=";
 
+  maximumOTPVersion = "27";
+  mainVersion = versions.major (getVersion erlang);
   maxAssert = versionAtLeast maximumOTPVersion mainVersion;
 
   proper = buildHex {
@@ -56,22 +42,27 @@ else
     LFE ${version} is supported on OTP <=${maximumOTPVersion}, not ${mainVersion}.
   '';
   buildRebar3 {
-    name = baseName;
+    name = "lfe";
+    inherit version;
 
-    inherit src version;
+    src = fetchFromGitHub {
+      owner = "lfe";
+      repo = "lfe";
+      tag = "v${version}";
+      inherit hash;
+    };
+
+    patches = [
+      ./fix-rebar-config.patch
+      ./dedup-ebins.patch
+    ];
 
     nativeBuildInputs = [
       makeWrapper
       erlang
     ];
+
     beamDeps = [ proper ];
-    patches = [
-      ./fix-rebar-config.patch
-      ./dedup-ebins.patch
-    ]
-    ++ patches;
-    doCheck = true;
-    checkTarget = "travis";
 
     makeFlags = [
       "-e"
@@ -79,26 +70,12 @@ else
       "PREFIX=$$out"
     ];
 
-    # These installPhase tricks are based on Elixir's Makefile.
-    # TODO: Make, upload, and apply a patch.
-    installPhase = optionalString (versionOlder version "1.3") ''
-      local libdir=$out/lib/lfe
-      local ebindir=$libdir/ebin
-      local bindir=$libdir/bin
+    # override buildRebar3's install to let the builder use make install
+    installPhase = "";
 
-      rm -Rf $ebindir
-      install -m755 -d $ebindir
-      install -m644 _build/default/lib/lfe/ebin/* $ebindir
+    doCheck = true;
+    checkTarget = "travis";
 
-      install -m755 -d $bindir
-
-      for bin in bin/lfe{,c,doc,script}; do install -m755 $bin $bindir; done
-
-      install -m755 -d $out/bin
-      for file in $bindir/*; do ln -sf $file $out/bin/; done
-    '';
-
-    # Thanks again, Elixir.
     postFixup = ''
       # LFE binaries are shell scripts which run erl and lfe.
       # Add some stuff to PATH so the scripts can run without problems.
@@ -124,7 +101,8 @@ else
       '';
 
       homepage = "https://lfe.io";
-      downloadPage = "https://github.com/rvirding/lfe/releases";
+      downloadPage = "https://github.com/lfe/lfe/releases";
+      changelog = "https://github.com/lfe/lfe/releases/tag/v${version}";
 
       license = licenses.asl20;
       teams = [ teams.beam ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5755,7 +5755,6 @@ with pkgs;
     rebar3WithPlugins
     fetchHex
     lfe
-    lfe_2_1
     ;
 
   beamPackages = dontRecurseIntoAttrs beam27Packages;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -52,7 +52,6 @@ in
       elixir_1_14
       elixir-ls
       lfe
-      lfe_2_1
       ;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I spoke with the upstream LFE maintainers, and they only support a single version of LFE. Therefore, I've simplified our support down to a single version, and updated it to the latest version (from January!).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
