### PR TITLE
opentoonz: force CMake compatibility

### DIFF
--- a/pkgs/by-name/op/opentoonz/package.nix
+++ b/pkgs/by-name/op/opentoonz/package.nix
@@ -24,13 +24,13 @@
 }:
 let
   libtiff-ver = "4.0.3"; # The version in thirdparty/tiff-*
-  opentoonz-ver = "1.7.1";
+  opentoonz-ver = "1.7.1.1";
 
   src = fetchFromGitHub {
     owner = "opentoonz";
     repo = "opentoonz";
     rev = "v${opentoonz-ver}";
-    hash = "sha256-5iXOvh4QTv+G0fjEHU62u7QCee+jbvKhK0+fQXbdJis=";
+    hash = "sha256-tyRZoOBW2wJgNc0+J/LeQgOJUtQATkyA6KWLKkztujU=";
   };
 
   opentoonz-opencv = opencv.override {

--- a/pkgs/by-name/op/opentoonz/package.nix
+++ b/pkgs/by-name/op/opentoonz/package.nix
@@ -2,6 +2,7 @@
   boost,
   cmake,
   fetchFromGitHub,
+  fetchpatch2,
   libglut,
   freetype,
   glew,
@@ -125,6 +126,17 @@ stdenv.mkDerivation {
   ];
 
   postUnpack = "sourceRoot=$sourceRoot/toonz";
+
+  patches = [
+    # CMake compatibility hotfix.
+    # Please remove after opentoonz-ver > 1.7.1.1
+    (fetchpatch2 {
+      url = "https://github.com/opentoonz/opentoonz/compare/v1.7.1.1...b56fc841ed94e46fdc5a478e5c135d5404800c9d.patch?full_index=1";
+      hash = "sha256-Wwp6gBYxEZ8t2c0v1b0iVkY8kuyRPCv/KYEVcd9CQwM=";
+      includes = [ "sources/CMakeLists.txt" ];
+      stripLen = 1;
+    })
+  ];
 
   cmakeDir = "../sources";
   cmakeFlags = [


### PR DESCRIPTION
Fixes #450378

Upstream is working on bumping the CMake version, but currently introduces build failures.
[opentoonz/opentoonz/pull/6063](https://github.com/opentoonz/opentoonz/pull/6063)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
