### PR TITLE
quick-lint-js: fix build with CMake 4

### DIFF
--- a/pkgs/by-name/qu/quick-lint-js/package.nix
+++ b/pkgs/by-name/qu/quick-lint-js/package.nix
@@ -2,6 +2,7 @@
   buildPackages,
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   ninja,
   stdenv,
@@ -19,9 +20,17 @@ let
     hash = "sha256-L2LCRm1Fsg+xRdPc8YmgxDnuXJo92nxs862ewzObZ3I=";
   };
 
+  patches = [
+    # Patch the vendored googletest to build with CMake >=3.5
+    (fetchpatch {
+      url = "https://github.com/quick-lint/quick-lint-js/commit/adc7db66a434f7d0ec6a1ab17679c6f57e079566.patch";
+      hash = "sha256-2uswkHyqJB7X4NT9nMfn/u2/po5xeDDwN6nTMIH8JGU=";
+    })
+  ];
+
   quick-lint-js-build-tools = buildPackages.stdenv.mkDerivation {
     pname = "quick-lint-js-build-tools";
-    inherit version src;
+    inherit version src patches;
 
     nativeBuildInputs = [
       cmake
@@ -45,7 +54,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "quick-lint-js";
-  inherit version src;
+  inherit version src patches;
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Integrate an upstream patch that fixes their vendored googletest when
building with CMake >=3.5. 

<https://github.com/quick-lint/quick-lint-js/commit/adc7db66a434f7d0ec6a1ab17679c6f57e079566>
<https://github.com/NixOS/nixpkgs/issues/445447>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
