### PR TITLE
ares: 145 -> 146

### DIFF
--- a/pkgs/by-name/ar/ares/darwin-build-fixes.patch
+++ b/pkgs/by-name/ar/ares/darwin-build-fixes.patch
@@ -24,15 +24,15 @@ index 3777ac98a..07ff17009 100644
      install(TARGETS ${target} BUNDLE DESTINATION "." COMPONENT Application)
    endif()
 diff --git a/ruby/cmake/os-macos.cmake b/ruby/cmake/os-macos.cmake
-index 39c339428..dafb58c66 100644
+index 7b594bb4a..18e886fe7 100644
 --- a/ruby/cmake/os-macos.cmake
 +++ b/ruby/cmake/os-macos.cmake
-@@ -43,7 +43,7 @@ target_link_libraries(
+@@ -41,7 +41,7 @@ target_link_libraries(
+ )
+ 
  if(SDL_FOUND)
-   target_link_libraries(
-     ruby
--    PRIVATE "$<LINK_LIBRARY:WEAK_FRAMEWORK,SDL::SDL>"
-+    PRIVATE "$<LINK_LIBRARY:WEAK_LIBRARY,SDL::SDL>"
-   )
+-  target_link_libraries(ruby PRIVATE "$<LINK_LIBRARY:WEAK_FRAMEWORK,SDL::SDL>")
++  target_link_libraries(ruby PRIVATE "$<LINK_LIBRARY:WEAK_LIBRARY,SDL::SDL>")
  endif()
  
+ if(librashader_FOUND)

--- a/pkgs/by-name/ar/ares/package.nix
+++ b/pkgs/by-name/ar/ares/package.nix
@@ -3,7 +3,7 @@
   alsa-lib,
   apple-sdk_14,
   cmake,
-  fetchFromGitHub,
+  fetchzip,
   gtk3,
   gtksourceview3,
   libGL,
@@ -29,13 +29,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ares";
-  version = "145";
+  version = "146";
 
-  src = fetchFromGitHub {
-    owner = "ares-emulator";
-    repo = "ares";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-es+K5+qlK7FcJCFEIMcOsXCZSnoXEEmtS0yhpCvaILM";
+  src = fetchzip {
+    url = "https://github.com/ares-emulator/ares/releases/download/v${finalAttrs.version}/ares-source.tar.gz";
+    hash = "sha256-D4N0u9NNlhs4nMoUrAY+sg6Ybt1xQPMiH1u0cV0Qixs=";
+    stripRoot = false;
   };
 
   nativeBuildInputs = [
@@ -80,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "ARES_BUILD_LOCAL" false)
     (lib.cmakeBool "ARES_SKIP_DEPS" true)
+    (lib.cmakeBool "ARES_BUILD_OFFICIAL" true)
   ];
 
   postInstall =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upgrades ares to version 146. Changelog: https://ares-emu.net/news/ares-v146-released

Changed it to use fetchzip because upstream uses `export-subst`, which leads to the contents of the source archive from GitHub not being deterministic.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
