### PR TITLE
adlplug: fix cmake 4 compatibility

### DIFF
--- a/pkgs/by-name/ad/adlplug/cmake-v4.patch
+++ b/pkgs/by-name/ad/adlplug/cmake-v4.patch
@@ -1,0 +1,19 @@
+From 17228e7435f0c3e4244fb8853835538807ca7505 Mon Sep 17 00:00:00 2001
+From: SkohTV <contact@skoh.dev>
+Date: Thu, 9 Oct 2025 15:51:07 -0400
+Subject: [PATCH] Increase `cmake_minimum_required`: 3.3 -> 3.10 cmake 4.0
+ dropped the support for cmake < 3.5
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1c26f9a..ca8e4c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION "3.3")
++cmake_minimum_required(VERSION 3.3...3.10)
+ cmake_policy(SET CMP0063 NEW)
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/pkgs/by-name/ad/adlplug/package.nix
+++ b/pkgs/by-name/ad/adlplug/package.nix
@@ -52,6 +52,19 @@ stdenv.mkDerivation {
     (lib.cmakeBool "ADLplug_Jack" withJack)
   ];
 
+  # See https://github.com/NixOS/nixpkgs/issues/445447
+  postPatch = ''
+    substituteInPlace thirdparty/{libADLMIDI,libOPNMIDI}/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required (VERSION 3.2)' \
+      'cmake_minimum_required (VERSION 3.10)'
+  '';
+
+  patches = [
+    # fix for CMake v4
+    # https://github.com/jpcima/ADLplug/pull/100
+    ./cmake-v4.patch
+  ];
+
   NIX_LDFLAGS = toString (
     lib.optionals stdenv.hostPlatform.isDarwin [
       # Framework that JUCE needs which don't get linked properly


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tracking issue https://github.com/NixOS/nixpkgs/issues/445447
Github upstream hasn't had an update in 4 years, so using postPatch
There were 3 different `CMakeLists.txt` to patch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
