### PR TITLE
bazel_8: 8.4.1 -> 8.4.2

### DIFF
--- a/pkgs/by-name/ba/bazel_8/examples.nix
+++ b/pkgs/by-name/ba/bazel_8/examples.nix
@@ -108,10 +108,10 @@ in
     bazelVendorDepsFOD = {
       outputHash =
         {
-          aarch64-darwin = "sha256-D5bwW35QuLLhVE22FDyV9Nl8N7ULx71wCHbzB81+Xx0=";
-          aarch64-linux = "sha256-F5X/cwtHR6sVFe1DzNDaEnGMIPR0SnXq2iIxhQeqIV8=";
-          x86_64-darwin = "sha256-DXuPy68m3p6hlgEid7tpY8fGgvJWQTXth6h2kMSNFCc=";
-          x86_64-linux = "sha256-oNLDccQ/XPg1Nl/9V14NdgiQsRoTvpaA6hyynMb414A=";
+          aarch64-darwin = "sha256-0QtaPtcBljyhiJGwA8ctSpi+UQp/9q/ZoHUHORizmlY=";
+          aarch64-linux = "sha256-zpiwQ8OB8KhY+kxSXlSOd/zmoH1VGYDGgojf4Or04pQ=";
+          x86_64-darwin = "sha256-+tCDSuYkon1DEARwWTYABJbmysSNAK9vy0tCm8YsGjQ=";
+          x86_64-linux = "sha256-wCWSRc20Yr/hdXn8szbhLAX7Oy3G5keyHTTdO0msnks=";
         }
         .${stdenv.hostPlatform.system};
       outputHashAlgo = "sha256";

--- a/pkgs/by-name/ba/bazel_8/package.nix
+++ b/pkgs/by-name/ba/bazel_8/package.nix
@@ -31,7 +31,7 @@
   cctools,
   # Allow to independently override the jdks used to build and run respectively
   jdk_headless,
-  version ? "8.4.1",
+  version ? "8.4.2",
 }:
 
 let
@@ -45,7 +45,7 @@ let
 
   src = fetchzip {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    hash = "sha256-DqJqW7C1QODOS+vJrs/+ixsP3coZh80VdpPM4g0vxFI=";
+    hash = "sha256-5oNYKHPaDkpunl6oC104Rh1wAEMWfLfvCFdGHlXZn4o=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/ba/bazel_8/package.nix
+++ b/pkgs/by-name/ba/bazel_8/package.nix
@@ -144,9 +144,7 @@ stdenv.mkDerivation rec {
     # Nixpkgs toolcahins do not support that (yet?) and get confused.
     # Also add an explicit /usr/bin prefix that will be patched below.
     (replaceVars ./patches/xcode.patch {
-      usrBinEnv = "${coreutils}/bin/env";
       clangDarwin = "${stdenv.cc}/bin/clang";
-      codesign = "${darwin.sigtool}/bin/codesign";
     })
 
     # Revert preference for apple_support over rules_cc toolchain for now

--- a/pkgs/by-name/ba/bazel_8/patches/apple_cc_toolchain.patch
+++ b/pkgs/by-name/ba/bazel_8/patches/apple_cc_toolchain.patch
@@ -8,11 +8,11 @@ index b3dde1c838..a54bf8141d 100644
  
 -# Depend on apple_support first and then rules_cc so that the Xcode toolchain
 -# from apple_support wins over the generic Unix toolchain from rules_cc.
--bazel_dep(name = "apple_support", version = "1.18.1")
+-bazel_dep(name = "apple_support", version = "1.23.1")
 +# Not Depend on apple_support first and then rules_cc so that the Xcode toolchain
 +# from apple_support not wins over the generic Unix toolchain from rules_cc.
  bazel_dep(name = "rules_cc", version = "0.1.1")
-+bazel_dep(name = "apple_support", version = "1.18.1")
++bazel_dep(name = "apple_support", version = "1.23.1")
  
  # repo_name needs to be used, until WORKSPACE mode is to be supported in bazel_tools
  bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")

--- a/pkgs/by-name/ba/bazel_8/patches/xcode.patch
+++ b/pkgs/by-name/ba/bazel_8/patches/xcode.patch
@@ -12,20 +12,16 @@ index 1bad14cba7..d312fe08bb 100755
    cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/xcode-locator
  fi
 diff --git a/tools/osx/BUILD b/tools/osx/BUILD
-index 0358fb0ffe..1e6eae1f33 100644
+index 5b99589ad4..3d3269772b 100644
 --- a/tools/osx/BUILD
 +++ b/tools/osx/BUILD
-@@ -27,9 +27,9 @@ exports_files([
+@@ -27,7 +27,7 @@ exports_files([
  ])
  
  DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
 -  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
--      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
--  env -i codesign --identifier $@ --force --sign - $@
 +  @clangDarwin@ -mmacosx-version-min=10.13 -fobjc-arc -framework CoreServices \
-+      -framework Foundation -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
-+  @usrBinEnv@ @codesign@ --identifier $@ --force --sign - $@
+       -framework Foundation -arch arm64 -arch x86_64 -o $@ $<
  """
  
- genrule(
 


### PR DESCRIPTION
Derived from automated update to make it build https://github.com/NixOS/nixpkgs/pull/447834 (adds https://github.com/r-ryantm/nixpkgs/pull/12 to it)

https://github.com/bazelbuild/bazel/releases/tag/8.4.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
