### PR TITLE
lib.teams: Remove .githubTeams in favor of singular .github

### DIFF
--- a/lib/tests/teams.nix
+++ b/lib/tests/teams.nix
@@ -27,9 +27,9 @@ let
           type = types.listOf (types.submodule (import ./maintainer-module.nix { inherit lib; }));
           default = [ ];
         };
-        githubTeams = lib.mkOption {
-          type = types.listOf types.str;
-          default = [ ];
+        github = lib.mkOption {
+          type = types.str;
+          default = "";
         };
       };
     };

--- a/maintainers/scripts/feature-freeze-teams.pl
+++ b/maintainers/scripts/feature-freeze-teams.pl
@@ -74,11 +74,9 @@ while (my ($team_nix_key, $team_config) = each %{$data}) {
     print {*STDERR} "$team_config->{shortName}:";
     # GitHub Teams
     my @github_members;
-    if (defined $team_config->{githubTeams}) {
-        foreach (@{$team_config->{githubTeams}}) {
-            print {*STDERR} " \@NixOS/${_}";
-            push @github_members, @{github_team_members($_, $github_user, $github_token)};
-        }
+    if (defined $team_config->{github}) {
+        print {*STDERR} " \@NixOS/$team_config->{github}";
+        push @github_members, @{github_team_members($team_config->{github}, $github_user, $github_token)};
     }
     my %github_members = map { $_ => 1 } @github_members;
     # Members

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -7,7 +7,7 @@
       shortName = "foo";
       # Optional
       enableFeatureFreezePing = true;
-      githubTeams = [ "my-subsystem" ];
+      github = "my-subsystem";
     };
 
   where
@@ -18,7 +18,7 @@
   - `enableFeatureFreezePing` will ping this team during the Feature Freeze announcements on releases
     - There is limited mention capacity in a single post, so this should be reserved for critical components
       or larger ecosystems within nixpkgs.
-  - `githubTeams` will ping specified GitHub teams as well
+  - `github` will ping the specified GitHub team as well
 
   More fields may be added in the future.
 
@@ -65,7 +65,7 @@ with lib.maintainers;
       RossComputerGuy
     ];
     scope = "Maintain Android-related tooling in nixpkgs.";
-    githubTeams = [ "android" ];
+    github = "android";
     shortName = "Android";
     enableFeatureFreezePing = true;
   };
@@ -117,7 +117,7 @@ with lib.maintainers;
       minijackson
       yurrriq
     ];
-    githubTeams = [ "beam" ];
+    github = "beam";
     scope = "Maintain BEAM-related packages and modules.";
     shortName = "BEAM";
     enableFeatureFreezePing = true;
@@ -205,7 +205,7 @@ with lib.maintainers;
       sigmasquadron
       tomodachi94
     ];
-    githubTeams = [ "categorization" ];
+    github = "categorization";
     scope = "Maintain the categorization system in Nixpkgs, per RFC 146. This team has authority over all categorization issues in Nixpkgs.";
     shortName = "Categorization";
   };
@@ -218,7 +218,7 @@ with lib.maintainers;
       wolfgangwalther
       zowoq
     ];
-    githubTeams = [ "nixpkgs-ci" ];
+    github = "nixpkgs-ci";
     scope = "Maintain Nixpkgs' in-tree Continuous Integration, including GitHub Actions.";
     shortName = "CI";
   };
@@ -237,7 +237,7 @@ with lib.maintainers;
     members = [ floriansanderscc ];
     scope = "Maintain Clever Cloud related packages.";
     shortName = "CleverCloud";
-    githubTeams = [ "CleverCloud" ];
+    github = "CleverCloud";
   };
 
   cloudposse = {
@@ -275,7 +275,7 @@ with lib.maintainers;
       thefossguy
       michaelBelsanti
     ];
-    githubTeams = [ "cosmic" ];
+    github = "cosmic";
     shortName = "cosmic";
     scope = "Maintain the COSMIC DE and related packages.";
     enableFeatureFreezePing = true;
@@ -300,7 +300,7 @@ with lib.maintainers;
     ];
     scope = "Maintain CUDA-enabled packages";
     shortName = "Cuda";
-    githubTeams = [ "cuda-maintainers" ];
+    github = "cuda-maintainers";
   };
 
   cyberus = {
@@ -320,7 +320,7 @@ with lib.maintainers;
       reckenrode
       toonn
     ];
-    githubTeams = [ "darwin-core" ];
+    github = "darwin-core";
     scope = "Maintain core platform support and packages for macOS and other Apple platforms.";
     shortName = "Darwin";
     enableFeatureFreezePing = true;
