### PR TITLE
ibus-engines.table-chinese: 1.8.12 -> 1.8.14

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
@@ -10,26 +10,16 @@
   writableTmpDirAsHomeHook,
 }:
 
-let
+stdenv.mkDerivation {
+  pname = "ibus-table-chinese";
+  version = "1.8.14";
+
   src = fetchFromGitHub {
     owner = "mike-fabian";
     repo = "ibus-table-chinese";
-    rev = "3a416012f3b898fe17225925f59d0672a8a0c0db";
-    sha256 = "sha256-KA4jRSlQ78IeP7od3VtgdR58Z/6psNkMCVwvg3vhFIM=";
+    rev = "44301450e681c23d60301747856c74b5b9d1312e";
+    sha256 = "sha256-CvODJhQTzqR58IlaL8cIP9Z1gcC8PfkfU0HWdq0Jjms=";
   };
-in
-stdenv.mkDerivation {
-  pname = "ibus-table-chinese";
-  version = "1.8.12";
-
-  inherit src;
-
-  postConfigure = ''
-    substituteInPlace cmake_install.cmake --replace-fail /var/empty $out
-    substituteInPlace CMakeLists.txt --replace-fail /var/empty $out
-  '';
-  # Fails otherwise with "no such file or directory: <table>.txt"
-  dontUseCmakeBuildDir = true;
 
   nativeBuildInputs = [
     cmake
@@ -46,7 +36,7 @@ stdenv.mkDerivation {
   meta = {
     isIbusEngine = true;
     description = "Chinese tables for IBus-Table";
-    homepage = "https://github.com/definite/ibus-table-chinese";
+    homepage = "https://github.com/mike-fabian/ibus-table-chinese";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ pneumaticat ];


### PR DESCRIPTION
This updates the package to the latest version and also fixes cmake4 build failure.

The used revision is the [1.8.14 release](https://github.com/mike-fabian/ibus-table-chinese/releases/tag/1.8.14) + [a merged pull request](https://github.com/mike-fabian/ibus-table-chinese/pull/10) from a Gentoo dev that makes packaging easier.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
