### PR TITLE
cmakerc: fix cmake_minimum_required to support modern CMake

### DIFF
--- a/pkgs/by-name/cm/cmakerc/0001-Fix-minimum-required-CMake-version-to-be-compatible-.patch
+++ b/pkgs/by-name/cm/cmakerc/0001-Fix-minimum-required-CMake-version-to-be-compatible-.patch
@@ -1,0 +1,25 @@
+From edba7fcb38457932337e442aac7d50528d2a5d71 Mon Sep 17 00:00:00 2001
+From: loner <2788892716@qq.com>
+Date: Thu, 9 Oct 2025 07:19:53 +0800
+Subject: [PATCH] Fix minimum required CMake version to be compatible with
+ modern CMake
+
+---
+ CMakeRC.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeRC.cmake b/CMakeRC.cmake
+index 6a5147a..5d48bbc 100644
+--- a/CMakeRC.cmake
++++ b/CMakeRC.cmake
+@@ -34,7 +34,7 @@ endif()
+
+ set(_version 2.0.0)
+
+-cmake_minimum_required(VERSION 3.3)
++cmake_minimum_required(VERSION 3.5...3.30)
+ include(CMakeParseArguments)
+
+ if(COMMAND cmrc_add_resource_library)
+--
+2.51.0

--- a/pkgs/by-name/cm/cmakerc/package.nix
+++ b/pkgs/by-name/cm/cmakerc/package.nix
@@ -15,6 +15,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-++16WAs2K9BKk8384yaSI/YD1CdtdyXVBIjGhqi4JIk=";
   };
 
+  # Fix the cmake_minimum_required version constraint in CMakeRC.cmake.
+  patches = [
+    ./0001-Fix-minimum-required-CMake-version-to-be-compatible-.patch
+  ];
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