@@ -367,7 +367,7 @@ with lib.maintainers;
 
   docs = {
     members = [ ];
-    githubTeams = [ "documentation-team" ];
+    github = "documentation-team";
     scope = "Maintain nixpkgs/NixOS documentation and tools for building it.";
     shortName = "Docs";
     enableFeatureFreezePing = true;
@@ -400,7 +400,7 @@ with lib.maintainers;
 
   enlightenment = {
     members = [ romildo ];
-    githubTeams = [ "enlightenment" ];
+    github = "enlightenment";
     scope = "Maintain Enlightenment desktop environment and related packages.";
     shortName = "Enlightenment";
     enableFeatureFreezePing = true;
@@ -409,9 +409,7 @@ with lib.maintainers;
   # Dummy group for the "everyone else" section
   feature-freeze-everyone-else = {
     members = [ ];
-    githubTeams = [
-      "nixpkgs-committers"
-    ];
+    github = "nixpkgs-committers";
     scope = "Dummy team for the #everyone else' section during feture freezes, not to be used as package maintainers!";
     shortName = "Everyone else";
     enableFeatureFreezePing = true;
@@ -427,7 +425,7 @@ with lib.maintainers;
     scope = "Maintain Flutter and Dart-related packages and build tools";
     shortName = "flutter";
     enableFeatureFreezePing = false;
-    githubTeams = [ "flutter" ];
+    github = "flutter";
   };
 
   flyingcircus = {
@@ -495,7 +493,7 @@ with lib.maintainers;
       sikmir
       willcohen
     ];
-    githubTeams = [ "geospatial" ];
+    github = "geospatial";
     scope = "Maintain geospatial, remote sensing and OpenStreetMap software.";
     shortName = "Geospatial";
     enableFeatureFreezePing = true;
@@ -520,7 +518,7 @@ with lib.maintainers;
       jtojnar
       dasj19
     ];
-    githubTeams = [ "gnome" ];
+    github = "gnome";
     scope = "Maintain GNOME desktop environment and platform.";
     shortName = "GNOME";
     enableFeatureFreezePing = true;
@@ -545,7 +543,7 @@ with lib.maintainers;
       qbit
       mfrw
     ];
-    githubTeams = [ "golang" ];
+    github = "golang";
     scope = "Maintain Golang compilers.";
     shortName = "Go";
     enableFeatureFreezePing = true;
@@ -569,7 +567,7 @@ with lib.maintainers;
       sternenseemann
       wolfgangwalther
     ];
-    githubTeams = [ "haskell" ];
+    github = "haskell";
     scope = "Maintain Haskell packages and infrastructure.";
     shortName = "Haskell";
     enableFeatureFreezePing = true;
@@ -604,7 +602,7 @@ with lib.maintainers;
       khaneliman
       NotAShelf
     ];
-    githubTeams = [ "hyprland" ];
+    github = "hyprland";
     scope = "Maintain Hyprland compositor and ecosystem";
     shortName = "Hyprland";
     enableFeatureFreezePing = true;
@@ -627,7 +625,7 @@ with lib.maintainers;
   };
 
   java = {
-    githubTeams = [ "java" ];
+    github = "java";
     members = [
       chayleaf
       fliegendewurst
@@ -674,7 +672,7 @@ with lib.maintainers;
   };
 
   k3s = {
-    githubTeams = [ "k3s" ];
+    github = "k3s";
     members = [
       euank
       frederictobiasc
@@ -744,7 +742,7 @@ with lib.maintainers;
       uthar
       hraban
     ];
-    githubTeams = [ "lisp" ];
+    github = "lisp";
     scope = "Maintain the Lisp ecosystem.";
     shortName = "lisp";
     enableFeatureFreezePing = true;
@@ -774,7 +772,7 @@ with lib.maintainers;
       rrbutani
       sternenseemann
     ];
-    githubTeams = [ "llvm" ];
+    github = "llvm";
     scope = "Maintain LLVM package sets and related packages";
     shortName = "LLVM";
     enableFeatureFreezePing = true;
@@ -795,14 +793,14 @@ with lib.maintainers;
       dramforever
       wegank
     ];
-    githubTeams = [ "loongarch64" ];
+    github = "loongarch64";
     scope = "Maintain LoongArch64 related packages and code";
     shortName = "LoongArch64";
     enableFeatureFreezePing = true;
   };
 
   lua = {
-    githubTeams = [ "lua" ];
+    github = "lua";
     scope = "Maintain the lua ecosystem.";
     shortName = "lua";
     enableFeatureFreezePing = true;
@@ -820,7 +818,7 @@ with lib.maintainers;
 
   lumina = {
     members = [ romildo ];
-    githubTeams = [ "lumina" ];
+    github = "lumina";
     scope = "Maintain lumina desktop environment and related packages.";
     shortName = "Lumina";
     enableFeatureFreezePing = true;
@@ -839,7 +837,7 @@ with lib.maintainers;
 
   lxqt = {
     members = [ romildo ];
-    githubTeams = [ "lxqt" ];
+    github = "lxqt";
     scope = "Maintain LXQt desktop environment and related packages.";
     shortName = "LXQt";
     enableFeatureFreezePing = true;
@@ -852,7 +850,7 @@ with lib.maintainers;
       thilobillerbeck
       tomberek
     ];
-    githubTeams = [ "marketing-team" ];
+    github = "marketing-team";
     scope = "Marketing of Nix/NixOS/nixpkgs.";
     shortName = "Marketing";
     enableFeatureFreezePing = true;
@@ -924,7 +922,7 @@ with lib.maintainers;
       mrcjkb
       perchun
     ];
-    githubTeams = [ "neovim" ];
+    github = "neovim";
     scope = "Maintain the vim and neovim text editors and related packages.";
     shortName = "Vim/Neovim";
   };
