### PR TITLE
androidndkPkgs_29: init at 29.0.14206865 (plus androidenv autoupdate)

### DIFF
--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -55,4 +55,5 @@ in
 lib.recurseIntoAttrs {
   "27" = makeNdkPkgs "27.0.12077973" pkgs.llvmPackages_18;
   "28" = makeNdkPkgs "28.0.13004108" pkgs.llvmPackages_19;
+  "29" = makeNdkPkgs "29.0.14206865" pkgs.llvmPackages_21;
 }

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -110,7 +110,9 @@ in
             1
           else
             coerceInt (parseVersion repo "platforms" minPlatformVersion);
-        latestPlatformVersionInt = lib.max minPlatformVersionInt (coerceInt repo.latest.platforms);
+        latestPlatformVersionInt = lib.max minPlatformVersionInt (
+          coerceInt (lib.versions.major repo.latest.platforms)
+        );
         firstPlatformVersionInt = lib.max minPlatformVersionInt (
           latestPlatformVersionInt - (lib.max 1 numLatestPlatformVersions) + 1
         );

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -91,7 +91,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -156,7 +156,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -233,7 +233,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -280,7 +280,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -357,7 +357,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -404,7 +404,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -483,7 +483,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -576,7 +576,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -669,7 +669,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -762,7 +762,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -855,7 +855,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -948,7 +948,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -1041,7 +1041,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1134,7 +1134,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -1227,7 +1227,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1320,7 +1320,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1413,7 +1413,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1478,7 +1478,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1543,7 +1543,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1608,7 +1608,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1673,7 +1673,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1738,7 +1738,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1803,7 +1803,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1869,7 +1869,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1900,7 +1900,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1931,7 +1931,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1960,7 +1960,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -2010,7 +2010,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2036,7 +2036,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2072,7 +2072,7 @@
         }
       },
       "displayName": "Google Play services",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2101,7 +2101,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2130,7 +2130,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK (Deprecated)",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2168,7 +2168,7 @@
         }
       },
       "displayName": "Google Repository",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2197,7 +2197,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2226,7 +2226,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2256,7 +2256,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2285,7 +2285,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2314,7 +2314,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20318,
+      "last-available-day": 20369,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2984,7 +2984,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -3030,7 +3030,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -3078,7 +3078,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -3130,7 +3130,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -3179,7 +3179,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -3229,7 +3229,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -3275,7 +3275,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -3323,7 +3323,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -3375,7 +3375,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -3431,7 +3431,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -3470,7 +3470,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -3516,7 +3516,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -3564,7 +3564,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -3616,7 +3616,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -3672,7 +3672,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3711,7 +3711,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3757,7 +3757,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3811,7 +3811,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3863,7 +3863,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3919,7 +3919,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3965,7 +3965,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -4013,7 +4013,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -4065,7 +4065,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -4121,7 +4121,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -4167,7 +4167,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -4215,7 +4215,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -4267,7 +4267,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -4316,7 +4316,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -4353,7 +4353,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -4392,7 +4392,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -4438,7 +4438,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -4484,7 +4484,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -4530,7 +4530,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -4571,7 +4571,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -4623,7 +4623,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -4675,7 +4675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -4727,7 +4727,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4776,7 +4776,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4815,7 +4815,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4861,7 +4861,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4907,7 +4907,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4953,7 +4953,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4994,7 +4994,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -5046,7 +5046,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -5098,7 +5098,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -5150,7 +5150,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -5199,7 +5199,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -5243,7 +5243,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -5282,7 +5282,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -5328,7 +5328,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -5374,7 +5374,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -5420,7 +5420,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -5461,7 +5461,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -5513,7 +5513,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -5565,7 +5565,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -5617,7 +5617,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -5673,7 +5673,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -5712,7 +5712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5758,7 +5758,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5804,7 +5804,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5850,7 +5850,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5898,7 +5898,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5950,7 +5950,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -6002,7 +6002,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -6056,7 +6056,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -6112,7 +6112,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -6158,7 +6158,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -6202,7 +6202,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -6241,7 +6241,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -6287,7 +6287,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -6333,7 +6333,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -6374,7 +6374,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -6426,7 +6426,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -6478,7 +6478,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -6530,7 +6530,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -6584,7 +6584,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -6655,7 +6655,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -6701,7 +6701,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -6752,7 +6752,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6796,7 +6796,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6840,7 +6840,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6891,7 +6891,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6958,7 +6958,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -7025,7 +7025,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -7094,7 +7094,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -7150,7 +7150,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -7201,7 +7201,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -7245,7 +7245,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -7289,7 +7289,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -7340,7 +7340,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -7407,7 +7407,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -7476,7 +7476,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -7537,7 +7537,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -7582,7 +7582,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -7628,7 +7628,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -7679,7 +7679,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -7716,7 +7716,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7753,7 +7753,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7804,7 +7804,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7871,7 +7871,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7938,7 +7938,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7997,7 +7997,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -8064,7 +8064,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -8131,7 +8131,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -8192,7 +8192,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -8252,7 +8252,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -8291,7 +8291,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -8354,7 +8354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -8417,7 +8417,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -8468,7 +8468,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -8525,7 +8525,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -8582,7 +8582,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -8641,7 +8641,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -8722,7 +8722,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -8803,7 +8803,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -8864,7 +8864,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8924,7 +8924,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8970,7 +8970,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear-cn/arm64-v8a",
@@ -9014,7 +9014,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear-cn/x86",
@@ -9053,7 +9053,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -9102,7 +9102,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -9153,7 +9153,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -9220,7 +9220,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -9287,7 +9287,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -9353,7 +9353,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -9434,7 +9434,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -9515,7 +9515,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -9586,7 +9586,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -9645,7 +9645,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -9696,7 +9696,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -9745,7 +9745,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9806,7 +9806,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9873,7 +9873,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9949,7 +9949,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -10016,7 +10016,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -10077,7 +10077,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -10130,7 +10130,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -10185,7 +10185,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -10234,7 +10234,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -10295,7 +10295,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -10362,7 +10362,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -10438,7 +10438,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -10519,7 +10519,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -10580,7 +10580,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -10633,7 +10633,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -10698,7 +10698,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -10757,7 +10757,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10803,7 +10803,7 @@
             }
           },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10847,7 +10847,7 @@
             }
           },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10898,7 +10898,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10947,7 +10947,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -11008,7 +11008,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -11075,7 +11075,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -11144,7 +11144,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -11211,7 +11211,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -11286,7 +11286,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -11335,7 +11335,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -11398,7 +11398,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -11458,7 +11458,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -11498,7 +11498,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -11535,7 +11535,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -11586,7 +11586,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -11635,7 +11635,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -11696,7 +11696,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -11764,7 +11764,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11834,7 +11834,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11903,7 +11903,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11966,7 +11966,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -12019,7 +12019,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -12088,7 +12088,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -12137,7 +12137,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -12178,7 +12178,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -12210,7 +12210,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -12256,7 +12256,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -12301,7 +12301,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -12348,7 +12348,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -12406,7 +12406,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -12466,7 +12466,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -12524,7 +12524,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -12584,7 +12584,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -12646,7 +12646,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -12700,7 +12700,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-arm64-v8a",
           "path": "system-images/android-35-ext15/android-wear/arm64-v8a",
