### PR TITLE
xemu: darwin support, add myself as maintainer

### DIFF
--- a/pkgs/by-name/xe/xemu/package.nix
+++ b/pkgs/by-name/xe/xemu/package.nix
@@ -187,7 +187,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/xemu-project/xemu/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     mainProgram = "xemu";
-    maintainers = with lib.maintainers; [ marcin-serwin ];
+    maintainers = with lib.maintainers; [
+      marcin-serwin
+      matteopacini
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/xe/xemu/package.nix
+++ b/pkgs/by-name/xe/xemu/package.nix
@@ -28,6 +28,9 @@
   which,
   wrapGAppsHook3,
   cacert,
+  darwin,
+  apple-sdk_12,
+  desktopToDarwinBundle,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -66,6 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
     which
     wrapGAppsHook3
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.sigtool
+    desktopToDarwinBundle
+  ]
   ++ (with python3Packages; [
     python
     pyyaml
@@ -79,22 +86,34 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     gtk3
     curl
-    libdrm
     libepoxy
     libpcap
     libsamplerate
     libslirp
-    libgbm
     openssl
-    vte
     vulkan-headers
     vulkan-loader
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libdrm
+    libgbm
+    vte
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_12
   ];
 
   configureFlags = [
     "--disable-strip"
     "--target-list=i386-softmmu"
     "--disable-werror"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # As seen in the official build script ($src/build.sh)
+    "--disable-cocoa"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    "--enable-hvf"
   ];
 
   buildFlags = [ "qemu-system-i386" ];
@@ -117,6 +136,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     configureFlagsArray+=("--extra-cflags=-DXBOX=1 -Wno-error=redundant-decls")
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    configureFlagsArray+=("-Wno-implicit-function-declaration")
+  ''
+  + ''
     # When the data below can't be obtained through git, the build process tries
     # to run `XEMU_COMMIT=$(cat XEMU_COMMIT)` (and similar)
     echo '${finalAttrs.version}' > XEMU_VERSION
@@ -126,6 +150,15 @@ stdenv.mkDerivation (finalAttrs: {
     cd build
     substituteInPlace ./build.ninja --replace /usr/bin/env $(which env)
   '';
+
+  postBuild =
+    lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
+      # Needed for HVF acceleration
+      codesign --entitlements $src/accel/hvf/entitlements.plist -f -s - qemu-system-i386-unsigned
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mv qemu-system-i386-unsigned qemu-system-i386
+    '';
 
   installPhase = ''
     runHook preInstall
@@ -155,6 +188,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     mainProgram = "xemu";
     maintainers = with lib.maintainers; [ marcin-serwin ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Notes:
- The official build script disables Cocoa, SDL works just fine
- HVF acceleration should be available for `x86-64-darwin`, but the `--enable-hvf` configure flag does not seem to turn it on - I left the code in there in case it becomes available at some point
- MoltenVK didn't get detected when added - the emu still works fine through the OpenGL-on-Metal implementation

<img width="700" height="500" alt="Screenshot 2025-10-09 at 08 05 18" src="https://github.com/user-attachments/assets/3e898108-4c00-4f3e-9d65-ccfd967db7cb" />
<img width="700" height="500" alt="Screenshot 2025-10-09 at 08 05 31" src="https://github.com/user-attachments/assets/d1d559d6-1739-4f00-86b2-b29d37c9ccfd" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
