### PR TITLE
libjxl: Disable known-borked tests on big-endian

### DIFF
--- a/pkgs/by-name/li/libjxl/package.nix
+++ b/pkgs/by-name/li/libjxl/package.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   brotli,
   cmake,
+  ctestCheckHook,
   giflib,
   gperftools,
   gtest,
@@ -97,6 +98,10 @@ stdenv.mkDerivation rec {
     libhwy
   ];
 
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
   cmakeFlags = [
     # For C dependencies like brotli, which are dynamically linked,
     # we want to use the system libraries, so that we don't have to care about
@@ -175,6 +180,30 @@ stdenv.mkDerivation rec {
   # FIXME x86_64-darwin:
   # https://github.com/NixOS/nixpkgs/pull/204030#issuecomment-1352768690
   doCheck = with stdenv; !(hostPlatform.isi686 || isDarwin && isx86_64);
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isBigEndian [
+    # https://github.com/libjxl/libjxl/issues/3629
+    "DecodeTest.ProgressionTestLosslessAlpha"
+    "DecodeTest.FlushTestLosslessProgressiveAlpha"
+    "EncodeTest.FrameSettingsTest"
+    "JxlTest.RoundtripAlphaResampling"
+    "JxlTest.RoundtripAlphaResamplingOnlyAlpha"
+    "JxlTest.RoundtripAlpha16"
+    "JxlTest.RoundtripProgressive"
+    "JxlTest.RoundtripProgressiveLevel2Slow"
+    "ModularTest.RoundtripLossyDeltaPalette"
+    "ModularTest.RoundtripLossy"
+    "ModularTest.RoundtripLossy16"
+    "PassesTest.ProgressiveDownsample2DegradesCorrectlyGrayscale"
+    "PassesTest.ProgressiveDownsample2DegradesCorrectly"
+  ];
+
+  ctestFlags = lib.optionals stdenv.hostPlatform.isBigEndian [
+    # https://github.com/libjxl/libjxl/issues/3629
+    # These didn't seem to be accepted via disabledTests
+    "--exclude-regex"
+    ".*bitSqueeze.*"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/libjxl/libjxl";


### PR DESCRIPTION
Upstream issue for tracking these: https://github.com/libjxl/libjxl/issues/3629

Assuming that the library isn't *completely* borked, and just disabling the failing tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] powerpc64-linux (native)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
