### PR TITLE
arduino-app-lab: init at 0.1.23

### DIFF
--- a/pkgs/by-name/ar/arduino-app-lab/package.nix
+++ b/pkgs/by-name/ar/arduino-app-lab/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  wrapGAppsHook3,
+  autoPatchelfHook,
+  webkitgtk_4_1,
+  gtk3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "arduino-app-lab";
+  version = "0.1.23";
+  src = fetchurl {
+    url = "https://downloads.arduino.cc/app-lab-release/ArduinoAppLab_${finalAttrs.version}_Linux_x86-64.tar.gz";
+    hash = "sha256-0Sw/xdC/sh2iXsOJrvfVuTMFMM7FCnH8qF4GuuNk0Uk=";
+  };
+  dontBuild = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D ./arduino-app-lab $out/bin/arduino-app-lab
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A powerful visual environment for managing your UNO Q board";
+    longDescription = ''
+      Combine prebuilt modules, called Bricks, with AI models to define your board’s behavior with ease.
+      App Lab supports both classic C++ sketches via the Arduino IDE and Python,
+      giving you full flexibility to develop the way you prefer.
+    '';
+    mainProgram = "arduino-app-lab";
+    homepage = "https://www.arduino.cc/en/software/#app-lab-section";
+    downloadPage = "https://www.arduino.cc/en/software/#app-lab-section";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
Added the recently-announced Arduino App Lab for x86_64.

I don't have Arduino UNO Q for testing thus only basic graphical behaviour is tested.

Formally speaking, they are open-source:

> The Arduino App lab is Open Source under terms of [GPL 3.0 License](https://www.gnu.org/licenses/gpl-3.0.en.html) and its source code is available [here](https://downloads.arduino.cc/app-lab-release/source-app-lab.zip).

But they only provide an unversioned link to some sources zip which is a mix of `.ts` and `.go` files, so at this stage I guess it is more predictable to just wrap the binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
