### PR TITLE
ungoogled-chromium: 141.0.7390.54-1 -> 141.0.7390.65-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -808,7 +808,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "141.0.7390.54",
+    "version": "141.0.7390.65",
     "deps": {
       "depot_tools": {
         "rev": "3f41e54ae17d53d4a39feecad64c3d3e6871b219",
@@ -820,16 +820,16 @@
         "hash": "sha256-WERLGrReUATmn3RhxtmyZcJBxdIY/WZqBDranCLDYEg="
       },
       "ungoogled-patches": {
-        "rev": "141.0.7390.54-1",
-        "hash": "sha256-Lu74ipJFj194vDPHmIXQ9FyPvexTNdbKJ/SlLZpW4B8="
+        "rev": "141.0.7390.65-1",
+        "hash": "sha256-xjfr2nSoytbbAEQg9WkWQCp4TuPadrBx8JSxJzjPZMI="
       },
       "npmHash": "sha256-i1eQ4YlrWSgY522OlFtGDDPmxE2zd1hDM03AzR8RafE="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "b95610d5c4a562d9cd834bc0a098d3316e2f533f",
-        "hash": "sha256-jraDPodJBdyFFHS30BcQTZOEUD+h9SFHQrO0GoMhtk8=",
+        "rev": "b2ec783d2b51a396804a4e3e33f6586be09a4e2d",
+        "hash": "sha256-9jZ7411NThelyL0R5yoLXB0lOkydOI3v6K5ORhjqfF4=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1059,8 +1059,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "65f160d43dc97a2e8eb5e1c2814179a519313884",
-        "hash": "sha256-VLMJ/WWCIzk92mmuBdx+P6Gi0ouiXuMGkiR0KVK5GWI="
+        "rev": "9c2c4cc7cf6c82ad460e1f3b49f34bb702d5fe11",
+        "hash": "sha256-qj1vR0FW2jiR2v18Nv8RqYgy/UEw2rgGUsQ68EhdHos="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",


### PR DESCRIPTION
Same underlying changes as #449929

https://chromereleases.googleblog.com/2025/10/stable-channel-update-for-desktop.html

This update includes 3 security fixes.

CVEs:
CVE-2025-11458 CVE-2025-11460 CVE-2025-11211

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
