### PR TITLE
bppsuite: fix build

### DIFF
--- a/pkgs/by-name/bp/bpp-core/package.nix
+++ b/pkgs/by-name/bp/bpp-core/package.nix
@@ -24,11 +24,16 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'cmake_minimum_required (VERSION 2.8.11)' 'cmake_minimum_required (VERSION 4.1)'
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   postFixup = ''
     substituteInPlace $out/lib/cmake/bpp-core/bpp-core-targets.cmake  \
-      --replace 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'
+      --replace-fail 'set(_IMPORT_PREFIX' '#set(_IMPORT_PREFIX'
   '';
   # prevents cmake from exporting incorrect INTERFACE_INCLUDE_DIRECTORIES
   # of form /nix/store/.../nix/store/.../include,

--- a/pkgs/by-name/bp/bpp-phyl/package.nix
+++ b/pkgs/by-name/bp/bpp-phyl/package.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation rec {
   pname = "bpp-phyl";
 
-  inherit (bpp-core) version;
+  inherit (bpp-core) version postPatch;
 
   src = fetchFromGitHub {
     owner = "BioPP";

--- a/pkgs/by-name/bp/bpp-popgen/package.nix
+++ b/pkgs/by-name/bp/bpp-popgen/package.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation rec {
   pname = "bpp-popgen";
 
-  inherit (bpp-core) version;
+  inherit (bpp-core) version postPatch;
 
   src = fetchFromGitHub {
     owner = "BioPP";

--- a/pkgs/by-name/bp/bpp-seq/package.nix
+++ b/pkgs/by-name/bp/bpp-seq/package.nix
@@ -8,7 +8,7 @@
 stdenv.mkDerivation rec {
   pname = "bpp-seq";
 
-  inherit (bpp-core) version;
+  inherit (bpp-core) version postPatch;
 
   src = fetchFromGitHub {
     owner = "BioPP";

--- a/pkgs/by-name/bp/bppsuite/package.nix
+++ b/pkgs/by-name/bp/bppsuite/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  texinfo,
   bpp-core,
   bpp-seq,
   bpp-phyl,
@@ -11,7 +12,7 @@
 stdenv.mkDerivation rec {
   pname = "bppsuite";
 
-  inherit (bpp-core) version;
+  inherit (bpp-core) version postPatch;
 
   src = fetchFromGitHub {
     owner = "BioPP";
@@ -20,7 +21,10 @@ stdenv.mkDerivation rec {
     sha256 = "1wdwcgczqbc3m116vakvi0129wm3acln3cfc7ivqnalwvi6lrpds";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    texinfo
+  ];
   buildInputs = [
     bpp-core
     bpp-seq


### PR DESCRIPTION
Fix build after the `cmake` update.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
