### PR TITLE
[25.05] openssh: patch CVE-2025-61984 and CVE-2025-61985 

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -697,6 +697,9 @@ MSCREATE.DIR  PINBALL.DOC  PINBALL.MID	Sounds	     WAVEMIX.INF
 - `extraPrefix`: Prefix pathnames by this string.
 - `excludes`: Exclude files matching these patterns (applies after the above arguments).
 - `includes`: Include only files matching these patterns (applies after the above arguments).
+- `hunks`: Choose the specified hunks from each file (applies after the above arguments).
+  Note that you can specify a list of numbers or ranges of numbers
+  (for example, `[ 1 2 3 4 ]`, `[ "1-4" ]`, `[ "-4" ]`, or `[ "1-" ]` would all be the same effective range in a patch applying 4 hunks to a single file).
 - `revert`: Revert the patch.
 
 Note that because the checksum is computed after applying these effects, using or modifying these arguments will have no effect unless the `hash` argument is changed as well.

--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -17,6 +17,7 @@
   extraPrefix ? null,
   excludes ? [ ],
   includes ? [ ],
+  hunks ? [ ],
   revert ? false,
   postFetch ? "",
   nativeBuildInputs ? [ ],
@@ -88,8 +89,12 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
 
         filterdiff \
           -p1 \
-          ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
-          ${builtins.toString (builtins.map (x: "-i ${lib.escapeShellArg x}") includes)} \
+          ${toString (map (x: "-x ${lib.escapeShellArg x}") excludes)} \
+          ${toString (map (x: "-i ${lib.escapeShellArg x}") includes)} \
+          ${
+            lib.optionalString (hunks != [ ])
+              "-# ${lib.escapeShellArg (lib.concatMapStringsSep "," toString hunks)}"
+          } \
           "$tmpfile" > "$out"
 
         if [ ! -s "$out" ]; then
@@ -113,6 +118,7 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
       "extraPrefix"
       "excludes"
       "includes"
+      "hunks"
       "revert"
       "postFetch"
       "nativeBuildInputs"

--- a/pkgs/build-support/fetchpatch/tests.nix
+++ b/pkgs/build-support/fetchpatch/tests.nix
@@ -24,18 +24,34 @@ in
         "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
   };
 
+  hunks = testers.invalidateFetcherByDrvHash fetchpatch {
+    url = "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043.patch";
+    stripLen = 1;
+    hunks = [
+      2
+      3
+      4
+      5
+      6
+      7
+    ];
+    sha256 =
+      if isFetchpatch2 then
+        "sha256-SXJALY4zC4y/ZV7uVglf+XB5cpC5tS4M8QDGlFRmcFM="
+      else
+        "sha256-MV7uGgA1ESMR7W6H5FjAIxKcpySdQjWB+L2zaHjd96M=";
+  };
+
   full = testers.invalidateFetcherByDrvHash fetchpatch {
     url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
     relative = "test";
     stripLen = 1;
     extraPrefix = "foo/bar/";
     excludes = [ "foo/bar/bernoulli_no_atomic_mp.cpp" ];
+    # Should result in no change.
+    hunks = [ "1-" ];
     revert = true;
-    sha256 =
-      if isFetchpatch2 then
-        "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM="
-      else
-        "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=";
+    sha256 = "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=";
   };
 
   decode = testers.invalidateFetcherByDrvHash fetchpatch {

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -55,6 +55,32 @@ stdenv.mkDerivation (finalAttrs: {
 
     # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
     ./dont_create_privsep_path.patch
+
+    # CVE-2025-61984:
+    # https://github.com/advisories/GHSA-hh67-847q-q3h9
+    # https://ubuntu.com/security/CVE-2025-61984#patch-details
+    (fetchpatch {
+      name = "CVE-2025-61984.patch";
+      url = "https://github.com/openssh/openssh-portable/commit/35d5917652106aede47621bb3f64044604164043.patch";
+      hunks = [ "2-" ];
+      hash = "sha256-HVnMrXCjUUerE7vENS5ZB+kJieVID9lLEkm12YHWi6A=";
+    })
+    # Fixes percent expansions test for the above.
+    (fetchpatch {
+      name = "CVE-2025-61984.test.patch";
+      url = "https://github.com/openssh/openssh-portable/commit/f64701ca25795548a61614d0b13391d6dfa7f38c.patch";
+      hunks = [ "2-" ];
+      hash = "sha256-6lxwwlDs9IUjoGHL2Orb6uJ3kTer/sXwm+cY/VWNDbI=";
+    })
+    # CVE-2025-61985:
+    # https://github.com/advisories/GHSA-8gmf-r74v-362p
+    # https://ubuntu.com/security/CVE-2025-61985#patch-details
+    (fetchpatch {
+      name = "CVE-2025-61985.patch";
+      url = "https://github.com/openssh/openssh-portable/commit/43b3bff47bb029f2299bacb6a36057981b39fdb0.patch";
+      hunks = [ "2-" ];
+      hash = "sha256-BCvaYGw6suLkQwzT9zJTYChLgX2TexzcNnBYzztFRYw=";
+    })
   ]
   ++ extraPatches;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Includes a backport of #450207 for the fetchpatch support.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
