### PR TITLE
buildstream: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/by-name/bu/buildstream/package.nix
+++ b/pkgs/by-name/bu/buildstream/package.nix
@@ -21,27 +21,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "buildstream";
-  version = "2.5.0";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "buildstream";
     tag = version;
-    hash = "sha256-/kGmAHx10//iVeqLXwcIWNI9FGIi0LlNJW+s6v0yU3Q=";
+    hash = "sha256-2Z+s0dQB85MBO06llhIEO3jwWfL53n74S28ENHcbe/Q=";
   };
-
-  # FIXME: To be removed in v2.6.0 of Buildstream.
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/apache/buildstream/commit/9c4378ab2ec71b6b79ef90ee4bd950dd709a0310.patch?full_index=1";
-      hash = "sha256-po3Dn7gCv7o7h3k8qhmoH/b6Vv6ikKO/pkA20RvdU1g=";
-    })
-    (fetchpatch {
-      url = "https://github.com/apache/buildstream/commit/456a464b2581c52cad2b0b48596f5c19ad1db23f.patch?full_index=1";
-      hash = "sha256-0oFENx4AUhd1uJxRzbKzO5acGDosCc4vFJaSJ6urvhk=";
-    })
-  ];
 
   build-system = with python3Packages; [
     cython
@@ -115,10 +103,6 @@ python3Packages.buildPythonApplication rec {
 
     # Blob not found in the local CAS
     "test_source_pull_partial_fallback_fetch"
-
-    # FAILED tests/sources/tar.py::test_out_of_basedir_hardlinks - AssertionError
-    # FIXME: To be removed in v2.6.0 of Buildstream.
-    "test_out_of_basedir_hardlinks"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Update the Buildstream package to the next release, v2.6.0.

Changelog:

- Add the `remote-apis-socket` sandbox configuration to offer build tools
   in the sandbox (e.g., recc or bazel) access to the Remote Execution API
   for caching or (nested) remote execution
- Add the `digest-environment` dependency configuration for use by
    Remote Execution API clients running in the sandbox
- Additional source provenance in SourceInfo
- Allow showing the element kind in `bst show`
- Accept pre-releases for plugins loaded from the `pip` origin
- BuildStream now requires BuildBox 1.2.6 or later
- Support Python 3.13.4+ and 3.14
- Support protobuf 6+ and Click 8.2+

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
