### PR TITLE
sofia_sip: Enable tests, adopt, modernise

### DIFF
--- a/pkgs/by-name/so/sofia_sip/2001-sofia-sip-Disable-some-tests.patch
+++ b/pkgs/by-name/so/sofia_sip/2001-sofia-sip-Disable-some-tests.patch
@@ -1,0 +1,109 @@
+diff --git a/libsofia-sip-ua-glib/su-glib/Makefile.am b/libsofia-sip-ua-glib/su-glib/Makefile.am
+index 6f54d34..c5bfd82 100644
+--- a/libsofia-sip-ua-glib/su-glib/Makefile.am
++++ b/libsofia-sip-ua-glib/su-glib/Makefile.am
+@@ -20,12 +20,12 @@ AM_CPPFLAGS =		-I$(S_BASE)/su -I$(B_BASE)/su $(GLIB_CFLAGS) \
+ 
+ noinst_LTLIBRARIES = 	libsu-glib.la
+ 
+-check_PROGRAMS = 	su_source_test torture_su_glib_timer
++check_PROGRAMS =
+ 
+ # ----------------------------------------------------------------------
+ # Tests
+ 
+-TESTS = 		su_source_test torture_su_glib_timer
++TESTS =
+ 
+ # ----------------------------------------------------------------------
+ # Rules for building the targets
+diff --git a/libsofia-sip-ua/nta/Makefile.am b/libsofia-sip-ua/nta/Makefile.am
+index c450fd1..4f322c3 100644
+--- a/libsofia-sip-ua/nta/Makefile.am
++++ b/libsofia-sip-ua/nta/Makefile.am
+@@ -26,9 +26,9 @@ AM_CPPFLAGS = 		-I$(srcdir)/../ipt -I../ipt \
+ noinst_LTLIBRARIES = 	libnta.la
+ 
+ check_PROGRAMS = 	check_nta test_nta_api test_nta portbind
+-dist_noinst_SCRIPTS =	run_test_nta_api run_test_nta
++dist_noinst_SCRIPTS =	run_test_nta_api
+ 
+-TESTS =			run_check_nta run_test_nta_api run_test_nta
++TESTS =			run_test_nta_api
+ 
+ TESTS_ENVIRONMENT =	$(SHELL)
+ 
+diff --git a/libsofia-sip-ua/nua/Makefile.am b/libsofia-sip-ua/nua/Makefile.am
+index 6b6dfaa..73ffd70 100644
+--- a/libsofia-sip-ua/nua/Makefile.am
++++ b/libsofia-sip-ua/nua/Makefile.am
+@@ -17,8 +17,8 @@ check_PROGRAMS =
+ TESTS =
+ 
+ if HAVE_CHECK
+-check_PROGRAMS +=	check_nua
+-TESTS += 		check_nua
++check_PROGRAMS +=
++TESTS +=
+ endif
+ 
+ # ----------------------------------------------------------------------
+diff --git a/libsofia-sip-ua/su/Makefile.am b/libsofia-sip-ua/su/Makefile.am
+index db3a331..0a31c72 100644
+--- a/libsofia-sip-ua/su/Makefile.am
++++ b/libsofia-sip-ua/su/Makefile.am
+@@ -20,7 +20,7 @@ check_PROGRAMS = 	torture_su torture_su_port \
+ 			torture_su_alloc torture_su_time torture_su_tag \
+ 			test_htable test_htable2 torture_rbtree torture_heap \
+ 			test_memmem torture_su_bm \
+-			torture_su_root torture_su_timer \
++			torture_su_timer \
+ 			test_su su_proxy test_poll $(OSXPROGS)
+ 
+ # ----------------------------------------------------------------------
+@@ -30,8 +30,8 @@ TESTS = 		torture_su torture_su_port \
+ 			torture_su_alloc torture_su_time torture_su_tag \
+ 			test_htable test_htable2 torture_rbtree torture_heap \
+ 			test_memmem torture_su_bm \
+-			torture_su_root torture_su_timer \
+-			run_addrinfo run_localinfo run_test_su \
++			torture_su_timer \
++			run_localinfo run_test_su \
+ 			$(OSXTESTS)
+ 
+ # ----------------------------------------------------------------------
+@@ -98,7 +98,7 @@ LDADD = 		libsu.la
+ # Install and distribution rules
+ 
+ EXTRA_DIST += 		su.docs \
+-			run_addrinfo run_localinfo run_test_su
++			run_localinfo run_test_su
+ 
+ dist_pkgdata_SCRIPTS = 	tag_dll.awk
+ 
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index cabc2b5..0184017 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -5,8 +5,8 @@
+ # Contact: Pekka Pessi <pekka.pessi@nokia.com>
+ # Licensed under LGPL. See file COPYING.
+ 
+-TESTS = test_nua
+-check_PROGRAMS = test_nua
++TESTS =
++check_PROGRAMS =
+ 
+ EXTRA_DIST = check_sofia.h check_sofia.c suite_for_nua.c
+ 
+@@ -33,8 +33,8 @@ libtestproxy_a_SOURCES = test_proxy.h test_proxy.c
+ libtestnat_a_SOURCES =	test_nat.h test_nat.c test_nat_tags.c
+ 
+ if HAVE_CHECK
+-TESTS += check_dlopen_sofia check_sofia
+-check_PROGRAMS += check_dlopen_sofia check_sofia
++TESTS += check_dlopen_sofia
++check_PROGRAMS += check_dlopen_sofia
+ endif
+ 
+ check_sofia_CFLAGS = @CHECK_CFLAGS@

