### PR TITLE
various: replace `mkdir` in systemd units with `*Directory` equivalents

### DIFF
--- a/nixos/modules/services/editors/infinoted.nix
+++ b/nixos/modules/services/editors/infinoted.nix
@@ -140,9 +140,9 @@ in
         User = cfg.user;
         Group = cfg.group;
         PermissionsStartOnly = true;
+        StateDirectory = [ "infinoted" ];
       };
       preStart = ''
-        mkdir -p /var/lib/infinoted
         install -o ${cfg.user} -g ${cfg.group} -m 0600 /dev/null /var/lib/infinoted/infinoted.conf
         cat >>/var/lib/infinoted/infinoted.conf <<EOF
         [infinoted]

--- a/nixos/modules/services/misc/spice-vdagentd.nix
+++ b/nixos/modules/services/misc/spice-vdagentd.nix
@@ -21,12 +21,10 @@ in
     systemd.services.spice-vdagentd = {
       description = "spice-vdagent daemon";
       wantedBy = [ "graphical.target" ];
-      preStart = ''
-        mkdir -p "/run/spice-vdagentd/"
-      '';
       serviceConfig = {
         Type = "forking";
         ExecStart = "${pkgs.spice-vdagent}/bin/spice-vdagentd";
+        RuntimeDirectory = "spice-vdagentd";
       };
     };
   };

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -172,7 +172,18 @@ in
             "CAP_SETUID"
           ];
           Restart = "on-abnormal";
-          StateDirectory = baseNameOf dataDir;
+          StateDirectory = [
+            (baseNameOf dataDir)
+            "${baseNameOf dataDir}/conf.d"
+            "sss/db"
+            "sss/gpo_cache"
+            "sss/mc"
+            "sss/pipes"
+            "sss/pipes/private"
+            "sss/pubconf"
+            "sss/pubconf/krb5.include.d"
+            "sss/secrets"
+          ];
           # We cannot use LoadCredential here because it's not available in ExecStartPre
           EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
         };
@@ -181,7 +192,6 @@ in
           StartLimitBurst = 5;
         };
         preStart = ''
-          mkdir -p "${dataDir}/conf.d"
           [ -f ${settingsFile} ] && rm -f ${settingsFile}
           old_umask=$(umask)
           umask 0177
@@ -189,7 +199,6 @@ in
             -o ${settingsFile} \
             -i ${settingsFileUnsubstituted}
           umask $old_umask
-          mkdir -p /var/lib/sss/{pubconf,db,mc,pipes,gpo_cache,secrets} /var/lib/sss/pipes/private /var/lib/sss/pubconf/krb5.include.d
         '';
       };
 

--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -186,7 +186,6 @@ in
     systemd.services.apcupsd = {
       description = "APC UPS Daemon";
       wantedBy = [ "multi-user.target" ];
-      preStart = "mkdir -p /run/apcupsd/";
       serviceConfig = {
         ExecStart = "${pkgs.apcupsd}/bin/apcupsd -b -f ${configFile} -d1";
         # TODO: When apcupsd has initiated a shutdown, systemd always ends up
@@ -196,6 +195,7 @@ in
         # This reduces the wait time from 90 seconds (default) to just 5. Then
         # systemd kills it with SIGKILL.
         TimeoutStopSec = 5;
+        RuntimeDirectory = "apcupsd";
       };
       unitConfig.Documentation = "man:apcupsd(8)";
     };

--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -32,7 +32,6 @@ in
         "dbus.service"
       ];
       requires = [ "dbus.service" ];
-      preStart = "mkdir -pv /var/lib/teamviewer /var/log/teamviewer";
 
       startLimitIntervalSec = 60;
       startLimitBurst = 10;
@@ -42,6 +41,8 @@ in
         PIDFile = "/run/teamviewerd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Restart = "on-abort";
+        StateDirectory = "teamviewer";
+        LogDirectory = "teamviewer";
       };
     };
   };

