### PR TITLE
maintainers: drop linquize

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14737,12 +14737,6 @@
     matrix = "@link2xt:matrix.org";
     name = "link2xt";
   };
-  linquize = {
-    email = "linquize@yahoo.com.hk";
-    github = "linquize";
-    githubId = 791115;
-    name = "Linquize";
-  };
   linsui = {
     email = "linsui555@gmail.com";
     github = "linsui";

--- a/pkgs/by-name/cc/cccc/package.nix
+++ b/pkgs/by-name/cc/cccc/package.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation rec {
     homepage = "https://cccc.sourceforge.net/";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.linquize ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/codeblocks/package.nix
+++ b/pkgs/by-name/co/codeblocks/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    maintainers = [ lib.maintainers.linquize ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     description = "Open source, cross platform, free C, C++ and Fortran IDE";
     longDescription = ''

--- a/pkgs/by-name/gb/gbdfed/package.nix
+++ b/pkgs/by-name/gb/gbdfed/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://sofia.nmsu.edu/~mleisher/Software/gbdfed/";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.linquize ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "gbdfed";
   };

--- a/pkgs/by-name/gf/gflags/package.nix
+++ b/pkgs/by-name/gf/gflags/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://gflags.github.io/gflags/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.linquize ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/li/libcangjie/package.nix
+++ b/pkgs/by-name/li/libcangjie/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     description = "C library implementing the Cangjie input method";
     homepage = "https://gitlab.freedesktop.org/cangjie/libcangjie";
     license = lib.licenses.lgpl3Plus;
-    maintainers = [ lib.maintainers.linquize ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "libcangjie-cli";
   };

--- a/pkgs/development/python-modules/pycangjie/default.nix
+++ b/pkgs/development/python-modules/pycangjie/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     description = "Python wrapper to libcangjie";
     homepage = "https://cangjians.github.io/projects/pycangjie/";
     license = licenses.lgpl3Plus;
-    maintainers = [ maintainers.linquize ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hasn't been active in Nixpkgs since 2016 ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3Alinquize), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Alinquize)), which is much longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs.

@linquize, you have 1 (one) week (Oct 18 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
