### PR TITLE
sidguesser: init at 1.0.5

### DIFF
--- a/pkgs/by-name/si/sidguesser/package.nix
+++ b/pkgs/by-name/si/sidguesser/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sidguesser";
+  version = "1.0.5";
+
+  src = fetchFromGitLab {
+    group = "kalilinux";
+    owner = "packages";
+    repo = "sidguesser";
+    # the kali patch release contains required build patches
+    rev = "kali/${finalAttrs.version}-1kali2";
+    hash = "sha256-8rLLXtgckU9fzBjW/h0BqpoiK+9ix4fLx251IhxHCnQ=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  # applying kalilinux build patches
+  prePatch = ''
+    for p in debian/patches/*.patch;do
+      patch -p1 < "$p"
+    done
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 sidguess $out/bin/sidguess
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Guesses SIDs/instances against an Oracle database according to a predefined dictionary file";
+    homepage = "https://www.kali.org/tools/sidguesser/";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ makefu ];
+    mainProgram = "sidguess";
+  };
+})


### PR DESCRIPTION
add versionCheck
in contribution to #81418


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] versionCheck
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
