### PR TITLE
maintainers: drop schneefux

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23108,12 +23108,6 @@
     github = "schmittlauch";
     githubId = 1479555;
   };
-  schneefux = {
-    email = "schneefux+nixos_pkg@schneefux.xyz";
-    github = "schneefux";
-    githubId = 15379000;
-    name = "schneefux";
-  };
   schnow265 = {
     email = "thesnowbox@icloud.com";
     github = "schnow265";

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -75,7 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Advanced IRC bouncer";
     homepage = "https://wiki.znc.in/ZNC";
     maintainers = with lib.maintainers; [
-      schneefux
       lnl7
     ];
     license = lib.licenses.asl20;

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -238,7 +238,6 @@ in
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [
         offline
-        schneefux
       ];
     };
   };

--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -81,7 +81,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "hugo";
     maintainers = with lib.maintainers; [
-      schneefux
       Br1ght0ne
       Frostman
     ];

--- a/pkgs/by-name/me/metabase/package.nix
+++ b/pkgs/by-name/me/metabase/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.agpl3Only;
     platforms = platforms.all;
     maintainers = with maintainers; [
-      schneefux
       thoughtpolice
       mmahut
     ];

--- a/pkgs/by-name/pf/pflogsumm/package.nix
+++ b/pkgs/by-name/pf/pflogsumm/package.nix
@@ -34,7 +34,7 @@ perlPackages.buildPerlPackage rec {
 
   meta = {
     homepage = "http://jimsun.linxnet.com/postfix_contrib.html";
-    maintainers = with lib.maintainers; [ schneefux ];
+    maintainers = [ ];
     description = "Postfix activity overview";
     mainProgram = "pflogsumm";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/sh/shaarli/package.nix
+++ b/pkgs/by-name/sh/shaarli/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     description = "Personal, minimalist, super-fast, database free, bookmarking service";
     license = licenses.gpl3Plus;
     homepage = "https://github.com/shaarli/Shaarli";
-    maintainers = with maintainers; [ schneefux ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/uw/uwsgi/package.nix
+++ b/pkgs/by-name/uw/uwsgi/package.nix
@@ -185,7 +185,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://uwsgi-docs.readthedocs.org/en/latest/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      schneefux
       globin
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/wa/wallabag/package.nix
+++ b/pkgs/by-name/wa/wallabag/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     homepage = "https://wallabag.org";
     changelog = "https://github.com/wallabag/wallabag/releases/tag/${version}";
-    maintainers = with lib.maintainers; [ schneefux ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -120,7 +120,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       antono
       relrod
-      schneefux
     ];
   };
 }


### PR DESCRIPTION
Hasn't been active in Nixpkgs since [2020](https://github.com/NixOS/nixpkgs/pull/105224) ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3Aschneefux), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aschneefux)), which is longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs.


@schneefux, you have 1 (one) week (Oct 18 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.
## Things done

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
