### PR TITLE
lib.filesystem: remove Nix 2.14 shim

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -56,25 +56,7 @@ in
 
     :::
   */
-  pathType =
-    builtins.readFileType or
-    # Nix <2.14 compatibility shim
-    (
-      path:
-      if
-        !pathExists path
-      # Fail irrecoverably to mimic the historic behavior of this function and
-      # the new builtins.readFileType
-      then
-        abort "lib.filesystem.pathType: Path ${toString path} does not exist."
-      # The filesystem root is the only path where `dirOf / == /` and
-      # `baseNameOf /` is not valid. We can detect this and directly return
-      # "directory", since we know the filesystem root can't be anything else.
-      else if dirOf path == path then
-        "directory"
-      else
-        (readDir (dirOf path)).${baseNameOf path}
-    );
+  pathType = builtins.readFileType;
 
   /**
     Whether a path exists and is a directory.


### PR DESCRIPTION
It was added in fcaa2b1097e46. Lix is based off of 2.18, and the minimum version for Nixpkgs has long since incorporated this builtin.

## Things done

- [x] Ran `nix-build lib/tests/release.nix`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md