### PR TITLE
leetcode-tui: init at 0.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21302,6 +21302,11 @@
     githubId = 30029970;
     keys = [ { fingerprint = "FA05 8A29 B45E 06C0 8FE9  4907 05D2 BE42 F3EC D7CC"; } ];
   };
+  Ra77a3l3-jar = {
+    email = "raffaelemeo77@gmail.com";
+    github = "Ra77a3l3-jar";
+    githubId = 175424218;
+  };
   raboof = {
     email = "arnout@bzzt.net";
     matrix = "@raboof:matrix.org";

--- a/pkgs/by-name/le/leetcode-tui/flake.lock
+++ b/pkgs/by-name/le/leetcode-tui/flake.lock
@@ -1,0 +1,22 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "path": "../../../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/pkgs/by-name/le/leetcode-tui/flake.nix
+++ b/pkgs/by-name/le/leetcode-tui/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Terminal UI for LeetCode";
+
+  inputs = {
+    nixpkgs.url = "path:../../../..";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      leetcode-tui = pkgs.callPackage ./package.nix { };
+    in
+    {
+      packages.${system} = {
+        default = leetcode-tui;
+        leetcode-tui = leetcode-tui;
+      };
+      
+      apps.${system} = {
+        default = {
+          type = "app";
+          program = "${leetcode-tui}/bin/leetui";
+        };
+        
+        leetcode-tui = {
+          type = "app";
+          program = "${leetcode-tui}/bin/leetui";
+        };
+      };
+    };
+}

--- a/pkgs/by-name/le/leetcode-tui/package.nix
+++ b/pkgs/by-name/le/leetcode-tui/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, stdenv
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "leetcode-tui";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "akarsh1995";
+    repo = "leetcode-tui";
+    rev = "53a4b89c135bace07f4002e7646c5fdd06181a61";
+    sha256 = "1iz5dv2aq7ldl7cq6qdgx2rxrbhkxyng6b6v0fndhly59bhg6p4a";
+  };
+
+  cargoHash = "sha256-JJMsJxadEHgo7Xk57zsjchEYZPUL31eJ3BmDA/f4rxI=";
+
+  # Ensure openssl-sys uses Nix's OpenSSL and build the right workspace member
+  OPENSSL_NO_VENDOR = 1;
+  cargoBuildFlags = [ "-p" "leetcode-tui-rs" ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Terminal UI for LeetCode - browse stats and manage problems from the terminal";
+    longDescription = ''
+      A lightweight, interactive terminal user interface for LeetCode that allows you to:
+      - Browse questions grouped by categories
+      - Read and solve problems in multiple programming languages
+      - Submit and run solutions directly from the terminal
+      - View your performance statistics
+      - Search problems by ID, topic, or title
+      - Work with popular problem sets like Neetcode 75
+
+      The tool provides a resource-efficient alternative to the web interface while
+      maintaining full functionality for competitive programming practice.
+    '';
+    homepage = "https://github.com/akarsh1995/leetcode-tui";
+    license = licenses.mit;
+    mainProgram = "leetui";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ Ra77a3l3-jar ];
+  };
+}


### PR DESCRIPTION
Terminal UI for LeetCode - browse stats and manage problems from the terminal. This package provides a lightweight, interactive terminal user interface for LeetCode that allows competitive programming practice without using the web interface.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
