### PR TITLE
airspy, soapyairspy: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/ai/airspy/package.nix
+++ b/pkgs/by-name/ai/airspy/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   libusb1,
@@ -18,6 +19,22 @@ stdenv.mkDerivation rec {
     sha256 = "1v7sfkkxc6f8ny1p9xrax1agkl6q583mjx8k0lrrwdz31rf9qgw9";
   };
 
+  patches = [
+    # CMake < 3.5 fix. Remove upon next version bump.
+    (fetchpatch {
+      url = "https://github.com/airspy/airspyone_host/commit/7290309a663ced66e1e51dc65c1604e563752310.patch";
+      hash = "sha256-DZ7hYFBu9O2e6Fdx3yJdoCHoE1uVhzih0+OpiPTvkaI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/airspy/airspyone_host/commit/3cf6f97976611c2ff6363f7927fe76c465995801.patch";
+      hash = "sha256-7LU3UvpvwQdDF8GPZw/W4Z2CSzUCNk47McNHti3YHP8=";
+    })
+    (fetchpatch {
+      url = "https://github.com/airspy/airspyone_host/commit/f467acd587617640741ecbfade819d10ecd032c2.patch";
+      hash = "sha256-qfJrxM1hq7NScxN++d9IH+fwFfXf/YwZZUDDOVbwIJk=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace airspy-tools/CMakeLists.txt --replace "/etc/udev/rules.d" "$out/etc/udev/rules.d"
   '';
@@ -30,7 +47,10 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   buildInputs = [ libusb1 ];
 
-  cmakeFlags = lib.optionals stdenv.hostPlatform.isLinux [ "-DINSTALL_UDEV_RULES=ON" ];
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isLinux [
+    "-DINSTALL_UDEV_RULES=ON"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/airspy/airspyone_host";

--- a/pkgs/by-name/so/soapyairspy/package.nix
+++ b/pkgs/by-name/so/soapyairspy/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   airspy,
   soapysdr,
@@ -22,6 +23,18 @@ stdenv.mkDerivation rec {
   buildInputs = [
     airspy
     soapysdr
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/pothosware/SoapyAirspy/commit/1be30c33b394fc4d2aeea4287e8df8701adad5a0.patch";
+      hash = "sha256-ZEIyyd2tOK1diPh8BsEqALHGgdVCV6tZP9xeQNeeXl8=";
+    })
+    # CMake < 3.5 compat fix. Remove after (https://github.com/pothosware/SoapyAirspy/pull/31 is merged && next version bump).
+    (fetchpatch {
+      url = "https://github.com/pothosware/SoapyAirspy/pull/31/commits/0ee4a5e8edff9f2bbea60dd069d2cc958e314a3e.patch";
+      hash = "sha256-TQs4rDw+kRmxnuUwhhq9ioCsbKKniwuspSk/c7wazMM=";
+    })
   ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tracking issue: #445447

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
