### PR TITLE
ci/pinned: update

### DIFF
--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "e57b3b16ad8758fd681511a078f35c416a8cc939",
-      "url": "https://github.com/NixOS/nixpkgs/archive/e57b3b16ad8758fd681511a078f35c416a8cc939.tar.gz",
-      "hash": "04zp6jjd4xr6jfps84p8yh5ym5962mii4825fn75lqk14sz4rq56"
+      "revision": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+      "url": "https://github.com/NixOS/nixpkgs/archive/d5faa84122bc0a1fd5d378492efce4e289f8eac1.tar.gz",
+      "hash": "0r2pkx7m1pb0fzfhb74jkr8y5qhs2b93sak5bd5rabvbm2zn36zs"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
-      "url": "https://github.com/numtide/treefmt-nix/archive/5eda4ee8121f97b218f7cc73f5172098d458f1d1.tar.gz",
-      "hash": "1vqns9hjhmbnhdq2xvcmdxng11jrmcn9lpk2ncfh1f969z9lj8y9"
+      "revision": "f56b1934f5f8fcab8deb5d38d42fd692632b47c2",
+      "url": "https://github.com/numtide/treefmt-nix/archive/f56b1934f5f8fcab8deb5d38d42fd692632b47c2.tar.gz",
+      "hash": "1klcfmqb4q4vvy9kdm5i9ddl26rhlyhf1mrd5aw1d4529bqnq5b5"
     }
   },
   "version": 5

--- a/nixos/tests/k3s/auto-deploy-charts.nix
+++ b/nixos/tests/k3s/auto-deploy-charts.nix
@@ -82,15 +82,16 @@ import ../make-test-python.nix (
             values-file = testChart // {
               # Remove unsafeDiscardStringContext workaround when Nix can convert a string to a path
               # https://github.com/NixOS/nix/issues/12407
-              values = /.
-              + builtins.unsafeDiscardStringContext (
-                builtins.toFile "k3s-test-chart-values.yaml" ''
-                  runCommand: "echo 'Hello, file!'"
-                  image:
-                    repository: test.local/test
-                    tag: local
-                ''
-              );
+              values =
+                /.
+                + builtins.unsafeDiscardStringContext (
+                  builtins.toFile "k3s-test-chart-values.yaml" ''
+                    runCommand: "echo 'Hello, file!'"
+                    image:
+                      repository: test.local/test
+                      tag: local
+                  ''
+                );
             };
             # advanced chart that should get installed in the "test" namespace with a custom
             # timeout and overridden values

--- a/pkgs/applications/science/misc/openmodelica/omlibrary/fakegit.nix
+++ b/pkgs/applications/science/misc/openmodelica/omlibrary/fakegit.nix
@@ -29,9 +29,9 @@ stdenv.mkDerivation {
 
   buildCommand = ''
     mkdir -pv $out/repos
-    ${lib.concatMapStrings (
-      r: "cp -r ${fetchgit r} $out/repos/${hashname r}\n"
-    ) (import ./src-libs.nix)}
+    ${lib.concatMapStrings (r: "cp -r ${fetchgit r} $out/repos/${hashname r}\n") (
+      import ./src-libs.nix
+    )}
 
     ${mkscript "$out/bin/checkout-git.sh" ''
       if test "$#" -ne 4; then

--- a/pkgs/by-name/te/textadept/package.nix
+++ b/pkgs/by-name/te/textadept/package.nix
@@ -36,9 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   ''
   + lib.concatStringsSep "\n" (
-    lib.mapAttrsToList (
-      name: params: "ln -s ${fetchurl params} $PWD/build/_deps/${name}"
-    ) (import ./deps.nix)
+    lib.mapAttrsToList (name: params: "ln -s ${fetchurl params} $PWD/build/_deps/${name}") (
+      import ./deps.nix
+    )
   );
 
   meta = {


### PR DESCRIPTION
This gives us [Nix 2.32](https://nix.dev/manual/nix/2.32/release-notes/rl-2.32.html) for use in CI's Eval job and [nixfmt 1.1.0](https://github.com/NixOS/nixfmt/releases/tag/v1.1.0).

From the nixpkgs-unstable channel:
https://hydra.nixos.org/build/311062898#tabs-buildinputs

Changes for treefmt-nix:
https://github.com/numtide/treefmt-nix/compare/5eda4ee8121f97b218f7cc73f5172098d458f1d1...f56b1934f5f8fcab8deb5d38d42fd692632b47c2

---

It does make eval slightly slower though, but it should be possible to mitigate by cranking up the `chunkSize` a lot higher.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
