### PR TITLE
maintainers: drop cmfwyp

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4907,12 +4907,6 @@
     githubId = 640797;
     name = "Roger Qiu";
   };
-  cmfwyp = {
-    email = "cmfwyp@riseup.net";
-    github = "cmfwyp";
-    githubId = 20808761;
-    name = "cmfwyp";
-  };
   cmm = {
     email = "repo@cmm.kakpryg.net";
     github = "cmm";

--- a/pkgs/by-name/ca/cabin/package.nix
+++ b/pkgs/by-name/ca/cabin/package.nix
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "http://www.impallari.com/cabin";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/do/dosis/package.nix
+++ b/pkgs/by-name/do/dosis/package.nix
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "http://www.impallari.com/dosis";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/en/encode-sans/package.nix
+++ b/pkgs/by-name/en/encode-sans/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://github.com/impallari/Encode-Sans";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/li/libre-baskerville/package.nix
+++ b/pkgs/by-name/li/libre-baskerville/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "http://www.impallari.com/projects/overview/libre-baskerville";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/li/libre-bodoni/package.nix
+++ b/pkgs/by-name/li/libre-bodoni/package.nix
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://github.com/impallari/Libre-Bodoni";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/li/libre-caslon/package.nix
+++ b/pkgs/by-name/li/libre-caslon/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     description = "Caslon fonts based on hand-lettered American Caslons of 1960s";
     homepage = "http://www.impallari.com/librecaslon";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/li/libre-franklin/package.nix
+++ b/pkgs/by-name/li/libre-franklin/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic";
     homepage = "https://github.com/impallari/Libre-Franklin";
     license = licenses.ofl;
-    maintainers = with maintainers; [ cmfwyp ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Hasn't been active in Nixpkgs since 2016 ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3Acmfwyp), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Acmfwyp)), which is longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs.

@cmfwyp, you have 1 (one) week (Oct 18 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
