### PR TITLE
added nixpkg for the Brother DCP-T730DW printer.

### DIFF
--- a/pkgs/by-name/cu/cups-brother-dcpt730dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpt730dw/package.nix
@@ -1,0 +1,112 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  perl,
+  ghostscript,
+  coreutils,
+  gnugrep,
+  which,
+  file,
+  gnused,
+  dpkg,
+  makeWrapper,
+  libredirect,
+  debugLvl ? "0",
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-dcpt730dw";
+  version = "3.6.1-1";
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf106527/dcpt730dwpdrv-${version}.amd64.deb";
+    hash = "sha256-tEC2iNa+LpqaaaK/TfP1bJDVLhSYWLz944VesMoFGJA=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    LPDDIR=$out/opt/brother/Printers/dcpt730dw/lpd
+    WRAPPER=$out/opt/brother/Printers/dcpt730dw/cupswrapper/brother_lpdwrapper_dcpt730dw
+
+    ln -s $LPDDIR/${stdenv.hostPlatform.linuxArch}/* $LPDDIR/
+
+    substituteInPlace $WRAPPER \
+      --replace-fail "PRINTER =~" "PRINTER = \"dcpt730dw\"; #" \
+      --replace-fail "basedir =~" "basedir = \"$out/opt/brother/Printers/dcpt730dw/\"; #" \
+      --replace-fail "lpdconf = " "lpdconf = \$lpddir.'/'.\$LPDCONFIGEXE.\$PRINTER; #" \
+      --replace-fail "\$DEBUG=0;" "\$DEBUG=${debugLvl};"
+
+    substituteInPlace $LPDDIR/filter_dcpt730dw \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/dcpt730dw/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"dcpt730dw\"; #"
+
+    wrapProgram $WRAPPER \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
+
+    wrapProgram $LPDDIR/filter_dcpt730dw \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          ghostscript
+          gnugrep
+          gnused
+          which
+          file
+        ]
+      }
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brdcpt730dwfilter
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brprintconf_dcpt730dw
+
+    wrapProgram $LPDDIR/brprintconf_dcpt730dw \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    wrapProgram $LPDDIR/brdcpt730dwfilter \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    mkdir -p "$out/lib/cups/filter" "$out/share/cups/model"
+
+    ln -s $out/opt/brother/Printers/dcpt730dw/cupswrapper/brother_lpdwrapper_dcpt730dw \
+      $out/lib/cups/filter/brother_lpdwrapper_dcpt730dw
+
+    ln -s "$out/opt/brother/Printers/dcpt730dw/cupswrapper/brother_dcpt730dw_printer_en.ppd" \
+      "$out/share/cups/model/"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Brother DCP-T730DW printer driver";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ u2x1 ];
+    platforms = [
+      "x86_64-linux"
+    ];
+    downloadPage = "https://support.brother.com/g/b/downloadtop.aspx?c=cn_ot&lang=en&prod=dcpt730dw_cn";
+    homepage = "http://www.brother.com/";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Description of changes
This commit adds a driver to cups for the Brother DCP-T730DW printer.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ]  aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@u2x1 