### PR TITLE
ankiAddons: fix update scripts

### DIFF
--- a/pkgs/by-name/an/anki/addons/anki-connect/default.nix
+++ b/pkgs/by-name/an/anki/addons/anki-connect/default.nix
@@ -2,7 +2,7 @@
   lib,
   anki-utils,
   fetchFromSourcehut,
-  nix-update-script,
+  gitUpdater,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "anki-connect";
@@ -10,11 +10,11 @@ anki-utils.buildAnkiAddon (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~foosoft";
     repo = "anki-connect";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-ZPjGqyxTyLg5DtOUPJWCBC/IMfDVxtWt86VeFrsE41k=";
   };
   sourceRoot = "${finalAttrs.src.name}/plugin";
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = gitUpdater { };
   meta = {
     description = ''
       Enable external applications such as Yomichan to communicate

--- a/pkgs/by-name/an/anki/addons/anki-utils.nix
+++ b/pkgs/by-name/an/anki/addons/anki-utils.nix
@@ -13,9 +13,6 @@
       finalAttrs:
       {
         pname,
-        version,
-        src,
-        sourceRoot ? "",
         configurePhase ? ''
           runHook preConfigure
           runHook postConfigure
@@ -26,7 +23,6 @@
         '',
         dontPatchELF ? true,
         dontStrip ? true,
-        nativeBuildInputs ? [ ],
         passthru ? { },
         meta ? { },
         # Script run after "user_files" folder is populated.
@@ -37,14 +33,10 @@
       }:
       {
         inherit
-          version
-          src
-          sourceRoot
           configurePhase
           buildPhase
           dontPatchELF
           dontStrip
-          nativeBuildInputs
           ;
 
         pname = "anki-addon-${pname}";

--- a/pkgs/by-name/an/anki/addons/reviewer-refocus-card/default.nix
+++ b/pkgs/by-name/an/anki/addons/reviewer-refocus-card/default.nix
@@ -6,7 +6,7 @@
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "reviewer-refocus-card";
-  version = "0-unstable-2022-12-24";
+  version = "0.3.0-unstable-2022-12-24";
   src = fetchFromGitHub {
     owner = "glutanimate";
     repo = "anki-addons-misc";


### PR DESCRIPTION
nix-update previously identified `anki-utils.nix` as every add-on's source file. I've diffed the outputs of all add-ons before and after this change to confirm there are no real differences. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
