### PR TITLE
nixos/searx: fix config file locations, modernize and harden service

### DIFF
--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -381,11 +381,54 @@ in
         after = [
           "searx-init.service"
           "network.target"
-        ];
+        ]
+        ++ lib.optionals cfg.redisCreateLocally [ "redis-searx.service" ];
         serviceConfig = {
           User = "searx";
+          DynamicUser = true;
           Group = "searx";
           ExecStart = lib.getExe cfg.package;
+
+          CacheDirectory = "searx";
+          CacheDirectoryMode = "0700";
+
+          ReadOnlyPaths = [ cfg.settingsPath ];
+          ReadWritePaths = lib.optional cfg.redisCreateLocally config.services.redis.servers.searx.unixSocket;
+
+          CapabilityBoundingSet = null;
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          PrivateDevices = true;
+          PrivateMounts = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          PrivateIPC = true;
+          RemoveIPC = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          SystemCallErrorNumber = "EPERM";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged @resources"
+          ];
+          UMask = "0077";
         }
         // optionalAttrs (cfg.environmentFile != null) {
           EnvironmentFile = cfg.environmentFile;

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -5,10 +5,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
+  inherit (lib)
+    literalExpression
+    mkDefault
+    mkIf
+    mkOption
+    mkPackageOption
+    mkRenamedOptionModule
+    optionalAttrs
+    types
+    ;
+
   runDir = "/run/searx";
 
   cfg = config.services.searx;
@@ -416,7 +424,7 @@ in
     networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.settings.server.port ]; };
   };
 
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     SuperSandro2000
     _999eagle
   ];

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -142,19 +142,19 @@ in
         '';
       };
 
-      settingsFile = mkOption {
+      settingsPath = mkOption {
         type = types.path;
-        default = "${runDir}/settings.yml";
+        default = runDir;
         description = ''
-          The path of the Searx server settings.yml file.
-          If no file is specified, a default file is used (default config file has debug mode enabled).
+          The path of the SearXNG settings directory or the settings.yml file.
+          If no path is specified, a default one is used (default config file has debug mode enabled).
 
           ::: {.note}
           Setting this options overrides [](#opt-services.searx.settings).
           :::
 
           ::: {.warning}
-          This file, along with any secret key it contains, will be copied into the world-readable Nix store.
+          This path, along with any secret keys it contains, will be copied into the world-readable Nix store.
           :::
         '';
       };
@@ -263,6 +263,7 @@ in
   };
 
   imports = [
+    (mkRenamedOptionModule [ "services" "searx" "settingsFile" ] [ "services" "searx" "settingsPath" ])
     (mkRenamedOptionModule [ "services" "searx" "configFile" ] [ "services" "searx" "settingsFile" ])
     (mkRenamedOptionModule [ "services" "searx" "runInUwsgi" ] [ "services" "searx" "configureUwsgi" ])
   ];
@@ -339,7 +340,7 @@ in
           enable-threads = true;
           module = "searx.webapp";
           env = [
-            "SEARXNG_SETTINGS_PATH=${cfg.settingsFile}"
+            "SEARXNG_SETTINGS_PATH=${cfg.settingsPath}"
           ];
           buffer-size = 32768;
           pythonPackages = _: [ cfg.package ];
@@ -390,7 +391,7 @@ in
           EnvironmentFile = cfg.environmentFile;
         };
         environment = {
-          SEARXNG_SETTINGS_PATH = cfg.settingsFile;
+          SEARXNG_SETTINGS_PATH = cfg.settingsPath;
         };
       };
 
@@ -399,7 +400,7 @@ in
         after = [ "searx-init.service" ];
         restartTriggers = [
           cfg.package
-          cfg.settingsFile
+          cfg.settingsPath
         ]
         ++ lib.optional (cfg.environmentFile != null) cfg.environmentFile;
       };

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -31,10 +31,22 @@ let
   generateConfig = ''
     cd ${runDir}
 
