### PR TITLE
rquickshare-legacy: drop

### DIFF
--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -1,13 +1,11 @@
 {
   lib,
   cargo-tauri,
-  cargo-tauri_1,
   fetchFromGitHub,
   glib-networking,
   libayatana-appindicator,
-  libsoup_2_4,
   libsoup_3,
-  nix-update,
+  nix-update-script,
   nodejs,
   openssl,
   pkg-config,
@@ -15,29 +13,11 @@
   protobuf,
   rustPlatform,
   stdenv,
-  webkitgtk_4_0,
   webkitgtk_4_1,
   wrapGAppsHook4,
-  writeShellScript,
-
-  # This package provides can be built using tauri v1 or v2.
-  # Try legacy (v1) version if main (v2) doesn't work.
-  app-type ? "main", # main or legacy
 }:
-let
-  app-type-either =
-    arg1: arg2:
-    if app-type == "main" then
-      arg1
-    else if app-type == "legacy" then
-      arg2
-    else
-      throw "Wrong argument for app-type in rquickshare package";
-
-  proper-cargo-tauri = app-type-either cargo-tauri cargo-tauri_1;
-in
 rustPlatform.buildRustPackage rec {
-  pname = "rquickshare" + (app-type-either "" "-legacy");
+  pname = "rquickshare";
   version = "0.11.5";
 
   src = fetchFromGitHub {
@@ -55,7 +35,7 @@ rustPlatform.buildRustPackage rec {
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
 
-  pnpmRoot = "app/${app-type}";
+  pnpmRoot = "app/main";
   pnpmDeps = pnpm_9.fetchDeps {
     inherit
       pname
@@ -65,19 +45,19 @@ rustPlatform.buildRustPackage rec {
       ;
     postPatch = "cd ${pnpmRoot}";
     fetcherVersion = 1;
-    hash = app-type-either "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=" "sha256-8QRigYNtxirXidFFnTzA6rP0+L64M/iakPqe2lZKegs=";
+    hash = "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=";
   };
 
-  cargoRoot = "app/${app-type}/src-tauri";
+  cargoRoot = "app/main/src-tauri";
   buildAndTestSubdir = cargoRoot;
   cargoPatches = [
     ./remove-duplicate-versions-of-sys-metrics.patch
     ./remove-code-signing-darwin.patch
   ];
-  cargoHash = app-type-either "sha256-XfN+/oC3lttDquLfoyJWBaFfdjW/wyODCIiZZksypLM=" "sha256-4vBHxuKg4P9H0FZYYNUT+AVj4Qvz99q7Bhd7x47UC2w=";
+  cargoHash = "sha256-XfN+/oC3lttDquLfoyJWBaFfdjW/wyODCIiZZksypLM=";
 
   nativeBuildInputs = [
-    proper-cargo-tauri.hook
+    cargo-tauri.hook
 
     # Setup pnpm
     nodejs
@@ -90,41 +70,24 @@ rustPlatform.buildRustPackage rec {
     wrapGAppsHook4
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux (
-    [
-      glib-networking
-      libayatana-appindicator
-      openssl
-    ]
-    ++ lib.optionals (app-type == "main") [
-      libsoup_3
-      webkitgtk_4_1
-    ]
-    ++ lib.optionals (app-type == "legacy") [
-      libsoup_2_4
-      webkitgtk_4_0
-    ]
-  );
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    libayatana-appindicator
+    libsoup_3
+    openssl
+    webkitgtk_4_1
+  ];
 
   env.OPENSSL_NO_VENDOR = 1;
 
-  passthru =
-    # Don't set an update script for the legacy version
-    # so r-ryantm won't create two duplicate PRs
-    lib.optionalAttrs (app-type == "main") {
-      updateScript = writeShellScript "update-rquickshare.sh" ''
-        ${lib.getExe nix-update} rquickshare
-        sed -i 's/version = "0.0.0";/' pkgs/by-name/rq/rquickshare/package.nix
-        ${lib.getExe nix-update} rquickshare-legacy
-      '';
-    };
+  passthru.updateScript = nix-update-script;
 
   meta = {
     description = "Rust implementation of NearbyShare/QuickShare from Android for Linux and macOS";
     homepage = "https://github.com/Martichou/rquickshare";
     changelog = "https://github.com/Martichou/rquickshare/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
-    mainProgram = app-type-either "rquickshare" "r-quick-share";
+    mainProgram = "rquickshare";
     maintainers = with lib.maintainers; [
       perchun
       luftmensch-luftmensch

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2345,6 +2345,7 @@ mapAliases {
   rote = throw "rote has been removed due to lack of upstream maintenance"; # Added 2025-09-10
   rnix-hashes = throw "'rnix-hashes' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   rpiboot-unstable = throw "'rpiboot-unstable' has been renamed to/replaced by 'rpiboot'"; # Converted to throw 2024-10-17
+  rquickshare-legacy = throw "The legacy version depends on insecure package libsoup2, please use the main version"; # Added 2025-10-09
   rr-unstable = rr; # Added 2022-09-17
   rtx = mise; # Added 2024-01-05
   ruby-zoom = throw "'ruby-zoom' has been removed due to lack of maintaince and had not been updated since 2020"; # Added 2025-08-24

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11957,8 +11957,6 @@ with pkgs;
     x11Support = true;
   };
 
-  rquickshare-legacy = rquickshare.override { app-type = "legacy"; };
-
   # a somewhat more maintained fork of ympd
   memento = qt6Packages.callPackage ../applications/video/memento { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Drops the legacy version, as it depends on an insecure libsoup2 package (see #450065). The main version should be fine.

`rquickshare-legacy` is already unavailable on master, as libsoup2 is marked as an insecure package and fails eval.

The derivation has changed because of the order in `buildInputs`:
<img width="947" height="265" alt="image" src="https://github.com/user-attachments/assets/f02f1c55-fce5-4df4-a31f-89685f7d87ed" />



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
