### PR TITLE
maintainers: drop vklquevs

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27334,12 +27334,6 @@
     githubId = 1476338;
     name = "Viktor Illmer";
   };
-  vklquevs = {
-    email = "vklquevs@gmail.com";
-    github = "vklquevs";
-    githubId = 1771234;
-    name = "vklquevs";
-  };
   vlaci = {
     email = "laszlo.vasko@outlook.com";
     github = "vlaci";

--- a/pkgs/by-name/mt/mtpaint/package.nix
+++ b/pkgs/by-name/mt/mtpaint/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
     homepage = "https://mtpaint.sourceforge.net/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.vklquevs ];
+    maintainers = [ ];
     mainProgram = "mtpaint";
   };
 }


### PR DESCRIPTION
Hasn't been active in Nixpkgs since 2017 ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3Avklquevs), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Avklquevs)), which is longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs. They have never updated the only package they maintain, [mtpaint](https://github.com/NixOS/nixpkgs/commits/571c71e6f73af34a229414f51585738894211408/pkgs/applications/graphics/mtpaint/default.nix?browsing_rename_history=true&new_path=pkgs/by-name/mt/mtpaint/package.nix&original_branch=master)

@vklquevs, you have 1 (one) week (Oct 18 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
