### PR TITLE
[25.05] immich: 1.142.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.92";
+  version = "2.2.94";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.90";
+  version = "2.2.92";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.89";
+  version = "2.2.90";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.95";
+  version = "2.2.96";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich-cli/package.nix
+++ b/pkgs/by-name/im/immich-cli/package.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "immich-cli";
-  version = "2.2.94";
+  version = "2.2.95";
   inherit (immich) src pnpmDeps;
 
   postPatch = ''

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -34,7 +34,7 @@
 }:
 let
   pnpm = pnpm_10;
-  version = "1.143.1";
+  version = "1.144.1";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,14 +108,14 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-lP/IrKV2B1Gq43jqVa1hIpx4HOJoiYBDUOvyTJB0t7k=";
+    hash = "sha256-lSe50nbVWNWej137JgfJawIOPhtMVoolHahfrd1ENJc=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     pname = "immich";
     inherit version src;
     fetcherVersion = 2;
-    hash = "sha256-ShKgfsYc9n+B+NnSaJOSyLb4ev43ZsympYhRgPZtlxs=";
+    hash = "sha256-+CwwTqjI+xOGCAb66lZplNMBwR2xJZBs6E0OyGHbSAE=";
   };
 
   web = stdenv.mkDerivation {

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -34,7 +34,7 @@
 }:
 let
   pnpm = pnpm_10;
-  version = "1.142.1";
+  version = "1.143.1";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,14 +108,14 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-u538GWupnkH2K81Uk9yEuHc3pAeVexnJOnhWo7gElL0=";
+    hash = "sha256-lP/IrKV2B1Gq43jqVa1hIpx4HOJoiYBDUOvyTJB0t7k=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     pname = "immich";
     inherit version src;
     fetcherVersion = 2;
-    hash = "sha256-aYG5SpFZxhbz32YAdP39RYwn2GV+mFWhddd4IFuPuz8=";
+    hash = "sha256-ShKgfsYc9n+B+NnSaJOSyLb4ev43ZsympYhRgPZtlxs=";
   };
 
   web = stdenv.mkDerivation {

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -34,7 +34,7 @@
 }:
 let
   pnpm = pnpm_10;
-  version = "1.142.0";
+  version = "1.142.1";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,7 +108,7 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-0nStZuSnb8tJ0+Y247MHitmMURl8vTuPLAhUm+OHctE=";
+    hash = "sha256-u538GWupnkH2K81Uk9yEuHc3pAeVexnJOnhWo7gElL0=";
   };
 
   pnpmDeps = pnpm.fetchDeps {

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -34,7 +34,7 @@
 }:
 let
   pnpm = pnpm_10;
-  version = "1.144.1";
+  version = "2.0.0";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,7 +108,7 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-lSe50nbVWNWej137JgfJawIOPhtMVoolHahfrd1ENJc=";
+    hash = "sha256-N9/vDOZzx4BQvWQBPE6ANCJ9RhWmytw8j1BgDU6ob+g=";
   };
 
   pnpmDeps = pnpm.fetchDeps {

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -34,7 +34,7 @@
 }:
 let
   pnpm = pnpm_10;
-  version = "2.0.0";
+  version = "2.0.1";
 
   esbuild' = buildPackages.esbuild.override {
     buildGoModule =
@@ -108,7 +108,7 @@ let
     owner = "immich-app";
     repo = "immich";
     tag = "v${version}";
-    hash = "sha256-N9/vDOZzx4BQvWQBPE6ANCJ9RhWmytw8j1BgDU6ob+g=";
+    hash = "sha256-lpFUjjS7Q2F/Uhog1NdJ8vaVIGjmZM9ZWxW5d0zoQsc=";
   };
 
   pnpmDeps = pnpm.fetchDeps {


### PR DESCRIPTION
backport of https://github.com/NixOS/nixpkgs/pull/443588, https://github.com/NixOS/nixpkgs/pull/445336, https://github.com/NixOS/nixpkgs/pull/447599, https://github.com/NixOS/nixpkgs/pull/447842, and https://github.com/NixOS/nixpkgs/pull/448299
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
