### PR TITLE
imgbrd-grabber: fix build with CMake 4

### DIFF
--- a/pkgs/by-name/im/imgbrd-grabber/cmake4-compat.patch
+++ b/pkgs/by-name/im/imgbrd-grabber/cmake4-compat.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.2)
++cmake_minimum_required(VERSION 3.10)
+
+ project(Grabber)
+
+diff --git a/lib/vendor/lexbor/CMakeLists.txt b/lib/vendor/lexbor/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/lib/vendor/lexbor/CMakeLists.txt
++++ b/lib/vendor/lexbor/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.10)
+
+ project(lexbor C)
+

--- a/pkgs/by-name/im/imgbrd-grabber/package.nix
+++ b/pkgs/by-name/im/imgbrd-grabber/package.nix
@@ -59,10 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./fix-for-qt6.patch
+    ./cmake4-compat.patch
   ];
 
   postPatch = ''
-
     # ensure the script uses the rsync package from nixpkgs
     substituteInPlace ../scripts/package.sh --replace-fail "rsync" "${lib.getExe rsync}"
 


### PR DESCRIPTION
Patch CMake files to work with CMake 4.

Closes #450520.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
