### PR TITLE
python3Packages.pyspeex-noise: 1.0.2 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pyspeex-noise/default.nix
+++ b/pkgs/development/python-modules/pyspeex-noise/default.nix
@@ -2,25 +2,23 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
-  pybind11,
   pytestCheckHook,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pyspeex-noise";
-  version = "1.0.2";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "pyspeex-noise";
-    tag = version;
-    hash = "sha256-XtLA5yVVCZdpALPu3fx+U+aaA729Vs1UeOJsIm6/S+k=";
+    tag = "v${version}";
+    hash = "sha256-sOm3zYXI84c/8Qh4rvEZGcBo/avqS+ul+uLwtmCCc1I=";
   };
 
   build-system = [
-    pybind11
     setuptools
   ];
 
@@ -31,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/rhasspy/pyspeex-noise/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/rhasspy/pyspeex-noise/blob/${src.tag}/CHANGELOG.md";
     description = "Noise suppression and automatic gain with speex";
     homepage = "https://github.com/rhasspy/pyspeex-noise";
     license = with lib.licenses; [


### PR DESCRIPTION
Diff: https://github.com/rhasspy/pyspeex-noise/compare/1.0.2...v2.0.0

Changelog: https://github.com/rhasspy/pyspeex-noise/blob/v2.0.0/CHANGELOG.md

related: https://github.com/NixOS/nixpkgs/pull/449705
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