--- a/nixos/modules/services/network-filesystems/nfsd.nix
+++ b/nixos/modules/services/network-filesystems/nfsd.nix
@@ -151,26 +151,20 @@ in
     systemd.services.nfs-server = {
       enable = true;
       wantedBy = [ "multi-user.target" ];
-
-      preStart = ''
-        mkdir -p /var/lib/nfs/v4recovery
-      '';
+      serviceConfig.StateDirectory = [ "nfs/v4recovery" ];
     };
 
     systemd.services.nfs-mountd = {
       enable = true;
       restartTriggers = [ exports ];
+      serviceConfig.StateDirectory = [ "nfs" ];
 
-      preStart = ''
-        mkdir -p /var/lib/nfs
-
-        ${lib.optionalString cfg.createMountPoints ''
-          # create export directories:
-          # skip comments, take first col which may either be a quoted
-          # "foo bar" or just foo (-> man export)
-          sed '/^#.*/d;s/^"\([^"]*\)".*/\1/;t;s/[ ].*//' ${exports} \
-          | xargs -d '\n' mkdir -p
-        ''}
+      preStart = lib.optionalString cfg.createMountPoints ''
+        # create export directories:
+        # skip comments, take first col which may either be a quoted
+        # "foo bar" or just foo (-> man export)
+        sed '/^#.*/d;s/^"\([^"]*\)".*/\1/;t;s/[ ].*//' ${exports} \
+        | xargs -d '\n' mkdir -p
       '';
     };
 

--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -211,6 +211,8 @@ in
             User = if cfg.dropPrivileges then "consul" else null;
             Restart = "on-failure";
             TimeoutStartSec = "infinity";
+            StateDirectory = [ (baseNameOf dataDir) ];
+            StateDirectoryMode = "0700";
           }
           // (lib.optionalAttrs (cfg.leaveOnStop) {
             ExecStop = "${lib.getExe cfg.package} leave";
@@ -232,9 +234,6 @@ in
                   "";
             in
             ''
-              mkdir -m 0700 -p ${dataDir}
-              chown -R consul ${dataDir}
-
               # Determine interface addresses
               getAddrOnce () {
                 ip ${family} addr show dev "$1" scope global \

--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -175,7 +175,6 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ dnsmasq ];
       preStart = ''
-        mkdir -m 755 -p ${stateDir}
         touch ${stateDir}/dnsmasq.leases
         chown -R dnsmasq ${stateDir}
         ${lib.optionalString cfg.resolveLocalQueries "touch /etc/dnsmasq-{conf,resolv}.conf"}
@@ -190,6 +189,8 @@ in
         ProtectSystem = true;
         ProtectHome = true;
         Restart = if cfg.alwaysKeepRunning then "always" else "on-failure";
+        StateDirectory = [ (baseNameOf stateDir) ];
+        StateDirectoryMode = "0755";
       };
       restartTriggers = [ config.environment.etc.hosts.source ];
     };

--- a/nixos/modules/services/networking/x2goserver.nix
+++ b/nixos/modules/services/networking/x2goserver.nix
@@ -180,12 +180,14 @@ in
         User = "x2go";
         Group = "x2go";
         RuntimeDirectory = "x2go";
-        StateDirectory = "x2go";
+        StateDirectory = [
+          "x2go"
+          "x2go/conf"
+        ];
       };
       preStart = ''
         if [ ! -e /var/lib/x2go/setup_ran ]
         then