@@ -12733,7 +12733,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-x86_64",
           "path": "system-images/android-35-ext15/android-wear/x86_64",
@@ -12780,7 +12780,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis/arm64-v8a",
@@ -12829,7 +12829,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis-x86_64",
           "path": "system-images/android-35-ext15/google_apis/x86_64",
@@ -12880,7 +12880,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis_playstore/arm64-v8a",
@@ -12929,7 +12929,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext15/google_apis_playstore/x86_64",
@@ -12958,6 +12958,98 @@
       }
     },
     "36": {
+      "android-tv": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "fbd4dcc6127e68c99278cb341041a5036a0ff690",
+              "size": 960176470,
+              "url": "https://dl.google.com/android/repository/sys-img/android-tv/arm64-v8a-36_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Android TV ARM 64 v8a System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-license",
+          "name": "system-image-36-android-tv-arm64-v8a",
+          "path": "system-images/android-36/android-tv/arm64-v8a",
+          "revision": "36-android-tv-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
+        },
+        "x86": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "cccbf99ffabe763c920650aba53678748c9f5f6b",
+              "size": 948236448,
+              "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-36_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
+          "displayName": "Android TV Intel x86 Atom System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-license",
+          "name": "system-image-36-android-tv-x86",
+          "path": "system-images/android-36/android-tv/x86",
+          "revision": "36-android-tv-x86",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:4": "x86",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
+        }
+      },
       "android-wear": {
         "arm64-v8a": {
           "archives": [
@@ -12970,7 +13062,7 @@
             }
           ],
           "displayName": "Wear OS 6.0 ARM 64 v8a System Image (signed)",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-arm64-v8a",
           "path": "system-images/android-36/android-wear-signed/arm64-v8a",
@@ -13003,7 +13095,7 @@
             }
           ],
           "displayName": "Wear OS 6.0 Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-x86_64",
           "path": "system-images/android-36/android-wear-signed/x86_64",
@@ -13032,9 +13124,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "d4e36a020d33b1411e14ca1d4dd74d3b908e538f",
-              "size": 1852726191,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36_r06.zip"
+              "sha1": "5a99183b6d924da606260e45fd41a3eb8eca6eb7",
+              "size": 1872691175,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -13044,19 +13136,19 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis-arm64-v8a",
           "path": "system-images/android-36/google_apis/arm64-v8a",
           "revision": "36-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "7"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
