### PR TITLE
mklittlefs: init at 4.1.0

### DIFF
--- a/pkgs/by-name/mk/mklittlefs/package.nix
+++ b/pkgs/by-name/mk/mklittlefs/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mklittlefs";
+  version = "4.1.0";
+
+  src = fetchFromGitHub {
+    owner = "earlephilhower";
+    repo = "mklittlefs";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-qCL5EG5HyUjObaRReptuNqMKKxOnyP8ZQpOKdLV4F80=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail '$(shell git describe --tag)' '${finalAttrs.version}' \
+      --replace-fail '$(shell git -C littlefs describe --tags || echo "unknown")' '2.11.1'
+
+      patchShebangs run_tests.sh
+      patchShebangs tests/test_create
+  '';
+
+  makeFlags = [
+    "BUILD_CONFIG_NAME=-nixos"
+  ];
+
+  env = {
+    CPPFLAGS =
+      "-DLFS_NAME_MAX=255"
+      + lib.optionalString stdenv.hostPlatform.isDarwin " -Wno-error=vla-cxx-extension";
+  };
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  checkPhase = ''
+     runHook preCheck
+
+    ./run_tests.sh tests
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 mklittlefs -t $out/bin
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Tool to build and unpack littlefs images";
+    homepage = "https://github.com/earlephilhower/mklittlefs";
+    changelog = "https://github.com/earlephilhower/mklittlefs/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ liberodark ];
+    mainProgram = "mklittlefs";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
