### PR TITLE
external-editor-revived: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17501,6 +17501,12 @@
     githubId = 14153763;
     name = "modderme123";
   };
+  mofrim = {
+    email = "mofrim@posteo.de";
+    github = "mofrim";
+    githubId = 46672819;
+    name = "mofrim";
+  };
   mog = {
     email = "mog-lists@rldn.net";
     github = "mogorman";

--- a/pkgs/by-name/ex/external-editor-revived/native-messaging.json
+++ b/pkgs/by-name/ex/external-editor-revived/native-messaging.json
@@ -1,0 +1,9 @@
+{
+  "name": "external_editor_revived",
+  "description": "Edit emails in external editors such as Vim, Neovim, Emacs, etc.",
+  "path": "@OUT@/bin/external-editor-revived",
+  "type": "stdio",
+  "allowed_extensions": [
+    "external-editor-revived@tsundere.moe"
+  ]
+}

--- a/pkgs/by-name/ex/external-editor-revived/package.nix
+++ b/pkgs/by-name/ex/external-editor-revived/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "external-editor-revived";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Frederick888";
+    repo = "external-editor-revived";
+    tag = "v${version}";
+    sha256 = "sha256-K5agRpFJ8iqvPnx3IIMTvrkObT/GB962EtdvWf7Eq4w=";
+  };
+
+  cargoHash = "sha256-QYSsdEBNwjpR7lppyOcsc0F8ombBY+dlFRY1GO/D8so=";
+
+  postInstall = ''
+    mkdir -p "$out/lib/mozilla/native-messaging-hosts"
+    substitute '${./native-messaging.json}' "$out/lib/mozilla/native-messaging-hosts/external_editor_revived.json" \
+      --replace-fail "@OUT@" "$out"
+  '';
+
+  meta = with lib; {
+    description = "Native messaging host for the Thunderbird addon allowing to edit mails in external programs";
+    homepage = "https://github.com/Frederick888/external-editor-revived";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ mofrim ];
+    mainProgram = "external-editor-revived";
+  };
+}


### PR DESCRIPTION
This package is the backend required for an addon/extension for the Thunderbird mail client. It enables the use of an external editor (like vim) for composing email in. The addon must be installed from inside thunderbird, but the backend is a seperate program packaged here. There once was another program providing the same functionality (https://github.com/exteditor/exteditor) but it is discontinued now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