@@ -13081,9 +13173,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "a9b0b4a0488e0c6c380f5485507950f011388511",
-              "size": 1875550742,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36_r06.zip"
+              "sha1": "c6bf44bdcd885bb902b4ba752d111a073ad7a817",
+              "size": 1895447397,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -13093,19 +13185,19 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis-x86_64",
           "path": "system-images/android-36/google_apis/x86_64",
           "revision": "36-google_apis-x86_64",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "7"
           },
           "type-details": {
             "abi:5": "x86_64",
@@ -13150,7 +13242,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore/arm64-v8a",
@@ -13199,7 +13291,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis_playstore-x86_64",
           "path": "system-images/android-36/google_apis_playstore/x86_64",
@@ -13232,9 +13324,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "2edacb5f0d7cd63e838b9e313a2b0cd002f29381",
-              "size": 1928649616,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36_r06.zip"
+              "sha1": "ddc41c615cf57cb91c9646d208e29234d92f881c",
+              "size": 1953548168,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -13244,19 +13336,19 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "36-page_size_16kb-arm64-v8a",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "7"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
@@ -13285,9 +13377,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "8ab4c932fce799060be81978ebfe00055303ebee",
-              "size": 1912261645,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36_r06.zip"
+              "sha1": "3814a7b029c3b8aa0a9c8f110459f412a20882e7",
+              "size": 1937396599,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36_r07.zip"
             }
           ],
           "dependencies": {
@@ -13297,19 +13389,19 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36-page_size_16kb-x86_64",
           "path": "system-images/android-36/google_apis_playstore_ps16k/x86_64",
           "revision": "36-page_size_16kb-x86_64",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "7"
           },
           "type-details": {
             "abi:6": "x86_64",
@@ -13319,6 +13411,316 @@
               "xsi:type": "ns12:sysImgDetailsType"
             },
             "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "36.1": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "818b27a07b6e851ddd305139f967fa11111502a3",
+              "size": 1933295305,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.1_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36.1-google_apis-arm64-v8a",
+          "path": "system-images/android-36.1/google_apis/arm64-v8a",
+          "revision": "36.1-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:5": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "269ca25dc3511e2a6bdcaf457734b585807af485",
+              "size": 1965091162,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.1_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-license",
+          "name": "system-image-36.1-google_apis-x86_64",
+          "path": "system-images/android-36.1/google_apis/x86_64",
+          "revision": "36.1-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:5": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "e829404c284fa09105b89e66e3aceeb1fac9a60c",
+              "size": 1960800700,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.1_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36.1-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_playstore/arm64-v8a",
+          "revision": "36.1-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:5": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "6c0cacff6e3e3021dedd8f80cd302d09dba354e3",
+              "size": 2008752086,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.1_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-license",
+          "name": "system-image-36.1-google_apis_playstore-x86_64",
+          "path": "system-images/android-36.1/google_apis_playstore/x86_64",
+          "revision": "36.1-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:5": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "page_size_16kb": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "fd7faf08bef691a89c6770f8d6965b23cf960ee7",
+              "size": 2017121646,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.1_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36.1-page_size_16kb-arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "36.1-page_size_16kb-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "41c208d5c4cc0100589999abca73814e78e951db",
+              "size": 2009997930,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.1_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20369,
+          "license": "android-sdk-license",
+          "name": "system-image-36.1-page_size_16kb-x86_64",
+          "path": "system-images/android-36.1/google_apis_playstore_ps16k/x86_64",
+          "revision": "36.1-page_size_16kb-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
             "tag:3": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -13360,7 +13762,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis/arm64-v8a",
@@ -13409,7 +13811,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis-x86_64",
           "path": "system-images/android-36-ext19/google_apis/x86_64",
@@ -13460,7 +13862,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis_playstore/arm64-v8a",
@@ -13509,7 +13911,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis_playstore-x86_64",
           "path": "system-images/android-36-ext19/google_apis_playstore/x86_64",
