### PR TITLE
go: restrict default pie patch to known good GOARCH

### DIFF
--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -24,6 +24,30 @@ let
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
 
   isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+
+  # In order for buildmode=pie to work either Go's internal linker must know how
+  # to produce position-independent executables or Go must be using an external linker.
+  #
+  # go-default-pie.patch tries to enable position-independent codegen (PIE) only when the platform
+  # reports support (via BuildModeSupported(..., "pie", ...)).
+  #
+  # That probe is not fully reliable: for example, `pkgsi686Linux.go` can fail during bootstrap
+  # with message 'default PIE binary requires external (cgo) linking, but cgo is not enabled'
+  # despite CGO being enabled. (we set `CGO_ENABLED=1`).
+  #
+  # To avoid such breakage, limit this patch to a small set of explicitly tested platforms
+  # rather than relying on the general BuildModeSupported("pie") check.
+  supportsDefaultPie =
+    let
+      hasPie = {
+        "amd64" = true;
+        "arm64" = true;
+        "ppc64le" = true;
+        "riscv64" = true;
+      };
+    in
+    hasPie.${stdenv.hostPlatform.go.GOARCH} or false
+    && hasPie.${stdenv.targetPlatform.go.GOARCH} or false;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
@@ -65,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
     ./go-env-go_ldso.patch
+  ]
+  ++ lib.optionals supportsDefaultPie [
     (replaceVars ./go-default-pie.patch {
       inherit (stdenv.targetPlatform.go) GOARCH;
     })

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -30,6 +30,30 @@ let
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
 
   isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+
+  # go-default-pie.patch tries to enable position-independent codegen (PIE) only when the platform
+  # reports support (via BuildModeSupported(..., "pie", ...)).
+  #
+  # In order for buildmode=pie to work either Go's internal linker must know how
+  # to produce position-independent executables or Go must be using an external linker.
+  #
+  # That probe is not fully reliable: for example, `pkgsi686Linux.go` can fail during bootstrap
+  # with message 'default PIE binary requires external (cgo) linking, but cgo is not enabled'
+  # despite CGO being enabled. (we set `CGO_ENABLED=1`).
+  #
+  # To avoid such breakage, limit this patch to a small set of explicitly tested platforms
+  # rather than relying on the general BuildModeSupported("pie") check.
+  supportsDefaultPie =
+    let
+      hasPie = {
+        "amd64" = true;
+        "arm64" = true;
+        "ppc64le" = true;
+        "riscv64" = true;
+      };
+    in
+    hasPie.${stdenv.hostPlatform.go.GOARCH} or false
+    && hasPie.${stdenv.targetPlatform.go.GOARCH} or false;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
@@ -75,6 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.23.patch
     ./go-env-go_ldso.patch
+  ]
+  ++ lib.optionals supportsDefaultPie [
     (replaceVars ./go-default-pie.patch {
       inherit (stdenv.targetPlatform.go) GOARCH;
     })


### PR DESCRIPTION
Blanket application of the patch was insufficiently pessimistic. The original plan from discussion in matrix
was that `BuildModeSupported("gc", "pie", goos, goarch)` should let us know if default pie would work, however it seems that in some cases BuildModeSupported can return true but we'll see failures bootstrapping go anyway.

Let's make an allowlist of GOARCH values so we aren't breaking anything that's not been tested.

This unbreaks `pkgsi686Linux.go`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
