### PR TITLE
lib: remove mapAttrsFlatten after a year

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -301,6 +301,8 @@
 - `reaction` has been updated to version 2, which includes some breaking changes.
   For more information, [check the release article](https://blog.ppom.me/en-reaction-v2).
 
+- `lib.mapAttrsFlatten` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.mapAttrsToList` instead.
+
 - `lib.options.mkPackageOptionMD` has been removed, following its deprecation in NixOS 24.11. Use `lib.options.mkPackageOption` instead.
 
 - The `buildPythonPackage` and `buildPythonApplication` functions now require

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -552,7 +552,6 @@ let
         modifySumArgs
         innerClosePropagation
         closePropagation
-        mapAttrsFlatten
         nvs
         setAttr
         setAttrMerge

--- a/lib/deprecated/misc.nix
+++ b/lib/deprecated/misc.nix
@@ -29,10 +29,7 @@ let
     nameValuePair
     tail
     toList
-    warn
     ;
-
-  inherit (lib.attrsets) removeAttrs mapAttrsToList;
 
   # returns default if env var is not set
   maybeEnv =
@@ -278,9 +275,6 @@ let
 
   closePropagation = if builtins ? genericClosure then closePropagationFast else closePropagationSlow;
 
-  # calls a function (f attr value ) for each record item. returns a list
-  mapAttrsFlatten = warn "lib.misc.mapAttrsFlatten is deprecated, please use lib.attrsets.mapAttrsToList instead." mapAttrsToList;
-
   # attribute set containing one attribute
   nvs = name: value: listToAttrs [ (nameValuePair name value) ];
   # adds / replaces an attribute of an attribute set
@@ -470,7 +464,6 @@ in
     innerClosePropagation
     innerModifySumArgs
     lazyGenericClosure
-    mapAttrsFlatten
     maybeAttr
     maybeAttrNullable
     maybeEnv


### PR DESCRIPTION
It was deprecated in b9c51260d0620ffb0ef59d09b85d1f9d7b979b8c (July 2024).

I didn't add a release note, but I could.

## Things done

- [x] Ran `nix-build lib/tests/release.nix`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md