### PR TITLE
within: init at 1.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8539,6 +8539,13 @@
     githubId = 63652646;
     name = "Xaver Oswald";
   };
+  examosa = {
+    email = "examosa@fastmail.com";
+    github = "examosa";
+    githubId = 23395221;
+    matrix = "@jamonith:matrix.org";
+    name = "Jules Amonith";
+  };
   exarkun = {
     email = "exarkun@twistedmatrix.com";
     github = "exarkun";

--- a/pkgs/by-name/wi/within/package.nix
+++ b/pkgs/by-name/wi/within/package.nix
@@ -1,0 +1,62 @@
+{
+  fetchFromCodeberg,
+  lib,
+  stdenv,
+  versionCheckHook,
+  nix-update-script,
+  runCommand,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "within";
+  version = "1.1.4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "sjmulder";
+    repo = "within";
+    tag = finalAttrs.version;
+    hash = "sha256-UyOgEe07K1LW5IbB7ngxelp+9Njq/NPPkWw3sxAQyVY=";
+  };
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  preVersionCheck = ''
+    versionCheckProgram=$(type -P echo)
+    versionCheckProgramArg=$(head -n 1 CHANGELOG.md)
+  '';
+
+  dontVersionCheck = lib.hasInfix "unstable" finalAttrs.version;
+
+  installFlags = [ "PREFIX:=$(out)" ];
+
+  passthru = {
+    tests.within =
+      runCommand "within-test"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          mkdir $out
+          result=$(within $PWD $out - pwd)
+          expected=$(printf '%s\n' "$PWD: $PWD" "$out: $out")
+          test "$result" = "$expected"
+        '';
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://codeberg.org/sjmulder/within";
+    description = "Run a command in other directories";
+    changelog = "https://codeberg.org/sjmulder/within/src/tag/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.examosa ];
+    platforms = lib.platforms.all;
+    mainProgram = "within";
+  };
+})


### PR DESCRIPTION
I came across this from [pkgsrc](https://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/sysutils/within/index.html) and thought it was neat. It allows one to run commands in other directories (optionally in parallel).
https://codeberg.org/sjmulder/within

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
