### PR TITLE
ruby.withPackages: set mainProgram

### DIFF
--- a/pkgs/development/ruby-modules/with-packages/default.nix
+++ b/pkgs/development/ruby-modules/with-packages/default.nix
@@ -96,6 +96,8 @@ let
         inherit wrappedRuby;
         gems = selected;
       };
+
+      meta.mainProgram = "ruby";
     };
 
 in


### PR DESCRIPTION
While looking at https://github.com/NixOS/nixpkgs/pull/450234, i noticed that `ruby.withPackages` does not have a mainProgram set, making `lib.getExe rb-env` emit a warning:
```
nix-repl> rb-env = ruby.withPackages (ps: with ps; [ http json jwt ])

nix-repl> lib.getExe rb-env
evaluation warning: getExe: Package "ruby-3.3.8-with-packages" does not have the
 meta.mainProgram attribute. We'll assume that the main program has the same name
 for now, but this behavior is deprecated, because it leads to surprising errors
 when the assumption does not hold. If the package has a main program, please set
 `meta.mainProgram` in its definition to make this warning go away. Otherwise, if
 the package does not have a main program, or if you don't control its definition,
 use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
"/nix/store/95jyg1sw02y6qxsj54yb5lyj9s76d4xj-ruby-3.3.8-with-packages/bin/ruby"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
