### PR TITLE
dnswalk: init at 2.0.2

### DIFF
--- a/pkgs/by-name/dn/dnswalk/package.nix
+++ b/pkgs/by-name/dn/dnswalk/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  perl,
+  perlPackages,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dnswalk";
+  version = "2.0.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/dnswalk/dnswalk-${finalAttrs.version}.tar.gz";
+    sha512 = "23e5408149ae65f69dbb6d0ecaf5b10233e2279a502f6e19f0dacde0e270ed4eed0aea72f8c12dd636228e99b0b115a335bb8327a0628ad1f36dae5f5572712c";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/BlackArch/blackarch/cb22ac52795e2a1e10ec9a51fb1d16ebfa3854e1/packages/dnswalk/dnswalk.patch";
+      name = "dnswalk.patch";
+      hash = "sha256-JnxKKRO1t5uTwNva0zdDkxwGTHdTqU4K9ZeAgCdyjEc=";
+    })
+    (fetchpatch {
+      url = "https://github.com/davebarr/dnswalk/commit/83625aeb4adbb844ce0832329896040663b55e6b.patch";
+      name = "0001-SOA-use-query-instead-of-packet.patch";
+      hash = "sha256-kyCoH9ghSS2WFb5haH3l1WX1DAWAFJlGVwsY9LNWb2c=";
+    })
+  ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  # unpacker appears to have produced no directories
+  unpackPhase = ''
+    mkdir -p $PWD/src
+    tar xzf $src -C $PWD/src
+    cd $PWD/src
+  '';
+
+  postPatch = ''
+    sed -i 's|/usr/contrib/bin/perl|${lib.getExe perl}|' dnswalk
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dnswalk $out/bin/dnswalk
+
+    mkdir -p $out/share/doc/dnswalk
+    install -m644 do-dnswalk CHANGES README TODO rfc1912.txt makereports sendreports $out/share/doc/dnswalk/
+    install -Dm644 dnswalk.1 $out/share/man/man1/dnswalk.1
+    install -m644 dnswalk.errors $out/share/doc/dnswalk/
+
+    wrapProgram $out/bin/dnswalk \
+      --set PERL5LIB "${perlPackages.NetDNS}/${perl.libPrefix}" \
+      --set PERL5OPT "-M-warnings=deprecated"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A DNS debugger and zone-transfer utility";
+    homepage = "http://sourceforge.net/projects/dnswalk/";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ makefu ];
+  };
+})


### PR DESCRIPTION
in contribution to #81418 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
