### PR TITLE
rocmPackages.hipblaslt: stop inlining war and peace in asm comments

### DIFF
--- a/pkgs/development/rocm-modules/6/hipblaslt/default.nix
+++ b/pkgs/development/rocm-modules/6/hipblaslt/default.nix
@@ -111,6 +111,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Support loading zstd compressed .dat files, required to keep output under
     # hydra size limit
     ./messagepack-compression-support.patch
+    # excessive comments are written to temporary asm files in build dir
+    # TODO: report upstream, find a better solution
+    ./reduce-comment-spam.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/rocm-modules/6/hipblaslt/reduce-comment-spam.patch
+++ b/pkgs/development/rocm-modules/6/hipblaslt/reduce-comment-spam.patch
@@ -1,0 +1,47 @@
+diff --git a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/format.hpp b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/format.hpp
+index b7dcb6f59a..b0625ba769 100644
+--- a/tensilelite/rocisa/rocisa/include/format.hpp
++++ b/tensilelite/rocisa/rocisa/include/format.hpp
+@@ -8,11 +8,13 @@ namespace rocisa
+     // Text format functions
+     inline std::string slash(const std::string& comment)
+     {
++        return "";
+         return "// " + comment + "\n";
+     }
+ 
+     inline std::string slash50(const std::string& comment)
+     {
++        return "";
+         std::ostringstream oss;
+         oss << std::setw(50) << ""
+             << " // " << comment << "\n";
+@@ -21,16 +23,19 @@ namespace rocisa
+ 
+     inline std::string block(const std::string& comment)
+     {
++        return "";
+         return "/* " + comment + " */\n";
+     }
+ 
+     inline std::string blockNewLine(const std::string& comment)
+     {
++        return "";
+         return "\n/* " + comment + " */\n";
+     }
+ 
+     inline std::string block3Line(const std::string& comment)
+     {
++        return "";
+         std::ostringstream oss;
+         oss << "\n/******************************************/\n";
+         std::istringstream iss(comment);
+@@ -52,7 +57,7 @@ namespace rocisa
+         {
+             formattedStr = "\"" + formattedStr + "\\n\\t\"";
+         }
+-        if(!comment.empty())
++        if(false)
+         {
+             std::string buffer = formattedStr
+                                  + std::string(std::max(0, 50 - int(formattedStr.length())), ' ')


### PR DESCRIPTION
Fixes #449880 by reducing peak build dir space usage to 150GB

hipblaslt was filling the build tmpfs on hydra, peaking at 240GB in `build/Tensile/build_tmp/TENSILE`

with this bodge we stop it from writing very verbose comments in the generated assembly kernels which were contributing a significant portion of the total build directory size

example excessive whitespace/comment content:
`s_nop 0                                            // 1 wait state required when next inst writes vgprs held by previous dwordx4 store inst
`

This is not an optimal fix. Ideally TensileCreateLibrary should be taught to throw away .S files as soon as possible by turning them into code objects, rather than its current approach that materializes all assembly files at the same time in one huge directory.
I will aim to create a better upstreamable fix; we need a short term fix so here we are. :upside_down_face: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