@@ -985,7 +983,7 @@ with lib.maintainers;
 
   ocaml = {
     members = [ alizter ];
-    githubTeams = [ "ocaml" ];
+    github = "ocaml";
     scope = "Maintain the OCaml compiler and package set.";
     shortName = "OCaml";
     enableFeatureFreezePing = true;
@@ -1023,7 +1021,7 @@ with lib.maintainers;
       davidak
       bobby285271
     ];
-    githubTeams = [ "pantheon" ];
+    github = "pantheon";
     scope = "Maintain Pantheon desktop environment and platform.";
     shortName = "Pantheon";
     enableFeatureFreezePing = true;
@@ -1047,7 +1045,7 @@ with lib.maintainers;
       piotrkwiecinski
       talyz
     ];
-    githubTeams = [ "php" ];
+    github = "php";
     scope = "Maintain PHP related packages and extensions.";
     shortName = "PHP";
     enableFeatureFreezePing = true;
@@ -1058,7 +1056,7 @@ with lib.maintainers;
       saschagrunert
       vdemeester
     ];
-    githubTeams = [ "podman" ];
+    github = "podman";
     scope = "Maintain Podman and CRI-O related packages and modules.";
     shortName = "Podman";
   };
@@ -1094,7 +1092,7 @@ with lib.maintainers;
       SuperSandro2000
       ttuegel
     ];
-    githubTeams = [ "qt-kde" ];
+    github = "qt-kde";
     scope = "Maintain the Qt framework, KDE application suite, Plasma desktop environment and related projects.";
     shortName = "Qt / KDE";
     enableFeatureFreezePing = true;
@@ -1124,7 +1122,7 @@ with lib.maintainers;
 
   release = {
     members = [ ];
-    githubTeams = [ "nixos-release-managers" ];
+    github = "nixos-release-managers";
     scope = "Manage the current nixpkgs/NixOS release.";
     shortName = "Release";
   };
@@ -1136,7 +1134,7 @@ with lib.maintainers;
       LunNova
       mschwaig
     ];
-    githubTeams = [ "rocm" ];
+    github = "rocm";
     scope = "Maintain ROCm and related packages.";
     shortName = "ROCm";
   };
@@ -1156,7 +1154,7 @@ with lib.maintainers;
       winter
       zowoq
     ];
-    githubTeams = [ "rust" ];
+    github = "rust";
     scope = "Maintain the Rust compiler toolchain and nixpkgs integration.";
     shortName = "Rust";
     enableFeatureFreezePing = true;
@@ -1180,7 +1178,7 @@ with lib.maintainers;
       marcin-serwin
       pbsds
     ];
-    githubTeams = [ "SDL" ];
+    github = "SDL";
     scope = "Maintain core SDL libraries.";
     shortName = "SDL";
     enableFeatureFreezePing = true;
@@ -1220,7 +1218,7 @@ with lib.maintainers;
     scope = "Maintain the standard environment and its surrounding logic.";
     shortName = "stdenv";
     enableFeatureFreezePing = true;
-    githubTeams = [ "stdenv" ];
+    github = "stdenv";
   };
 
   steam = {
@@ -1261,7 +1259,7 @@ with lib.maintainers;
       aanderse
       grimmauld
     ];
-    githubTeams = [ "systemd" ];
+    github = "systemd";
     scope = "Maintain systemd for NixOS.";
     shortName = "systemd";
     enableFeatureFreezePing = true;
@@ -1322,7 +1320,7 @@ with lib.maintainers;
     scope = "Maintain the Xen Project Hypervisor and the related tooling ecosystem.";
     shortName = "Xen Project Hypervisor";
     enableFeatureFreezePing = true;
-    githubTeams = [ "xen-project" ];
+    github = "xen-project";
   };
 
   xfce = {


### PR DESCRIPTION
No team was using the feature of having multiple GitHub teams, and this would make it tricky to try to sync maintainer teams with GitHub teams, so let's switch teams to a singular list instead. This is a step towards https://github.com/NixOS/nixpkgs/issues/447514

It might be a bit overkill to do the entire deprecation dance for `lib.teams.*.githubTeams`, but I figured it won't hurt.

Tested with:
- `maintainers/scripts/feature-freeze-teams.pl`
- `nix-build lib/tests/teams.nix`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
