### PR TITLE
bpftrace: 0.23.5 -> 0.24.1

### DIFF
--- a/nixos/tests/bpf.nix
+++ b/nixos/tests/bpf.nix
@@ -21,7 +21,12 @@
     # simple BEGIN probe (user probe on bpftrace itself)
     print(machine.succeed("bpftrace -e 'BEGIN { print(\"ok\\n\"); exit(); }'"))
     # tracepoint
-    print(machine.succeed("bpftrace -e 'tracepoint:syscalls:sys_enter_* { print(probe); exit() }'"))
+    # workaround: this needs more than the default of 1k FD to attach ~350 probes, bump fd limit
+    # see https://github.com/bpftrace/bpftrace/issues/2110
+    print(machine.succeed("""
+        ulimit -n 2048
+        bpftrace -e 'tracepoint:syscalls:sys_enter_* { print(probe); exit() }'
+    """))
     # kprobe
     print(machine.succeed("bpftrace -e 'kprobe:schedule { print(probe); exit() }'"))
     # BTF


### PR DESCRIPTION
This fixes build error due to updaded llvm.
 
bpftrace 0.24.1 had a couple of regressions, so backport fix and
temporarily raise ulimit in test.
A better solution for ulimit will probably make it in 0.24.2 but
that is likely harmless enough in practice so go ahead as is.

Notes:
- add new xxd build dep to fix build
- INSTALL_TOOL_DOCS was removed, .txt files are now comments in scripts
  themselves
- USE_SYSTEM_LIBBPF is optional right now but needed on master, just set
  it as there is no harm and next auto-update will be less work

Link: https://github.com/bpftrace/bpftrace/issues/4713 [1]
Fixes: #450444


(Note I'm also touching the tests a bit for aarch64 in #446368 -- ideally I'd like that one in before we upgrade to v0.24.x with the fix... Reviews appreciated.)


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
