### PR TITLE
pytrainer: Upgrade to webkitgtk_4_1

### DIFF
--- a/pkgs/by-name/py/pytrainer/package.nix
+++ b/pkgs/by-name/py/pytrainer/package.nix
@@ -12,7 +12,7 @@
   perl,
   sqlite,
   tzdata,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   wrapGAppsHook3,
   xvfb-run,
 }:
@@ -60,7 +60,7 @@ python.pkgs.buildPythonApplication rec {
   buildInputs = [
     sqlite
     gtk3
-    webkitgtk_4_0
+    webkitgtk_4_1
     glib-networking
     adwaita-icon-theme
     gdk-pixbuf
@@ -89,6 +89,10 @@ python.pkgs.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace pytrainer/platform.py \
         --replace-fail 'sys.prefix' "\"$out\""
+
+    # https://github.com/pytrainer/pytrainer/pull/281
+    substituteInPlace pytrainer/extensions/mapviewer.py \
+        --replace-fail "gi.require_version('WebKit2', '4.0')" "gi.require_version('WebKit2', '4.1')"
   '';
 
   checkPhase = ''


### PR DESCRIPTION

See https://github.com/NixOS/nixpkgs/pull/450065

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
