### PR TITLE
pytomlpp: remove setup_requires to avoid setuptools fetching deps in Nix

### DIFF
--- a/pkgs/development/python-modules/pytomlpp/0001-remove-setup_requires.patch
+++ b/pkgs/development/python-modules/pytomlpp/0001-remove-setup_requires.patch
@@ -1,0 +1,24 @@
+From 8479bb8809a318f49ae5b881b65890db40b0e693 Mon Sep 17 00:00:00 2001
+From: loner <2788892716@qq.com>
+Date: Thu, 9 Oct 2025 10:18:44 +0800
+Subject: [PATCH] Remove deprecated setup_requires from setup.cfg
+
+---
+ setup.cfg | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index 78468c0..7a875bb 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -27,8 +27,6 @@ classifiers =
+ keywords = toml, parser, serilization, deserialization, serdes
+
+ [options]
+-setup_requires =
+-    pybind11~=2.10
+ zip_safe = false
+ packages = find:
+ package_dir = =src
+--
+2.51.0

--- a/pkgs/development/python-modules/pytomlpp/default.nix
+++ b/pkgs/development/python-modules/pytomlpp/default.nix
@@ -25,6 +25,9 @@ buildPythonPackage rec {
     hash = "sha256-P41jEs1ShpiuSenreE4ykesY2wgBaR7TUKuv3tcD5J0=";
   };
 
+  # The latest setuptools has deprecated `setup_requires` and will attempt to automatically invoke `pip` to install dependencies during the build.
+  patches = [ ./0001-remove-setup_requires.patch ];
+
   buildInputs = [ pybind11 ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Removed `setup_requires = pybind11~=2.10` from setup.cfg.
- This prevents setuptools from trying to install pybind11 via pip, which fails in Nix builds where pip may not be available.
- Dependencies like pybind11 should be provided via Nix's nativeBuildInputs instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
