### PR TITLE
catimg: use proper patch for cmake 4 compatibility

### DIFF
--- a/pkgs/by-name/ca/catimg/package.nix
+++ b/pkgs/by-name/ca/catimg/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
 }:
 
@@ -16,13 +17,17 @@ stdenv.mkDerivation rec {
     sha256 = "0a2dswbv4xddb2l2d55hc43lzvjwrjs5z9am7v6i0p0mi2fmc89s";
   };
 
-  nativeBuildInputs = [ cmake ];
-
-  # Fix build with CMake 4: https://github.com/NixOS/nixpkgs/issues/449801
-  # CMake 4 removed support for CMake < 3.5, so we set the minimum policy version
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  patches = [
+    # Update CMake minimum required version for CMake 4 compatibility
+    # https://github.com/NixOS/nixpkgs/issues/449801
+    # https://github.com/posva/catimg/pull/73
+    (fetchpatch {
+      url = "https://github.com/posva/catimg/commit/155786229230e2ddc2dd97e4e0219d1e2aa66099.patch";
+      hash = "sha256-eDXYa8eGvhC7NGL6V+R3Ui5FBtx/APGUC6Sw9rv2ho4=";
+    })
   ];
+
+  nativeBuildInputs = [ cmake ];
 
   env = lib.optionalAttrs (stdenv.hostPlatform.libc == "glibc") {
     CFLAGS = "-D_DEFAULT_SOURCE";


### PR DESCRIPTION
Replace CMAKE_POLICY_VERSION_MINIMUM workaround from #449906 with a proper patch that updates the CMakeLists.txt to require CMake 3.10.

## Changes

- Removes the `cmakeFlags` workaround
- Adds a proper patch file that updates `cmake_minimum_required(VERSION 2.8)` to `cmake_minimum_required(VERSION 3.10)`
- Patches the source instead of working around the issue at build time

## Rationale

This approach is preferred as it:
- Fixes the issue at the source level
- Can be carried as a patch until merged upstream
- Follows the recommendations from #445447

## Testing

- [x] Built successfully with `nix-build -A catimg`
- [x] Patch has been submitted upstream: https://github.com/posva/catimg/pull/73

Fixes #449801
Supersedes #449906