### PR TITLE
piliplus: 1.1.4.4 -> 1.1.4.10

### DIFF
--- a/pkgs/by-name/pi/piliplus/disable-auto-update.patch
+++ b/pkgs/by-name/pi/piliplus/disable-auto-update.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/utils/update.dart b/lib/utils/update.dart
+index cb35c3bd..52e01d53 100644
+--- a/lib/utils/update.dart
++++ b/lib/utils/update.dart
+@@ -19,7 +19,6 @@ import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+ abstract class Update {
+   // 检查更新
+   static Future<void> checkUpdate([bool isAuto = true]) async {
+-    if (kDebugMode) return;
+     SmartDialog.dismiss();
+     try {
+       final res = await Request().get(

--- a/pkgs/by-name/pi/piliplus/git-hashes.json
+++ b/pkgs/by-name/pi/piliplus/git-hashes.json
@@ -1,12 +1,18 @@
 {
   "auto_orientation": "sha256-0QOEW8+0PpBIELmzilZ8+z7ozNRxKgI0BzuBS8c1Fng=",
-  "canvas_danmaku": "sha256-3cBsQCvXuc5XvSRNY4QX33+t8aF2AfOQhRt+MCQWdOA=",
+  "canvas_danmaku": "sha256-V7o8NonNWo07PvWu8BI/ZugLZU6i3u45DuALg9UYtTE=",
   "chat_bottom_container": "sha256-um9KwZUDxWBhFsGHfv00TjPzxDHmp43TLRF0GwuV1xs=",
-  "extended_nested_scroll_view": "sha256-5X8ghUlEO/lvz/3PmYuipCjcs+QrIciaH5wgWp9i+24=",
+  "extended_nested_scroll_view": "sha256-Vjv5zp5c0Xob1H8/U0+lUueLqOKo7qwusOCchdt3Z7M=",
   "floating": "sha256-TJ2i3hTOQ4euHWr+lfQU44L3vVehmWVdZuAzNyVaEfA=",
   "flutter_sortable_wrap": "sha256-Qj9Lzh+pJy+vHznGt5M3xwoJtaVtt00fxm4JJXL4bFI=",
   "material_design_icons_flutter": "sha256-KMwjnzJJj8nemCqUCSwYafPOwTYbtoHNenxstocJtz4=",
-  "media_kit_libs_android_video": "sha256-o5qsqJe4TjOhwtgnc20Ga1y4IyxdhC/VmeAsFMDoHuo=",
-  "media_kit_video": "sha256-TPYmT5Muv98wuZUO9evd40uIWp/XDk0+GIfEgd/m4mg=",
-  "webdav_client": "sha256-euNF7HdDtZ68BqSEq9BvO10BK09MxX2wWGoElFS0yeE="
+  "media_kit": "sha256-9tGeTDXX3L5/xdyZMnVCbiCa6LYV+ELcpU/Ro5wg1Lc=",
+  "media_kit_libs_android_video": "sha256-9tGeTDXX3L5/xdyZMnVCbiCa6LYV+ELcpU/Ro5wg1Lc=",
+  "media_kit_libs_video": "sha256-9tGeTDXX3L5/xdyZMnVCbiCa6LYV+ELcpU/Ro5wg1Lc=",
+  "media_kit_libs_windows_video": "sha256-9tGeTDXX3L5/xdyZMnVCbiCa6LYV+ELcpU/Ro5wg1Lc=",
+  "media_kit_native_event_loop": "sha256-9tGeTDXX3L5/xdyZMnVCbiCa6LYV+ELcpU/Ro5wg1Lc=",
+  "media_kit_video": "sha256-9tGeTDXX3L5/xdyZMnVCbiCa6LYV+ELcpU/Ro5wg1Lc=",
+  "super_sliver_list": "sha256-G24uRql1aIc1TDJwKqwQ72Pi4YbJybMn6lxOUySSDwk=",
+  "webdav_client": "sha256-euNF7HdDtZ68BqSEq9BvO10BK09MxX2wWGoElFS0yeE=",
+  "window_manager": "sha256-UAN3uOXKMfWk+G9GTHyhD2dGDojKA76mGbUR+EFc2Qo="
 }

--- a/pkgs/by-name/pi/piliplus/package.nix
+++ b/pkgs/by-name/pi/piliplus/package.nix
@@ -2,103 +2,93 @@
   lib,
   fetchFromGitHub,
   flutter335,
-  makeShellWrapper,
   makeDesktopItem,
   copyDesktopItems,
   alsa-lib,
   mpv-unwrapped,
   libplacebo,
+  libappindicator,
 }:
 
 let
-  version = "1.1.4.4";
-  rev = "f0f52246777f2640025048f561e908cf1d3c3ead";
-
+  srcInfo = lib.importJSON ./src-info.json;
   description = "Third-party Bilibili client developed in Flutter";
 in
-flutter335.buildFlutterApplication.override
-  {
-    # makeBinaryWrapper does not support `--run`.
-    makeWrapper = makeShellWrapper;
-  }
-  {
-    pname = "piliplus";
-    inherit version;
+flutter335.buildFlutterApplication {
+  pname = "piliplus";
+  inherit (srcInfo) version;
 
-    src = fetchFromGitHub {
-      owner = "bggRGjQaUbCoE";
-      repo = "PiliPlus";
-      inherit rev;
-      hash = "sha256-5ISSlYMbP0SaSP0SLIHXC3VRXrVZ78kfl07ekgzFhNA=";
-    };
+  src = fetchFromGitHub {
+    owner = "bggRGjQaUbCoE";
+    repo = "PiliPlus";
+    inherit (srcInfo) rev hash;
+  };
 
-    # Disable update check.
-    postPatch = ''
-      substituteInPlace lib/utils/update.dart \
-        --replace-fail "if (kDebugMode) " ""
-    '';
+  patches = [ ./disable-auto-update.patch ];
 
-    pubspecLock = lib.importJSON ./pubspec.lock.json;
-    gitHashes = lib.importJSON ./git-hashes.json;
+  pubspecLock = lib.importJSON ./pubspec.lock.json;
+  gitHashes = lib.importJSON ./git-hashes.json;
 
-    nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs = [ copyDesktopItems ];
 
-    buildInputs = [
-      alsa-lib
-      mpv-unwrapped
-      libplacebo
-    ];
+  buildInputs = [
+    alsa-lib
+    mpv-unwrapped
+    libplacebo
+    libappindicator
+  ];
 
-    # See lib/scripts/build.sh.
-    preBuild = ''
-      cat <<EOL > lib/build_config.dart
-      class BuildConfig {
-        static const int buildTime = $SOURCE_DATE_EPOCH;
-        static const String commitHash = '${rev}';
-      }
-      EOL
-    '';
+  # See lib/scripts/build.sh.
+  preBuild = ''
+    cat <<EOL > lib/build_config.dart
+    class BuildConfig {
+      static const int versionCode = ${toString srcInfo.revCount};
+      static const String versionName = '${srcInfo.version}';
 
-    # The app attempts to get the total size of TMPDIR at startup.
-    extraWrapProgramArgs = ''
-      --run 'export TMPDIR="$(mktemp -d)"'
-    '';
+      static const int buildTime = ${toString srcInfo.commitDate};
+      static const String commitHash = '${srcInfo.rev}';
+    }
+    EOL
+  '';
 
-    postInstall = ''
-      declare -A sizes=(
-        [mdpi]=128
-        [hdpi]=192
-        [xhdpi]=256
-        [xxhdpi]=384
-        [xxxhdpi]=512
-      )
-      for var in "''${!sizes[@]}"; do
-        width=''${sizes[$var]}
-        install -Dm644 "android/app/src/main/res/drawable-$var/splash.png" \
-          "$out/share/icons/hicolor/$widthx$width/apps/piliplus.png"
-      done
-    '';
+  postInstall = ''
+    declare -A sizes=(
+      [mdpi]=128
+      [hdpi]=192
+      [xhdpi]=256
+      [xxhdpi]=384
+      [xxxhdpi]=512
+    )
+    for var in "''${!sizes[@]}"; do
+      width=''${sizes[$var]}
+      install -Dm644 "android/app/src/main/res/drawable-$var/splash.png" \
+        "$out/share/icons/hicolor/''${width}x$width/apps/piliplus.png"
+    done
+  '';
 
-    desktopItems = [
-      (makeDesktopItem {
-        name = "piliplus";
-        exec = "piliplus";
-        icon = "piliplus";
-        desktopName = "PiliPlus";
-        categories = [ "Video" ];
-        comment = description;
-      })
-    ];
+  desktopItems = [
+    (makeDesktopItem {
+      name = "piliplus";
+      exec = "piliplus";
+      icon = "piliplus";
+      desktopName = "PiliPlus";
+      categories = [
+        "Video"
+        "AudioVideo"
+      ];
+      comment = description;
+    })
+  ];
 
-    passthru.updateScript = ./update.rb;
+  passthru.updateScript = ./update.rb;
 
-    meta = {
-      inherit description;
-      homepage = "https://github.com/bggRGjQaUbCoE/PiliPlus";
-      changelog = "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/${version}";
-      license = lib.licenses.gpl3Plus;
-      maintainers = with lib.maintainers; [ ulysseszhan ];
-      platforms = lib.platforms.linux;
-      mainProgram = "piliplus";
-    };
-  }
+  meta = {
+    inherit description;
+    homepage = "https://github.com/bggRGjQaUbCoE/PiliPlus";
+    changelog = "https://github.com/bggRGjQaUbCoE/PiliPlus/releases/tag/${srcInfo.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "piliplus";
+  };
+}

--- a/pkgs/by-name/pi/piliplus/pubspec.lock.json
+++ b/pkgs/by-name/pi/piliplus/pubspec.lock.json
@@ -4,31 +4,21 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7",
+        "sha256": "0eb33edbbe99a02e73b8bbeb6f2b65972023d902117ee8d1bf0ea1a79f83aa7b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "67.0.0"
+      "version": "90.0.0"
     },
     "analyzer": {
       "dependency": "transitive",
       "description": {
         "name": "analyzer",
-        "sha256": "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d",
+        "sha256": "711e3a890bb529bf55f07d73b8706f4b7504ad77e90d2f205626b116c048583f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.4.1"
-    },
-    "animations": {
-      "dependency": "direct main",
-      "description": {
-        "name": "animations",
-        "sha256": "d3d6dcfb218225bbe68e87ccf6378bbb2e32a94900722c5f81611dad089911cb",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.11"
+      "version": "8.3.0"
     },
     "ansicolor": {
       "dependency": "transitive",
@@ -195,21 +185,21 @@
       "dependency": "transitive",
       "description": {
         "name": "build",
-        "sha256": "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0",
+        "sha256": "dfb67ccc9a78c642193e0c2d94cb9e48c2c818b3178a86097d644acdcde6a8d9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.1"
+      "version": "4.0.2"
     },
     "build_config": {
       "dependency": "transitive",
       "description": {
         "name": "build_config",
-        "sha256": "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33",
+        "sha256": "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     "build_daemon": {
       "dependency": "transitive",
@@ -221,35 +211,15 @@
       "source": "hosted",
       "version": "4.0.4"
     },
-    "build_resolvers": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build_resolvers",
-        "sha256": "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.4.2"
-    },
     "build_runner": {
       "dependency": "direct dev",
       "description": {
         "name": "build_runner",
-        "sha256": "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d",
+        "sha256": "4e54dbeefdc70691ba80b3bce3976af63b5425c8c07dface348dfee664a0edc1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.13"
-    },
-    "build_runner_core": {
-      "dependency": "transitive",
-      "description": {
-        "name": "build_runner_core",
-        "sha256": "f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "7.3.2"
+      "version": "2.9.0"
     },
     "built_collection": {
       "dependency": "transitive",
@@ -265,11 +235,11 @@
       "dependency": "transitive",
       "description": {
         "name": "built_value",
-        "sha256": "1b3b173f3379c8f941446267868548b6fc67e9134d81f4842eb98bb729451359",
+        "sha256": "a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.11.2"
+      "version": "8.12.0"
     },
     "cached_network_image": {
       "dependency": "direct main",
@@ -301,22 +271,12 @@
       "source": "hosted",
       "version": "1.3.1"
     },
-    "cached_network_svg_image": {
-      "dependency": "direct main",
-      "description": {
-        "name": "cached_network_svg_image",
-        "sha256": "fe9df0217c12e3903558dad14e1bb938c51296a1d96faa080415c6146bbd7a7d",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.2.0"
-    },
     "canvas_danmaku": {
       "dependency": "direct main",
       "description": {
         "path": ".",
         "ref": "main",
-        "resolved-ref": "1c8cd0bb44f4883fe0a37d06aa11f9bfd1da6379",
+        "resolved-ref": "454790117e05e96782b05ee3d28d0283741b3cde",
         "url": "https://github.com/bggRGjQaUbCoE/canvas_danmaku.git"
       },
       "source": "git",
@@ -326,11 +286,11 @@
       "dependency": "direct main",
       "description": {
         "name": "catcher_2",
-        "sha256": "ffdad9d314a91d2baabd90b3332bccda00b5f2fabd9d6afa4f988479b9bc3eca",
+        "sha256": "45070a33cf072bed4b45f6141bb2be98a804a76d27e2d0fa9e4319af5fa12195",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.3"
+      "version": "2.1.5"
     },
     "characters": {
       "dependency": "transitive",
@@ -387,11 +347,11 @@
       "dependency": "transitive",
       "description": {
         "name": "code_builder",
-        "sha256": "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e",
+        "sha256": "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.10.1"
+      "version": "4.11.0"
     },
     "collection": {
       "dependency": "direct main",
@@ -407,11 +367,11 @@
       "dependency": "direct main",
       "description": {
         "name": "connectivity_plus",
-        "sha256": "b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec",
+        "sha256": "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.1.5"
+      "version": "7.0.0"
     },
     "connectivity_plus_platform_interface": {
       "dependency": "transitive",
@@ -497,11 +457,11 @@
       "dependency": "transitive",
       "description": {
         "name": "dart_style",
-        "sha256": "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9",
+        "sha256": "c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.6"
+      "version": "3.1.2"
     },
     "dbus": {
       "dependency": "transitive",
@@ -517,11 +477,11 @@
       "dependency": "direct main",
       "description": {
         "name": "device_info_plus",
-        "sha256": "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a",
+        "sha256": "49413c8ca514dea7633e8def233b25efdf83ec8522955cc2c0e3ad802927e7c6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "11.5.0"
+      "version": "12.1.0"
     },
     "device_info_plus_platform_interface": {
       "dependency": "transitive",
@@ -562,16 +522,6 @@
       },
       "source": "hosted",
       "version": "2.1.1"
-    },
-    "document_file_save_plus": {
-      "dependency": "direct main",
-      "description": {
-        "name": "document_file_save_plus",
-        "sha256": "ff05c6a3b072377566e8e92666db38eb277786f90c0ac267ea47dc22725c1df3",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.0"
     },
     "dynamic_color": {
       "dependency": "direct main",
@@ -638,7 +588,7 @@
       "description": {
         "path": ".",
         "ref": "mod",
-        "resolved-ref": "8289673adc2b0485ab2abda49bea42ef8b899bf0",
+        "resolved-ref": "4bb4e827628b3b7ccc88a4b98ef76a036a5a51ac",
         "url": "https://github.com/bggRGjQaUbCoE/extended_nested_scroll_view.git"
       },
       "source": "git",
@@ -673,6 +623,16 @@
       },
       "source": "hosted",
       "version": "7.0.1"
+    },
+    "file_picker": {
+      "dependency": "direct main",
+      "description": {
+        "name": "file_picker",
+        "sha256": "f2d9f173c2c14635cc0e9b14c143c49ef30b4934e8d1d274d6206fcb0086a06f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "10.3.3"
     },
     "file_selector_linux": {
       "dependency": "transitive",
@@ -728,11 +688,11 @@
       "dependency": "direct main",
       "description": {
         "name": "fl_chart",
-        "sha256": "d3f82f4a38e33ba23d05a08ff304d7d8b22d2a59a5503f20bd802966e915db89",
+        "sha256": "7ca9a40f4eb85949190e54087be8b4d6ac09dc4c54238d782a34cf1f7c011de9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "flex_seed_scheme": {
       "dependency": "direct main",
@@ -775,11 +735,11 @@
       "dependency": "direct main",
       "description": {
         "name": "flutter_displaymode",
-        "sha256": "42c5e9abd13d28ed74f701b60529d7f8416947e58256e6659c5550db719c57ef",
+        "sha256": "ecd44b1e902b0073b42ff5b55bf283f38e088270724cdbb7f7065ccf54aa60a8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.6.0"
+      "version": "0.7.0"
     },
     "flutter_html": {
       "dependency": "direct main",
@@ -921,11 +881,11 @@
       "dependency": "transitive",
       "description": {
         "name": "flutter_plugin_android_lifecycle",
-        "sha256": "b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31",
+        "sha256": "c2fe1001710127dfa7da89977a08d591398370d099aacdaa6d44da7eb14b8476",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.30"
+      "version": "2.0.31"
     },
     "flutter_smart_dialog": {
       "dependency": "direct main",
@@ -984,11 +944,11 @@
       "dependency": "transitive",
       "description": {
         "name": "fluttertoast",
-        "sha256": "25e51620424d92d3db3832464774a6143b5053f15e382d8ffbfd40b6e795dcf1",
+        "sha256": "144ddd74d49c865eba47abe31cbc746c7b311c82d6c32e571fd73c4264b740e2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.2.12"
+      "version": "9.0.0"
     },
     "font_awesome_flutter": {
       "dependency": "direct main",
@@ -999,16 +959,6 @@
       },
       "source": "hosted",
       "version": "10.9.0"
-    },
-    "frontend_server_client": {
-      "dependency": "transitive",
-      "description": {
-        "name": "frontend_server_client",
-        "sha256": "f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "4.0.0"
     },
     "get": {
       "dependency": "direct main",
@@ -1080,16 +1030,6 @@
       "source": "hosted",
       "version": "1.1.0"
     },
-    "hive_generator": {
-      "dependency": "direct dev",
-      "description": {
-        "name": "hive_generator",
-        "sha256": "06cb8f58ace74de61f63500564931f9505368f45f98958bd7a6c35ba24159db4",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.1"
-    },
     "html": {
       "dependency": "direct main",
       "description": {
@@ -1154,31 +1094,31 @@
       "dependency": "direct main",
       "description": {
         "name": "image_cropper",
-        "sha256": "4e9c96c029eb5a23798da1b6af39787f964da6ffc78fd8447c140542a9f7c6fc",
+        "sha256": "46c8f9aae51c8350b2a2982462f85a129e77b04675d35b09db5499437d7a996b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.1.0"
+      "version": "11.0.0"
     },
     "image_cropper_for_web": {
       "dependency": "transitive",
       "description": {
         "name": "image_cropper_for_web",
-        "sha256": "fd81ebe36f636576094377aab32673c4e5d1609b32dec16fad98d2b71f1250a9",
+        "sha256": "e09749714bc24c4e3b31fbafa2e5b7229b0ff23e8b14d4ba44bd723b77611a0f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.1.0"
+      "version": "7.0.0"
     },
     "image_cropper_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "image_cropper_platform_interface",
-        "sha256": "6ca6b81769abff9a4dcc3bbd3d75f5dfa9de6b870ae9613c8cd237333a4283af",
+        "sha256": "886a30ec199362cdcc2fbb053b8e53347fbfb9dbbdaa94f9ff85622609f5e7ff",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.1.0"
+      "version": "8.0.0"
     },
     "image_picker": {
       "dependency": "direct main",
@@ -1194,11 +1134,11 @@
       "dependency": "transitive",
       "description": {
         "name": "image_picker_android",
-        "sha256": "28f3987ca0ec702d346eae1d90eda59603a2101b52f1e234ded62cff1d5cfa6e",
+        "sha256": "dd7a61daaa5896cc34b7bc95f66c60225ae6bee0d167dde0e21a9d9016cac0dc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.8.13+1"
+      "version": "0.8.13+4"
     },
     "image_picker_for_web": {
       "dependency": "transitive",
@@ -1284,11 +1224,11 @@
       "dependency": "transitive",
       "description": {
         "name": "js",
-        "sha256": "f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3",
+        "sha256": "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.6.7"
+      "version": "0.7.2"
     },
     "json_annotation": {
       "dependency": "direct main",
@@ -1304,11 +1244,11 @@
       "dependency": "transitive",
       "description": {
         "name": "leak_tracker",
-        "sha256": "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0",
+        "sha256": "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "11.0.1"
+      "version": "11.0.2"
     },
     "leak_tracker_flutter_testing": {
       "dependency": "transitive",
@@ -1364,11 +1304,11 @@
       "dependency": "direct main",
       "description": {
         "name": "logger",
-        "sha256": "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c",
+        "sha256": "a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.6.1"
+      "version": "2.6.2"
     },
     "logging": {
       "dependency": "transitive",
@@ -1424,11 +1364,12 @@
     "media_kit": {
       "dependency": "direct main",
       "description": {
-        "name": "media_kit",
-        "sha256": "1f1deee148533d75129a6f38251ff8388e33ee05fc2d20a6a80e57d6051b7b62",
-        "url": "https://pub.dev"
+        "path": "media_kit",
+        "ref": "version_1.2.5",
+        "resolved-ref": "8f15c273f3e5c05476d8b19881719a1bd906c4f2",
+        "url": "https://github.com/bggRGjQaUbCoE/media-kit.git"
       },
-      "source": "hosted",
+      "source": "git",
       "version": "1.1.11"
     },
     "media_kit_libs_android_video": {
@@ -1436,8 +1377,8 @@
       "description": {
         "path": "libs/android/media_kit_libs_android_video",
         "ref": "version_1.2.5",
-        "resolved-ref": "f89452bc27af26324a83961c8286d4f41432a5f9",
-        "url": "https://github.com/My-Responsitories/media-kit.git"
+        "resolved-ref": "8f15c273f3e5c05476d8b19881719a1bd906c4f2",
+        "url": "https://github.com/bggRGjQaUbCoE/media-kit.git"
       },
       "source": "git",
       "version": "1.3.7"
@@ -1475,31 +1416,34 @@
     "media_kit_libs_video": {
       "dependency": "direct main",
       "description": {
-        "name": "media_kit_libs_video",
-        "sha256": "20bb4aefa8fece282b59580e1cd8528117297083a6640c98c2e98cfc96b93288",
-        "url": "https://pub.dev"
+        "path": "libs/universal/media_kit_libs_video",
+        "ref": "version_1.2.5",
+        "resolved-ref": "8f15c273f3e5c05476d8b19881719a1bd906c4f2",
+        "url": "https://github.com/bggRGjQaUbCoE/media-kit.git"
       },
-      "source": "hosted",
+      "source": "git",
       "version": "1.0.5"
     },
     "media_kit_libs_windows_video": {
-      "dependency": "transitive",
+      "dependency": "direct overridden",
       "description": {
-        "name": "media_kit_libs_windows_video",
-        "sha256": "dff76da2778729ab650229e6b4ec6ec111eb5151431002cbd7ea304ff1f112ab",
-        "url": "https://pub.dev"
+        "path": "libs/windows/media_kit_libs_windows_video",
+        "ref": "version_1.2.5",
+        "resolved-ref": "8f15c273f3e5c05476d8b19881719a1bd906c4f2",
+        "url": "https://github.com/bggRGjQaUbCoE/media-kit.git"
       },
-      "source": "hosted",
-      "version": "1.0.11"
+      "source": "git",
+      "version": "1.0.10"
     },
     "media_kit_native_event_loop": {
       "dependency": "direct overridden",
       "description": {
-        "name": "media_kit_native_event_loop",
-        "sha256": "7d82e3b3e9ded5c35c3146c5ba1da3118d1dd8ac3435bac7f29f458181471b40",
-        "url": "https://pub.dev"
+        "path": "media_kit_native_event_loop",
+        "ref": "version_1.2.5",
+        "resolved-ref": "8f15c273f3e5c05476d8b19881719a1bd906c4f2",
+        "url": "https://github.com/bggRGjQaUbCoE/media-kit.git"
       },
-      "source": "hosted",
+      "source": "git",
       "version": "1.0.9"
     },
     "media_kit_video": {
@@ -1507,11 +1451,21 @@
       "description": {
         "path": "media_kit_video",
         "ref": "version_1.2.5",
-        "resolved-ref": "c4655bfb4bf81b6bb450d252184da20e2fbba292",
+        "resolved-ref": "8f15c273f3e5c05476d8b19881719a1bd906c4f2",
         "url": "https://github.com/bggRGjQaUbCoE/media-kit.git"
       },
       "source": "git",
       "version": "1.2.5"
+    },
+    "menu_base": {
+      "dependency": "transitive",
+      "description": {
+        "name": "menu_base",
+        "sha256": "820368014a171bd1241030278e6c2617354f492f5c703d7b7d4570a6b8b84405",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.1"
     },
     "meta": {
       "dependency": "transitive",
@@ -1567,11 +1521,11 @@
       "dependency": "direct main",
       "description": {
         "name": "package_info_plus",
-        "sha256": "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968",
+        "sha256": "f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.3.1"
+      "version": "9.0.0"
     },
     "package_info_plus_platform_interface": {
       "dependency": "transitive",
@@ -1617,11 +1571,11 @@
       "dependency": "transitive",
       "description": {
         "name": "path_provider_android",
-        "sha256": "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db",
+        "sha256": "3b4c1fc3aa55ddc9cd4aa6759984330d5c8e66aa7702a6223c61540dc6380c37",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.2.18"
+      "version": "2.2.19"
     },
     "path_provider_foundation": {
       "dependency": "transitive",
@@ -1663,18 +1617,8 @@
       "source": "hosted",
       "version": "2.3.0"
     },
-    "permission_handler": {
-      "dependency": "direct main",
-      "description": {
-        "name": "permission_handler",
-        "sha256": "bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "12.0.1"
-    },
     "permission_handler_android": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "permission_handler_android",
         "sha256": "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6",
@@ -1684,7 +1628,7 @@
       "version": "13.0.1"
     },
     "permission_handler_apple": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "permission_handler_apple",
         "sha256": "f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023",
@@ -1693,18 +1637,8 @@
       "source": "hosted",
       "version": "9.4.7"
     },
-    "permission_handler_html": {
-      "dependency": "transitive",
-      "description": {
-        "name": "permission_handler_html",
-        "sha256": "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.1.3+5"
-    },
     "permission_handler_platform_interface": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "permission_handler_platform_interface",
         "sha256": "eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878",
@@ -1712,16 +1646,6 @@
       },
       "source": "hosted",
       "version": "4.3.0"
-    },
-    "permission_handler_windows": {
-      "dependency": "transitive",
-      "description": {
-        "name": "permission_handler_windows",
-        "sha256": "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "0.2.1"
     },
     "petitparser": {
       "dependency": "transitive",
@@ -1767,11 +1691,11 @@
       "dependency": "transitive",
       "description": {
         "name": "pool",
-        "sha256": "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a",
+        "sha256": "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     "posix": {
       "dependency": "transitive",
@@ -1797,11 +1721,11 @@
       "dependency": "direct main",
       "description": {
         "name": "protobuf",
-        "sha256": "de9c9eb2c33f8e933a42932fe1dc504800ca45ebc3d673e6ed7f39754ee4053e",
+        "sha256": "826d6a306be26f29e5cd9faeb0c97aad5897270341dab6dbd7b8acd675937006",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "4.2.0"
+      "version": "5.0.0"
     },
     "pub_semver": {
       "dependency": "transitive",
@@ -1857,11 +1781,11 @@
       "dependency": "transitive",
       "description": {
         "name": "safe_local_storage",
-        "sha256": "ede4eb6cb7d88a116b3d3bf1df70790b9e2038bc37cb19112e381217c74d9440",
+        "sha256": "e9a21b6fec7a8aa62cc2585ff4c1b127df42f3185adbd2aca66b47abe2e80236",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.2"
+      "version": "2.0.1"
     },
     "saver_gallery": {
       "dependency": "direct main",
@@ -1873,18 +1797,8 @@
       "source": "hosted",
       "version": "4.0.1"
     },
-    "screen_brightness": {
-      "dependency": "direct main",
-      "description": {
-        "name": "screen_brightness",
-        "sha256": "5f70754028f169f059fdc61112a19dcbee152f8b293c42c848317854d650cba3",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.7"
-    },
     "screen_brightness_android": {
-      "dependency": "transitive",
+      "dependency": "direct overridden",
       "description": {
         "name": "screen_brightness_android",
         "sha256": "d34f5321abd03bc3474f4c381f53d189117eba0b039eac1916aa92cca5fd0a96",
@@ -1894,7 +1808,7 @@
       "version": "2.1.3"
     },
     "screen_brightness_ios": {
-      "dependency": "transitive",
+      "dependency": "direct overridden",
       "description": {
         "name": "screen_brightness_ios",
         "sha256": "2493953340ecfe8f4f13f61db50ce72533a55b0bbd58ba1402893feecf3727f5",
@@ -1903,28 +1817,8 @@
       "source": "hosted",
       "version": "2.1.2"
     },
-    "screen_brightness_macos": {
-      "dependency": "transitive",
-      "description": {
-        "name": "screen_brightness_macos",
-        "sha256": "4edf330ad21078686d8bfaf89413325fbaf571dcebe1e89254d675a3f288b5b9",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.1"
-    },
-    "screen_brightness_ohos": {
-      "dependency": "transitive",
-      "description": {
-        "name": "screen_brightness_ohos",
-        "sha256": "a93a263dcd39b5c56e589eb495bcd001ce65cdd96ff12ab1350683559d5c5bb7",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.2"
-    },
     "screen_brightness_platform_interface": {
-      "dependency": "transitive",
+      "dependency": "direct main",
       "description": {
         "name": "screen_brightness_platform_interface",
         "sha256": "737bd47b57746bc4291cab1b8a5843ee881af499514881b0247ec77447ee769c",
@@ -1933,45 +1827,75 @@
       "source": "hosted",
       "version": "2.1.0"
     },
-    "screen_brightness_windows": {
-      "dependency": "transitive",
-      "description": {
-        "name": "screen_brightness_windows",
-        "sha256": "d3518bf0f5d7a884cee2c14449ae0b36803802866de09f7ef74077874b6b2448",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.1.0"
-    },
-    "scrollable_positioned_list": {
+    "screen_retriever": {
       "dependency": "direct main",
       "description": {
-        "name": "scrollable_positioned_list",
-        "sha256": "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287",
+        "name": "screen_retriever",
+        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.8"
+      "version": "0.2.0"
+    },
+    "screen_retriever_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_linux",
+        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_macos",
+        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_platform_interface",
+        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "screen_retriever_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever_windows",
+        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
     },
     "sentry": {
       "dependency": "transitive",
       "description": {
         "name": "sentry",
-        "sha256": "d9f3dcf1ecdd600cf9ce134f622383adde5423ecfdaf0ca9b20fbc1c44849337",
+        "sha256": "0a3a1e6b3b3873070d4dbefc6968f0d31e698ed55b4eb8ee185b230f35733b59",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "9.6.0"
+      "version": "9.7.0"
     },
     "share_plus": {
       "dependency": "direct main",
       "description": {
         "name": "share_plus",
-        "sha256": "d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1",
+        "sha256": "3424e9d5c22fd7f7590254ba09465febd6f8827c8b19a44350de4ac31d92d3a6",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "11.1.0"
+      "version": "12.0.0"
     },
     "share_plus_platform_interface": {
       "dependency": "transitive",
@@ -1997,11 +1921,11 @@
       "dependency": "transitive",
       "description": {
         "name": "shared_preferences_android",
-        "sha256": "a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74",
+        "sha256": "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.4.12"
+      "version": "2.4.15"
     },
     "shared_preferences_foundation": {
       "dependency": "transitive",
@@ -2067,37 +1991,27 @@
       "dependency": "transitive",
       "description": {
         "name": "shelf_web_socket",
-        "sha256": "cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67",
+        "sha256": "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.1"
+      "version": "3.0.0"
+    },
+    "shortid": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shortid",
+        "sha256": "d0b40e3dbb50497dad107e19c54ca7de0d1a274eb9b4404991e443dadb9ebedb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
     },
     "sky_engine": {
       "dependency": "transitive",
       "description": "flutter",
       "source": "sdk",
       "version": "0.0.0"
-    },
-    "source_gen": {
-      "dependency": "transitive",
-      "description": {
-        "name": "source_gen",
-        "sha256": "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.5.0"
-    },
-    "source_helper": {
-      "dependency": "transitive",
-      "description": {
-        "name": "source_helper",
-        "sha256": "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.3.5"
     },
     "source_span": {
       "dependency": "transitive",
@@ -2209,6 +2123,17 @@
       "source": "hosted",
       "version": "1.4.1"
     },
+    "super_sliver_list": {
+      "dependency": "direct main",
+      "description": {
+        "path": ".",
+        "ref": "mod",
+        "resolved-ref": "71f34fa179e2d05818004e22e632dd59f2a223be",
+        "url": "https://github.com/bggRGjQaUbCoE/super_sliver_list.git"
+      },
+      "source": "git",
+      "version": "0.4.1"
+    },
     "synchronized": {
       "dependency": "direct main",
       "description": {
@@ -2239,15 +2164,15 @@
       "source": "hosted",
       "version": "0.7.6"
     },
-    "timing": {
-      "dependency": "transitive",
+    "tray_manager": {
+      "dependency": "direct main",
       "description": {
-        "name": "timing",
-        "sha256": "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe",
+        "name": "tray_manager",
+        "sha256": "537e539f48cd82d8ee2240d4330158c7b44c7e043e8e18b5811f2f8f6b7df25a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.0.2"
+      "version": "0.5.1"
     },
     "tuple": {
       "dependency": "transitive",
@@ -2279,25 +2204,15 @@
       "source": "hosted",
       "version": "2.2.2"
     },
-    "universal_platform": {
-      "dependency": "direct main",
-      "description": {
-        "name": "universal_platform",
-        "sha256": "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.1.0"
-    },
     "uri_parser": {
       "dependency": "transitive",
       "description": {
         "name": "uri_parser",
-        "sha256": "6543c9fd86d2862fac55d800a43e67c0dcd1a41677cb69c2f8edfe73bbcf1835",
+        "sha256": "ff4d2c720aca3f4f7d5445e23b11b2d15ef8af5ddce5164643f38ff962dcb270",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.0.2"
+      "version": "3.0.0"
     },
     "url_launcher": {
       "dependency": "direct main",
@@ -2313,11 +2228,11 @@
       "dependency": "transitive",
       "description": {
         "name": "url_launcher_android",
-        "sha256": "69ee86740f2847b9a4ba6cffa74ed12ce500bbe2b07f3dc1e643439da60637b7",
+        "sha256": "5c8b6c2d89a78f5a1cca70a73d9d5f86c701b36b42f9c9dac7bad592113c28e9",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.18"
+      "version": "6.3.24"
     },
     "url_launcher_ios": {
       "dependency": "transitive",
@@ -2453,31 +2368,31 @@
       "dependency": "direct main",
       "description": {
         "name": "wakelock_plus",
-        "sha256": "a474e314c3e8fb5adef1f9ae2d247e57467ad557fa7483a2b895bc1b421c5678",
+        "sha256": "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.2"
+      "version": "1.4.0"
     },
     "wakelock_plus_platform_interface": {
       "dependency": "transitive",
       "description": {
         "name": "wakelock_plus_platform_interface",
-        "sha256": "e10444072e50dbc4999d7316fd303f7ea53d31c824aa5eb05d7ccbdd98985207",
+        "sha256": "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.3"
+      "version": "1.3.0"
     },
     "watcher": {
       "dependency": "transitive",
       "description": {
         "name": "watcher",
-        "sha256": "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c",
+        "sha256": "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     "waterfall_flow": {
       "dependency": "direct main",
@@ -2534,11 +2449,11 @@
       "dependency": "transitive",
       "description": {
         "name": "win32",
-        "sha256": "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03",
+        "sha256": "d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.14.0"
+      "version": "5.15.0"
     },
     "win32_registry": {
       "dependency": "transitive",
@@ -2549,6 +2464,17 @@
       },
       "source": "hosted",
       "version": "2.1.0"
+    },
+    "window_manager": {
+      "dependency": "direct main",
+      "description": {
+        "path": "packages/window_manager",
+        "ref": "main",
+        "resolved-ref": "974ab0a71d37cfca9d9bd5b295d7bd1df80b790b",
+        "url": "https://github.com/bggRGjQaUbCoE/window_manager.git"
+      },
+      "source": "git",
+      "version": "0.5.1"
     },
     "xdg_directories": {
       "dependency": "transitive",
@@ -2583,6 +2509,6 @@
   },
   "sdks": {
     "dart": ">=3.9.0 <4.0.0",
-    "flutter": ">=3.35.3"
+    "flutter": "3.35.5"
   }
 }

--- a/pkgs/by-name/pi/piliplus/src-info.json
+++ b/pkgs/by-name/pi/piliplus/src-info.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.1.4.10",
+  "rev": "4cf1c25b36d2d3bb7b1efa1b00b1d33c593ce4b0",
+  "revCount": 4215,
+  "commitDate": 1760358940,
+  "hash": "sha256-sToT5saB/cPSvyrOG4XfMianXXLfg3iQlvJvwtAf6b8="
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The upstream added status bar icon support and now depends on libappindicator, so the update script could not work.

Also addresses https://github.com/NixOS/nixpkgs/pull/436676#discussion_r2303768828.

Also the patch suggested by https://github.com/NixOS/nixpkgs/pull/436676#issuecomment-3264470097 is now unnecessary because the upstream fixed it themselves.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