@@ -13544,9 +13946,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "012427119cb7382eaea36bde92172cccd1eb2b7c",
-              "size": 1813124028,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-Baklava_r04.zip"
+              "sha1": "315442c5f27b1a03704c0262bd6e99af4e905140",
+              "size": 1918116152,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.0-Baklava_r01.zip"
             }
           ],
           "dependencies": {
@@ -13556,29 +13958,29 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
-          "path": "system-images/android-Baklava/google_apis/arm64-v8a",
+          "path": "system-images/android-36.0-Baklava/google_apis/arm64-v8a",
           "revision": "Baklava-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "1"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
-            "api-level:0": "35",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "Baklava",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "16",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
@@ -13594,9 +13996,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "a5158e787b4357422a8ebe971e2a310930adcb70",
-              "size": 1822731345,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-Baklava_r04.zip"
+              "sha1": "dc5a0f14318ac2f18c876e1286809fcde665f507",
+              "size": 1948776235,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.0-Baklava_r01.zip"
             }
           ],
           "dependencies": {
@@ -13606,29 +14008,29 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
-          "path": "system-images/android-Baklava/google_apis/x86_64",
+          "path": "system-images/android-36.0-Baklava/google_apis/x86_64",
           "revision": "Baklava-google_apis-x86_64",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "1"
           },
           "type-details": {
             "abi:6": "x86_64",
-            "api-level:0": "35",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "Baklava",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "16",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
@@ -13646,9 +14048,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "a04a36068b98b2fee3dea444425c4e38e6431876",
-              "size": 1832396476,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-Baklava_r04.zip"
+              "sha1": "52ea8a6c582c4027bd5b401b017a22af1070ddf8",
+              "size": 1945286774,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.0-Baklava_r01.zip"
             }
           ],
           "dependencies": {
@@ -13658,29 +14060,29 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-Baklava/google_apis_playstore/arm64-v8a",
+          "path": "system-images/android-36.0-Baklava/google_apis_playstore/arm64-v8a",
           "revision": "Baklava-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "1"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
-            "api-level:0": "35",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "Baklava",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "16",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
@@ -13696,9 +14098,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "1b274676d5920772015689ce480763caf6c72cd7",
-              "size": 1856730222,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-Baklava_r04.zip"
+              "sha1": "1bea1a3bcd67c3be28818f087d8e3497f8cd5050",
+              "size": 1991845954,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.0-Baklava_r01.zip"
             }
           ],
           "dependencies": {
@@ -13708,29 +14110,29 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
-          "path": "system-images/android-Baklava/google_apis_playstore/x86_64",
+          "path": "system-images/android-36.0-Baklava/google_apis_playstore/x86_64",
           "revision": "Baklava-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "1"
           },
           "type-details": {
             "abi:6": "x86_64",
-            "api-level:0": "35",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "Baklava",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "16",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
@@ -13748,9 +14150,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "fc3cf2d62ae0705ee0411d59e15fcb9d5e062f61",
-              "size": 1890722992,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-Baklava_r04.zip"
+              "sha1": "dfd829e7efb9fd8f548be2f9c5610d79f7f41e21",
+              "size": 2001327175,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.0-Baklava_r01.zip"
             }
           ],
           "dependencies": {
@@ -13760,29 +14162,29 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-Baklava/google_apis_playstore_ps16k/arm64-v8a",
+          "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "Baklava-page_size_16kb-arm64-v8a",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "1"
           },
           "type-details": {
             "abi:7": "arm64-v8a",
-            "api-level:0": "35",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "Baklava",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "16",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -13802,9 +14204,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "10a84e0c1cbc56d6cd1cf6de17890603a88de395",
-              "size": 1862515759,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-Baklava_r04.zip"
+              "sha1": "492f339f3767a4a2cd1a428ac5ed99c8ccf249aa",
+              "size": 1993597199,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.0-Baklava_r01.zip"
             }
           ],
           "dependencies": {
@@ -13814,29 +14216,29 @@
               },
               "min-revision:0": {
                 "major:0": "35",
-                "micro:2": "10",
-                "minor:1": "2"
+                "micro:2": "9",
+                "minor:1": "4"
               }
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
-          "path": "system-images/android-Baklava/google_apis_playstore_ps16k/x86_64",
+          "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/x86_64",
           "revision": "Baklava-page_size_16kb-x86_64",
           "revision-details": {
-            "major:0": "4"
+            "major:0": "1"
           },
           "type-details": {
             "abi:7": "x86_64",
-            "api-level:0": "35",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "Baklava",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "16",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -13860,9 +14262,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "d1f856a0a3b4034787b77c3f10e3e7fd75fa9531",
-              "size": 1910594067,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.0-CANARY_r02.zip"
+              "sha1": "d3e00c6f779ae63bf8334991243194ed8726f50f",
+              "size": 1926900131,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.0-CANARY_r03.zip"
             }
           ],
           "dependencies": {
@@ -13878,23 +14280,23 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-google_apis-arm64-v8a",
-          "path": "system-images/android-36.0-CANARY/google_apis/arm64-v8a",
+          "path": "system-images/android-CANARY/google_apis/arm64-v8a",
           "revision": "CANARY-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
-            "api-level:0": "36.0",
+            "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "19",
+            "extension-level:2": "20",
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
@@ -13910,9 +14312,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "06999469c59997683bbf08b6e4406ac8e4b61858",
-              "size": 1942528271,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.0-CANARY_r02.zip"
+              "sha1": "9183e8f62265c01ad1604a4a0d7dc3d85833cbe9",
+              "size": 1962644486,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.0-CANARY_r03.zip"
             }
           ],
           "dependencies": {
@@ -13928,23 +14330,23 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-google_apis-x86_64",
-          "path": "system-images/android-36.0-CANARY/google_apis/x86_64",
+          "path": "system-images/android-CANARY/google_apis/x86_64",
           "revision": "CANARY-google_apis-x86_64",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "x86_64",
-            "api-level:0": "36.0",
+            "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "19",
+            "extension-level:2": "20",
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
@@ -13962,9 +14364,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "54c5a2d2750bebd5eaa681b2a3d52c4b9b5d7298",
-              "size": 1937268325,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.0-CANARY_r02.zip"
+              "sha1": "f6229e271519531634c27cf7e9263fa2d957b22f",
+              "size": 1953862507,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.0-CANARY_r03.zip"
             }
           ],
           "dependencies": {
@@ -13980,23 +14382,23 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-36.0-CANARY/google_apis_playstore/arm64-v8a",
+          "path": "system-images/android-CANARY/google_apis_playstore/arm64-v8a",
           "revision": "CANARY-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
-            "api-level:0": "36.0",
+            "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "19",
+            "extension-level:2": "20",
             "tag:4": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
@@ -14012,9 +14414,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "8afb6a1b2a7e7b4c090cd3aaa0a0eba86e448131",
-              "size": 1985255940,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.0-CANARY_r02.zip"
+              "sha1": "03efb3c709569c93a86ef1c342f6ed8608442bfd",
+              "size": 2005819876,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.0-CANARY_r03.zip"
             }
           ],
           "dependencies": {
@@ -14030,23 +14432,23 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-google_apis_playstore-x86_64",
-          "path": "system-images/android-36.0-CANARY/google_apis_playstore/x86_64",
+          "path": "system-images/android-CANARY/google_apis_playstore/x86_64",
           "revision": "CANARY-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "x86_64",
-            "api-level:0": "36.0",
+            "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "19",
+            "extension-level:2": "20",
             "tag:4": {
               "display:1": "Google Play",
               "id:0": "google_apis_playstore"
@@ -14064,9 +14466,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "ab794ced3006692f3dcfab3d821c68b3d2b12cce",
-              "size": 1990330997,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.0-CANARY_r02.zip"
+              "sha1": "bb42e465d6e0786c95b106731a117fad5a52fd97",
+              "size": 2007500541,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36.0-CANARY_r03.zip"
             }
           ],
           "dependencies": {
@@ -14082,23 +14484,23 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/arm64-v8a",
+          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "CANARY-page_size_16kb-arm64-v8a",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:7": "arm64-v8a",
-            "api-level:0": "36.0",
+            "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "19",
+            "extension-level:2": "20",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -14118,9 +14520,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "bfc22a8e70c29c3b02af6bde5d644ecf2c18670f",
-              "size": 1982737255,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.0-CANARY_r02.zip"
+              "sha1": "4e3a2b8e5c639da2e31e8ecc3a4db48cffaae24d",
+              "size": 2004446653,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36.0-CANARY_r03.zip"
             }
           ],
           "dependencies": {
@@ -14136,23 +14538,23 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20318,
+          "last-available-day": 20369,
           "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-page_size_16kb-x86_64",
-          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/x86_64",
+          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/x86_64",
           "revision": "CANARY-page_size_16kb-x86_64",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "4"
           },
           "type-details": {
             "abi:7": "x86_64",
-            "api-level:0": "36.0",
+            "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "19",
+            "extension-level:2": "20",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -14743,16 +15145,16 @@
     }
   },
   "latest": {
-    "build-tools": "36.0.0",
-    "cmake": "4.1.0",
+    "build-tools": "36.1.0",
+    "cmake": "4.1.1",
     "cmdline-tools": "19.0",
-    "emulator": "36.1.9",
-    "ndk": "28.2.13676358",
+    "emulator": "36.2.10",
+    "ndk": "29.0.14206865",
     "ndk-bundle": "22.1.7171670",
     "platform-tools": "36.0.0",
-    "platforms": "36",
-    "skiaparser": "7",
-    "sources": "36",
+    "platforms": "36.1",
+    "skiaparser": "8",
+    "sources": "36.1",
     "tools": "26.1.1"
   },
   "licenses": {
@@ -14818,7 +15220,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14867,7 +15269,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14916,7 +15318,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14965,7 +15367,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15014,7 +15416,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15063,7 +15465,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15112,7 +15514,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15161,7 +15563,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15210,7 +15612,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -15258,7 +15660,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -15306,7 +15708,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15355,7 +15757,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15404,7 +15806,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15453,7 +15855,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15502,7 +15904,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15551,7 +15953,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -15599,7 +16001,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15648,7 +16050,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -15696,7 +16098,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15745,7 +16147,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -15793,7 +16195,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -15841,7 +16243,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -15889,7 +16291,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -15937,7 +16339,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -15985,7 +16387,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -16033,7 +16435,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -16081,7 +16483,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -16129,7 +16531,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -16177,7 +16579,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -16225,7 +16627,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -16273,7 +16675,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -16321,7 +16723,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -16369,7 +16771,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -16417,7 +16819,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -16465,7 +16867,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -16513,7 +16915,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -16561,7 +16963,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -16609,7 +17011,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -16657,7 +17059,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -16705,7 +17107,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16755,7 +17157,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16805,7 +17207,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -16853,7 +17255,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -16901,7 +17303,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -16949,7 +17351,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -16997,7 +17399,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17047,7 +17449,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17097,7 +17499,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17147,7 +17549,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -17195,7 +17597,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -17243,7 +17645,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -17291,7 +17693,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -17339,7 +17741,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -17387,7 +17789,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -17435,7 +17837,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -17476,7 +17878,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -17517,7 +17919,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -17558,7 +17960,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -17600,7 +18002,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -17641,7 +18043,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -17682,7 +18084,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -17723,7 +18125,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -17764,7 +18166,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -17805,7 +18207,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -17847,7 +18249,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -17889,7 +18291,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -17931,7 +18333,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -17972,7 +18374,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -18014,7 +18416,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -18056,7 +18458,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -18098,7 +18500,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -18140,7 +18542,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -18181,7 +18583,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0",
@@ -18222,7 +18624,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -18264,7 +18666,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -18306,7 +18708,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -18348,7 +18750,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc5",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc5",
@@ -18358,6 +18760,89 @@
           "micro:2": "0",
           "minor:1": "0",
           "preview:3": "5"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.1.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "936a0d6bd5ae3e2118a7567dddbc95ff67ed46e9",
+            "size": 64195204,
+            "url": "https://dl.google.com/android/repository/build-tools_r36.1_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "95f048ae758dad90617975fe3f787f038b03338c",
+            "size": 59366211,
+            "url": "https://dl.google.com/android/repository/build-tools_r36.1_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "d365b05ca1810ca92b428b92717865ad4188b5e1",
+            "size": 80527175,
+            "url": "https://dl.google.com/android/repository/build-tools_r36.1_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 36.1",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "build-tools",
+        "path": "build-tools/36.1.0",
+        "revision": "36.1.0",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "0",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.1.0-rc1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "63a81b0689c2358da5462b4f2b00eef622420f4a",
+            "size": 63756747,
+            "url": "https://dl.google.com/android/repository/build-tools_r36.1-rc1_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "db361020bc9545dec77379d44dcc0b15be1de1ba",
+            "size": 59047572,
+            "url": "https://dl.google.com/android/repository/build-tools_r36.1-rc1_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "bb4e1a9c3ac77300ae00138fb8fb16da79ff32c0",
+            "size": 79856260,
+            "url": "https://dl.google.com/android/repository/build-tools_r36.1-rc1_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 36.1-rc1",
+        "last-available-day": 20369,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/36.1.0-rc1",
+        "revision": "36.1.0-rc1",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "0",
+          "minor:1": "1",
+          "preview:3": "1"
         },
         "type-details": {
           "element-attributes": {
@@ -18399,7 +18884,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -18440,7 +18925,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -18481,7 +18966,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -18522,7 +19007,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -18563,7 +19048,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -18604,7 +19089,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -18645,7 +19130,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -18686,7 +19171,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -18727,7 +19212,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -18768,7 +19253,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -18809,7 +19294,7 @@
           }
         ],
         "displayName": "CMake 3.31.6",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.6",
