### PR TITLE
nautilus-open-any-terminal: 0.6.3 -> 0.7.0

### DIFF
--- a/pkgs/by-name/na/nautilus-open-any-terminal/hardcode-gsettings.patch
+++ b/pkgs/by-name/na/nautilus-open-any-terminal/hardcode-gsettings.patch
@@ -1,45 +1,67 @@
-diff --git a/nautilus_open_any_terminal/nautilus_open_any_terminal.py b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
-index 05b6514..b5541dc 100644
---- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
-+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
-@@ -413,9 +413,10 @@ if API_VERSION in ("3.0", "2.0"):
-         """Provide keyboard shortcuts for opening terminals in Nautilus."""
-
-         def __init__(self):
+diff --git i/nautilus_open_any_terminal/nautilus_open_any_terminal.py w/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+index 559c923..45585d6 100644
+--- i/nautilus_open_any_terminal/nautilus_open_any_terminal.py
++++ w/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+@@ -434,9 +434,12 @@ if API_VERSION == "4.0":
+             super().__init__()
+             self.previous_cwd = expanduser("~")
+ 
 -            gsettings_source = Gio.SettingsSchemaSource.get_default()
 -            if gsettings_source.lookup(GSETTINGS_PATH, True):
 -                self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
-+            gsettings_source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
++            gsettings_source = Gio.SettingsSchemaSource.new_from_directory(
++                "@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True
++            )
 +            if True:
 +                _schema = gsettings_source.lookup(GSETTINGS_PATH, False)
-+                self._gsettings = Gio.Settings.new_full(_schema, None, None);
++                self._gsettings = Gio.Settings.new_full(_schema, None, None)
+                 self._setup_keybindings()
+ 
+         def get_background_items(self, current_folder: FileManager.FileInfo):
+@@ -500,10 +503,12 @@ elif API_VERSION in ("3.0", "2.0"):
+         """Provide keyboard shortcuts for opening terminals in Nautilus/Caja."""
+ 
+         def __init__(self):
+-            super().__init__()
+-            gsettings_source = Gio.SettingsSchemaSource.get_default()
+-            if gsettings_source.lookup(GSETTINGS_PATH, True):
+-                self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
++            gsettings_source = Gio.SettingsSchemaSource.new_from_directory(
++                "@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True
++            )
++            if True:
++                _schema = gsettings_source.lookup(GSETTINGS_PATH, False)
++                self._gsettings = Gio.Settings.new_full(_schema, None, None)
                  self._gsettings.connect("changed", self._bind_shortcut)
                  self._create_accel_group()
              self._window = None
-@@ -452,9 +453,10 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
+@@ -540,10 +545,12 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
      """Provide context menu items for opening terminals in Nautilus."""
-
+ 
      def __init__(self):
+-        super().__init__()
 -        gsettings_source = Gio.SettingsSchemaSource.get_default()
 -        if gsettings_source.lookup(GSETTINGS_PATH, True):
 -            self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
-+        gsettings_source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
++        gsettings_source = Gio.SettingsSchemaSource.new_from_directory(
++            "@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True
++        )
 +        if True:
 +            _schema = gsettings_source.lookup(GSETTINGS_PATH, False)
-+            self._gsettings = Gio.Settings.new_full(_schema, None, None);
-
++            self._gsettings = Gio.Settings.new_full(_schema, None, None)
+ 
      def _get_terminal_name(self):
          if self._gsettings.get_boolean(GSETTINGS_USE_GENERIC_TERMINAL_NAME):
-@@ -512,8 +514,9 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
+@@ -603,8 +610,9 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
          )
-
-
+ 
+ 
 -source = Gio.SettingsSchemaSource.get_default()
 -if source is not None and source.lookup(GSETTINGS_PATH, True):
 -    _gsettings = Gio.Settings.new(GSETTINGS_PATH)
 +source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
 +if True:
 +    _schema = source.lookup(GSETTINGS_PATH, False)
-+    _gsettings = Gio.Settings.new_full(_schema, None, None);
++    _gsettings = Gio.Settings.new_full(_schema, None, None)
      _gsettings.connect("changed", set_terminal_args)
      set_terminal_args()

--- a/pkgs/by-name/na/nautilus-open-any-terminal/package.nix
+++ b/pkgs/by-name/na/nautilus-open-any-terminal/package.nix
@@ -16,14 +16,14 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "nautilus-open-any-terminal";
-  version = "0.6.3";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Stunkymonkey";
     repo = "nautilus-open-any-terminal";
     tag = version;
-    hash = "sha256-wL2PyEbJ94O9PY8jDBLXk0QvNpuO7Pg8yyblFBwSENA=";
+    hash = "sha256-+qBgTjVJ6gMFtkbqaF9bDYgoJYpM570Vpg+DLRBaFX0=";
   };
 
   patches = [ ./hardcode-gsettings.patch ];


### PR DESCRIPTION
https://github.com/Stunkymonkey/nautilus-open-any-terminal/releases/tag/0.7.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