--- a/pkgs/by-name/so/sofia_sip/package.nix
+++ b/pkgs/by-name/so/sofia_sip/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
+  gitUpdater,
+  testers,
   autoconf,
   automake,
   check,
@@ -14,23 +16,23 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sofia-sip";
   version = "1.13.17";
 
   src = fetchFromGitHub {
     owner = "freeswitch";
     repo = "sofia-sip";
-    rev = "v${version}";
-    sha256 = "sha256-7QmK2UxEO5lC0KBDWB3bwKTy0Nc7WrdTLjoQYzezoaY=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-7QmK2UxEO5lC0KBDWB3bwKTy0Nc7WrdTLjoQYzezoaY=";
   };
 
   patches = [
     # Fix build with gcc 14 from https://github.com/freeswitch/sofia-sip/pull/249
     (fetchpatch2 {
       name = "sofia-sip-fix-incompatible-pointer-type.patch";
-      url = "https://github.com/freeswitch/sofia-sip/commit/46b02f0655af0a9594e805f09a8ee99278f84777.diff";
-      hash = "sha256-4uZVtKnXG+BPW8byjd7tu4uEZo9SYq9EzTEvMwG0Bak=";
+      url = "https://github.com/freeswitch/sofia-sip/commit/46b02f0655af0a9594e805f09a8ee99278f84777.patch?full_index=1";
+      hash = "sha256-bZzjg7GBxR2wSlPH81krZRCK43OirGLWH/lrLRZ0L0k=";
     })
 
     # Disable some failing tests
@@ -85,11 +87,25 @@ stdenv.mkDerivation rec {
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
-  meta = with lib; {
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+  };
+
+  meta = {
     description = "Open-source SIP User-Agent library, compliant with the IETF RFC3261 specification";
     homepage = "https://github.com/freeswitch/sofia-sip";
-    platforms = platforms.unix;
-    license = licenses.lgpl2;
+    platforms = lib.platforms.unix;
+    license = lib.licenses.lgpl2Plus;
     teams = [ lib.teams.ngi ];
+    pkgConfigModules = [
+      "sofia-sip-ua"
+      "sofia-sip-ua-glib"
+    ];
   };
-}
+})

--- a/pkgs/by-name/so/sofia_sip/package.nix
+++ b/pkgs/by-name/so/sofia_sip/package.nix
@@ -3,10 +3,15 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
+  autoconf,
+  automake,
+  check,
   glib,
+  libtool,
   openssl,
   pkg-config,
-  autoreconfHook,
+  valgrind,
+  zlib,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,16 +32,58 @@ stdenv.mkDerivation rec {
       url = "https://github.com/freeswitch/sofia-sip/commit/46b02f0655af0a9594e805f09a8ee99278f84777.diff";
       hash = "sha256-4uZVtKnXG+BPW8byjd7tu4uEZo9SYq9EzTEvMwG0Bak=";
     })
+
+    # Disable some failing tests
+    # https://github.com/freeswitch/sofia-sip/issues/234
+    # run_addrinfo: Fails due to limited networking during build
+    # torture_su_root: Aborts with: bit out of range 0 - FD_SETSIZE on fd_set
+    # run_check_nta: Times out in client_2_1_1 test, which seems to test some connection protocol fallback thing
+    # run_test_nta: "no valid IPv6 addresses available", likely due to no networking in sandbox
+    # check_nua, check_sofia, test_nua: Times out no matter how much time is given to it
+    ./2001-sofia-sip-Disable-some-tests.patch
+  ];
+
+  # This actually breaks these tests, leading to bash trying to execute itself
+  # https://github.com/freeswitch/sofia-sip/issues/234
+  postPatch = ''
+    substituteInPlace libsofia-sip-ua/nta/Makefile.am \
+      --replace-fail 'TESTS_ENVIRONMENT =' '#TESTS_ENVIRONMENT ='
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkg-config
   ];
 
   buildInputs = [
     glib
     openssl
   ];
-  nativeBuildInputs = [
-    autoreconfHook
-    pkg-config
+
+  nativeCheckInputs = [
+    valgrind
   ];
+
+  checkInputs = [
+    check
+    zlib
+  ];
+
+  preConfigure = ''
+    ./bootstrap.sh
+  '';
+
+  configureFlags = [
+    (lib.strings.enableFeature true "expensive-checks")
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   meta = with lib; {
     description = "Open-source SIP User-Agent library, compliant with the IETF RFC3261 specification";

--- a/pkgs/by-name/so/sofia_sip/package.nix
+++ b/pkgs/by-name/so/sofia_sip/package.nix
@@ -90,5 +90,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/freeswitch/sofia-sip";
     platforms = platforms.unix;
     license = licenses.lgpl2;
+    teams = [ lib.teams.ngi ];
   };
 }


### PR DESCRIPTION
Upstreaming from NGIpkgs. We will depend on this for BigBlueButton, so adopting it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
