### PR TITLE
openzl: init at 0.1.0

### DIFF
--- a/pkgs/by-name/op/openzl/package.nix
+++ b/pkgs/by-name/op/openzl/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  cmakeMinimal,
+  fetchFromGitHub,
+  ninja,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openzl";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "openzl";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-oL0ajfedlLu0cfXbzpzG8D3cJ3zaB+AfX5BvpHDhv2Q=";
+  };
+
+  nativeBuildInputs = [
+    cmakeMinimal
+    ninja
+  ];
+
+  cmakeFlags = [
+    "-GNinja"
+  ];
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+  ];
+
+  postInstall = ''
+    install -D cli/zli* $bin/bin/zli
+    install -D tools/sddl/sddl_compiler* $bin/bin/sddl_compiler
+  '';
+
+  meta = {
+    description = "Graph-based data compression framework";
+    homepage = "https://openzl.org";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.theoparis ];
+    platforms = lib.platforms.unix;
+    changelog = "https://github.com/facebook/openzl/blob/${finalAttrs.src.tag}/CHANGELOG";
+    mainProgram = "zli";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

OpenZL is a new graph-based data compression framework made by Facebook. [It currently lacks a proper make install target with the tool/cli binaries](https://github.com/facebook/openzl/issues/56). so I had to workaround that with a postInstall script for now. It also pulls in googletest via the CMake FetchContent module instead of a submodule so I wasn't able to build the tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
