### PR TITLE
fetchpatch: support `hunks` option

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -699,6 +699,9 @@ MSCREATE.DIR  PINBALL.DOC  PINBALL.MID	Sounds	     WAVEMIX.INF
 - `extraPrefix`: Prefix pathnames by this string.
 - `excludes`: Exclude files matching these patterns (applies after the above arguments).
 - `includes`: Include only files matching these patterns (applies after the above arguments).
+- `hunks`: Choose the specified hunks from each file (applies after the above arguments).
+  Note that you can specify a list of numbers or ranges of numbers
+  (for example, `[ 1 2 3 4 ]`, `[ "1-4" ]`, `[ "-4" ]`, or `[ "1-" ]` would all be the same effective range in a patch applying 4 hunks to a single file).
 - `revert`: Revert the patch.
 
 Note that because the checksum is computed after applying these effects, using or modifying these arguments will have no effect unless the `hash` argument is changed as well.

--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -17,6 +17,7 @@
   extraPrefix ? null,
   excludes ? [ ],
   includes ? [ ],
+  hunks ? [ ],
   revert ? false,
   postFetch ? "",
   nativeBuildInputs ? [ ],
@@ -90,6 +91,10 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
           -p1 \
           ${toString (map (x: "-x ${lib.escapeShellArg x}") excludes)} \
           ${toString (map (x: "-i ${lib.escapeShellArg x}") includes)} \
+          ${
+            lib.optionalString (hunks != [ ])
+              "-# ${lib.escapeShellArg (lib.concatMapStringsSep "," toString hunks)}"
+          } \
           "$tmpfile" > "$out"
 
         if [ ! -s "$out" ]; then
@@ -113,6 +118,7 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
       "extraPrefix"
       "excludes"
       "includes"
+      "hunks"
       "revert"
       "postFetch"
       "nativeBuildInputs"

--- a/pkgs/build-support/fetchpatch/tests.nix
+++ b/pkgs/build-support/fetchpatch/tests.nix
@@ -24,18 +24,34 @@ in
         "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
   };
 
+  hunks = testers.invalidateFetcherByDrvHash fetchpatch {
+    url = "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043.patch";
+    stripLen = 1;
+    hunks = [
+      2
+      3
+      4
+      5
+      6
+      7
+    ];
+    sha256 =
+      if isFetchpatch2 then
+        "sha256-SXJALY4zC4y/ZV7uVglf+XB5cpC5tS4M8QDGlFRmcFM="
+      else
+        "sha256-MV7uGgA1ESMR7W6H5FjAIxKcpySdQjWB+L2zaHjd96M=";
+  };
+
   full = testers.invalidateFetcherByDrvHash fetchpatch {
     url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
     relative = "test";
     stripLen = 1;
     extraPrefix = "foo/bar/";
     excludes = [ "foo/bar/bernoulli_no_atomic_mp.cpp" ];
+    # Should result in no change.
+    hunks = [ "1-" ];
     revert = true;
-    sha256 =
-      if isFetchpatch2 then
-        "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM="
-      else
-        "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=";
+    sha256 = "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=";
   };
 
   decode = testers.invalidateFetcherByDrvHash fetchpatch {


### PR DESCRIPTION
We can pick individual hunks or ranges of hunks with filterdiff, so expose that in fetchpatch.

This was originally useful for openssh, since the first hunks always look like this (that is, only differing in the date):

```
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh.c,v 1.616 2025/08/29 03:50:38 djm Exp $ */
+/* $OpenBSD: ssh.c,v 1.617 2025/09/04 00:29:09 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
```

The usage looks something like this to skip the first hunk in the patch. Numbers work too, if you'd like to only pick out specific hunks.

```
fetchpatch {
  name = "my-patch";
  url = "...";
  hunks = [ "2-" ];
  hash = "...";
}
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
