### PR TITLE
sshm: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4505,6 +4505,12 @@
     github = "cdombroski";
     githubId = 244909;
   };
+  cedev-1 = {
+    name = "Cedev";
+    email = "cedev@ce-dev.eu";
+    github = "cedev-1";
+    githubId = 121963179;
+  };
   ceedubs = {
     email = "ceedubs@gmail.com";
     github = "ceedubs";

--- a/pkgs/by-name/ss/sshm/package.nix
+++ b/pkgs/by-name/ss/sshm/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "sshm";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "Gu1llaum-3";
+    repo = "sshm";
+    tag = "v${version}";
+    hash = "sha256-tDaRRZXj0XJ8XpCxs2b6Bm3qvfcE8t9CfR3mxuOrPDM=";
+  };
+
+  vendorHash = "sha256-aU/+bxcETs/Jq5FVAdiioyuc1AufvWeiqFQ7uo1cK1k=";
+
+  subPackages = [ "." ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/Gu1llaum-3/sshm/cmd.AppVersion=${version}"
+  ];
+
+  meta = {
+    description = "Terminal UI to manage and connect to SSH hosts";
+    mainProgram = "sshm";
+    homepage = "https://github.com/Gu1llaum-3/sshm";
+    changelog = "https://github.com/Gu1llaum-3/sshm/releases/tag/${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cedev-1 ];
+  };
+}

--- a/pkgs/by-name/ss/sshm/package.nix
+++ b/pkgs/by-name/ss/sshm/package.nix
@@ -4,33 +4,34 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "sshm";
   version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "Gu1llaum-3";
     repo = "sshm";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-tDaRRZXj0XJ8XpCxs2b6Bm3qvfcE8t9CfR3mxuOrPDM=";
   };
 
   vendorHash = "sha256-aU/+bxcETs/Jq5FVAdiioyuc1AufvWeiqFQ7uo1cK1k=";
 
   subPackages = [ "." ];
+
   ldflags = [
     "-s"
     "-w"
-    "-X=github.com/Gu1llaum-3/sshm/cmd.AppVersion=${version}"
+    "-X=github.com/Gu1llaum-3/sshm/cmd.AppVersion=${finalAttrs.version}"
   ];
 
   meta = {
     description = "Terminal UI to manage and connect to SSH hosts";
-    mainProgram = "sshm";
     homepage = "https://github.com/Gu1llaum-3/sshm";
-    changelog = "https://github.com/Gu1llaum-3/sshm/releases/tag/${version}";
+    changelog = "https://github.com/Gu1llaum-3/sshm/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ cedev-1 ];
+    mainProgram = "sshm";
   };
-}
+})


### PR DESCRIPTION
Add sshm, a modern terminal UI to manage and connect to SSH hosts.

sshm is a cross-platform Go application providing a beautiful TUI for SSH host management and quick SSH connections.  
This PR packages the latest release (1.8.0) in Nixpkgs, following the by-name guidelines.

Homepage: https://github.com/Gu1llaum-3/sshm  
License: MIT  
Main program: sshm

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
