### PR TITLE
ffmpeg: apply lcevcdec compat patch to 7.1

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -508,16 +508,18 @@ stdenv.mkDerivation (
       ++ optionals (lib.versionAtLeast version "7.1" && lib.versionOlder version "7.1.1") [
         ./fix-fate-ffmpeg-spec-disposition-7.1.patch
       ]
+      ++ optionals (lib.versionAtLeast version "7.1") [
+        (fetchpatch2 {
+          name = "lcevcdec-4.0.0-compat.patch";
+          url = "https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/fa23202cc7baab899894e8d22d82851a84967848.patch";
+          hash = "sha256-Ixkf1xzuDGk5t8J/apXKtghY0X9cfqSj/q987zrUuLQ=";
+        })
+      ]
       ++ optionals (lib.versionAtLeast version "7.1.1") [
         # Expose a private API for Chromium / Qt WebEngine.
         (fetchpatch2 {
           url = "https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg/-/raw/a02c1a15706ea832c0d52a4d66be8fb29499801a/add-av_stream_get_first_dts-for-chromium.patch";
           hash = "sha256-DbH6ieJwDwTjKOdQ04xvRcSLeeLP2Z2qEmqeo8HsPr4=";
-        })
-        (fetchpatch2 {
-          name = "lcevcdec-4.0.0-compat.patch";
-          url = "https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/fa23202cc7baab899894e8d22d82851a84967848.patch";
-          hash = "sha256-Ixkf1xzuDGk5t8J/apXKtghY0X9cfqSj/q987zrUuLQ=";
         })
       ]
       ++ optionals (lib.versionOlder version "7.2") [


### PR DESCRIPTION
## Summary
- apply the upstream LCEVC decoder compatibility patch to the 7.1 ffmpeg build so handbrake can build again

## Testing
- nix build .#handbrake

Fixes #450339