### PR TITLE
uboot: 2025.07 -> 2025.10

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -98,8 +98,19 @@ let
         hardeningDisable = [ "all" ];
         dontStrip = true;
 
-        # breaks secondary CPU bringup on at least RK3588, maybe others
-        env.NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
+        env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
+          # breaks secondary CPU bringup on at least RK3588, maybe others
+          "-fomit-frame-pointer"
+
+          # Breaks compilation of armTrustedFirmwareRK3399:
+          # /nix/store/hash-arm-none-eabi-binutils-2.44/bin/arm-none-eabi-ld: /build/source/build/rk3399/release/m0/rk3399m0.elf: error: PHDR segment not covered by LOAD segment
+          #
+          # This was caused by ccc56d1a79ff2a0f528cecf5e36eb76beaacc8c0 adding the flag `--enable-default-pie`.
+          # According to https://trustedfirmware-a.readthedocs.io/en/v2.2/getting_started/user-guide.html,
+          # Trusted Firmware-A has an option called ENABLE_PIE, which is turned off by default.
+          # Someone with more knowledge of the implications can try using that option instead.
+          "-no-pie"
+        ];
 
         meta =
           with lib;

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -34,10 +34,10 @@
 }@pkgs:
 
 let
-  defaultVersion = "2025.07";
+  defaultVersion = "2025.10";
   defaultSrc = fetchurl {
     url = "https://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    hash = "sha256-D5M/bFpCaJW/MG6T5qxTxghw5LVM2lbZUhG+yZ5jvsc=";
+    hash = "sha256-tPAyhI5WzI8hOtWfkTLAhNu7YyvCkXbQJOWCIODv30o=";
   };
 
   # Dependencies for the tools need to be included as either native or cross,


### PR DESCRIPTION
Update U-Boot to the latest version.
Also fix arm-trusted-firmware.

I executed nixpkgs-review on x86_64 and aarch64.
I verified that all the U-Boot packages still compile (exceptions below).
I compiled all the packages for the different Arm architectures natively on an armv8 CPU, all the packages for x86 or x86_64 on an x86_64 CPU and the RISC-V packages and `ubootLibreTechCC` using cross-compilation on my x86_64 CPU.
`ubootAmx335xEVM` and `ubootSheevaplug` are marked as broken and I verified that they are still broken.
I could not check that `ubootGuruplug` still compiles because some dependencies seem to not compile or have flaky tests.

I tested this on real hardware (a board, which does not yet have support in Nixpkgs).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
