### PR TITLE
oscanner: init at 1.0.6

### DIFF
--- a/pkgs/by-name/os/oscanner/package.nix
+++ b/pkgs/by-name/os/oscanner/package.nix
@@ -1,0 +1,77 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  makeWrapper,
+  coreutils,
+  versionCheckHook,
+  jre,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oscanner";
+  version = "1.0.6";
+
+  src = fetchFromGitLab {
+    group = "kalilinux";
+    owner = "packages";
+    repo = "oscanner";
+    tag = "kali/${finalAttrs.version}-1kali3";
+    hash = "sha256-zb6u01wv+PDQp958qmI54upH+hKk8gltqZHGMEMMA5E=";
+  };
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  sourceRoot = "source";
+
+  # start launcher from share directory which contains jar files
+  postPatch = ''
+    for i in *.sh;do
+      sed -i '4i cd "$(dirname "$(readlink -f "$0")")"/../share/oscanner' "$i"
+    done
+  '';
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -dm755 $out/share/oscanner
+
+    install -D -m644 COPYING $out/share/doc/oscanner/COPYING
+
+    # install launchers
+    install -Dm755 oscanner.sh $out/bin/oscanner
+    install -Dm755 reportviewer.sh $out/bin/reportviewer
+
+    # cleanup before copy
+    rm -f *.exe COPYING oscanner.sh reportviewer.sh
+
+    cp -r . $out/share/oscanner
+
+    for bin in $out/bin/*;do
+      wrapProgram $bin \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            jre
+            coreutils # required for launcher directory switch
+          ]
+        }
+    done
+
+    runHook postInstall
+  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
+
+  meta = {
+    description = "An Oracle assessment framework developed in Java";
+    homepage = "https://www.kali.org/tools/oscanner/";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ makefu ];
+    mainProgram = "oscanner";
+  };
+})


### PR DESCRIPTION
add versionCheck
in contribution to #81418

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] versionCheckHook
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
