### PR TITLE
nixos-rebuild-ng: do not handle build exceptions in re-exec

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import sys
 from subprocess import CalledProcessError, run
 from typing import Final, assert_never
@@ -290,12 +289,7 @@ def execute(argv: list[str]) -> None:
 
     # Re-exec to a newer version of the script before building to ensure we get
     # the latest fixes
-    if (
-        WITH_REEXEC
-        and can_run
-        and not args.no_reexec
-        and not os.environ.get("_NIXOS_REBUILD_REEXEC")
-    ):
+    if WITH_REEXEC and can_run and not args.no_reexec:
         services.reexec(argv, args, build_flags, flake_build_flags)
 
     profile = Profile.from_arg(args.profile_name)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 from pathlib import Path
-from subprocess import CalledProcessError
 from typing import Final
 
 from . import nix, tmpdir
@@ -26,26 +25,22 @@ def reexec(
     flake_build_flags: Args,
 ) -> None:
     drv = None
-    try:
-        # Parsing the args here but ignore ask_sudo_password since it is not
-        # needed and we would end up asking sudo password twice
-        if flake := Flake.from_arg(args.flake, Remote.from_arg(args.target_host, None)):
-            drv = nix.build_flake(
-                NIXOS_REBUILD_ATTR,
-                flake,
-                flake_build_flags | {"no_link": True},
-            )
-        else:
-            build_attr = BuildAttr.from_arg(args.attr, args.file)
-            drv = nix.build(
-                NIXOS_REBUILD_ATTR,
-                build_attr,
-                build_flags | {"no_out_link": True},
-            )
-    except CalledProcessError:
-        logger.warning(
-            "could not build a newer version of nixos-rebuild, using current version",
-            exc_info=logger.isEnabledFor(logging.DEBUG),
+    # Parsing the args here but ignore ask_sudo_password since it is not
+    # needed and we would end up asking sudo password twice
+    if flake := Flake.from_arg(
+        args.flake, Remote.from_arg(args.target_host, ask_sudo_password=None)
+    ):
+        drv = nix.build_flake(
+            NIXOS_REBUILD_ATTR,
+            flake,
+            flake_build_flags | {"no_link": True},
+        )
+    else:
+        build_attr = BuildAttr.from_arg(args.attr, args.file)
+        drv = nix.build(
+            NIXOS_REBUILD_ATTR,
+            build_attr,
+            build_flags | {"no_out_link": True},
         )
 
     if drv:


### PR DESCRIPTION
Classic `nixos-rebuild` bails-out if re-exec fails, but `nixos-rebuild-ng` tries to keep going. The problem this is causing is that failures in re-exec evaluation almost always are errors in the user configuration, for example:

```diff
diff --git i/modules/nixos/default.nix w/modules/nixos/default.nix
index 1d8ef762..cb7e2c9d 100644
--- i/modules/nixos/default.nix
+++ w/modules/nixos/default.nix
@@ -11,6 +11,6 @@
     ./nix
     ./server
     ./system
-    ./window-manager
+    ./window-manager;
   ];
 }
```

And if you try to run, you get the following output:

```
$ nixos-rebuild switch
warning: Git tree '/etc/nixos' is dirty
error:
       … while calling the 'seq' builtin
         at /nix/store/9v6qa656sq3xc58vkxslqy646p0ajj61-source/lib/modules.nix:361:18:
          360|         options = checked options;
          361|         config = checked (removeAttrs config [ "_module" ]);
             |                  ^
          362|         _module = checked (config._module);

       … while evaluating a branch condition
         at /nix/store/9v6qa656sq3xc58vkxslqy646p0ajj61-source/lib/modules.nix:297:9:
          296|       checkUnmatched =
          297|         if config._module.check && config._module.freeformType == null && merged.unmatchedDefns != [ ] then
             |         ^
          298|           let

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: syntax error, unexpected ';'
       at /nix/store/c7zc5zg8c2hfnk7ihxaq574c83kjqav3-source/modules/nixos/default.nix:14:21:
           13|     ./system
           14|     ./window-manager;
             |                     ^
           15|   ];
warning: could not build a newer version of nixos-rebuild, using current version
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
error:
       … while calling the 'seq' builtin
         at /nix/store/9v6qa656sq3xc58vkxslqy646p0ajj61-source/lib/modules.nix:361:18:
          360|         options = checked options;
          361|         config = checked (removeAttrs config [ "_module" ]);
             |                  ^
          362|         _module = checked (config._module);

       … while evaluating a branch condition
         at /nix/store/9v6qa656sq3xc58vkxslqy646p0ajj61-source/lib/modules.nix:297:9:
          296|       checkUnmatched =
          297|         if config._module.check && config._module.freeformType == null && merged.unmatchedDefns != [ ] then
             |         ^
          298|           let

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: syntax error, unexpected ';'
       at /nix/store/c7zc5zg8c2hfnk7ihxaq574c83kjqav3-source/modules/nixos/default.nix:14:21:
           13|     ./system
           14|     ./window-manager;
             |                     ^
           15|   ];
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '/etc/nixos#nixosConfigurations."blackrockshooter-nixos".config.system.build.toplevel' --no-link' returned non-zero exit status 1.
```

The error is printed twice because we first try to eval (and fail) for re-exec and since we keep going the actual build also fails. Since classic `nixos-rebuild` bails out in the re-exec eval failure, it should be safe to not handle the exception here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
