### PR TITLE
toml11: only build tests when they're enabled & use system `doctest`/`nlohmann_json`

### DIFF
--- a/pkgs/by-name/to/toml11/package.nix
+++ b/pkgs/by-name/to/toml11/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
   cmakeFlags = [
-    (lib.cmakeBool "TOML11_BUILD_TOML_TESTS" true)
+    (lib.cmakeBool "TOML11_BUILD_TOML_TESTS" finalAttrs.finalPackage.doCheck)
   ];
   doCheck = true;
 

--- a/pkgs/by-name/to/toml11/package.nix
+++ b/pkgs/by-name/to/toml11/package.nix
@@ -3,7 +3,9 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  doctest,
   fetchpatch,
+  nlohmann_json,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,8 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ToruNiina";
     repo = "toml11";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NnM+I43UVcd72Y9h+ysAAc7s5gZ78mjVwIMReTJ7G5M=";
-    fetchSubmodules = true;
+    hash = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
   };
 
   patches = [
@@ -26,11 +27,21 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # Required to use the system `doctest` over upstream's submodule
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
+    substituteInPlace tests/*.{c,h}pp \
+      --replace-warn '"doctest.h"' '"doctest/doctest.h"'
+  '';
+
   nativeBuildInputs = [
     cmake
   ];
   cmakeFlags = [
     (lib.cmakeBool "TOML11_BUILD_TOML_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+  checkInputs = [
+    doctest
+    nlohmann_json
   ];
   doCheck = true;
 


### PR DESCRIPTION
> [!NOTE]
> This (indirectly) fixes the main `NixOS/nix` flake when building against current NixOS unstable - as they have been overriding the source, but [don't include submodules](https://github.com/NixOS/nix/blob/ce38b46e063e4a8cf891689263bf7d8c0cde069c/packaging/dependencies.nix#L62-L67). This leads to `doctest`/`nlohmann_json` not being found when building tests...which is exactly how I found this :(


[Previously](https://github.com/NixOS/nixpkgs/pull/442682), upstream's submodules were used when building tests instead of our own versions of the libraries. `nlohmann_json` works OOTB, but `doctest` needed a small patch to the test files to be picked up

This also ensures that the aforementioned tests are only built when checks are actually enabled

Built against nixos-unstable c9b6fb7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
