### PR TITLE
python3Packages.pyroaring: 1.0.2 -> 1.0.3

### DIFF
--- a/pkgs/development/python-modules/pyroaring/default.nix
+++ b/pkgs/development/python-modules/pyroaring/default.nix
@@ -10,20 +10,15 @@
 
 buildPythonPackage rec {
   pname = "pyroaring";
-  version = "1.0.2";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Ezibenroc";
     repo = "PyRoaringBitMap";
     tag = version;
-    hash = "sha256-g+xpQ2DuVn8b0DiIOY69QOH6iwOYHG4bltX1zbDemdI=";
+    hash = "sha256-of4BuTHtIIwdpWUm0d9CByWc8YiaxXNQ1oDXUZYWRjU=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "cython>=3.0.2,<3.1.0" "cython"
-  '';
 
   build-system = [
     cython


### PR DESCRIPTION
Bump `pyroaring` to v1.0.3, and revert c92de0a516ea1ace0cad87a744e3ffe02986b6ca., as `pyroaring` v1.0.3 fixes the need for that commit.

`pyroaring` changelog:

- Use buffer interface for deserialization by @SamHames in https://github.com/Ezibenroc/PyRoaringBitMap/pull/135
- Fix floating point slice indices in _string_rep in Cython 3.1.* by @zachoverflow in https://github.com/Ezibenroc/PyRoaringBitMap/pull/136

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
