### PR TITLE
feyngame: fix source reproducibility

### DIFF
--- a/pkgs/by-name/fe/feyngame/package.nix
+++ b/pkgs/by-name/fe/feyngame/package.nix
@@ -18,12 +18,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     repo = "FeynGame";
     tag = finalAttrs.version;
     leaveDotGit = true; # the build script uses git log to find last commit date
-    hash = "sha256-PhdspIr0Lnuv4e8bjMEAXnVDK1YVlrI5XI+rP9qXNQ0=";
+    hash = "sha256-ySBEka978jRWRRI6WpKNEfwsB3kZMhOrcotbstTAhzQ=";
+    postFetch = ''
+      git --git-dir=$out/.git log -1 --date=format:"%d.%m.%Y %H:%M:%S" --format="%ad" > $out/.gitdate
+      rm -rf $out/.git
+    '';
   };
 
   postPatch = ''
     patchShebangs buildfile
     substituteInPlace buildfile \
+      --replace-fail 'git log -1 --date=format:"%d.%m.%Y %H:%M:%S" --format="%ad"' 'cat .gitdate' \
       --replace-fail '$Prefix/bin/feyngame %U' 'feyngame %U' \
       --replace-fail '$Prefix/share/pixmaps/fglogo.png' 'fglogo'
   '';
@@ -40,7 +45,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    git
     jdk
     desktop-file-utils
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Not sure why the source hash changed since I initially packaged it. It should be better now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
