### PR TITLE
libad9361: fix CMake 4 compatibility

### DIFF
--- a/pkgs/by-name/li/libad9361/cmake-3.10.patch
+++ b/pkgs/by-name/li/libad9361/cmake-3.10.patch
@@ -1,0 +1,34 @@
+From a54a5ff97c4ce0125207544e8c4e2586551dfded Mon Sep 17 00:00:00 2001
+From: Dave Walker <dave@daviey.com>
+Date: Thu, 9 Oct 2025 15:27:42 +0100
+Subject: [PATCH] Update CMake minimum required version to 3.10
+
+CMake 4 removed compatibility with CMake versions < 3.5, and versions
+between 3.5-3.10 are deprecated.
+
+This change updates the minimum required version to 3.10 to ensure
+compatibility with modern CMake versions including CMake 4.x.
+
+This issue is affecting NixOS users (see
+https://github.com/NixOS/nixpkgs/issues/450318) and will likely impact
+other distributions as they upgrade to CMake 4.x.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 04d5c45..8316999 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,7 @@
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ # Lesser General Public License for more details.
+ 
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.10)
+ project(ad9361 C)
+ 
+ set(LIBAD9361_VERSION_MAJOR 0)
+-- 
+2.51.0
+

--- a/pkgs/by-name/li/libad9361/package.nix
+++ b/pkgs/by-name/li/libad9361/package.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-9e66qSrKpczatZY9lPAzi/6f7lHChnl2+Pih53oa28Y=";
   };
 
+  patches = [
+    # Update CMake minimum required version for CMake 4 compatibility
+    # https://github.com/analogdevicesinc/libad9361-iio/pull/134
+    ./cmake-3.10.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ libiio ];


### PR DESCRIPTION
Adds a patch to update cmake_minimum_required from 2.8.12 to 3.10.

CMake 4 doesn't support versions older than 3.5, and versions between 3.5-3.10 are deprecated.

Upstream PR: https://github.com/analogdevicesinc/libad9361-iio/pull/134

Fixes: #450318