-    # write NixOS settings as JSON
+    # write NixOS settings
     (
       umask 077
-      ${pkgs.envsubst}/bin/envsubst < ${settingsFile} > settings.yml
+      ${lib.getExe pkgs.envsubst} < ${settingsFile} > settings.yml
+      ${
+        if (cfg.faviconsSettings != { }) then
+          "ln -sf ${faviconsSettingsFile} favicons.toml"
+        else
+          "rm -f favicons.toml"
+      }
+      ${
+        if (cfg.limiterSettings != { }) then
+          "ln -sf ${limiterSettingsFile} limiter.toml"
+        else
+          "rm -f limiter.toml"
+      }
     )
   '';
 in
@@ -263,17 +275,7 @@ in
       }
     ];
 
-    environment = {
-      etc = {
-        "searxng/favicons.toml" = lib.mkIf (cfg.faviconsSettings != { }) {
-          source = faviconsSettingsFile;
-        };
-        "searxng/limiter.toml" = lib.mkIf (cfg.limiterSettings != { }) {
-          source = limiterSettingsFile;
-        };
-      };
-      systemPackages = [ cfg.package ];
-    };
+    environment.systemPackages = [ cfg.package ];
 
     services = {
       nginx = lib.mkIf cfg.configureNginx {

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -20,13 +20,13 @@ let
   runDir = "/run/searx";
 
   cfg = config.services.searx;
+  yamlFormat = pkgs.formats.yaml { };
+  tomlFormat = pkgs.formats.toml { };
 
-  settingsFile = pkgs.writeText "settings.yml" (
-    builtins.toJSON (removeAttrs cfg.settings [ "redis" ])
-  );
+  settingsFile = yamlFormat.generate "settings.yml" (builtins.removeAttrs cfg.settings [ "redis" ]);
 
-  faviconsSettingsFile = (pkgs.formats.toml { }).generate "favicons.toml" cfg.faviconsSettings;
-  limiterSettingsFile = (pkgs.formats.toml { }).generate "limiter.toml" cfg.limiterSettings;
+  faviconsSettingsFile = tomlFormat.generate "favicons.toml" cfg.faviconsSettings;
+  limiterSettingsFile = tomlFormat.generate "limiter.toml" cfg.limiterSettings;
 
   generateConfig = ''
     cd ${runDir}
@@ -37,20 +37,6 @@ let
       ${pkgs.envsubst}/bin/envsubst < ${settingsFile} > settings.yml
     )
   '';
-
-  settingType =
-    with types;
-    (oneOf [
-      bool
-      int
-      float
-      str
-      (listOf settingType)
-      (attrsOf settingType)
-    ])
-    // {
-      description = "JSON value";
-    };
 in
 {
   options = {
@@ -115,7 +101,7 @@ in
               lib.warn "Obsolete option `services.searx.settings.redis' is used. It was renamed to `services.searx.settings.valkey'" config.redis
             );
 
-            freeformType = settingType;
+            freeformType = yamlFormat.type;
           }
         );
         default = { };
@@ -162,7 +148,7 @@ in
       };
 
       faviconsSettings = mkOption {
-        type = types.attrsOf settingType;
+        type = types.attrsOf tomlFormat.type;
         default = { };
         example = literalExpression ''
           {
@@ -190,7 +176,7 @@ in
       };
 
       limiterSettings = mkOption {
-        type = types.attrsOf settingType;
+        type = types.attrsOf tomlFormat.type;
         default = { };
         example = literalExpression ''
           {

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -180,14 +180,19 @@ in
         default = { };
         example = literalExpression ''
           {
-            real_ip = {
-              x_for = 1;
+            botdetection = {
               ipv4_prefix = 32;
               ipv6_prefix = 56;
-            }
-            botdetection.ip_lists.block_ip = [
-              # "93.184.216.34" # example.org
-            ];
+
+              trusted_proxies = [
+                "127.0.0.0/8"
+                "::1"
+              ];
+
+              ip_lists.block_ip = [
+                # "93.184.216.34" # example.org
+              ];
+            };
           }
         '';
         description = ''


### PR DESCRIPTION
- Remove usage of `with lib;`.
- Fix config file not found errors by moving all config files to the same directory and pointing `SEARXNG_SETTINGS_PATH` to the directory instead of the main config file.
- Apply strict systemd service hardening options.
- Rename `sevices.searx.settingsFile` to `sevices.searx.settingsPath` to match what the option actually does.
- Update outdated example limiter config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
