### PR TITLE
cfitsio: 4.6.2 -> 4.6.3

### DIFF
--- a/pkgs/by-name/cf/cfitsio/package.nix
+++ b/pkgs/by-name/cf/cfitsio/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   gitUpdater,
   cmake,
   bzip2,
@@ -12,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cfitsio";
-  version = "4.6.2";
+  version = "4.6.3";
 
   src = fetchFromGitHub {
     owner = "HEASARC";
-    repo = finalAttrs.pname;
-    tag = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-WLsX23hNhaITjCvMEV7NUEvyDfQiObSJt1qFC12z7wY=";
+    repo = "cfitsio";
+    tag = "cfitsio-${finalAttrs.version}";
+    hash = "sha256-nKxX3YNRJZpmcP8/0O2pMsYjcH6vzAWMpqaHYO+HoUo=";
   };
 
   outputs = [
@@ -30,12 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./cfitsio-pc-cmake.patch
-
-    (fetchpatch {
-      name = "cfitsio-fix-cmake-4.patch";
-      url = "https://github.com/HEASARC/cfitsio/commit/101e0880fca41e2223df7eec56d9e84e90b9ed56.patch";
-      hash = "sha256-rufuqOBfE7ItTYwsGdu9G4BXSz4vZd52XmJi09kqrCM=";
-    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

Update cfitsio 4.6.2 -> 4.6.3 and drop cmake patch that is now included in release.


Changelog:

<details>

```
Version 4.6.3 - Sep 2025

  - For greater C23 compatibility, updated cfortran.h file and
    removed old-style function declarations. 
 
  - Cleanup of multiple compiler warnings.  Our thanks to petesmc for
    help with this.
     
  - Updated 'speed' utility to use higher precision total time.
  
  - Fixes for FreeBSD and OpenBSD build issues. Our thanks to Diab
    Jerius.

  - Added RPM support file cfitsio.spec, and packaging helper file
    ax_cfitsio.m4. Our thanks to Richard Mathar for these.
  
  - Added files portfile.cmake and vcpkg.json.  Our thanks to 
    D. Partridge for these. 
     
  - Fixed possible memory leaks in certain error exit conditions.
    Our thanks to petesmc.
  
  - Fix to minor truncation error in ffgthd.
```
</details>

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
