### PR TITLE
nixos/ups: ups-killpower add logging, fix command permission

### DIFF
--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -668,10 +668,9 @@ in
 
     systemd.services.ups-killpower = lib.mkIf (cfg.upsmon.settings.POWERDOWNFLAG != null) {
       enable = cfg.upsd.enable;
-      description = "UPS Kill Power";
-      wantedBy = [ "shutdown.target" ];
-      after = [ "shutdown.target" ];
-      before = [ "final.target" ];
+      description = "Initiate delayed UPS shutdown";
+      wantedBy = [ "final.target" ];
+      before = [ "umount.target" ];
       unitConfig = {
         ConditionPathExists = cfg.upsmon.settings.POWERDOWNFLAG;
         DefaultDependencies = "no";
@@ -679,8 +678,11 @@ in
       environment = envVars;
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${cfg.package}/bin/upsdrvctl shutdown";
-        Slice = "system-ups.slice";
+        ExecStart = "${cfg.package}/bin/upsdrvctl -u root shutdown";
+        # ups-killpower should not be in the system-ups slice.
+        # If it is in a slice, the shutdown command
+        # will not be executed as a Late Shutdown Service
+        # Slice = "";
       };
     };
 


### PR DESCRIPTION
Background:  During Late Shutdown Services, the computer needs to tell the UPS that it also needs to shutdown and disconnect the computer from battery power.  The BIOS option "Restore power on AC"  needs power to be cut a few seconds to work.

This pull request fixes several issues in the current implementation and has been successfully tested with a HP Z230 computer and Eaton Ellipse ECO 650 UPS unit.

Commit message:
Update wantedBy and before service config: ConfigExample book from NUT project recommends executing the UPS killpower command before unmounting filesystems.  See https://github.com/networkupstools/ConfigExamples/releases/latest/download/ConfigExamples.pdf

Fix Permission Denied error by using '-u root' flag with upsdrvctl

Remove ups-killpower service from system-ups.slice.  The killpower command will not be executed if this service is in the system-ups.slice.

Use a more descriptive description.

@bjornfor 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
