### PR TITLE
libretro.{citra,dolphin,thepowdertoy,tic80}: fix build

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/citra.nix
+++ b/pkgs/applications/emulators/libretro/cores/citra.nix
@@ -30,17 +30,27 @@ mkLibretroCore {
   extraNativeBuildInputs = [ cmake ];
 
   # https://github.com/libretro/citra/blob/a31aff7e1a3a66f525b9ea61633d2c5e5b0c8b31/.gitlab-ci.yml#L6
-  cmakeFlags = [
-    (lib.cmakeBool "ENABLE_TESTS" false)
-    (lib.cmakeBool "ENABLE_DEDICATED_ROOM" false)
-    (lib.cmakeBool "ENABLE_SDL2" false)
-    (lib.cmakeBool "ENABLE_QT" false)
-    (lib.cmakeBool "ENABLE_WEB_SERVICE" false)
-    (lib.cmakeBool "ENABLE_SCRIPTING" false)
-    (lib.cmakeBool "ENABLE_OPENAL" false)
-    (lib.cmakeBool "ENABLE_LIBUSB" false)
-    (lib.cmakeBool "CITRA_ENABLE_BUNDLE_TARGET" false)
-    (lib.cmakeBool "CITRA_WARNINGS_AS_ERRORS" false)
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "ENABLE_TESTS" false)
+    (cmakeBool "ENABLE_DEDICATED_ROOM" false)
+    (cmakeBool "ENABLE_SDL2" false)
+    (cmakeBool "ENABLE_QT" false)
+    (cmakeBool "ENABLE_WEB_SERVICE" false)
+    (cmakeBool "ENABLE_SCRIPTING" false)
+    (cmakeBool "ENABLE_OPENAL" false)
+    (cmakeBool "ENABLE_LIBUSB" false)
+    (cmakeBool "CITRA_ENABLE_BUNDLE_TARGET" false)
+    (cmakeBool "CITRA_WARNINGS_AS_ERRORS" false)
+    # Workaround the following error:
+    # > CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
+    # > Compatibility with CMake < 3.5 has been removed from CMake.
+    #
+    # > Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+    # > to tell CMake that the project requires at least <min> but has been updated
+    # > to work with policies introduced by <max> or earlier.
+    #
+    # > Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+    (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
 
   meta = {

--- a/pkgs/applications/emulators/libretro/cores/dolphin.nix
+++ b/pkgs/applications/emulators/libretro/cores/dolphin.nix
@@ -53,14 +53,16 @@ mkLibretroCore {
   ];
 
   makefile = "Makefile";
-  cmakeFlags = [
-    "-DLIBRETRO=ON"
-    "-DLIBRETRO_STATIC=1"
-    "-DENABLE_QT=OFF"
-    "-DENABLE_LTO=OFF"
-    "-DUSE_UPNP=OFF"
-    "-DUSE_DISCORD_PRESENCE=OFF"
+
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "ENABLE_LTO" true)
+    (cmakeBool "ENABLE_NOGUI" false)
+    (cmakeBool "ENABLE_QT" false)
+    (cmakeBool "ENABLE_TESTS" false)
+    (cmakeBool "LIBRETRO" true)
+    (cmakeBool "USE_SHARED_ENET" false)
   ];
+
   dontUseCmakeBuildDir = true;
 
   meta = {

--- a/pkgs/applications/emulators/libretro/cores/dolphin.nix
+++ b/pkgs/applications/emulators/libretro/cores/dolphin.nix
@@ -61,6 +61,16 @@ mkLibretroCore {
     (cmakeBool "ENABLE_TESTS" false)
     (cmakeBool "LIBRETRO" true)
     (cmakeBool "USE_SHARED_ENET" false)
+    # Workaround the following error:
+    # > CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
+    # > Compatibility with CMake < 3.5 has been removed from CMake.
+    #
+    # > Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+    # > to tell CMake that the project requires at least <min> but has been updated
+    # > to work with policies introduced by <max> or earlier.
+    #
+    # > Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+    (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
 
   dontUseCmakeBuildDir = true;

--- a/pkgs/applications/emulators/libretro/cores/thepowdertoy.nix
+++ b/pkgs/applications/emulators/libretro/cores/thepowdertoy.nix
@@ -16,7 +16,22 @@ mkLibretroCore {
   };
 
   extraNativeBuildInputs = [ cmake ];
+
+  cmakeFlags = with lib.strings; [
+    # Workaround the following error:
+    # > CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
+    # > Compatibility with CMake < 3.5 has been removed from CMake.
+    #
+    # > Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+    # > to tell CMake that the project requires at least <min> but has been updated
+    # > to work with policies introduced by <max> or earlier.
+    #
+    # > Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+    (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+
   makefile = "Makefile";
+
   postBuild = "cd src";
 
   meta = {

--- a/pkgs/applications/emulators/libretro/cores/tic80.nix
+++ b/pkgs/applications/emulators/libretro/cores/tic80.nix
@@ -21,16 +21,30 @@ mkLibretroCore {
     cmake
     pkg-config
   ];
+
   makefile = "Makefile";
-  cmakeFlags = [
-    "-DBUILD_LIBRETRO=ON"
-    "-DBUILD_DEMO_CARTS=OFF"
-    "-DBUILD_PRO=OFF"
-    "-DBUILD_PLAYER=OFF"
-    "-DBUILD_SDL=OFF"
-    "-DBUILD_SOKOL=OFF"
+
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "BUILD_LIBRETRO" true)
+    (cmakeBool "BUILD_DEMO_CARTS" false)
+    (cmakeBool "BUILD_PRO" false)
+    (cmakeBool "BUILD_PLAYER" false)
+    (cmakeBool "BUILD_SDL" false)
+    (cmakeBool "BUILD_SOKOL" false)
+    # Workaround the following error:
+    # > CMake Error at 3rdparty/libzip/libzip/CMakeLists.txt:1 (cmake_minimum_required):
+    # > Compatibility with CMake < 3.5 has been removed from CMake.
+    #
+    # > Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+    # > to tell CMake that the project requires at least <min> but has been updated
+    # > to work with policies introduced by <max> or earlier.
+    #
+    # > Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+    (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
+
   preConfigure = "cd core";
+
   postBuild = "cd lib";
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix issue #450196.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