@@ -18857,7 +19342,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -18898,7 +19383,7 @@
           }
         ],
         "displayName": "CMake 4.0.2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.2",
@@ -18939,7 +19424,7 @@
           }
         ],
         "displayName": "CMake 4.0.3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.3",
@@ -18980,7 +19465,7 @@
           }
         ],
         "displayName": "CMake 4.1.0",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.0",
@@ -18988,6 +19473,47 @@
         "revision-details": {
           "major:0": "4",
           "micro:2": "0",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "4.1.1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "33a36c403071cdd43bd5d611552fe5e8955626c2",
+            "size": 31269415,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.1-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "9b670a019b956eba9c1d908aae0ec1a341d0ac06",
+            "size": 43666138,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.1-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "5b66ca33b43b0d526dad95bac20ca9f79ba8490d",
+            "size": 20951734,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.1-windows.zip"
+          }
+        ],
+        "displayName": "CMake 4.1.1",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "cmake",
+        "path": "cmake/4.1.1",
+        "revision": "4.1.1",
+        "revision-details": {
+          "major:0": "4",
+          "micro:2": "1",
           "minor:1": "1"
         },
         "type-details": {
@@ -19023,7 +19549,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -19063,7 +19589,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -19103,7 +19629,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -19181,7 +19707,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -19259,7 +19785,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -19299,7 +19825,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -19340,7 +19866,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -19381,7 +19907,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -19421,7 +19947,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -19462,7 +19988,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -19502,7 +20028,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0",
@@ -19542,7 +20068,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -19583,7 +20109,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -19624,7 +20150,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -19664,7 +20190,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -19704,7 +20230,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -19744,7 +20270,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -19784,7 +20310,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -19824,7 +20350,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -19864,7 +20390,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -19904,7 +20430,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -20947,7 +21473,7 @@
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -20956,6 +21482,54 @@
           "major:0": "36",
           "micro:2": "9",
           "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.2.10": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "be997b895f4813f063de60b19da55d1faf364707",
+            "size": 320127757,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14110321.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "9574ce9a61f39a8e5249205ea40eb533f9c3249c",
+            "size": 395795926,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14110321.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "eb99c872ac3c90a136589b60522b17fa844d170f",
+            "size": 313350828,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14110321.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "b58146adf64103d46e7157637c7e7822fe458c39",
+            "size": 443358079,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14110321.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.2.10",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "10",
+          "minor:1": "2"
         },
         "type-details": {
           "element-attributes": {
@@ -21004,6 +21578,54 @@
           "major:0": "36",
           "micro:2": "4",
           "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.3.3": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "e21c011ffadbf29413aa168786e445075249e634",
+            "size": 325930034,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14204996.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "4ea7d17a22a4eb9935549e90706a8e21a1e11a03",
+            "size": 468828491,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14204996.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "08c0b09ba9651a2ce2c6f596efcf5592e27b5eea",
+            "size": 380627684,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14204996.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "e650e368272687e65f599424c064ee0983d9d9f3",
+            "size": 449700640,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14204996.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20369,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.3.3",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "3",
+          "minor:1": "3"
         },
         "type-details": {
           "element-attributes": {
@@ -21135,7 +21757,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -21197,7 +21819,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -21259,7 +21881,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -21321,7 +21943,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -21384,7 +22006,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -21446,7 +22068,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -21510,7 +22132,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -21574,7 +22196,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -21636,7 +22258,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -21684,7 +22306,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -21733,7 +22355,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -21781,7 +22403,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -21837,7 +22459,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -21893,7 +22515,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -21948,7 +22570,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -22004,7 +22626,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -22059,7 +22681,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -22114,7 +22736,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -22169,7 +22791,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -22225,7 +22847,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -22280,7 +22902,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -22335,7 +22957,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -22391,7 +23013,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -22447,7 +23069,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -22503,7 +23125,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -22552,7 +23174,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -22601,7 +23223,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -22650,7 +23272,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -22698,7 +23320,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -22746,7 +23368,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -22794,7 +23416,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -22843,7 +23465,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -22892,7 +23514,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -22941,7 +23563,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -22989,7 +23611,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -23038,7 +23660,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -23087,7 +23709,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -23136,7 +23758,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -23185,7 +23807,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -23233,7 +23855,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -23281,7 +23903,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -23329,7 +23951,7 @@
           }
         },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -23371,7 +23993,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -23413,7 +24035,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -23454,7 +24076,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -23495,7 +24117,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -23536,7 +24158,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -23577,7 +24199,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -23619,7 +24241,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -23661,7 +24283,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -23702,7 +24324,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -23743,7 +24365,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -23784,7 +24406,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.3.13750724",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.3.13750724",
@@ -23825,7 +24447,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -23867,7 +24489,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -23909,7 +24531,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -23951,7 +24573,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -23992,7 +24614,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.1.13356709",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.1.13356709",
@@ -24033,7 +24655,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.2.13676358",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.2.13676358",
@@ -24074,7 +24696,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13113456",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13113456",
@@ -24116,7 +24738,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13599879",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13599879",
@@ -24158,7 +24780,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13846066",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13846066",
@@ -24168,6 +24790,89 @@
           "micro:2": "13846066",
           "minor:1": "0",
           "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "29.0.14033849-rc4": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "ecba553458e222a7c9b24945a3690e80a4730104",
+            "size": 783674133,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta4-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "7e9dce149b885efa43760830edd52f347d2e954c",
+            "size": 1049644109,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta4-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "c99b0f02915cd47ba1b64f4ab3f0daf02281a9c7",
+            "size": 833962952,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta4-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 29.0.14033849",
+        "last-available-day": 20369,
+        "license": "android-sdk-preview-license",
+        "name": "ndk",
+        "path": "ndk/29.0.14033849",
+        "revision": "29.0.14033849-rc4",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "14033849",
+          "minor:1": "0",
+          "preview:3": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "29.0.14206865": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "87e2bb7e9be5d6a1c6cdf5ec40dd4e0c6d07c30b",
+            "size": 783549481,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "03d29fbb57e3c05a7d53597dd011d856c1456a4f",
+            "size": 1049519838,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "ab3bb30fbb9e6903666d60c55d11e78b04e07472",
+            "size": 833850862,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 29.0.14206865",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "ndk",
+        "path": "ndk/29.0.14206865",
+        "revision": "29.0.14206865",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "14206865",
+          "minor:1": "0"
         },
         "type-details": {
           "element-attributes": {
@@ -24223,7 +24928,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24285,7 +24990,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24347,7 +25052,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24409,7 +25114,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -24472,7 +25177,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24534,7 +25239,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -24598,7 +25303,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -24662,7 +25367,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24724,7 +25429,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24772,7 +25477,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24821,7 +25526,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24869,7 +25574,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24925,7 +25630,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24981,7 +25686,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25036,7 +25741,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25092,7 +25797,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25147,7 +25852,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25202,7 +25907,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25257,7 +25962,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25313,7 +26018,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25368,7 +26073,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25423,7 +26128,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25479,7 +26184,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25535,7 +26240,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25591,7 +26296,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25754,7 +26459,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -25795,7 +26500,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -25824,7 +26529,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -25863,7 +26568,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -25902,7 +26607,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -25941,7 +26646,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -25980,7 +26685,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -26019,7 +26724,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -26058,7 +26763,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -26097,7 +26802,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -26136,7 +26841,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -26175,7 +26880,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -26228,7 +26933,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26268,7 +26973,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -26307,7 +27012,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -26346,7 +27051,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -26385,7 +27090,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -26424,7 +27129,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -26463,7 +27168,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -26502,7 +27207,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -26541,7 +27246,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -26580,7 +27285,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -26619,7 +27324,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -26672,7 +27377,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26712,7 +27417,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -26751,7 +27456,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -26790,7 +27495,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -26829,7 +27534,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -26869,7 +27574,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -26904,7 +27609,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26950,7 +27655,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -26983,7 +27688,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -27021,7 +27726,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext15",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext15",
@@ -27054,7 +27759,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36",
@@ -27076,6 +27781,39 @@
           }
         }
       },
