### PR TITLE
typespec: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/by-name/ty/typespec/package.nix
+++ b/pkgs/by-name/ty/typespec/package.nix
@@ -16,13 +16,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "typespec";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typespec";
     tag = "typespec-stable@${finalAttrs.version}";
-    hash = "sha256-huyEQA+XhlGVxnxUzQH1aIZUE4EbCN6HakitzuDyR18=";
+    hash = "sha256-tVFkS5DFP2a9Ib8ntwDRZdYDw6G0IrAd0B2RO2brC4Y=";
   };
 
   nativeBuildInputs = [
@@ -43,7 +43,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       postPatch
       ;
     fetcherVersion = 2;
-    hash = "sha256-ztig1B10cQQy+4XKZjwwlCxGenwcU+C28TfTWHqZ59Y=";
+    hash = "sha256-7YUlEiVE2xfwq0OQ52LEn4GrKTCASKPh4A0QzWyD6zg=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ty/typespec/package.nix
+++ b/pkgs/by-name/ty/typespec/package.nix
@@ -2,7 +2,9 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  jq,
   makeWrapper,
+  moreutils,
   nix-update-script,
   nodejs,
   pnpm,
@@ -24,7 +26,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    jq
     makeWrapper
+    moreutils
     nodejs
     pnpm.configHook
   ];
@@ -45,8 +49,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postPatch = ''
     # The `packageManager` attribute matches the version _exactly_, which makes
     # the build fail if it doesn't match exactly.
-    substituteInPlace package.json \
-      --replace-fail '"packageManager": "pnpm@10.11.0"' '"packageManager": "pnpm"'
+    jq 'del(.packageManager)' package.json | sponge package.json
     # `fetchFromGitHub` doesn't clone via git and thus installing would otherwise fail.
     substituteInPlace packages/compiler/scripts/generate-manifest.js \
       --replace-fail 'execSync("git rev-parse HEAD").toString().trim()' '"${finalAttrs.src.rev}"'


### PR DESCRIPTION
[CHANGELOG](https://github.com/microsoft/typespec/releases/tag/typespec-stable%401.5.0)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
