### PR TITLE
kata-runtime: 3.16.0 -> 3.21.0

### DIFF
--- a/pkgs/by-name/ka/kata-runtime/kata-images.nix
+++ b/pkgs/by-name/ka/kata-runtime/kata-images.nix
@@ -4,6 +4,7 @@
   lib,
   stdenv,
   version,
+  zstd,
 }:
 
 let
@@ -16,16 +17,17 @@ let
 
   imageHash =
     {
-      "x86_64-linux" = "sha256-7xDc5Rr3rP36zS3kpM2QEqOCtmka3EAnts4Z1h8MNWY=";
-      "aarch64-linux" = "sha256-8nLHTPetEfIrdtrpiT9Czcpf0NhL97TZ2DXyeBL04LA=";
+      "x86_64-linux" = "sha256-roS2pGO00ORN+xxNU3/uqJG9RzhVqf8gCkt8EJJbY/g=";
+      "aarch64-linux" = "sha256-AuK5a2Qtd176B91+vSsEFwuWICpe8wcGTbXoE7B8b20=";
     }
     ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
 in
 fetchzip {
   name = "kata-images-${version}";
-  url = "https://github.com/kata-containers/kata-containers/releases/download/${version}/kata-static-${version}-${imageSuffix}.tar.xz";
+  url = "https://github.com/kata-containers/kata-containers/releases/download/${version}/kata-static-${version}-${imageSuffix}.tar.zst";
   hash = imageHash;
+  nativeBuildInputs = [ zstd ];
 
   postFetch = ''
     mv $out/kata/share/kata-containers kata-containers

--- a/pkgs/by-name/ka/kata-runtime/package.nix
+++ b/pkgs/by-name/ka/kata-runtime/package.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "3.16.0";
+  version = "3.21.0";
 
   kata-images = callPackage ./kata-images.nix { inherit version; };
 
@@ -34,7 +34,7 @@ buildGoModule rec {
     owner = "kata-containers";
     repo = "kata-containers";
     rev = version;
-    hash = "sha256-+SppAF77NbXlSrBGvIm40AmNC12GrexbX7fAPBoDAcs=";
+    hash = "sha256-gOPabvimKzP7U1/BRzjKPDKE0MHnhKI4j0WZPM6ZTSA=";
   };
 
   sourceRoot = "${src.name}/src/runtime";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is an upgrade of kata-runtime package from 3.16.0 to 3.21.0, along with associated QEMU VM image whose kernel is now 6.12.47 (from 6.12.22).

This is a follow-up to previously merged https://github.com/NixOS/nixpkgs/pull/404480

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (only sha256)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] there are no package tests in the original package, but I tested that both nix-build -A kata-runtime and nix-build -A kata-runtime.kata-images complete successfully
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
    ```
    /nix/store/008rcik73c1cacwjvzr3lscxqqg9na9v-kata-runtime-3.21.0/bin/kata-runtime --version
    kata-runtime  : 3.21.0
    commit   : <<unknown>>
    OCI specs: 1.2.1
    
    /nix/store/008rcik73c1cacwjvzr3lscxqqg9na9v-kata-runtime-3.21.0/bin/kata-monitor --version
    kata-monitor
    Version:       0.3.0
    Go version:    go1.25.1
    Git commit:
    OS/Arch:       linux/amd64
    
    /nix/store/008rcik73c1cacwjvzr3lscxqqg9na9v-kata-runtime-3.21.0/bin/containerd-shim-kata-v2 --version
    Kata Containers containerd shim (Golang): id: "io.containerd.kata.v2", version: 3.21.0, commit:
    
    docker run --rm --runtime io.containerd.kata.v2 alpine uname -r
    6.12.47
    ```
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
