### PR TITLE
ccls: fix build

### DIFF
--- a/pkgs/by-name/cc/ccls/package.nix
+++ b/pkgs/by-name/cc/ccls/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  llvmPackages,
+  llvmPackages_19,
   rapidjson,
   runtimeShell,
 }:
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    llvmPackages.llvm.dev
+    llvmPackages_19.llvm.dev
   ];
-  buildInputs = with llvmPackages; [
+  buildInputs = with llvmPackages_19; [
     libclang
     llvm
     rapidjson
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     cmakeFlagsArray+=(-DCMAKE_CXX_FLAGS="-fvisibility=hidden -fno-rtti")
   '';
 
-  clang = llvmPackages.clang;
+  clang = llvmPackages_19.clang;
   shell = runtimeShell;
 
   postFixup = ''


### PR DESCRIPTION
The version of the `llvmPackages` package set was recently updated from 19 to 21, breaking a few packages. This PR explicitly uses the older package set to fix the `ccls` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
