### PR TITLE
haskellPackages.HsOpenSSL-x509-system: fix Mac runtime

### DIFF
--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -94,7 +94,7 @@ self: super:
       drv:
       lib.optionalAttrs (!pkgs.stdenv.cc.nativeLibc) {
         postPatch = ''
-          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
+          substituteInPlace System/X509/MacOS.hs --replace-fail security /usr/bin/security
         ''
         + (drv.postPatch or "");
       }
@@ -103,7 +103,7 @@ self: super:
       drv:
       lib.optionalAttrs (!pkgs.stdenv.cc.nativeLibc) {
         postPatch = ''
-          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
+          substituteInPlace System/X509/MacOS.hs --replace-fail security /usr/bin/security
         ''
         + (drv.postPatch or "");
       }
@@ -133,7 +133,7 @@ self: super:
       # when called from GHC, probably because clang is version 7, but we are
       # using LLVM8.
       preCompileBuildDriver = ''
-        substituteInPlace Setup.hs --replace "addToLdLibraryPath libDir" "pure ()"
+        substituteInPlace Setup.hs --replace-fail "addToLdLibraryPath libDir" "pure ()"
       ''
       + (oldAttrs.preCompileBuildDriver or "");
     }) super.llvm-hs;
@@ -174,7 +174,7 @@ self: super:
     HTF = overrideCabal (drv: {
       # GNU find is not prefixed in stdenv
       postPatch = ''
-        substituteInPlace scripts/local-htfpp --replace "find=gfind" "find=find"
+        substituteInPlace scripts/local-htfpp --replace-fail "find=gfind" "find=find"
       ''
       + (drv.postPatch or "");
     }) super.HTF;
@@ -194,7 +194,7 @@ self: super:
     # however linking against it is also not necessary there
     GLHUI = overrideCabal (drv: {
       postPatch = ''
-        substituteInPlace GLHUI.cabal --replace " rt" ""
+        substituteInPlace GLHUI.cabal --replace-fail " rt" ""
       ''
       + (drv.postPatch or "");
     }) super.GLHUI;
@@ -203,7 +203,7 @@ self: super:
       # Prevent darwin-specific configuration code path being taken
       # which doesn't work with nixpkgs' SDL libraries
       postPatch = ''
-        substituteInPlace configure --replace xDarwin noDarwinSpecialCasing
+        substituteInPlace configure --replace-fail xDarwin noDarwinSpecialCasing
       ''
       + (drv.postPatch or "");
       patches = [
@@ -216,7 +216,7 @@ self: super:
     # doesn't work with nixpkgs' SDL libraries
     SDL-mixer = overrideCabal (drv: {
       postPatch = ''
-        substituteInPlace configure --replace xDarwin noDarwinSpecialCasing
+        substituteInPlace configure --replace-fail xDarwin noDarwinSpecialCasing
       ''
       + (drv.postPatch or "");
     }) super.SDL-mixer;
@@ -322,7 +322,7 @@ self: super:
     # Remove a problematic assert, the length is sometimes 1 instead of 2 on darwin
     di-core = overrideCabal (drv: {
       preConfigure = ''
-        substituteInPlace test/Main.hs --replace \
+        substituteInPlace test/Main.hs --replace-fail \
           "2 @=? List.length (List.nub (List.sort (map Di.log_time logs)))" ""
       '';
     }) super.di-core;

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -108,6 +108,15 @@ self: super:
         + (drv.postPatch or "");
       }
     ) super.crypton-x509-system;
+    HsOpenSSL-x509-system = overrideCabal (
+      drv:
+      lib.optionalAttrs (!pkgs.stdenv.cc.nativeLibc) {
+        postPatch = ''
+          substituteInPlace OpenSSL/X509/SystemStore/MacOSX.hs --replace-fail security /usr/bin/security
+        ''
+        + (drv.postPatch or "");
+      }
+    ) super.HsOpenSSL-x509-system;
 
     # https://github.com/haskell-foundation/foundation/pull/412
     foundation = dontCheck super.foundation;


### PR DESCRIPTION
`HsOpenSSL-x509-system` has platform-specific code for getting at system certs.
For Mac, it calls `security` and trusts the `$PATH`. This doesn't work on Nix.
I use the same bandaid `security -> /usr/bin/security` applied to similar packages.

This issue has cropped up plenty over time, most recently:

* https://github.com/NixOS/nixpkgs/pull/315141

The fix never got propagated to `HsOpenSSL-x509-system`, which is used by the less-popular `http-client-openssl`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