+      "36.1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "f87dc23b7ddba6934908da6cfb58fd5b258077ce",
+            "size": 66270841,
+            "url": "https://dl.google.com/android/repository/platform-36.1_r01.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform 36.1",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "platforms",
+        "path": "platforms/android-36.1",
+        "revision": "36.1",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "36.1",
+          "base-extension:2": "true",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "extension-level:1": "20",
+          "layoutlib:3": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
       "36x": {
         "archives": [
           {
@@ -27087,7 +27825,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36-ext19",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36-ext19",
@@ -27134,7 +27872,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27188,7 +27926,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27242,7 +27980,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27282,7 +28020,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -27321,7 +28059,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -27360,7 +28098,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -27393,28 +28131,28 @@
           {
             "arch": "all",
             "os": "all",
-            "sha1": "9dcd49009a005b0bdce2384cad0d9ca0fe74f1ce",
-            "size": 65604289,
-            "url": "https://dl.google.com/android/repository/platform-Baklava_r05.zip"
+            "sha1": "7842268e95c0538a9d59ab813f39a5ee69bdbb86",
+            "size": 66332697,
+            "url": "https://dl.google.com/android/repository/platform-36.0-Baklava-ext19_r01.zip"
           }
         ],
-        "displayName": "Android SDK Platform Baklava",
-        "last-available-day": 20318,
+        "displayName": "Android SDK Platform Baklava-ext19",
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
-        "path": "platforms/android-Baklava",
+        "path": "platforms/android-Baklava-ext19",
         "revision": "Baklava",
         "revision-details": {
-          "major:0": "5"
+          "major:0": "1"
         },
         "type-details": {
-          "api-level:0": "35",
-          "base-extension:3": "true",
+          "api-level:0": "36.0x",
+          "base-extension:3": "false",
           "codename:1": "Baklava",
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
-          "extension-level:2": "16",
+          "extension-level:2": "19",
           "layoutlib:4": {
             "element-attributes": {
               "api": "15"
@@ -27427,28 +28165,28 @@
           {
             "arch": "all",
             "os": "all",
-            "sha1": "163262487a541e01d0af42cca7cc20a7d46a461b",
-            "size": 66239501,
-            "url": "https://dl.google.com/android/repository/platform-36.0-CANARY_r02.zip"
+            "sha1": "a8201ba194c5241bf6e80d9c21f981e502f5d69c",
+            "size": 66388262,
+            "url": "https://dl.google.com/android/repository/platform-CANARY_r04.zip"
           }
         ],
         "displayName": "Android SDK Platform CANARY",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-preview-license",
         "name": "platforms",
         "path": "platforms/android-CANARY",
         "revision": "CANARY",
         "revision-details": {
-          "major:0": "2"
+          "major:0": "4"
         },
         "type-details": {
-          "api-level:0": "36.0",
+          "api-level:0": "36.1",
           "base-extension:3": "true",
           "codename:1": "CANARY",
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
-          "extension-level:2": "19",
+          "extension-level:2": "20",
           "layoutlib:4": {
             "element-attributes": {
               "api": "15"
@@ -27498,7 +28236,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27616,7 +28354,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -27737,7 +28475,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -27796,6 +28534,52 @@
             "xsi:type": "ns5:genericDetailsType"
           }
         }
+      },
+      "8": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "044c943903d6e29b27e0c39bf6b11caa40969e82",
+            "size": 15894999,
+            "url": "https://dl.google.com/android/repository/skiaparser-14118104-linux-x64.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "03c288712f84edc0fd2d81d519fda950d0ed7247",
+            "size": 4883789,
+            "url": "https://dl.google.com/android/repository/skiaparser-14118104-darwin-x64.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "705ff5a687a2210538db854ab9cfbc85e94c6011",
+            "size": 4326024,
+            "url": "https://dl.google.com/android/repository/skiaparser-14118104-darwin-aarch64.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "b9f9b7bbf0a6483d897db6b857be043238c7cb0f",
+            "size": 4598454,
+            "url": "https://dl.google.com/android/repository/skiaparser-14118104-win-x64.zip"
+          }
+        ],
+        "displayName": "Layout Inspector image server for API 31-36",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "skiaparser",
+        "path": "skiaparser/3",
+        "revision": "8",
+        "revision-details": {
+          "major:0": "8"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "sources": {
@@ -27810,7 +28594,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -27840,7 +28624,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -27869,7 +28653,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -27898,7 +28682,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -27927,7 +28711,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -27956,7 +28740,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -27985,7 +28769,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -28014,7 +28798,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -28043,7 +28827,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -28072,7 +28856,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -28101,7 +28885,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -28130,7 +28914,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -28159,7 +28943,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -28188,7 +28972,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -28217,7 +29001,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -28246,7 +29030,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -28275,7 +29059,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -28304,7 +29088,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -28333,7 +29117,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -28362,7 +29146,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -28392,7 +29176,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -28422,7 +29206,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -28452,7 +29236,7 @@
           }
         ],
         "displayName": "Sources for Android 36",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36",
@@ -28467,6 +29251,34 @@
             "xsi:type": "ns11:sourceDetailsType"
           },
           "extension-level:1": "17"
+        }
+      },
+      "36.1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "54cea0371ec284404e06051cd389646d34470da4",
+            "size": 51810808,
+            "url": "https://dl.google.com/android/repository/source-36.1_r01.zip"
+          }
+        ],
+        "displayName": "Sources for Android 36.1",
+        "last-available-day": 20369,
+        "license": "android-sdk-license",
+        "name": "sources",
+        "path": "sources/android-36.1",
+        "revision": "36.1",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "36.1",
+          "base-extension:2": "true",
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          },
+          "extension-level:1": "20"
         }
       }
     },
@@ -28519,7 +29331,7 @@
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20318,
+        "last-available-day": 20369,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1715,6 +1715,7 @@ with pkgs;
   androidndkPkgs = androidndkPkgs_27;
   androidndkPkgs_27 = (callPackage ../development/androidndk-pkgs { })."27";
   androidndkPkgs_28 = (callPackage ../development/androidndk-pkgs { })."28";
+  androidndkPkgs_29 = (callPackage ../development/androidndk-pkgs { })."29";
 
   androidsdk = androidenv.androidPkgs.androidsdk;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
