### PR TITLE
wxGTK31/wxGTK32: disable withWebKit on RiscV

### DIFF
--- a/pkgs/by-name/wx/wxGTK31/package.nix
+++ b/pkgs/by-name/wx/wxGTK31/package.nix
@@ -20,7 +20,7 @@
   withPrivateFonts ? false,
   withEGL ? true,
   withMesa ? !stdenv.hostPlatform.isDarwin,
-  withWebKit ? stdenv.hostPlatform.isDarwin,
+  withWebKit ? lib.meta.availableOn stdenv.hostPlatform webkitgtk_4_1,
   webkitgtk_4_1,
   libpng,
 }:
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional withCurl curl
   ++ lib.optional withMesa libGLU
-  ++ lib.optional (withWebKit && !stdenv.hostPlatform.isDarwin) webkitgtk_4_1
+  ++ lib.optional withWebKit webkitgtk_4_1
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libpng
   ];

--- a/pkgs/by-name/wx/wxGTK32/package.nix
+++ b/pkgs/by-name/wx/wxGTK32/package.nix
@@ -27,7 +27,7 @@
   compat30 ? true,
   unicode ? true,
   withMesa ? !stdenv.hostPlatform.isDarwin,
-  withWebKit ? true,
+  withWebKit ? lib.meta.availableOn stdenv.hostPlatform webkitgtk_4_1,
   webkitgtk_4_1,
 }:
 let
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     xorgproto
   ]
   ++ lib.optional withMesa libGLU
-  ++ lib.optional (withWebKit && stdenv.hostPlatform.isLinux) webkitgtk_4_1
+  ++ lib.optional withWebKit webkitgtk_4_1
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     expat
   ];

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -76,6 +76,7 @@
   withLibsecret ? true,
   systemdSupport ? lib.meta.availableOn clangStdenv.hostPlatform systemd,
   testers,
+  stdenv,
 }:
 
 # https://webkitgtk.org/2024/10/04/webkitgtk-2.46.html recommends building with clang.
@@ -263,6 +264,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     ];
     platforms = platforms.linux ++ platforms.darwin;
     teams = [ teams.gnome ];
-    broken = clangStdenv.hostPlatform.isDarwin;
+    broken = clangStdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isRiscV64;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
