### PR TITLE
catalyst: fix build on x86_64-darwin

### DIFF
--- a/pkgs/by-name/ca/catalyst/package.nix
+++ b/pkgs/by-name/ca/catalyst/package.nix
@@ -75,10 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ ctestCheckHook ] ++ lib.optional mpiSupport mpiCheckPhaseHook;
 
-  disabledTests = lib.optionals fortranSupport [
-    # unexpected fortran binding symbol *__iso_c_binding_C_ptr
-    "catalyst-abi-nm"
-  ];
+  disabledTests =
+    lib.optionals (fortranSupport || stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64)
+      [
+        # unexpected fortran binding symbol *__iso_c_binding_C_ptr
+        # unexpected symbol in libc++ from darwin sdk
+        "catalyst-abi-nm"
+      ];
 
   pythonImportsCheck = [ "catalyst" ];
 


### PR DESCRIPTION
darwin stdenv swtich to use system libc++ from sdk, hence the abi test failed on x86_64-darwin.
fix build by disabling abi test on x86_64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
