### PR TITLE
claude-code: 2.0.10 -> 2.0.13

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "claude-code";
     publisher = "anthropic";
-    version = "2.0.10";
-    hash = "sha256-wtqtjvU7HZZWUxRRN/H7I0lgCMRzGZy/Mu5s30ZbJ0g=";
+    version = "2.0.13";
+    hash = "sha256-rXQKpc75TGFSMXDIjNtxm4CrCkfXv6Fqa3bAYHplUsA=";
   };
 
   meta = {

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -7,11 +7,11 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.0.10";
+  version = "2.0.13";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-f90cIyUofV3emYtluLL/KtfAsgjG3gFQGQPGYgDWL2M=";
+    hash = "sha256-wazALudqwwYVCm7qCYIuOkOVcFxRTzLjkDnRXaHLFIQ=";
   };
 
   npmDepsHash = "sha256-DehkeMZvzn+hvcCDzJfd4p9oYc1GSZm8gu8vKS4Uncw=";


### PR DESCRIPTION
## Summary
Update claude-code CLI and VSCode extension from version 2.0.10 to 2.0.13

### Changes
- Updated CLI package (`pkgs/by-name/cl/claude-code/package.nix`)
  - Version: 2.0.10 → 2.0.13
  - Updated source hash
- Updated VSCode extension (`pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix`)
  - Version: 2.0.10 → 2.0.13
  - Updated extension hash

### Testing
- [x] Built and tested CLI package successfully
- [x] Built and tested VSCode extension successfully
- [x] Version check passed for CLI

### Changelog
See https://www.npmjs.com/package/@anthropic-ai/claude-code?activeTab=versions for release notes