-          mkdir -p /var/lib/x2go/conf
           cp -r ${cfg.package}/etc/x2go/* /var/lib/x2go/conf/
           ln -sf ${x2goServerConf} /var/lib/x2go/conf/x2goserver.conf
           ln -sf ${x2goAgentOptions} /var/lib/x2go/conf/x2goagent.options

--- a/nixos/modules/services/networking/zerotierone.nix
+++ b/nixos/modules/services/networking/zerotierone.nix
@@ -62,10 +62,6 @@ in
       path = [ cfg.package ];
 
       preStart = ''
-        mkdir -p /var/lib/zerotier-one/networks.d
-        chmod 700 /var/lib/zerotier-one
-        chown -R root:root /var/lib/zerotier-one
-
         # cleans up old symlinks also if we unset localConf
         if [[ -L "${localConfFilePath}" && "$(readlink "${localConfFilePath}")" =~ ^${builtins.storeDir}.* ]]; then
           rm ${localConfFilePath}
@@ -83,6 +79,8 @@ in
       '';
 
       serviceConfig = {
+        StateDirectory = [ "zerotier-one/networks.d" ];
+        StateDirectoryMode = "0700";
         ExecStart = "${cfg.package}/bin/zerotier-one -p${toString cfg.port}";
         Restart = "always";
         KillMode = "process";

--- a/nixos/modules/services/web-apps/ente.nix
+++ b/nixos/modules/services/web-apps/ente.nix
@@ -209,7 +209,6 @@ in
           ${utils.genJqSecretsReplacementSnippet cfgApi.settings "/run/ente/local.yaml"}
 
           # Setup paths
-          mkdir -p ${dataDir}/configurations
           ln -sTf /run/ente/local.yaml ${dataDir}/configurations/local.yaml
         '';
 
@@ -259,7 +258,10 @@ in
           Group = cfgApi.group;
 
           SyslogIdentifier = "ente";
-          StateDirectory = "ente";
+          StateDirectory = [
+            (baseNameOf dataDir)
+            "${baseNameOf dataDir}/configurations"
+          ];
           WorkingDirectory = dataDir;
           RuntimeDirectory = "ente";
         };

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -169,6 +169,13 @@ in
         # TODO: might get renamed to MATOMO_USER_PATH in future versions
         # chown + chmod in preStart needs root
         PermissionsStartOnly = true;
+
+        StateDirectory = [
+          (baseNameOf dataDir)
+          "${baseNameOf dataDir}/misc"
+        ];
+        # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
+        StateDirectoryMode = "2770";
       };
 
       # correct ownership and permissions in case they're not correct anymore,
@@ -197,11 +204,7 @@ in
         ln -sfT ${cfg.package} ${dataDir}/current-package
       '';
       script = ''
-        # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
-        # Copy config folder
-        chmod g+s "${dataDir}"
         cp -r "${cfg.package}/share/config" "${dataDir}/"
-        mkdir -p "${dataDir}/misc"
         chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
 
         # check whether user setup has already been done

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -140,11 +140,13 @@ in
     };
 
     systemd.services.selfoss-config = {
-      serviceConfig.Type = "oneshot";
+      serviceConfig = {
+        Type = "oneshot";
+        StateDirectory = [ (baseNameOf dataDir) ];
+        StateDirectoryMode = "0755";
+        WorkingDirectory = dataDir;
+      };
       script = ''
-        mkdir -m 755 -p ${dataDir}
-        cd ${dataDir}
-
         # Delete all but the "data" folder
         ls | grep -v data | while read line; do rm -rf $line; done || true
 
@@ -164,6 +166,7 @@ in
     systemd.services.selfoss-update = {
       serviceConfig = {
         ExecStart = "${pkgs.php83}/bin/php ${dataDir}/cliupdate.php";
+        StateDirectory = [ (baseNameOf dataDir) ];
         User = "${cfg.user}";
       };
       startAt = "hourly";

--- a/nixos/modules/services/web-servers/lighttpd/cgit.nix
+++ b/nixos/modules/services/web-servers/lighttpd/cgit.nix
@@ -93,11 +93,7 @@ in
       }
     '';
 
-    systemd.services.lighttpd.preStart = ''
-      mkdir -p /var/cache/cgit
-      chown lighttpd:lighttpd /var/cache/cgit
-    '';
-
+    systemd.services.lighttpd.serviceConfig.CacheDirectory = "cgit";
   };
 
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR goes over a few modules, and moves some of the `mkdir`, `chown`, `umask` and `cd` commands into equivalent systemd directives. For some units, this frees up the `ExecStartPre` script fully, for others it just moves the logic out of the way. It integrates better with systemd (required mounts automatically handled, `systemctl clean`, etc.), as well as just making the units more declarative.

I have mostly avoided services which either use the existence of the `/var/lib/<name>` directory as a conditional for migration of old logic, and those with movable data directories.

### Services with nixos tests

- [ ] zerotierone
- [X] lighttpd
- [ ] spice-vdagentd
- [ ] x2goserver
- [ ] uptime
- [X] nfs ([`nfs3.simple` fails for unrelated reasons](https://hydra.nixos.org/build/310059214))
- [X] sssd
- [ ] infinoted
- [X] consul
- [X] ente
- [ ] selfoss
- [X] matomo
- [X] dnsmasq (enabled in a bunch of other tests, indirectly tests through e.g. `dnscrypt-proxy`)
- [X] apcupsd
- [ ] teamviewer

`NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#nixosTests.lighttpd .#nixosTests.nfs4.simple .#nixosTests.nfs4.kerberos .\#nixosTests.sssd-legacy-config .#nixosTests.sssd-ldap .#nixosTests.consul .#nixosTests.ente .#nixosTests.matomo .#nixosTests.dnscrypt-proxy .#nixosTests.apcupsd`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
