### PR TITLE
ghostty{,-bin}: 1.2.1 -> 1.2.2, add update script

### DIFF
--- a/pkgs/by-name/gh/ghostty-bin/package.nix
+++ b/pkgs/by-name/gh/ghostty-bin/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ghostty-bin";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchurl {
     url = "https://release.files.ghostty.org/${finalAttrs.version}/Ghostty.dmg";
-    hash = "sha256-rFXYJxz6UPE8KKhrPLvksLLvxUdlZzvoxLGhIF3hTGM=";
+    hash = "sha256-gSuOOWZUzKKihCGmqEnieJJ8iP4xFeoSQIL536ka454=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -159,6 +159,7 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (nixosTests) allTerminfo;
       nixos = nixosTests.terminal-emulators.ghostty;
     };
+    updateScript = ./update.nu;
   };
 
   meta = {

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -38,7 +38,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ghostty";
-  version = "1.2.1";
+  version = "1.2.2";
 
   outputs = [
     "out"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ghostty-org";
     repo = "ghostty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LIJ8ZzOzpZMwgJOlOE/n6yiJ/mVKHI4pt/1Bm93gbG8=";
+    hash = "sha256-BTIH8G1GKrcoMasvlA3fje8f1vZvr4uuAUHfvZq6LVY=";
   };
 
   deps = callPackage ./deps.nix {

--- a/pkgs/by-name/gh/ghostty/update.nu
+++ b/pkgs/by-name/gh/ghostty/update.nu
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p nushell nixfmt common-updater-scripts
+
+let latest = ^list-git-tags --url=https://github.com/ghostty-org/ghostty
+  | lines
+  | sort --natural
+  | last
+  | str trim --left --char "v"
+
+let current = ^nix-instantiate --eval -A ghostty.version | str trim -c '"'
+
+if $latest == $current {
+  print "Up to date!"
+  exit
+}
+
+print $"Updating Ghostty: ($current) -> ($latest)"
+
+^update-source-version ghostty $latest --file=./pkgs/by-name/gh/ghostty/package.nix
+
+# Update deps.nix
+http get $"https://raw.githubusercontent.com/ghostty-org/ghostty/refs/tags/v($latest)/build.zig.zon.nix"
+  | ^nixfmt
+  | save -f ./pkgs/by-name/gh/ghostty/deps.nix
+
+# In extraordinary cases the DMG might take a while to be notarized by Apple
+# and so it's possible for a Git tag to have no corresponding notarized DMG download.
+# Don't fail here if that happens.
+try {
+  ^update-source-version ghostty-bin $latest --file=./pkgs/by-name/gh/ghostty-bin/package.nix
+} catch {
+  print "Failed to update bin package (is the DMG file uploaded yet?)"
+}
+


### PR DESCRIPTION
TL;DR: A regression was found where Ghostty was leaking pathological amounts of memory.

https://ghostty.org/docs/install/release-notes/1-2-2

Also took my time to write a simple update script so that quick fixes can land quicker

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
