### PR TITLE
ettercap: 0.8.3.1 -> 0.8.4-unstable-2025-07-16

### DIFF
--- a/pkgs/by-name/et/ettercap/package.nix
+++ b/pkgs/by-name/et/ettercap/package.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.ettercap-project.org/";
     changelog = "https://github.com/Ettercap/ettercap/releases/tag/${src.tag}";
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];
   };

--- a/pkgs/by-name/et/ettercap/package.nix
+++ b/pkgs/by-name/et/ettercap/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Ettercap";
     repo = "ettercap";
-    rev = "v${version}";
-    sha256 = "1sdf1ssa81ib6k0mc5m2jzbjl4jd1yv6ahv5dwx2x9w4b2pyqg1c";
+    tag = "v${version}";
+    hash = "sha256-LDzsr1iEpy46b2VDZbYPTRIq15eiFlbBNCsGpLQOruk=";
   };
 
   patches = [
@@ -87,6 +87,7 @@ stdenv.mkDerivation rec {
       analysis.
     '';
     homepage = "https://www.ettercap-project.org/";
+    changelog = "https://github.com/Ettercap/ettercap/releases/tag/${src.tag}";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/by-name/et/ettercap/package.nix
+++ b/pkgs/by-name/et/ettercap/package.nix
@@ -1,72 +1,68 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  fetchpatch2,
+  atk,
+  bison,
   cmake,
-  libpcap,
-  libnet,
-  zlib,
   curl,
-  pcre2,
-  openssl,
-  ncurses,
+  fetchFromGitHub,
+  flex,
+  geoip,
   glib,
   gtk3,
-  atk,
-  pango,
-  flex,
-  bison,
-  geoip,
   harfbuzz,
+  libmaxminddb,
+  libnet,
+  libpcap,
+  ncurses,
+  openssl,
+  pango,
+  pcre2,
   pkg-config,
+  zlib,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ettercap";
-  version = "0.8.3.1";
+  version = "0.8.4-unstable-2025-07-16";
 
   src = fetchFromGitHub {
     owner = "Ettercap";
     repo = "ettercap";
-    tag = "v${version}";
-    hash = "sha256-LDzsr1iEpy46b2VDZbYPTRIq15eiFlbBNCsGpLQOruk=";
+    rev = "26ef2d2e1432b866460f9c4ddf9e4dce3db1a5ab";
+    hash = "sha256-T3LsOD2LGbk4f5un3l5Ybf5/kgYQJfw7lGa2UXB/brY=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      name = "curl-8.patch";
-      url = "https://github.com/Ettercap/ettercap/commit/9ec4066addc49483e40055e0738c2e0ef144702f.diff";
-      sha256 = "6D8lIxub0OS52BFr42yWRyqS2Q5CrpTLTt6rcItXFMM=";
-    })
-  ];
-
   strictDeps = true;
+
   nativeBuildInputs = [
+    bison
     cmake
     flex
-    bison
     pkg-config
   ];
+
   buildInputs = [
-    libpcap
-    libnet
-    zlib
+    atk
     curl
-    pcre2
-    openssl
-    ncurses
+    geoip
     glib
     gtk3
-    atk
-    pango
-    geoip
     harfbuzz
+    libmaxminddb
+    libnet
+    libpcap
+    ncurses
+    openssl
+    pango
+    pcre2
+    zlib
   ];
 
   preConfigure = ''
-    substituteInPlace CMakeLists.txt --replace /etc \$\{INSTALL_PREFIX\}/etc \
-                                     --replace /usr \$\{INSTALL_PREFIX\}
+    substituteInPlace CMakeLists.txt \
+      --replace-fail /etc \$\{INSTALL_PREFIX\}/etc \
+      --replace-fail /usr \$\{INSTALL_PREFIX\}
   '';
 
   cmakeFlags = [
@@ -87,7 +83,7 @@ stdenv.mkDerivation rec {
       analysis.
     '';
     homepage = "https://www.ettercap-project.org/";
-    changelog = "https://github.com/Ettercap/ettercap/releases/tag/${src.tag}";
+    changelog = "https://github.com/Ettercap/ettercap/releases/tag/${version}";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
