### PR TITLE
python3Packages.nutpie: 0.15.2 -> 0.16.7

### DIFF
--- a/pkgs/development/python-modules/arro3/default.nix
+++ b/pkgs/development/python-modules/arro3/default.nix
@@ -10,19 +10,19 @@
   pandas,
 }:
 let
-  version = "0.5.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "kylebarron";
     repo = "arro3";
     tag = "py-v${version}";
-    hash = "sha256-RTr+mf5slfxxvXp9cwPuy08AZUswPtIIRz+vngdg/k0=";
+    hash = "sha256-Zlc+M+h8pgYLLhEGgv2W6YfahYtdm9Q8ezVK+Kwd2lw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit version src;
     pname = "arro3-vendor";
-    hash = "sha256-YQA8Z86Ul8yAHncMgYrGmNe10KSpubHjaokCjaqTAxo=";
+    hash = "sha256-f36qIkQIu6Jl2hb3HJaMpnLbWVaR3z4WrQ1aLZr4VvQ=";
   };
 
   commonMeta = {
@@ -40,7 +40,7 @@ let
       pythonImportsCheck,
       dependencies ? [ ],
     }:
-    buildPythonPackage rec {
+    buildPythonPackage {
       inherit
         pname
         version

--- a/pkgs/development/python-modules/nutpie/default.nix
+++ b/pkgs/development/python-modules/nutpie/default.nix
@@ -10,10 +10,13 @@
   rustc,
 
   # dependencies
+  arro3-core,
   arviz,
+  obstore,
   pandas,
   pyarrow,
   xarray,
+  zarr,
 
   # tests
   # bridgestan, (not packaged)
@@ -29,21 +32,21 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nutpie";
-  version = "0.15.2";
+  version = "0.16.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
     repo = "nutpie";
-    tag = "v${version}";
-    hash = "sha256-9rcQtEdaafMyuNb/ezcqUmrwXbQFa9hdajGAtANdHOw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pZlUS8Rd8uNAau7q3yogtdRUvDkN8MiTWj+3lZolBSY=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    hash = "sha256-6JWBJYGhSNUL8KYiEE2ZBW9xP4CmkCcwwhsO6aOvZyA=";
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-F9WuFPyJd7IVaboUHnFpf3GiLB5AWap8RBScuqlZB3s=";
   };
 
   build-system = [
@@ -54,15 +57,14 @@ buildPythonPackage rec {
     rustc
   ];
 
-  pythonRelaxDeps = [
-    "xarray"
-  ];
-
   dependencies = [
+    arro3-core
     arviz
+    obstore
     pandas
     pyarrow
     xarray
+    zarr
   ];
 
   pythonImportsCheck = [ "nutpie" ];
@@ -81,10 +83,6 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlags = [
-    "-v"
-  ];
-
   disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # flaky (assert np.float64(0.0017554642626285276) > 0.01)
     "test_normalizing_flow"
@@ -98,8 +96,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python wrapper for nuts-rs";
     homepage = "https://github.com/pymc-devs/nutpie";
-    changelog = "https://github.com/pymc-devs/nutpie/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/pymc-devs/nutpie/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Diff: https://github.com/pymc-devs/nutpie/compare/v0.15.2...v0.16.6
Changelog: https://github.com/pymc-devs/nutpie/blob/v0.16.6/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc