### PR TITLE
gbforth: unstable-2023-03-02 -> unstable-2025-10-08

### DIFF
--- a/pkgs/by-name/gb/gbforth/package.nix
+++ b/pkgs/by-name/gb/gbforth/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   gforth,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
@@ -39,6 +40,8 @@ stdenv.mkDerivation {
     $out/bin/gbforth examples/simon/simon.fs
     runHook postInstallCheck
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     homepage = "https://gbforth.org/";

--- a/pkgs/by-name/gb/gbforth/package.nix
+++ b/pkgs/by-name/gb/gbforth/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "gbforth";
-  version = "unstable-2023-03-02";
+  version = "unstable-2025-10-08";
 
   src = fetchFromGitHub {
     owner = "ams-hackers";
     repo = "gbforth";
-    rev = "428fcf5054fe301e90ac74b1d920ee3ecc375b5b";
-    hash = "sha256-v1bdwT15Wg1VKpo74Cc3tsTl1uOKvKdlHWtbZkJ/qbA=";
+    rev = "39ec80520bf7bedf881eca01909cc9eeb7334a60";
+    hash = "sha256-3Zky+ZKA0FPhO1l5pFdmDQgdwvvO3QgPGsgVracY5xw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates `gbforth` to the latest version, what also makes it compatible with the most recent `gforth` version, allowing it to work fine with #449792 .

Discussed in https://github.com/ams-hackers/gbforth/issues/345 .
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
