### PR TITLE
lib.attrsets: remove deprecated names

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -303,6 +303,12 @@
 
 - `lib.mapAttrsFlatten` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.mapAttrsToList` instead.
 
+- `lib.attrsets.cartesianProductOfSets` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.cartesianProduct` instead.
+
+- `lib.attrsets.zip` has been removed, following its deprecation in 2013. Use `lib.attrsets.zipAttrsWith` instead.
+
+- `lib.attrsets.zipWithNames` has been removed, following its deprecation in 2009. Use `lib.attrsets.zipAttrsWithNames` instead.
+
 - `lib.options.mkPackageOptionMD` has been removed, following its deprecation in NixOS 24.11. Use `lib.options.mkPackageOption` instead.
 
 - The `buildPythonPackage` and `buildPythonApplication` functions now require

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -6,12 +6,7 @@
 let
   inherit (builtins) head length typeOf;
   inherit (lib.asserts) assertMsg;
-  inherit (lib.trivial)
-    oldestSupportedReleaseIsAtLeast
-    mergeAttrs
-    warn
-    warnIf
-    ;
+  inherit (lib.trivial) oldestSupportedReleaseIsAtLeast mergeAttrs;
   inherit (lib.strings)
     concatStringsSep
     concatMapStringsSep
@@ -2234,16 +2229,4 @@ rec {
       ) intersection;
     in
     (x // y) // mask;
-
-  # DEPRECATED
-  zipWithNames = warn "lib.zipWithNames is a deprecated alias of lib.zipAttrsWithNames." zipAttrsWithNames;
-
-  # DEPRECATED
-  zip = warn "lib.zip is a deprecated alias of lib.zipAttrsWith." zipAttrsWith;
-
-  # DEPRECATED
-  cartesianProductOfSets =
-    warnIf (oldestSupportedReleaseIsAtLeast 2405)
-      "lib.cartesianProductOfSets is a deprecated alias of lib.cartesianProduct."
-      cartesianProduct;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -232,12 +232,9 @@ let
         getInclude
         getMan
         chooseDevOutputs
-        zipWithNames
-        zip
         recurseIntoAttrs
         dontRecurseIntoAttrs
         cartesianProduct
-        cartesianProductOfSets
         mapCartesianProduct
         updateManyAttrsByPath
         listToAttrs


### PR DESCRIPTION
These have been deprecated for long enough.

- `lib.attrsets.cartesianProductOfSets` was deprecated in 228621e42dc43 (Apr 15, 2024)
- `lib.attrsets.zip` was deprecated in fcbc4fe9ffe55 (2013!)
- `lib.attrsets.zipWithNames` was deprecated in 00127bef3f2d7 (2009!)

The time has come.

I didn't add a release note, but can if needed.

## Things done

- [x] Ran `nix-build lib/tests/release.nix`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md