### PR TITLE
sfuzz: init at 0.7.0-unstable

### DIFF
--- a/pkgs/by-name/sf/sfuzz/package.nix
+++ b/pkgs/by-name/sf/sfuzz/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  versionCheckHook,
+  gnugrep,
+  gnused,
+  gzip,
+  gnutar,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sfuzz";
+  version = "0.7.1-unstable-2023-08-17";
+
+  src = fetchFromGitHub {
+    owner = "apconole";
+    repo = "Simple-Fuzzer";
+    rev = "e1b62bd8fe8950de81abb1c2606bdbe3ab037a95";
+    hash = "sha256-E5DuDWTRU8CsUfvqGIt0w+MKICdUuuMn8ho0JKX399w=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gnugrep
+    gnused
+    gzip
+    gnutar
+  ];
+
+  postPatch = ''
+    sed -i 's#\(WHICH=\).*#\1${lib.getExe which}#' configure
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-V";
+  doInstallCheck = true;
+
+  passthru.updateScript = unstableGitUpdater { };
+  preVersionCheck = ''
+    export version=$(echo '${finalAttrs.version}' | cut -d- -f1)
+  '';
+
+  meta = {
+    description = "A simple config-file driven block/mutation based fuzzing system";
+    mainProgram = "sfuzz";
+    homepage = "http://aconole.bytheb.org/projects/sfuzz";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ makefu ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
in contribution to #81418 this PR adds sfuzz to nixpkgs

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] versionCheckHook
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
