### PR TITLE
wasmtime: fix multiple-output derivation

### DIFF
--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -37,6 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "lib"
   ];
 
   nativeBuildInputs = [
@@ -55,27 +56,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
       # error: linker `rust-lld` not found
       !isAarch64;
 
-  # prevent $out from being propagated to $dev:
-  # the library and header files are not dependent on the binaries
-  propagatedBuildOutputs = [ ];
-
   postInstall =
     let
       inherit (stdenv.hostPlatform.rust) cargoShortTarget;
     in
     ''
-      moveToOutput lib $dev
-      ${lib.optionalString (!enableShared) "rm -f $dev/lib/*.so{,.*}"}
-      ${lib.optionalString (!enableStatic) "rm -f $dev/lib/*.a"}
+      moveToOutput lib $lib
+      ${lib.optionalString (!enableShared) "rm -f $lib/lib/*.so{,.*}"}
+      ${lib.optionalString (!enableStatic) "rm -f $lib/lib/*.a"}
 
       # copy the build.rs generated c-api headers
       # https://github.com/rust-lang/cargo/issues/9661
+      mkdir $dev
       cp -r target/${cargoShortTarget}/release/build/wasmtime-c-api-impl-*/out/include $dev/include
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       install_name_tool -id \
-        $dev/lib/libwasmtime.dylib \
-        $dev/lib/libwasmtime.dylib
+        $lib/lib/libwasmtime.dylib \
+        $lib/lib/libwasmtime.dylib
     ''
     + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd wasmtime \


### PR DESCRIPTION
`propagatedBuildOutputs = [ ]` meant that the `wasmtime` binary didn't get added to `$PATH` when used in devShells.
This fixes the problem by moving the libraries into their own `lib` output, to which the `wasmtime.out` output doesn't propagate - achieving the same result without messing up user's devShells.

Closes #449638.

---

Sorry for the churn on the package trying to get the library stuff to work, but I guess it's part of learning by doing. :sweat_smile:
I also gave this a try on my neovim branch where I'm actually consuming the wasmtime C library, and it works there.
Another note for future maintainers, including myself: it seems like Rust/Cargo 1.91 will finally allow better control over where the C-API headers end up, so we should take another look at that part of `postInstall` once it lands in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
