### PR TITLE
stoat-desktop: init at 1.1.12; maintainers: add v3rm1n0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26994,6 +26994,12 @@
     github = "deviant";
     githubId = 68829907;
   };
+  v3rm1n0 = {
+    name = "Niklas Choinowski";
+    email = "niklas.choinowski@proton.me";
+    github = "v3rm1n0";
+    githubId = 57269010;
+  };
   vaavaav = {
     name = "Pedro Peixoto";
     github = "vaavaav";

--- a/pkgs/by-name/st/stoat-desktop/package.nix
+++ b/pkgs/by-name/st/stoat-desktop/package.nix
@@ -1,0 +1,99 @@
+{
+  stdenvNoCC,
+  lib,
+  asar,
+  fetchurl,
+  fetchzip,
+  makeDesktopItem,
+  copyDesktopItems,
+  makeWrapper,
+  electron,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "stoat-desktop";
+  version = "1.1.12";
+
+  src = fetchzip {
+    url = "https://github.com/stoatchat/for-desktop/releases/download/v${version}/Stoat-linux-x64-${version}.zip";
+    hash = "sha256-S3uJ4ADzDgrpKVxBdEpz73Q6bqOakzk9bObaoRZopbM=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    asar
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    set -euo pipefail
+
+    mkdir -p "$out/bin" "$out/share/applications" "$out/share/stoat-desktop"
+
+    asarPath="$(find "$src" -type f -path '*/resources/app.asar' -print -quit || true)"
+    if [ -z "$asarPath" ]; then
+      echo "ERROR: could not find resources/app.asar in $src" >&2
+      exit 1
+    fi
+
+    resDir="$(dirname "$asarPath")"
+    appDir="$(dirname "$resDir")"
+
+    cp -a "$resDir" "$out/share/stoat-desktop/resources"
+    if [ -d "$appDir/locales" ]; then
+      cp -a "$appDir/locales" "$out/share/stoat-desktop/locales"
+    fi
+
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    install -m644 ${
+      fetchurl {
+        url = "https://raw.githubusercontent.com/stoatchat/assets/628eb2f8255c215148007f4227d2e0d5d1a67582/desktop/icon.svg";
+        hash = "sha256-EMDwnAtfTZqhw8hMGTbMjZUrnVkP+2HkyHlSy6pZmik=";
+      }
+    } "$out/share/icons/hicolor/scalable/apps/stoat-desktop.svg"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Stoat";
+      exec = "stoat-desktop %u";
+      icon = "stoat-desktop";
+      desktopName = "Stoat";
+      genericName = meta.description;
+      categories = [
+        "Network"
+        "Chat"
+        "InstantMessaging"
+      ];
+      startupNotify = false;
+    })
+  ];
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron "$out/bin/stoat-desktop" \
+      --add-flags "$out/share/stoat-desktop/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+  '';
+
+  meta = {
+    description = "Open source user-first chat platform";
+    homepage = "https://stoat.chat/";
+    changelog = "https://github.com/stoatchat/for-desktop/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      heyimnova
+      magistau
+      v3rm1n0
+    ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "stoat-desktop";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Revolt.chat has been rebranded to Stoat.chat, and its build process has changed accordingly.
This PR updates the package to the latest upstream release, adapts the build process to the new structure, and renames the derivation to match the new project identity.

### Changes

- Updated to Stoat Desktop v1.1.12
- Adjusted installation to reflect new Electron packaging layout
- Added myself to maintainers
- Signed over previous maintainer from the old revolt-desktop package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

Ps: My first package pls provide feedback so I can improve accordingly o7
