### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "async";
       ename = "async";
-      version = "1.9.9.0.20250826.51747";
+      version = "1.9.9.0.20251005.63407";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/async-1.9.9.0.20250826.51747.tar";
-        sha256 = "1a05lli45vls1qdy7bvgb0vb1drm3q8dlbn67hzyszscknrrnjal";
+        url = "https://elpa.gnu.org/devel/async-1.9.9.0.20251005.63407.tar";
+        sha256 = "1mb8wvmkyi5baykccps4dl17jpk90yar043594aa7fsy8rqzdw7c";
       };
       packageRequires = [ ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.0.0.20250808.215752";
+      version = "14.1.0.0.20251007.83053";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.1.0.0.20250808.215752.tar";
-        sha256 = "1li0njqva88asr5flf1xiy4wibdxnkynp813fy38vqi3v9ckg96c";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.0.0.20251007.83053.tar";
+        sha256 = "18v9vfscvkzsj106rr8wp690v71x9lfh952wvar4cvb1jw6715zy";
       };
       packageRequires = [ ];
       meta = {
@@ -548,10 +548,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.2.1.0.20250518.225313";
+      version = "0.3.1.0.20250905.185219";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.2.1.0.20250518.225313.tar";
-        sha256 = "0mqvlnqib2my2alm2lbvij89r5c8r6zzi7lwvpgylays342lrry0";
+        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.3.1.0.20250905.185219.tar";
+        sha256 = "0jplpq1mrcqp924j12bc9kf949ndb64pzmrc4l1njn2wliykapq8";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.4.0.20250811.165718";
+      version = "0.1.4.0.20251006.205101";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20250811.165718.tar";
-        sha256 = "006m3qmad18x3h4jdhxf8nx43krk34sj636ccxlxild5lncqdf8a";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20251006.205101.tar";
+        sha256 = "1ciq4v2h29ic3amh6qdl27miz23c71533rhks1i5w4xp6wxvs4iz";
       };
       packageRequires = [ ];
       meta = {
@@ -993,14 +993,36 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "1.1.0.20250818.175416";
+      version = "1.2.0.20250914.184401";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bufferlo-1.1.0.20250818.175416.tar";
-        sha256 = "109fvfi5bvj75sr7gxqv72maj42y7wj73xrq2542w9gkjm41ayg7";
+        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20250914.184401.tar";
+        sha256 = "1xfgizjfwclgvy7sbjqfsrgp59xk8n7cixgkiwsnviysyyxh1rwv";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/bufferlo.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  buframe = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      timeout,
+    }:
+    elpaBuild {
+      pname = "buframe";
+      ename = "buframe";
+      version = "0.2.0.20250917.90933";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/buframe-0.2.0.20250917.90933.tar";
+        sha256 = "1wlivzwzfmq3j8b1zgaw4bzln3c27d1xr9fvqq2p31cjh5ra36nl";
+      };
+      packageRequires = [ timeout ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/buframe.html";
         license = lib.licenses.free;
       };
     }
@@ -1084,10 +1106,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.1.0.20250807.213828";
+      version = "2.1.0.20250920.155804";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250807.213828.tar";
-        sha256 = "1vlxp4fh3ch2148kmv9fx54pj3m4963pywr9z2mws59mbffyh6qv";
+        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250920.155804.tar";
+        sha256 = "1hh5adcv1d7p29bbd49351rn2kx57kld4g4qlp1ifzn02w1gfdpz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1297,10 +1319,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.4.0.20250825.181603";
+      version = "1.2.4.0.20251006.212555";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20250825.181603.tar";
-        sha256 = "01f5m6cs0mpw1qb7fg6bkwip7f7h5cdic6ficdzj4gfn8b6q6vh7";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20251006.212555.tar";
+        sha256 = "170v711l6qapsypzg7i56kkmwvnzc0h625wbb5hgv205zkcqvrzw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1365,10 +1387,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20250805.152556";
+      version = "1.0.2.0.20250911.12909";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250805.152556.tar";
-        sha256 = "15c22xk1m3m071yvagw89vijb46qsys7a3kvq7h61nnxw4za5x9n";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250911.12909.tar";
+        sha256 = "1186p5rzaxiz9hc4s254b9q7c9vpqcdv788h87mnmniabv18yf26";
       };
       packageRequires = [ ];
       meta = {
@@ -1525,10 +1547,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.7.0.20250821.173915";
+      version = "2.8.0.20251008.43406";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-2.7.0.20250821.173915.tar";
-        sha256 = "18a831akjfipb42f1d158m9l40z17469f5crmlaqsp3384j9qk7h";
+        url = "https://elpa.gnu.org/devel/consult-2.8.0.20251008.43406.tar";
+        sha256 = "05673j1jjr8il31g854ijgy73haplvcjsk0v41bri1iv9cyfiqaf";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1638,10 +1660,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.3.0.20250804.224308";
+      version = "2.3.0.20250923.125035";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.3.0.20250804.224308.tar";
-        sha256 = "0vbn7lg0706s8hjizzwda6wm105pkhfmc825y3a64imi1brz17dw";
+        url = "https://elpa.gnu.org/devel/corfu-2.3.0.20250923.125035.tar";
+        sha256 = "0sc7q6l53d4vpyvnsnqhawl0bcl5p61nbna9v6xfrn1lw86xdcqi";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1919,10 +1941,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.24.1.0.20250825.172742";
+      version = "0.24.1.0.20251006.200603";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20250825.172742.tar";
-        sha256 = "14dnib8w7lv2w7a0ha0q5yq3rkmndq71xkszbp1fjljfdy0m7p06";
+        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20251006.200603.tar";
+        sha256 = "1c1rkhzc2b8r8dnmh670gs9v9k5bh1kafkz2inli7f221hkmvq16";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2006,10 +2028,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.44.0.20250826.75956";
+      version = "0.45.0.20250929.72502";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.44.0.20250826.75956.tar";
-        sha256 = "0lmagkv1wq2w8llmbf1vxbaw79i0byqvrbbl56fdjib1fz35aakv";
+        url = "https://elpa.gnu.org/devel/debbugs-0.45.0.20250929.72502.tar";
+        sha256 = "1mfvlfsjx10ndns6rfl2sap2vfb8d602ng4sn0iw0la9ywsaw6pg";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2053,10 +2075,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.0.0.0.20250819.183753";
+      version = "4.0.0.0.20251007.45843";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20250819.183753.tar";
-        sha256 = "1jikp1d5kai3v1vw2zbd0l6m7990ymw2asdz9887ky3wzhz6ia0c";
+        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20251007.45843.tar";
+        sha256 = "0b6fzi9mhkqy0wky7rz9nnq6x8wigagc5ry918qm9zb30f5pg1xg";
       };
       packageRequires = [ ];
       meta = {
@@ -2075,10 +2097,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.1.1.0.20250826.41610";
+      version = "0.1.1.0.20250908.94202";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250826.41610.tar";
-        sha256 = "0c17447h15c9s61rrww6kp45lhrz2an18hb6nkx7ryzy0lqdvss9";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250908.94202.tar";
+        sha256 = "1gpyxh9bb1pk9frg676zazk8jdmy466r23110c3m59hx35rqmdy3";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2119,10 +2141,10 @@
     elpaBuild {
       pname = "denote-menu";
       ename = "denote-menu";
-      version = "1.4.0.0.20250317.132443";
+      version = "1.4.0.0.20250829.94810";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-menu-1.4.0.0.20250317.132443.tar";
-        sha256 = "0xrqfc3ik8n6d76s1rmqnh8v7h8plhm8lm3i714kscmpkzkd9wsp";
+        url = "https://elpa.gnu.org/devel/denote-menu-1.4.0.0.20250829.94810.tar";
+        sha256 = "1q0n6zrpilz20fj9b4fiianr68zpkdrfzh4nxhwim5z12dbkn3bb";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2141,10 +2163,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.1.1.0.20250823.62813";
+      version = "0.1.1.0.20250829.181530";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-org-0.1.1.0.20250823.62813.tar";
-        sha256 = "0rn70j1nsjlxf6dia24lj49i6gkb0cvfagdzbyzm8gqnb4l0gyzz";
+        url = "https://elpa.gnu.org/devel/denote-org-0.1.1.0.20250829.181530.tar";
+        sha256 = "1y6fadg2wv5lizn7p53j2hziz8mq7r5m0pxvm253b9j8r6390r8k";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2185,10 +2207,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.1.1.0.20250822.171436";
+      version = "0.1.1.0.20250905.174858";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250822.171436.tar";
-        sha256 = "07jn2s5wjra5xl9vr9lr6fllfbgj36d2q90l0yyyn9clcpkv1mgy";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250905.174858.tar";
+        sha256 = "126rhzjfbp1f94s8ivqis6vd2pi85zrn5ass5k8a6sd9sh4ahnja";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2297,10 +2319,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "0.6.0.20250804.224351";
+      version = "1.0.0.20251008.104111";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-0.6.0.20250804.224351.tar";
-        sha256 = "1prlld2r6cc38gdkkbgh6pnbxq8z64xrn77x18l0rvj9fi0x6lk0";
+        url = "https://elpa.gnu.org/devel/dicom-1.0.0.20251008.104111.tar";
+        sha256 = "0fmrnw2phx45xfshi9hwjldk8hbcywdnf9dv0q2cs7yw3l60f02n";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2347,10 +2369,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20250731.22728";
+      version = "1.10.0.0.20251008.224129";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250731.22728.tar";
-        sha256 = "09acwwc86iw8awvl7yc505vspvydwfb778g3fcvs9mx39mqcx9md";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20251008.224129.tar";
+        sha256 = "1161jxws89flszfy9x7wrz1jzzlg3c9xbpcnik9x3x5wamhr7bh9";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2643,10 +2665,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.3.0.0.20250823.65805";
+      version = "0.4.0.0.20251004.101735";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-0.3.0.0.20250823.65805.tar";
-        sha256 = "1iy73srwflia95x7kzjb35dp99p608a5yb5vs3z0qzasmm6b4axy";
+        url = "https://elpa.gnu.org/devel/doric-themes-0.4.0.0.20251004.101735.tar";
+        sha256 = "1dlsfy3faww658v03886gc44mf696pjr33igp2cfzw9ya1xsszaf";
       };
       packageRequires = [ ];
       meta = {
@@ -2845,10 +2867,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20250607.0.20250607.11108";
+      version = "20250914.0.20250914.191243";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20250607.0.20250607.11108.tar";
-        sha256 = "1gjqyr05qyp491dp095q2i9rq87g55ifbi1qy2z3i8s1ghfyp00l";
+        url = "https://elpa.gnu.org/devel/eev-20250914.0.20250914.191243.tar";
+        sha256 = "1ns804y302xdnvf2vczk4banvcysgw5dv54yv3ffjsjchgn2z5qs";
       };
       packageRequires = [ ];
       meta = {
@@ -2862,16 +2884,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      modus-themes,
     }:
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.10.0.0.20250808.64044";
+      version = "1.11.0.0.20251007.75143";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.10.0.0.20250808.64044.tar";
-        sha256 = "0g0f4kjlc1wl29g5qy1j59dxkm20a1wkbhvr5r07wav2a0is1rlr";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.11.0.0.20251007.75143.tar";
+        sha256 = "1sg7dhgxrgs7c2sy4128rv1iikj9ymigiwz3kx0a1smwn6vrmh71";
       };
-      packageRequires = [ ];
+      packageRequires = [ modus-themes ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/ef-themes.html";
         license = lib.licenses.free;
@@ -2894,10 +2917,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18.0.20250819.161828";
+      version = "1.18.0.20251003.84456";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250819.161828.tar";
-        sha256 = "0b7jh9xvi1cfyrmvhbgpb3vpvyv2306zvcyi6j4vwj08wlr9ln49";
+        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20251003.84456.tar";
+        sha256 = "0avj1q1m7qmdivvz3nqysbq9lxnzpy6cfw599wl44ij5xdfnpwrx";
       };
       packageRequires = [
         eldoc
@@ -2923,10 +2946,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.4.8.0.20250606.193102";
+      version = "2.5.3.0.20251008.162616";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/el-job-2.4.8.0.20250606.193102.tar";
-        sha256 = "13p5mdll5qhf3h9y3k2c35frfnh8v9aci8f5la2c23b9k53qpvhb";
+        url = "https://elpa.gnu.org/devel/el-job-2.5.3.0.20251008.162616.tar";
+        sha256 = "0vqng5mcrpima2wnpgs5cqb1v0fk0d2fcpz15vq8pcdsd3zm7h10";
       };
       packageRequires = [ ];
       meta = {
@@ -3067,10 +3090,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.8.2.0.20250801.174017";
+      version = "1.8.6.0.20250918.160602";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-1.8.2.0.20250801.174017.tar";
-        sha256 = "0drgpw3q5lm4x8fkf7nymv08vkjizbybmh1k66p1fy6sxxbjyfz9";
+        url = "https://elpa.gnu.org/devel/ellama-1.8.6.0.20250918.160602.tar";
+        sha256 = "0x1nndmivxvhpqjbns038qpksr9g02gh7rpg9r1jmkdmhvkiihgp";
       };
       packageRequires = [
         compat
@@ -3203,10 +3226,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "23.0.20250731.114728";
+      version = "23.0.20251002.104209";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-23.0.20250731.114728.tar";
-        sha256 = "0dxqq6c1w6v7qgsbsznqkwf518dy0a3zaxs31j5ldyz6b2ylfsrh";
+        url = "https://elpa.gnu.org/devel/emms-23.0.20251002.104209.tar";
+        sha256 = "072l1pkqwpkk00px2251jvl4x0769kjlldd6l4a5d1cdi0kam074";
       };
       packageRequires = [
         cl-lib
@@ -3292,10 +3315,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20250825.211748";
+      version = "5.6.1snapshot0.20250904.171225";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250825.211748.tar";
-        sha256 = "09fs9p1fjjzzripdnzmp3z0r1j6b0cl3wga4v8rlrkz7s0sikbpv";
+        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250904.171225.tar";
+        sha256 = "07mm33az8c055p2i22ihp4vrs460wvk75fdcy960b45qlsd19kwp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3339,10 +3362,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20250729.82713";
+      version = "25.1.0.0.20251003.204431";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250729.82713.tar";
-        sha256 = "1c6pk6dxzqi4xx06a0yirrzrpvrqsdf3pidbkw08m6ddjg75qrcp";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20251003.204431.tar";
+        sha256 = "1njv0vdxi7v9wn00mn0k3qxhxliz80hh74jx9nzm4j2n003lf8y9";
       };
       packageRequires = [ ];
       meta = {
@@ -3411,10 +3434,10 @@
     elpaBuild {
       pname = "expreg";
       ename = "expreg";
-      version = "1.4.1.0.20250703.235736";
+      version = "1.4.1.0.20250918.220913";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/expreg-1.4.1.0.20250703.235736.tar";
-        sha256 = "0v661v52xhni1mljz8b952vaybkj30542xjabkfzdn6bby98k118";
+        url = "https://elpa.gnu.org/devel/expreg-1.4.1.0.20250918.220913.tar";
+        sha256 = "1fdwxr3albv7ww87w8ib8r0rid8zkibcgbl3qhp29vm8g28s89ws";
       };
       packageRequires = [ ];
       meta = {
@@ -3455,10 +3478,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20250728.33017";
+      version = "0.34.0.20250919.75516";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20250728.33017.tar";
-        sha256 = "07xhfbi7qlp9csqdbcz70w9xfr97ylgzh7f819lzxliqlxzcmw9s";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20250919.75516.tar";
+        sha256 = "1fm2mmni78xif4lva5rwsrv40ywbz8m0cc1gl3krqsilb3a150y8";
       };
       packageRequires = [
         compat
@@ -3502,10 +3525,10 @@
     elpaBuild {
       pname = "filechooser";
       ename = "filechooser";
-      version = "0.2.3.0.20250624.102108";
+      version = "0.2.4.0.20250910.151030";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/filechooser-0.2.3.0.20250624.102108.tar";
-        sha256 = "0va3sbq28xsg127yzn6fwjmqivykg0r74ll0gsi6knq7yggapfhg";
+        url = "https://elpa.gnu.org/devel/filechooser-0.2.4.0.20250910.151030.tar";
+        sha256 = "1b82fyqvbaq0mq6pz6m6i0h3i6kjcz59a3i9qfzlhvvjfa07zfyp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3589,10 +3612,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.1.0.20250823.114435";
+      version = "1.4.1.0.20250906.55308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250823.114435.tar";
-        sha256 = "0xw00vq7p4vwxfcp9jlkajgpplipgs18hh522ld1mmg87likm0zq";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250906.55308.tar";
+        sha256 = "1wy77d63mlcax9sksf3js0acqmx33hkn03iz37aqlyikjy51vbs9";
       };
       packageRequires = [
         eldoc
@@ -3981,10 +4004,10 @@
     elpaBuild {
       pname = "gnu-elpa-keyring-update";
       ename = "gnu-elpa-keyring-update";
-      version = "2022.12.1.0.20240525.173808";
+      version = "2025.10.1.0.20251008.190710";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gnu-elpa-keyring-update-2022.12.1.0.20240525.173808.tar";
-        sha256 = "0s8fydk7b3qc6zv90n3bjniczr5911jkza5xqwi69cb1v9fbfjyd";
+        url = "https://elpa.gnu.org/devel/gnu-elpa-keyring-update-2025.10.1.0.20251008.190710.tar";
+        sha256 = "0fvx7yh0n3glb8h2m9bb3an0q2pc34qpxcwz3ggsgp3fwsxf3k6f";
       };
       packageRequires = [ ];
       meta = {
@@ -4100,10 +4123,10 @@
     elpaBuild {
       pname = "gpr-query";
       ename = "gpr-query";
-      version = "1.0.4.0.20231018.92052";
+      version = "1.0.4.0.20251001.94944";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gpr-query-1.0.4.0.20231018.92052.tar";
-        sha256 = "0j0p685v1v0byma8x5lpihvfj6hyg30dx8jqa6q0xmm2c6i8cqai";
+        url = "https://elpa.gnu.org/devel/gpr-query-1.0.4.0.20251001.94944.tar";
+        sha256 = "17cj6rks98nc40991nwzx8znbws1pkjhfsnznfhack76i8612hxi";
       };
       packageRequires = [
         gnat-compiler
@@ -4409,10 +4432,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20250819.124153";
+      version = "9.0.2pre0.20250914.231303";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250819.124153.tar";
-        sha256 = "09798m66pv8f528djsqwcqqm3aa1y2a6nncm18n64ld9zppy82xc";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250914.231303.tar";
+        sha256 = "07nk16nkvl9myr7mxhrql5wpxsr1qa2nj4r76x4fh6lvsh9nfnim";
       };
       packageRequires = [ ];
       meta = {
@@ -4807,10 +4830,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.3.0.20250804.224330";
+      version = "2.3.0.20251007.170933";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.3.0.20250804.224330.tar";
-        sha256 = "08lbppgqgnqvmzvbwc1z9zan0d6fsf0jacdifqcinlr6s7qlnrci";
+        url = "https://elpa.gnu.org/devel/jinx-2.3.0.20251007.170933.tar";
+        sha256 = "0ihjqsvckn08fq9z1c8yy8ic1lfjzid2835s8xa2sq07qk7389fi";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4893,10 +4916,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.25.0.20250225.2515";
+      version = "1.0.25.0.20250907.123924";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20250225.2515.tar";
-        sha256 = "1zfgpyrlbydnqwim4zrh9xbj37g8yqbwdz9ci0r90d1s4h6nyzgv";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20250907.123924.tar";
+        sha256 = "115x2m52fga5mxj9dbvc2vk380m5qx130zczaisgc2r23qw8gwjb";
       };
       packageRequires = [ ];
       meta = {
@@ -5259,10 +5282,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.27.1.0.20250809.223521";
+      version = "0.27.2.0.20251004.1607";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.27.1.0.20250809.223521.tar";
-        sha256 = "0ynsbvz9csg7mnd5f8ycwknghyqf7zvvlf4qcs7za84mgjnya5la";
+        url = "https://elpa.gnu.org/devel/llm-0.27.2.0.20251004.1607.tar";
+        sha256 = "00vf791pjf4sxja3wp9nl7s514gk3c3rcdmdw37nfcvw8vx3qa9h";
       };
       packageRequires = [
         compat
@@ -5499,10 +5522,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.2.0.20250824.83436";
+      version = "2.3.0.20251006.112635";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.2.0.20250824.83436.tar";
-        sha256 = "0x6lpwpx64xlbm2p0jzykgpjd4cnablyjirz3h907sf1amnwhkqf";
+        url = "https://elpa.gnu.org/devel/marginalia-2.3.0.20251006.112635.tar";
+        sha256 = "1kca6q6c0bncal0bim1hzldkjbgm4ia0l5v40h5zl9ybakzqlvp3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5584,10 +5607,10 @@
     elpaBuild {
       pname = "mathsheet";
       ename = "mathsheet";
-      version = "1.2.0.20250705.223649";
+      version = "1.3.0.20250928.180349";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mathsheet-1.2.0.20250705.223649.tar";
-        sha256 = "0a198rd5djvhbldscy5pnl4xifw787amnrla3s7wy6jrr1lqna19";
+        url = "https://elpa.gnu.org/devel/mathsheet-1.3.0.20250928.180349.tar";
+        sha256 = "0mkmfm3ck71pm75r5rii1l89a9m50hgw68n92ww1m016z2zrw6va";
       };
       packageRequires = [ peg ];
       meta = {
@@ -5605,10 +5628,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "6.3.0.20250607.211810";
+      version = "7.1.1.0.20251001.101359";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-6.3.0.20250607.211810.tar";
-        sha256 = "1pa9llf04ib6lzhf5lp3nf6asjland076bhrqkfp7h551qs7j4zs";
+        url = "https://elpa.gnu.org/devel/matlab-mode-7.1.1.0.20251001.101359.tar";
+        sha256 = "1s4kvfan9xlv2m1l92y59ib7lfzycnidkh456pq2pva74if810a5";
       };
       packageRequires = [ ];
       meta = {
@@ -5626,10 +5649,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0.0.20250724.62824";
+      version = "1.1.0.0.20250827.55853";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20250724.62824.tar";
-        sha256 = "0gvznkbcd8igj9bkz249zc9qwzy07qayil38a2d7b25b2mfbchsq";
+        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20250827.55853.tar";
+        sha256 = "0hspc3q453k7wmaiwh9q4b83n41l5fp2nc6di3slzghpjfnskpp6";
       };
       packageRequires = [ ];
       meta = {
@@ -5798,10 +5821,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.6.0.0.20250819.191029";
+      version = "0.6.0.0.20250915.11734";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.6.0.0.20250819.191029.tar";
-        sha256 = "1hq7slvzp1n89v5w4vm0vhlsday3zmq47pl7xkn5b70xa396ynqd";
+        url = "https://elpa.gnu.org/devel/minuet-0.6.0.0.20250915.11734.tar";
+        sha256 = "1ghnibrqwvmq6dw3rn3z1knh50x5294jvskv4grawzirs7ki252p";
       };
       packageRequires = [
         dash
@@ -5835,6 +5858,27 @@
       };
     }
   ) { };
+  mode-line-maker = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "mode-line-maker";
+      ename = "mode-line-maker";
+      version = "0.1.0.20250912.174809";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/mode-line-maker-0.1.0.20250912.174809.tar";
+        sha256 = "08pwkdf94v4gzvfpjvs2dqkkzfr2w9c8k2qm5fwpjr7mb0y67fq5";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/mode-line-maker.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   modus-themes = callPackage (
     {
       elpaBuild,
@@ -5844,10 +5888,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.8.1.0.20250718.41026";
+      version = "4.8.1.0.20251007.41506";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.8.1.0.20250718.41026.tar";
-        sha256 = "0j0nz06mh0k927l2w46zij4vilg5r3zxvkza171aarnz3x01lvfr";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.8.1.0.20251007.41506.tar";
+        sha256 = "0xidd1aw3byzvbz79nw1mjk9f9qnnqfgw6v4aycqbw0zlz2s8wvv";
       };
       packageRequires = [ ];
       meta = {
@@ -6081,10 +6125,10 @@
     elpaBuild {
       pname = "nano-theme";
       ename = "nano-theme";
-      version = "0.3.4.0.20250820.51020";
+      version = "0.3.4.0.20250902.55900";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/nano-theme-0.3.4.0.20250820.51020.tar";
-        sha256 = "1dia2jpl2mxamhr3hw7z9q9963psagnzhl5qqbag3a1d9bnn1bwa";
+        url = "https://elpa.gnu.org/devel/nano-theme-0.3.4.0.20250902.55900.tar";
+        sha256 = "0yz9k9v980vzxyylywvkphk6bbgkfgw8a40q5za83kb7g3gf7sx6";
       };
       packageRequires = [ ];
       meta = {
@@ -6249,10 +6293,10 @@
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.17.0.20250810.115209";
+      version = "0.18.3.0.20250909.170257";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/oauth2-0.17.0.20250810.115209.tar";
-        sha256 = "1vzis99y0lwm8zfy0qbhzwwh4qj6r02m2l6jwmzy0n9m63964pij";
+        url = "https://elpa.gnu.org/devel/oauth2-0.18.3.0.20250909.170257.tar";
+        sha256 = "08bgi2ql4ifqkisxrjhxqyjd6zfnx2na7sgkvd9z70mq1wxs5wfp";
       };
       packageRequires = [ ];
       meta = {
@@ -6378,10 +6422,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.5.0.20250728.24301";
+      version = "1.5.0.20250922.134410";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20250728.24301.tar";
-        sha256 = "082inppxd4ab2n1mq4dn7pnv2077kwp5bg1d6ic0x63dz8yiqww9";
+        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20250922.134410.tar";
+        sha256 = "10i2hyyj5ki8cga21rdprjq5qnbqlhqxw1kn92d0zm1f2w1h9ykg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6399,10 +6443,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20250817.94001";
+      version = "9.8pre0.20251006.171414";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250817.94001.tar";
-        sha256 = "0g4mi27zfpm3pss1hpmj66y22yhwqa583imjdxbrxxv1b9fn3z0l";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20251006.171414.tar";
+        sha256 = "1sfjf93fgmlmjm3ys86npcp7djmzgdl2w8y50mjzd8bc4zgf73ab";
       };
       packageRequires = [ ];
       meta = {
@@ -6421,10 +6465,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20250820.180336";
+      version = "1.1.0.20250905.33527";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250820.180336.tar";
-        sha256 = "0s7wlh9a5fsbmp76lrxvcs4gz7xg6qky2d6q0ixbpb6pq6arxx4i";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250905.33527.tar";
+        sha256 = "1d5d41lrliv30ngqx974lsm3am8k6zll8mh940a777isc4mglvhn";
       };
       packageRequires = [ org ];
       meta = {
@@ -6518,10 +6562,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.9.0.20250804.224509";
+      version = "1.9.0.20250924.170536";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.9.0.20250804.224509.tar";
-        sha256 = "10rffsxn989yqqawdg36ymz3i1k82z1hwp4l49gy37szcrpmc5ps";
+        url = "https://elpa.gnu.org/devel/org-modern-1.9.0.20250924.170536.tar";
+        sha256 = "05x6c3hq0xwml82047lmxvgck83pmxcmq4aff3vy57m6b2dd9p7w";
       };
       packageRequires = [
         compat
@@ -6698,10 +6742,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.7.0.20250804.224343";
+      version = "1.7.0.20251008.104137";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.7.0.20250804.224343.tar";
-        sha256 = "1iqpfzn6rcswkn8sgskwyqya07q21xs0c1s3xrlfxrskybrh1rpd";
+        url = "https://elpa.gnu.org/devel/osm-1.7.0.20251008.104137.tar";
+        sha256 = "15c74hby5j5dzki8m4avlsf3jrnz5qz1p8cyi2khyzlaf7jihpy7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6911,10 +6955,10 @@
     elpaBuild {
       pname = "persist";
       ename = "persist";
-      version = "0.6.1.0.20250213.95218";
+      version = "0.7.0.20250930.85116";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/persist-0.6.1.0.20250213.95218.tar";
-        sha256 = "0rvd38k3hzz70dcn3xpmcilkp7vmq32gdic349184548b220jypm";
+        url = "https://elpa.gnu.org/devel/persist-0.7.0.20250930.85116.tar";
+        sha256 = "0iapa9d0njc1qyqjbkl71fwws7hfz5303i17b69d6xdaynb7dajr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7252,10 +7296,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.0.20241203.135521";
+      version = "0.4.1.0.20250829.60323";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.4.0.20241203.135521.tar";
-        sha256 = "0pcncvr4nv251fm0c66c3wqazv89vxqcv9j2jq0kvylx9ks2vzaz";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.4.1.0.20250829.60323.tar";
+        sha256 = "0qbpzbwfg1d3jh7nh7xvxhy4pdmxd75yzl652vcyb7cy8h4kc6ac";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7296,10 +7340,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20250824.2348";
+      version = "0.11.1.0.20251001.102725";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250824.2348.tar";
-        sha256 = "0rd684rv45snxn14h6z9dm2ffridygpcmphraszy953rn8syr7xx";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20251001.102725.tar";
+        sha256 = "0cyqqz8q0qis1lvgpdkwkzddj8zgraj9vn20xlc2bq52mmdql3a2";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7432,10 +7476,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20250807.130628";
+      version = "0.30.0.20250925.170612";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20250807.130628.tar";
-        sha256 = "0p6r82k9vbwdb3kdbxfh9a4a088fdssa7wz3rdxz61c0jqvia2bw";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20250925.170612.tar";
+        sha256 = "1pkanqqv9c5046nzl1b83bh2cs1wchqh28y6vzwxn23l0yn7b23i";
       };
       packageRequires = [
         compat
@@ -7564,10 +7608,10 @@
     elpaBuild {
       pname = "rcirc-mentions";
       ename = "rcirc-mentions";
-      version = "1.0.3.0.20250822.43114";
+      version = "1.0.5.0.20250908.131006";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/rcirc-mentions-1.0.3.0.20250822.43114.tar";
-        sha256 = "064k7r6digaljdi156m49wcasf7k37rj195lxbarh18qavragqv7";
+        url = "https://elpa.gnu.org/devel/rcirc-mentions-1.0.5.0.20250908.131006.tar";
+        sha256 = "04l93gigrw6jkrarwf2ckakpq0p2n3nr6iigzc7mhflj1kbx1wm0";
       };
       packageRequires = [ ];
       meta = {
@@ -7884,10 +7928,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.1.0.20250814.100832";
+      version = "2.1.0.20250904.163151";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/relint-2.1.0.20250814.100832.tar";
-        sha256 = "10xj341zrf6plvz5816w0bimfz2dc2kfc6qs59yxcyk3j33bs5jd";
+        url = "https://elpa.gnu.org/devel/relint-2.1.0.20250904.163151.tar";
+        sha256 = "11abw06nwq50xpin61qnmka3zdlkdmpljl34gs3ahf0b7p4w1g9b";
       };
       packageRequires = [ xr ];
       meta = {
@@ -8146,10 +8190,10 @@
     elpaBuild {
       pname = "setup";
       ename = "setup";
-      version = "1.4.0.0.20241224.124645";
+      version = "1.5.0.0.20250829.105526";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/setup-1.4.0.0.20241224.124645.tar";
-        sha256 = "00qyav0lrskbm9jryqlbyk4nlh9bv2191l0bjqhqhryj2hzm26rm";
+        url = "https://elpa.gnu.org/devel/setup-1.5.0.0.20250829.105526.tar";
+        sha256 = "167qy96rkvz1i1np6vjh7h0f3zm32pihyr4rcpwpxamkggb8x6vj";
       };
       packageRequires = [ ];
       meta = {
@@ -8188,10 +8232,10 @@
     elpaBuild {
       pname = "shell-command-plus";
       ename = "shell-command+";
-      version = "2.4.2.0.20240912.220425";
+      version = "2.5.0.0.20250930.194048";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/shell-command+-2.4.2.0.20240912.220425.tar";
-        sha256 = "16yxmv8nhbnsdancnn8zj81zba9dfzmkfjxp9sb9d2f0wnyza2i4";
+        url = "https://elpa.gnu.org/devel/shell-command+-2.5.0.0.20250930.194048.tar";
+        sha256 = "1p6s6rp10mg23vvnls5pxgx014jf86x6427xbqms3bbdz0fpzn5j";
       };
       packageRequires = [ ];
       meta = {
@@ -8251,10 +8295,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.3.1.0.20250826.74910";
+      version = "1.0.0.0.20250907.131347";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-0.3.1.0.20250826.74910.tar";
-        sha256 = "0m5g2qkcs97liqk98x3qnsimkg7bp6fysxpvinmkah66gq0lx5b7";
+        url = "https://elpa.gnu.org/devel/show-font-1.0.0.0.20250907.131347.tar";
+        sha256 = "13z63f0sxpl078hzqd1v3naynb4j9h6c26xpxkjifjsl3rw333ch";
       };
       packageRequires = [ ];
       meta = {
@@ -8293,10 +8337,10 @@
     elpaBuild {
       pname = "site-lisp";
       ename = "site-lisp";
-      version = "0.1.2.0.20240308.82403";
+      version = "0.2.0.0.20250918.230122";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/site-lisp-0.1.2.0.20240308.82403.tar";
-        sha256 = "0c9r5pp2lr4wmpcfa8qz0xvq1vhzyhvnn14kawjarhx9p5mvgdq1";
+        url = "https://elpa.gnu.org/devel/site-lisp-0.2.0.0.20250918.230122.tar";
+        sha256 = "0m72y6vlnwmj25wdy687hl14v77s81m00p9mjs6rv5sgcplnff8l";
       };
       packageRequires = [ ];
       meta = {
@@ -8720,16 +8764,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      modus-themes,
     }:
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.2.0.0.20250803.41715";
+      version = "2.2.0.0.20251008.94216";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250803.41715.tar";
-        sha256 = "1mykgalrlgr154g4hdslvdfd3jajzv8dkgg2w5rjy2lihnslcds5";
+        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20251008.94216.tar";
+        sha256 = "0f5fb0d5wzzz1amqf4a6gsliwzff9d7f0q6zdgl6hjdjdcmk9dij";
       };
-      packageRequires = [ ];
+      packageRequires = [ modus-themes ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/standard-themes.html";
         license = lib.licenses.free;
@@ -8938,10 +8983,10 @@
     elpaBuild {
       pname = "system-packages";
       ename = "system-packages";
-      version = "1.0.13.0.20230908.453";
+      version = "1.1.1.0.20250919.135435";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/system-packages-1.0.13.0.20230908.453.tar";
-        sha256 = "0qh4z6sik94hkms5nfharx2y8np2a1a2r9yrf8lw6xihdnd7bfcv";
+        url = "https://elpa.gnu.org/devel/system-packages-1.1.1.0.20250919.135435.tar";
+        sha256 = "0j7cyrgiyn0vyyc77wz7rjmn4rp7zsv3pqrn5zws2p254r2dyn6g";
       };
       packageRequires = [ ];
       meta = {
@@ -9097,14 +9142,35 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.5.0.20250823.200409";
+      version = "1.6.0.20250920.84834";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.5.0.20250823.200409.tar";
-        sha256 = "0rsaq2b0k37q03kq7rknfg26ma87j1m89n2l1s9s7pg9kvjqyrkk";
+        url = "https://elpa.gnu.org/devel/tempel-1.6.0.20250920.84834.tar";
+        sha256 = "0l9b21ijpi6wx5z1da2xg95qnh1g168lhmsqkx2dqljlsrjmg5cv";
       };
       packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/tempel.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  termint = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "termint";
+      ename = "termint";
+      version = "0.1.1.0.20251004.2413";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/termint-0.1.1.0.20251004.2413.tar";
+        sha256 = "0dvfm0kbhbv84l1hjc0gwafp8vphq466mjq4x7p4awdab594x114";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/termint.html";
         license = lib.licenses.free;
       };
     }
@@ -9194,6 +9260,27 @@
       };
     }
   ) { };
+  timeout = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "timeout";
+      ename = "timeout";
+      version = "2.1.0.20250911.163956";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/timeout-2.1.0.20250911.163956.tar";
+        sha256 = "1arsi968crr146qgqifx4s71ah50w3d3kl5m4k42mkgc50awy1r2";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/timeout.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   timerfunctions = callPackage (
     {
       cl-lib ? null,
@@ -9246,10 +9333,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.1.0.0.20250823.55117";
+      version = "1.2.0.0.20251006.73242";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.1.0.0.20250823.55117.tar";
-        sha256 = "16mp83rl6sfgxqncgz1qw68alh1xj57yqc4yy1z7cxjg5p4vbbj6";
+        url = "https://elpa.gnu.org/devel/tmr-1.2.0.0.20251006.73242.tar";
+        sha256 = "1ll3776pbkjvxiqy2d0n11armxakckacjfmjwz6cpm19iz3h0gx4";
       };
       packageRequires = [ ];
       meta = {
@@ -9335,10 +9422,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.1.0.20250730.65308";
+      version = "2.8.0.3.0.20250929.70756";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.0.1.0.20250730.65308.tar";
-        sha256 = "1yzd022xgx5x81k19pam97lw0sr75xz4pns681h77q5yhwz4r3yr";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.0.3.0.20250929.70756.tar";
+        sha256 = "18zlii5z5qpp18ab6cylndvbcp0586b4g6xjih536g27awqki4i9";
       };
       packageRequires = [ ];
       meta = {
@@ -9421,10 +9508,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.9.4.0.20250801.114942";
+      version = "0.10.1.0.20251006.181532";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.9.4.0.20250801.114942.tar";
-        sha256 = "10ly70n16v6hrhgjvhihpzv9hpq4zdx3lrq8ywjprdcp9ir5bx0r";
+        url = "https://elpa.gnu.org/devel/transient-0.10.1.0.20251006.181532.tar";
+        sha256 = "04jzkvi4sd5mm73n86gcq3cfmqpl833864sy4q8rzqwshak211k7";
       };
       packageRequires = [
         compat
@@ -9515,10 +9602,10 @@
     elpaBuild {
       pname = "triples";
       ename = "triples";
-      version = "0.6.0.0.20250510.230302";
+      version = "0.6.1.0.20251004.160701";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/triples-0.6.0.0.20250510.230302.tar";
-        sha256 = "0xgx32rwxw4cf1c178mfasvpw7ng85mrakqyvzmmmbysj16dkcw8";
+        url = "https://elpa.gnu.org/devel/triples-0.6.1.0.20251004.160701.tar";
+        sha256 = "05xplf1ipdykw5l25zsfgcghb5a5pq1la93059w82nqyqsa9401r";
       };
       packageRequires = [ seq ];
       meta = {
@@ -9781,10 +9868,10 @@
     elpaBuild {
       pname = "vc-backup";
       ename = "vc-backup";
-      version = "1.1.0.0.20220825.144758";
+      version = "1.1.1.0.20250918.224711";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-backup-1.1.0.0.20220825.144758.tar";
-        sha256 = "1jd3mv5467vy3ddrrhsv6nwsmyksqls5zhnb8hjb6imrhsylprbv";
+        url = "https://elpa.gnu.org/devel/vc-backup-1.1.1.0.20250918.224711.tar";
+        sha256 = "10a6a12xqsxvhpq88wwc1ylv5zy3x347d9l2bv2wpfrq7n7nrpr7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9845,10 +9932,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.3.0.20250825.81224";
+      version = "0.4.0.20251007.180307";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.3.0.20250825.81224.tar";
-        sha256 = "1f3xclsgglk93b2h7nc6gclydg578ffzc7zqxlbgbxbri5kmb0a9";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.4.0.20251007.180307.tar";
+        sha256 = "0n1kqx2wlr94qb6zsd3mgikf6imb0gn0bg1hajpqv794xv58mlh8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9978,10 +10065,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.4.0.20250824.101737";
+      version = "2.5.0.20250909.214050";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.4.0.20250824.101737.tar";
-        sha256 = "0xkad13qk8aibmd1j40lv1l30bifav2pfmh07cy6j548nb7y5d8j";
+        url = "https://elpa.gnu.org/devel/vertico-2.5.0.20250909.214050.tar";
+        sha256 = "0iikcz47zmdzij62q35q2f4pr6a729nk6i5hqg7bzy3fwjhryy2v";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10001,10 +10088,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.8.0.0.20250211.11642";
+      version = "0.9.0.0.20250910.92713";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-posframe-0.8.0.0.20250211.11642.tar";
-        sha256 = "0l9s2r9s8gm2xyaz8alik7m3qy4jjg6mdpbdrgd5n9bp6jk85kz5";
+        url = "https://elpa.gnu.org/devel/vertico-posframe-0.9.0.0.20250910.92713.tar";
+        sha256 = "17lzg4w68rws0824dm1qn1fv9a63pwscvhabfqlfvicnkrpz7rzb";
       };
       packageRequires = [
         posframe
@@ -10109,10 +10196,10 @@
     elpaBuild {
       pname = "vundo";
       ename = "vundo";
-      version = "2.4.0.0.20250617.174826";
+      version = "2.4.0.0.20250927.224241";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250617.174826.tar";
-        sha256 = "17pshwr9drw113az1mbw9val2lpf0cafgh8g7cpspzkph5x9149q";
+        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250927.224241.tar";
+        sha256 = "0y6zx6mld7dy2cqlcr81zm4g0vdm7ib92c9d1zca2b8i5pg5qfrp";
       };
       packageRequires = [ ];
       meta = {
@@ -10523,10 +10610,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.1.0.20250814.100809";
+      version = "2.1.0.20250904.163110";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xr-2.1.0.20250814.100809.tar";
-        sha256 = "0dnpwvc6bbvi3w25q38xwpcfplwx0dsfsgxjqzjyxm17zijmgnfp";
+        url = "https://elpa.gnu.org/devel/xr-2.1.0.20250904.163110.tar";
+        sha256 = "1xa4y8dlkcskxhvd3gyfpfibkhgxfx25lf89km33wwz4d7vibzc9";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -527,10 +527,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.2.1";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.2.1.tar";
-        sha256 = "020sf13hiyx6g32vixdf65bdcf9sdkh12rixcln6zgm23pw5rdgl";
+        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.3.1.tar";
+        sha256 = "1qqyl5qz3ldp28qm1vwbq4q7csb4wy6b3w3z72fhasvkcpb266iw";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -972,14 +972,36 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "1.1";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/bufferlo-1.1.tar";
-        sha256 = "0g72k2y5nfqa6j3y0c4z0x3crn8ynlkgvwysxhgh9vypq7cqldj0";
+        url = "https://elpa.gnu.org/packages/bufferlo-1.2.tar";
+        sha256 = "0144bvgi63cvh7fcqdiz3zy0nncj8jslxd3x9jaw7m4pwadvaqvq";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/bufferlo.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  buframe = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      timeout,
+    }:
+    elpaBuild {
+      pname = "buframe";
+      ename = "buframe";
+      version = "0.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/buframe-0.2.tar";
+        sha256 = "0bnj4xvwmda62j9i7a9pnd0x20wa6g3il8cl55df26qpgqmjjpkq";
+      };
+      packageRequires = [ timeout ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/buframe.html";
         license = lib.licenses.free;
       };
     }
@@ -1505,10 +1527,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.7";
+      version = "2.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-2.7.tar";
-        sha256 = "1r4rjq537j1yr73apr8ga86kzs5h0xk4s0xf9983pq9spgd0wrpi";
+        url = "https://elpa.gnu.org/packages/consult-2.8.tar";
+        sha256 = "01vvv5q1rlbi7db0hya8dilr6ywq0skf43mc49jka3c3gj3a924v";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1965,10 +1987,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.44";
+      version = "0.45";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/debbugs-0.44.tar";
-        sha256 = "02kb24rscbhs4w6xknf5d6l1cicy99b0004hr20pkki6faapzpx2";
+        url = "https://elpa.gnu.org/packages/debbugs-0.45.tar";
+        sha256 = "1rbj3ms2hkg0ra30y0bwzmdlcq58p15vzhin28a1rw2rmbwx5irc";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2251,10 +2273,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "0.6";
+      version = "1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dicom-0.6.tar";
-        sha256 = "0z548wa0hxj6z6vh7pwps4gsgrgh6p3g57j703777d5g75jb3j3m";
+        url = "https://elpa.gnu.org/packages/dicom-1.0.tar";
+        sha256 = "05v20pac5xgcmcqn6hw0f3n8dlz3nr178044y2xry6zz0psc3vx0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2597,10 +2619,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.3.0";
+      version = "0.4.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-0.3.0.tar";
-        sha256 = "1i2wrg3j2gpwyb3y1fb8wwmzl0hk5dw8i1160vcffpwmbf3mppza";
+        url = "https://elpa.gnu.org/packages/doric-themes-0.4.0.tar";
+        sha256 = "0dh5gib95fqfqdlk493y8dpdln2bqs2v5gg4gghy4rhgg79six5j";
       };
       packageRequires = [ ];
       meta = {
@@ -2799,10 +2821,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20250607";
+      version = "20250914";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20250607.tar";
-        sha256 = "0rrm6mldhmf0ijjr8nri9a6sasxknd8wivq2fkni60c47m65m2md";
+        url = "https://elpa.gnu.org/packages/eev-20250914.tar";
+        sha256 = "1bn7nv42pkd910s47if2jzrzfd10s2nbhid3adh96p9bpy46k639";
       };
       packageRequires = [ ];
       meta = {
@@ -2820,10 +2842,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.10.0";
+      version = "1.11.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ef-themes-1.10.0.tar";
-        sha256 = "1mpaw1icvalq1ydxby9zfbjdgkk9wvld31xjrbr684ps5ix8f1f2";
+        url = "https://elpa.gnu.org/packages/ef-themes-1.11.0.tar";
+        sha256 = "086d2fmgzgnjil97zjn2i0ii81dq9l8rr859j0kyaxiy83r27rqb";
       };
       packageRequires = [ ];
       meta = {
@@ -2881,10 +2903,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.4.8";
+      version = "2.5.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/el-job-2.4.8.tar";
-        sha256 = "1g7kmsxq2hdsfl2glm9yaqhqx87kl4amg5wi3872kjlbrwfd78kk";
+        url = "https://elpa.gnu.org/packages/el-job-2.5.3.tar";
+        sha256 = "0wigrrn5qw0dknlr9jwgq89jvhbmpyxvxsyh4lb9lm0vpd1vdfyg";
       };
       packageRequires = [ ];
       meta = {
@@ -3025,10 +3047,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.8.2";
+      version = "1.8.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-1.8.2.tar";
-        sha256 = "0gkkm3hfxwn2x12vbbrp3nydkzs91abd90cf8qmwaxgdl6fvlg4d";
+        url = "https://elpa.gnu.org/packages/ellama-1.8.6.tar";
+        sha256 = "03ckmz16r1xinb7h7gcf5h030b4axv44l9wanw9d6qwydgy6hl6r";
       };
       packageRequires = [
         compat
@@ -3459,10 +3481,10 @@
     elpaBuild {
       pname = "filechooser";
       ename = "filechooser";
-      version = "0.2.3";
+      version = "0.2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/filechooser-0.2.3.tar";
-        sha256 = "17dqms6knc0l47m02581jlm7ikcs662nmxdnsklipnnn0gfjmkmm";
+        url = "https://elpa.gnu.org/packages/filechooser-0.2.4.tar";
+        sha256 = "0bw1yvypm2vk6bh81h88505fd1538rrga9y40gmy7w144spfi6sb";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3937,10 +3959,10 @@
     elpaBuild {
       pname = "gnu-elpa-keyring-update";
       ename = "gnu-elpa-keyring-update";
-      version = "2022.12.1";
+      version = "2025.10.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gnu-elpa-keyring-update-2022.12.1.tar";
-        sha256 = "0yb81ly7y5262fpa0n96yngqmz1rgfwrpm0a6vqghdpr5x0c8z6n";
+        url = "https://elpa.gnu.org/packages/gnu-elpa-keyring-update-2025.10.1.tar";
+        sha256 = "0p3125llm6hiasxx1rxl5anwfa317w2m8ybj9zl8133m5sjzzvsf";
       };
       packageRequires = [ ];
       meta = {
@@ -5219,10 +5241,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.27.1";
+      version = "0.27.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.27.1.tar";
-        sha256 = "0qdzkjm9cihhcj5ains8m952hwkjfy4glr6yzrs5dws3bl3yqqbh";
+        url = "https://elpa.gnu.org/packages/llm-0.27.2.tar";
+        sha256 = "0wkz4l2ica2wrmb30yylqdbdp1q2xflarcdl0z399lh315jdbypg";
       };
       packageRequires = [
         compat
@@ -5457,10 +5479,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.2";
+      version = "2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.2.tar";
-        sha256 = "16h0zdzjip10ryalanygfkz4i2bf21vr6f4348l5cgx0mnx10cvx";
+        url = "https://elpa.gnu.org/packages/marginalia-2.3.tar";
+        sha256 = "0k2ndssravhd94b63fyiv2h7rvny2fik988w1dnpdy6q9vj2vdgw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5542,10 +5564,10 @@
     elpaBuild {
       pname = "mathsheet";
       ename = "mathsheet";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/mathsheet-1.2.tar";
-        sha256 = "1wx67cnpxlqnpr3bsdnw4ccsg2fgjazcdbddbkr6r69pdbrp6m3g";
+        url = "https://elpa.gnu.org/packages/mathsheet-1.3.tar";
+        sha256 = "1gyn47fzpa866i5xmdj6yq934xr9dsaq8za2r5z7hda660rh4wqi";
       };
       packageRequires = [ peg ];
       meta = {
@@ -5563,10 +5585,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "6.3";
+      version = "7.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/matlab-mode-6.3.tar";
-        sha256 = "0m3h60629p9rv8k2fk23iwfdgzsdmlk78y1j83xz5m53z7vl3a7m";
+        url = "https://elpa.gnu.org/packages/matlab-mode-7.1.1.tar";
+        sha256 = "0axqvarxnvn02pcqmqf9sf6kg0xfz5a8wfzjw8if6xsbk45krlcz";
       };
       packageRequires = [ ];
       meta = {
@@ -6197,24 +6219,19 @@
   ) { };
   oauth2 = callPackage (
     {
-      cl-lib ? null,
       elpaBuild,
       fetchurl,
       lib,
-      nadvice,
     }:
     elpaBuild {
       pname = "oauth2";
       ename = "oauth2";
-      version = "0.17";
+      version = "0.18.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/oauth2-0.17.tar";
-        sha256 = "0ah0h3k6hiqm977414kyg96r6rrvnwvik3hz3ra3r0mxx7lksqha";
+        url = "https://elpa.gnu.org/packages/oauth2-0.18.3.tar";
+        sha256 = "1xn9jkf55b9sc6fidzn6p1falvvgvpc08iz53fvmmp7fandgwbxi";
       };
-      packageRequires = [
-        cl-lib
-        nadvice
-      ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/oauth2.html";
         license = lib.licenses.free;
@@ -6863,6 +6880,7 @@
   ) { };
   persist = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -6870,12 +6888,12 @@
     elpaBuild {
       pname = "persist";
       ename = "persist";
-      version = "0.6.1";
+      version = "0.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/persist-0.6.1.tar";
-        sha256 = "1a7lls81q247mbkcnifmsva16cfjjma6yihxmj5zrj8ac774z9j3";
+        url = "https://elpa.gnu.org/packages/persist-0.7.tar";
+        sha256 = "0g38vf4a4f4b8cp35qc7pwzj1qwrnw6dd6mc83mrjs35fx43lpjn";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/persist.html";
         license = lib.licenses.free;
@@ -7169,10 +7187,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/preview-auto-0.4.tar";
-        sha256 = "0jsahj6ylrs4hlr57i0ibkj9bhc3jbg84k3pk8g5rg27xiwncczy";
+        url = "https://elpa.gnu.org/packages/preview-auto-0.4.1.tar";
+        sha256 = "0wdjka1wixhlzi1sksswa2jnialpna0gj770z0gl6faxdi310p9l";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7480,10 +7498,10 @@
     elpaBuild {
       pname = "rcirc-mentions";
       ename = "rcirc-mentions";
-      version = "1.0.3";
+      version = "1.0.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/rcirc-mentions-1.0.3.tar";
-        sha256 = "1dk651cm30kigbg8ns26k5fmr42ha9w6yx27j1iiwrxyifsxyb12";
+        url = "https://elpa.gnu.org/packages/rcirc-mentions-1.0.5.tar";
+        sha256 = "1qf3zsqjryqsx31y1dmmqdvny5w4f4z96mxb2ibj39ah9j2vgixb";
       };
       packageRequires = [ ];
       meta = {
@@ -8062,10 +8080,10 @@
     elpaBuild {
       pname = "setup";
       ename = "setup";
-      version = "1.4.0";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/setup-1.4.0.tar";
-        sha256 = "0id7j8xvbkbpfiv7m55dl64y27dpiczljagldf4p9q6qwlhf42f7";
+        url = "https://elpa.gnu.org/packages/setup-1.5.0.tar";
+        sha256 = "184g3kd9caxyhwq41w94spkjs1j45vblg4sqfb5h5pqb5h9p95n5";
       };
       packageRequires = [ ];
       meta = {
@@ -8104,10 +8122,10 @@
     elpaBuild {
       pname = "shell-command-plus";
       ename = "shell-command+";
-      version = "2.4.2";
+      version = "2.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/shell-command+-2.4.2.tar";
-        sha256 = "1kjj8n3nws7dl7k3ksnfx0s0kwvqb9wzy9k42xs5s51k7xrp1l18";
+        url = "https://elpa.gnu.org/packages/shell-command+-2.5.0.tar";
+        sha256 = "0svmrar0blgq3ffg9sll6b5vnqi1nw7snkbl04x2s9qln2i88dzx";
       };
       packageRequires = [ ];
       meta = {
@@ -8146,10 +8164,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.3.1";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/show-font-0.3.1.tar";
-        sha256 = "1ahlv8khf5vcmxvprz6swk3sw3i1rbbv45jp1c46mkhdg6bkmc7m";
+        url = "https://elpa.gnu.org/packages/show-font-1.0.0.tar";
+        sha256 = "1caga09ypj6vb4vziw6slvhkjbzj6a3vss9lbgbigzb4m6q8caqf";
       };
       packageRequires = [ ];
       meta = {
@@ -8188,10 +8206,10 @@
     elpaBuild {
       pname = "site-lisp";
       ename = "site-lisp";
-      version = "0.1.2";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/site-lisp-0.1.2.tar";
-        sha256 = "1w27nd061y7a5qhdmij2056751wx9nwv89qx3hxcl473iz03b09l";
+        url = "https://elpa.gnu.org/packages/site-lisp-0.2.0.tar";
+        sha256 = "17wwn1wjkq4vjzhgzq5pyn5x6bzai6nwmxcsp9d375b88qwp973n";
       };
       packageRequires = [ ];
       meta = {
@@ -8812,10 +8830,10 @@
     elpaBuild {
       pname = "system-packages";
       ename = "system-packages";
-      version = "1.0.13";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/system-packages-1.0.13.tar";
-        sha256 = "0xlbq44c7f2assp36g5z9hn5gldq76wzpcinp782whqzpgz2k4sy";
+        url = "https://elpa.gnu.org/packages/system-packages-1.1.1.tar";
+        sha256 = "0ndnx94ilxha7mby47n29qvr0lrypmsa7d1mxdwd66jd150sar5r";
       };
       packageRequires = [ ];
       meta = {
@@ -8946,14 +8964,35 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.5";
+      version = "1.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.5.tar";
-        sha256 = "14q5sn2xvxpy96qyk3w6r8y39ysz3xkxklly00zarfvkcdcdbw1x";
+        url = "https://elpa.gnu.org/packages/tempel-1.6.tar";
+        sha256 = "1h5k3cc5kl4g11chrfjgnhr1vg29fj3qz706rimilki367n2sra5";
       };
       packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/tempel.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  termint = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "termint";
+      ename = "termint";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/termint-0.1.1.tar";
+        sha256 = "1d6hg6bs105a8dzr0v2by0mb9c7v87jwqi4dxxzm6287448x7qqa";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/termint.html";
         license = lib.licenses.free;
       };
     }
@@ -9043,6 +9082,27 @@
       };
     }
   ) { };
+  timeout = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "timeout";
+      ename = "timeout";
+      version = "2.1";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/timeout-2.1.tar";
+        sha256 = "1mm4yp1spw512dnav1p3wnxqrsyls918i14azg03by4v32r9945p";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/timeout.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   timerfunctions = callPackage (
     {
       cl-lib ? null,
@@ -9095,10 +9155,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tmr-1.1.0.tar";
-        sha256 = "1bvysr05007qgzy2z6rxhhxpaq4b648icfmnj6qf8ydn8b5ih5kw";
+        url = "https://elpa.gnu.org/packages/tmr-1.2.0.tar";
+        sha256 = "0ywy3wz6km4smp7igzn44fwincc79nwzm0a55jv7hyz6bv78n8xr";
       };
       packageRequires = [ ];
       meta = {
@@ -9184,10 +9244,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.0.1";
+      version = "2.8.0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.0.1.tar";
-        sha256 = "1g7srsdyqldqx0hn8yv5x94dawfbqdbkbsi1l9ax06g3kn360sd7";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.0.3.tar";
+        sha256 = "1qszpb4qywpnx5x7ynx8srq6m6aiygdimffghihxcviv1r1mxs53";
       };
       packageRequires = [ ];
       meta = {
@@ -9270,10 +9330,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.9.4";
+      version = "0.10.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.9.4.tar";
-        sha256 = "191d04n8y9brkfsbp205h29wmrlzk7adsff4jrhq9y4ml78az7n9";
+        url = "https://elpa.gnu.org/packages/transient-0.10.1.tar";
+        sha256 = "1qxml619jpjp2an4iiq7c2n0vy0xam73rjl6076lialfwsa05hqd";
       };
       packageRequires = [
         compat
@@ -9364,10 +9424,10 @@
     elpaBuild {
       pname = "triples";
       ename = "triples";
-      version = "0.6.0";
+      version = "0.6.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/triples-0.6.0.tar";
-        sha256 = "12qf91ldgkwgkwj3a5g68qy4sbmrqmxq4qcgcnygj570ipjv49q8";
+        url = "https://elpa.gnu.org/packages/triples-0.6.1.tar";
+        sha256 = "0rziyr9gwab140afs0hhwqbi6kvp2ypv7clp0y9yckmpj1b0bzrv";
       };
       packageRequires = [ seq ];
       meta = {
@@ -9622,6 +9682,7 @@
   ) { };
   vc-backup = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -9629,12 +9690,12 @@
     elpaBuild {
       pname = "vc-backup";
       ename = "vc-backup";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vc-backup-1.1.0.tar";
-        sha256 = "0a45bbrvk4s9cj3ih3hb6vqjv4hkwnz7m9a4mr45m6cb0sl9b8a3";
+        url = "https://elpa.gnu.org/packages/vc-backup-1.1.1.tar";
+        sha256 = "0lalz700s7cppayjyv7bvmgzcfl9hk1w84i2q00k1ns84h4qzji1";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/vc-backup.html";
         license = lib.licenses.free;
@@ -9693,10 +9754,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.3";
+      version = "0.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vc-jj-0.3.tar";
-        sha256 = "1pikbl7i7cqwdqq01bm1rlcd1d9736bqa42g6dz2zxlavi7cbq6n";
+        url = "https://elpa.gnu.org/packages/vc-jj-0.4.tar";
+        sha256 = "1wws05yybiwxnx1qyapnw87k74glv8izkk2zlzn21hvqscbknz1y";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9826,10 +9887,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.4";
+      version = "2.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-2.4.tar";
-        sha256 = "1jxsxkmy80iba77iamrx4ybwg2phmxvsb5ab008iwz6rymjv60jv";
+        url = "https://elpa.gnu.org/packages/vertico-2.5.tar";
+        sha256 = "06yj03x61406zfs75q4blh9fav284psnigsy3g5wpqrv3p79b89s";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9849,10 +9910,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.8.0";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-posframe-0.8.0.tar";
-        sha256 = "0iqy8m1cf819x7ln5sp8b3sh4dk291k9sril35hxsxkiyjal1rqk";
+        url = "https://elpa.gnu.org/packages/vertico-posframe-0.9.0.tar";
+        sha256 = "16vnacmz52d1rwdmddsr1rm1zki1p3bw10ngpw39a3dszbwqkl3m";
       };
       packageRequires = [
         posframe

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1629,6 +1629,8 @@ let
 
           preview-dvisvgm = mkHome super.preview-dvisvgm;
 
+          procress = mkHome super.procress;
+
           # https://github.com/micdahl/projectile-trailblazer/issues/4
           projectile-trailblazer = addPackageRequires super.projectile-trailblazer [ self.projectile-rails ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -54,10 +54,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.5.0.20250818.124701";
+      version = "1.5.0.20250927.10200";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.5.0.20250818.124701.tar";
-        sha256 = "0y32fj69y0vvk3gcf7lrpwcmqk7y55gxrpl59l1wc9rwq42rsv90";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.5.0.20250927.10200.tar";
+        sha256 = "1sf2h2d7g1jf60vm6s5j6la27q43ckpz7b3pnyxka9rpy51ffnfr";
       };
       packageRequires = [
         compat
@@ -572,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.20.0snapshot0.20250806.194437";
+      version = "1.20.0snapshot0.20250902.153000";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.20.0snapshot0.20250806.194437.tar";
-        sha256 = "1z7v7f8pal8z4pgr6qzmh1g8ir1rdwshx2hifzngkp33lqmvd15x";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.20.0snapshot0.20250902.153000.tar";
+        sha256 = "04rgbpa53mzpbfhaj8y4yczv189i9v571xbq60lvxj3sy7lvbjkm";
       };
       packageRequires = [
         clojure-mode
@@ -622,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.6.0snapshot0.20250815.44110";
+      version = "0.6.0snapshot0.20251003.205157";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20250815.44110.tar";
-        sha256 = "1nn9bg4lpv5vxwvmxhlfbkk4zdg8sk52lk6mhpx5679jbgc8kx7q";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20251003.205157.tar";
+        sha256 = "0cx9w4nj9v373yhz1ydrqh747xqjfsjjn08fd1s4byrkw6ll7d83";
       };
       packageRequires = [ ];
       meta = {
@@ -655,6 +655,27 @@
       };
     }
   ) { };
+  cond-let = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cond-let";
+      ename = "cond-let";
+      version = "0.1.1.0.20250903.164604";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.1.1.0.20250903.164604.tar";
+        sha256 = "1h6hb7wwwvcvxzykyh68a4ayjdrmc0dav8fb3s5y9wp3b9r8wvjx";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/cond-let.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   consult-flycheck = callPackage (
     {
       consult,
@@ -666,10 +687,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20250804.224423";
+      version = "1.0.0.20250923.111441";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250804.224423.tar";
-        sha256 = "1xjin3rf75l8id6yc5h4whqwsaarvmhy5fjm7adl4xikq6i2cbm4";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250923.111441.tar";
+        sha256 = "1lky8vw8x641qnjf8ah1mlchirf3nfyqs5gskqh91q9iq0y48yxj";
       };
       packageRequires = [
         consult
@@ -781,10 +802,10 @@
     elpaBuild {
       pname = "cycle-at-point";
       ename = "cycle-at-point";
-      version = "0.2.0.20250611.32851";
+      version = "0.2.0.20250913.225149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20250611.32851.tar";
-        sha256 = "17pw2g8nh1byp42qb06568lrir0b6msbqhvkw45dwp89dd7nkrc4";
+        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20250913.225149.tar";
+        sha256 = "12x1dfcqhx9gf6ll51a4na4vwnvq1m95lkzg22jwdhhxfbp7h7l3";
       };
       packageRequires = [ recomplete ];
       meta = {
@@ -930,10 +951,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20250611.51010";
+      version = "0.2.0.20250913.225150";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250611.51010.tar";
-        sha256 = "1i7x02ccvsbaayvzv9sbi09a6vfzpqhnaqkzcqjbkff538v6kcy1";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250913.225150.tar";
+        sha256 = "0i6147bhn1wl46d13wni1frbkg2zxccb46yp2wgs6vxgsvn8fikl";
       };
       packageRequires = [ ];
       meta = {
@@ -973,10 +994,10 @@
     elpaBuild {
       pname = "doc-show-inline";
       ename = "doc-show-inline";
-      version = "0.1.0.20250209.60743";
+      version = "0.1.0.20250913.225149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20250209.60743.tar";
-        sha256 = "172shyhapbfllc2pv5wrbp58qxfp10gmz49ny5av4yf3ayqd6cm5";
+        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20250913.225149.tar";
+        sha256 = "0rfpjmgkd76k2q9bxpv0q9vipzvrydyxvpd9ia8b9bwzaszdw8x2";
       };
       packageRequires = [ ];
       meta = {
@@ -1122,10 +1143,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20250808.184702";
+      version = "0.11.0.0.20250905.2405";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250808.184702.tar";
-        sha256 = "1j2zspg9i7r0rnjy79c7032cd3nxir9r1j7img0bwwc1sv7az32y";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250905.2405.tar";
+        sha256 = "06gwq2fr79l1abcxg2fqyqrkadg35fn6zm30bv6d8nvz7f1msfzq";
       };
       packageRequires = [ ];
       meta = {
@@ -1206,10 +1227,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.5.0.20250306.150410";
+      version = "3.6.6.0.20250929.142203";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.5.0.20250306.150410.tar";
-        sha256 = "1ah1vsbigz7ip7iz7f53w0bnmwf7dhfzyn1dx1dkfp4lkpr8gc7g";
+        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.6.0.20250929.142203.tar";
+        sha256 = "03p5z3r79303vxxs0q5cxhfmnjc18yr76pnfrsga11my6c9j7lza";
       };
       packageRequires = [ ];
       meta = {
@@ -1227,10 +1248,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.1.0.20250811.210334";
+      version = "4.3.2.0.20250901.154446";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.1.0.20250811.210334.tar";
-        sha256 = "1c76h1l5d2yjyy4xxk65scmivfp5qshngjy653fcqh8zhn4as6vx";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.2.0.20250901.154446.tar";
+        sha256 = "1jj49nx5id54xxxzr3nr1xgzymwxa5mrdlf4a4n07bp4xn2jgwhi";
       };
       packageRequires = [ ];
       meta = {
@@ -1272,10 +1293,10 @@
     elpaBuild {
       pname = "evil";
       ename = "evil";
-      version = "1.15.0.0.20250812.102316";
+      version = "1.15.0.0.20250929.165020";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250812.102316.tar";
-        sha256 = "05wx37b8vnjxx4swcpzmi0lf3g2b82dswd9j49xcphmqc0br4a6x";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250929.165020.tar";
+        sha256 = "0qq60l5wy38izbixv4ymga32wvvl0fmxy2lc56s55fcg0safiwmc";
       };
       packageRequires = [
         cl-lib
@@ -1633,10 +1654,10 @@
     elpaBuild {
       pname = "exec-path-from-shell";
       ename = "exec-path-from-shell";
-      version = "2.2.0.20241107.71915";
+      version = "2.2.0.20250922.141302";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20241107.71915.tar";
-        sha256 = "17wyy2agi9j7vny0wdi5mxp1nz7zpzi6ayx55ls1cdxwd7v2jyvf";
+        url = "https://elpa.nongnu.org/nongnu-devel/exec-path-from-shell-2.2.0.20250922.141302.tar";
+        sha256 = "1g70dg5ssw3k4jxcqqpi76qlckcl5n5rn7x812bm6xs9xp6izg1z";
       };
       packageRequires = [ ];
       meta = {
@@ -1815,10 +1836,10 @@
     elpaBuild {
       pname = "flymake-pyrefly";
       ename = "flymake-pyrefly";
-      version = "0.1.6.0.20250805.190746";
+      version = "0.1.8.0.20251007.82059";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flymake-pyrefly-0.1.6.0.20250805.190746.tar";
-        sha256 = "10r5f7zqnwwcp5ds9bh6d3hlfkp0wa614iknw7dgzhbg83v2c6r8";
+        url = "https://elpa.nongnu.org/nongnu-devel/flymake-pyrefly-0.1.8.0.20251007.82059.tar";
+        sha256 = "08120i69qmf25s84kdpxq9rp25v9ivyly1gg7pi5fsaiprf84pk4";
       };
       packageRequires = [ ];
       meta = {
@@ -1924,10 +1945,10 @@
     elpaBuild {
       pname = "geiser";
       ename = "geiser";
-      version = "0.32.0.20250810.134607";
+      version = "0.32.0.20250922.234403";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.32.0.20250810.134607.tar";
-        sha256 = "0gwwdnpfhn37xk8dmw3izxr4w0ky37yv7va64m90ibzblrbgvfcf";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-0.32.0.20250922.234403.tar";
+        sha256 = "0r0nxkba7hj2hh90d7j471p3v26q91v0jfq3p7xddbc64zb27hbc";
       };
       packageRequires = [ project ];
       meta = {
@@ -2200,10 +2221,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.5.0.20250531.221751";
+      version = "1.4.6.0.20250901.160839";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.5.0.20250531.221751.tar";
-        sha256 = "16h7v25rrd818lcnrdh7x6nq4v4q2qb9iisfh4vaya28jysj5wda";
+        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.6.0.20250901.160839.tar";
+        sha256 = "146x7r2dhj4smanpwlbvdwg4229kshcd4lshlpzzmqn1xk6z8yga";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2225,10 +2246,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.5.0.20250815.134629";
+      version = "0.5.5.0.20251001.70740";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.5.0.20250815.134629.tar";
-        sha256 = "0ricm6spfgybd5z6k6si868rb00s34ci9cmbdlh439q6n1w0i3j3";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.5.0.20251001.70740.tar";
+        sha256 = "05x98zgr6lxaxxsy76yxb15h5mwihp5xk2ppsrl9csc26sv3z2d6";
       };
       packageRequires = [
         compat
@@ -2401,10 +2422,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.8.5.0.20250823.231025";
+      version = "0.9.9.0.20251006.195737";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.5.0.20250823.231025.tar";
-        sha256 = "0lrydk1lby15iz4z9h1w23mhi4h6vfm6xdcan72qphg9d33xc33y";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.0.20251006.195737.tar";
+        sha256 = "0sfwlcg103zgm1f12slc2q2lygxcp92bvb7iddn79609hh1gg9ww";
       };
       packageRequires = [
         compat
@@ -2532,10 +2553,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20250812.135807";
+      version = "17.5.0.20250930.172812";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250812.135807.tar";
-        sha256 = "17nbn2dl75v3bvzk4c1yag27ji2mrlhfpc3js0kldcz999sxn52w";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250930.172812.tar";
+        sha256 = "0wjqyxnjvdxzfaipax3bbm8yjrmxkq54zhm78mr13gx3p1awz0id";
       };
       packageRequires = [ ];
       meta = {
@@ -2575,10 +2596,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.3.2.0.20250629.84650";
+      version = "1.3.4.0.20250922.153032";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.3.2.0.20250629.84650.tar";
-        sha256 = "09n25ag4pjxyx5k6ffwpny6cdgblrg9v9kw64v6ili4zni0bvf6k";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.3.4.0.20250922.153032.tar";
+        sha256 = "0glcsp3kvnmqxcydj154shwgyamial6y987z1i0y5jz9rgn9zz7w";
       };
       packageRequires = [ ];
       meta = {
@@ -2598,10 +2619,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.5.0.20250823.30001";
+      version = "4.0.6.0.20251005.61450";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.5.0.20250823.30001.tar";
-        sha256 = "180qb00slqj3iswdns8lhb6fj04qrypfxskzsdlmrbywn7g7gprz";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20251005.61450.tar";
+        sha256 = "1m1qx22gcz5vgnji8qys1vkmsck9rz830fpc2kany6nzr7z2v8mm";
       };
       packageRequires = [
         helm-core
@@ -2623,10 +2644,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.5.0.20250823.30001";
+      version = "4.0.6.0.20251005.61450";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.5.0.20250823.30001.tar";
-        sha256 = "183z699pn0bdy4qfygnfmi0qaik5pmly8cl16b5zm39qabph4nrs";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20251005.61450.tar";
+        sha256 = "0cv2lqibs6as1b8zfqwz9wlg4cfxbljd7mld1qa51p7nmxm3rzjw";
       };
       packageRequires = [ async ];
       meta = {
@@ -2686,10 +2707,10 @@
     elpaBuild {
       pname = "hl-block-mode";
       ename = "hl-block-mode";
-      version = "0.2.0.20250113.124218";
+      version = "0.2.0.20250913.225150";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20250113.124218.tar";
-        sha256 = "00xs4cdcwyggccvlsv7l0q58hv4qhbyv0fyl3js8hqs9091qyv70";
+        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20250913.225150.tar";
+        sha256 = "1zwgalb0s1jprfyfldxin9a4gqwjngqf46k24gnxxpw7039gszyw";
       };
       packageRequires = [ ];
       meta = {
@@ -2811,10 +2832,10 @@
     elpaBuild {
       pname = "idle-highlight-mode";
       ename = "idle-highlight-mode";
-      version = "1.1.4.0.20240421.64727";
+      version = "1.1.4.0.20250922.133045";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idle-highlight-mode-1.1.4.0.20240421.64727.tar";
-        sha256 = "0wdzvy6zhxsr4i7s0169s8pl0bd3sms2xjqlvppkyqfmvwiggqkm";
+        url = "https://elpa.nongnu.org/nongnu-devel/idle-highlight-mode-1.1.4.0.20250922.133045.tar";
+        sha256 = "004axcdjrp10pflhx1s58ygjic0kcq17l2dg01sj6r8lck89gin9";
       };
       packageRequires = [ ];
       meta = {
@@ -2834,10 +2855,10 @@
     elpaBuild {
       pname = "idris-mode";
       ename = "idris-mode";
-      version = "1.1.0.0.20250825.75833";
+      version = "1.1.0.0.20251006.81904";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20250825.75833.tar";
-        sha256 = "0ifxj3na8i0xhrkkh5j5xlassjxjv9snaybkaqd8ah5khj4y8cq9";
+        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20251006.81904.tar";
+        sha256 = "0yga8jfw275c6vkr1dz23d9bm5jshqidzg0fhakpxrl2aiyd8qkh";
       };
       packageRequires = [
         cl-lib
@@ -2969,10 +2990,10 @@
     elpaBuild {
       pname = "j-mode";
       ename = "j-mode";
-      version = "2.0.1.0.20240920.120622";
+      version = "2.0.2.0.20251003.80527";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/j-mode-2.0.1.0.20240920.120622.tar";
-        sha256 = "1v0qffz9qd943fmxny0ik5vrgrfskmf6rv9mgxp7xz6wz3v38ypd";
+        url = "https://elpa.nongnu.org/nongnu-devel/j-mode-2.0.2.0.20251003.80527.tar";
+        sha256 = "1nzfxdx2ngkndrig2bbqh5y3459gslh9s00r4p9kwwvc5m0wrj47";
       };
       packageRequires = [ ];
       meta = {
@@ -3054,10 +3075,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.4.0.20250531.221920";
+      version = "1.4.5.0.20250901.161025";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.4.0.20250531.221920.tar";
-        sha256 = "03v4xsg22b86wbbf2cb9cgrid4c1mh5hrj6v7vmwg2f14rdqhl7q";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.5.0.20250901.161025.tar";
+        sha256 = "0dj814wrkb24hr5dfghviqnl9c1pnwzw600dx4d00gfy93mpfsq2";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3097,10 +3118,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.0.0.20250812.133610";
+      version = "1.0.1.0.20250901.154405";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.0.0.20250812.133610.tar";
-        sha256 = "0ybk2b9nq9sm88376j3ighbzhkklvlga78zl4rim8llafk8yjsi9";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.1.0.20250901.154405.tar";
+        sha256 = "1qksx33xaavzqd8ywiyb412bi6ykqlyxxk28k4zgkak6sxwrn2jd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3150,10 +3171,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.14.0.0.20250810.194832";
+      version = "0.14.0.0.20251008.15638";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250810.194832.tar";
-        sha256 = "0s07913f6y63vwrm4zpb4k1wx6sl75vpmfawczyzxgldkjjslnpq";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20251008.15638.tar";
+        sha256 = "1jmlrbac8psymd17v6hhks7ldqzik99g32cqc756gp5gj9ixdxyf";
       };
       packageRequires = [
         compat
@@ -3264,6 +3285,7 @@
   magit = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3276,13 +3298,14 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.3.8.0.20250704.230026";
+      version = "4.4.2.0.20251006.184033";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.3.8.0.20250704.230026.tar";
-        sha256 = "0bardjnsk52yjz5yd10yv1grzr6rsgzc30v7azmp64hki175xakl";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.4.2.0.20251006.184033.tar";
+        sha256 = "1jl4wnxca90vfr42v5wl66arrh8c8ybxcr18lgq4af32shcpz758";
       };
       packageRequires = [
         compat
+        cond-let
         llama
         magit-section
         seq
@@ -3298,6 +3321,7 @@
   magit-section = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3307,13 +3331,14 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.3.8.0.20250704.230026";
+      version = "4.4.2.0.20251006.184033";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.3.8.0.20250704.230026.tar";
-        sha256 = "057npc4k3yxccjd2qwl7fr3zcms1q9n02nmjym1ysak3q16kkynm";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.4.2.0.20251006.184033.tar";
+        sha256 = "1lb6lm7fq0svjrfk6h7x45rhbwfspri46rfsnz2rv54l7jxzb7dh";
       };
       packageRequires = [
         compat
+        cond-let
         llama
         seq
       ];
@@ -3355,10 +3380,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.2.0.20250801.103236";
+      version = "2.0.3.0.20251006.174033";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.2.0.20250801.103236.tar";
-        sha256 = "0wgx53vlg2ifajmr298a3hrz8fy08sgdx909jfbm44kbf4myhm2m";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.3.0.20251006.174033.tar";
+        sha256 = "1b0wxpzgi5g5n8n3kxsxshfpx7nb8xywc0a2qk8qjarii2dlm6wc";
       };
       packageRequires = [
         persist
@@ -3430,10 +3455,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20250803.54141";
+      version = "1.5.0.0.20250914.165407";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250803.54141.tar";
-        sha256 = "1yjr5bc90f93vwwnb1gj8ni1i0h8mh5sl51vafyh24dnd49rw9c3";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250914.165407.tar";
+        sha256 = "02wq0az10vqa7m55mga89aipjfqdwbw83rrf0xdyzc1f1r8841bm";
       };
       packageRequires = [ ];
       meta = {
@@ -3536,10 +3561,10 @@
     elpaBuild {
       pname = "multiple-cursors";
       ename = "multiple-cursors";
-      version = "1.5.0.0.20250210.181349";
+      version = "1.5.0.0.20251006.133827";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.5.0.0.20250210.181349.tar";
-        sha256 = "072vlw8cb1f1mbzlx68lg8yrmyc7ca2f2iyxmvjy5nn3lx7v6lkd";
+        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.5.0.0.20251006.133827.tar";
+        sha256 = "0lm29y8vhb1l9aprinpwngwhkh6h0vvihg3hfnf3nr1sh7lcmqzc";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -3805,10 +3830,10 @@
     elpaBuild {
       pname = "org-superstar";
       ename = "org-superstar";
-      version = "1.5.1.0.20230116.151025";
+      version = "1.7.0.0.20250914.130856";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-superstar-1.5.1.0.20230116.151025.tar";
-        sha256 = "02f3lzb8k51rhf13a2warvhg8ib11wagw1zrfaknni7ssiwdj3x6";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-superstar-1.7.0.0.20250914.130856.tar";
+        sha256 = "0j2yxmsikpv75asbn8n15fkp1r79ca59in3gfipwnsh1yb5bmc4z";
       };
       packageRequires = [ org ];
       meta = {
@@ -3876,10 +3901,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.3.0.20250823.203621";
+      version = "2.0.5.0.20250901.181058";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.3.0.20250823.203621.tar";
-        sha256 = "0zdblah0hz8lcmvgq035djl79np57bb01ynm2kksflnpz6bsmhsk";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.5.0.20250901.181058.tar";
+        sha256 = "1cisgrfca4ry2fayl55swp2h9nr3nxngjyvfdm79z6lv5rciinr1";
       };
       packageRequires = [
         compat
@@ -3923,10 +3948,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.26.0.20250819.130417";
+      version = "0.26.0.20250828.150659";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250819.130417.tar";
-        sha256 = "0fsjd3sry469xrpkfabid2bh7f3p50ddhwj6c9vabg9fad3yykyd";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250828.150659.tar";
+        sha256 = "0lm66fw4qf5i2jndfpbpglgh8k9hs15fq08vxwmf19sg2mgi8c8l";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -4124,10 +4149,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.58.0.20250823.202123";
+      version = "0.60.0.20250928.144633";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.58.0.20250823.202123.tar";
-        sha256 = "0ddi6025ydm9dzacnnkiry72pc3lwdjb0gljslar15cl9ks2bi0x";
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.60.0.20250928.144633.tar";
+        sha256 = "0899g9r151ymhimlv40pnb4mx5kqyizbwa1ml6pnqk3as6lld0bj";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4145,10 +4170,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20250602.130847";
+      version = "1.26.1.0.20250928.131854";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250602.130847.tar";
-        sha256 = "0bhwg683jk5sjlq9kvp0318cgp1w7yvi7cfl5svr5qd3d44j7mgk";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250928.131854.tar";
+        sha256 = "10px7l5j7z0zxzviccng3snp5j8ha7k1vzapmd0dvagjwn6l6dcp";
       };
       packageRequires = [ ];
       meta = {
@@ -4229,10 +4254,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20250811.112700";
+      version = "4.6snapshot0.20250915.103850";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250811.112700.tar";
-        sha256 = "1gwdwq8lb22b03fq8a046dqyy4kgdbaf7lhiah64pndhl8649xhq";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250915.103850.tar";
+        sha256 = "0kanqrxdv0ayf5q6i3wj5xbc2nb7abhvw3sssn2nhn9kzy2yip1m";
       };
       packageRequires = [ ];
       meta = {
@@ -4273,10 +4298,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250711.83643";
+      version = "1.0.20250830.122523";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250711.83643.tar";
-        sha256 = "0fz97vmiwlqbgvbzp0zaa5jy5pbpdbhzg16db1rg01f101x5368h";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250830.122523.tar";
+        sha256 = "01nqdsblxn2l7c2yv91d7phdpfasz6k4ifsk05647ccjqbvqsr45";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4336,10 +4361,10 @@
     elpaBuild {
       pname = "raku-mode";
       ename = "raku-mode";
-      version = "0.2.1.0.20240429.100744";
+      version = "0.2.1.0.20250930.115108";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/raku-mode-0.2.1.0.20240429.100744.tar";
-        sha256 = "0nz5gp98m5cl6l0agk2chz7llqldzkl7swkcmka5i4r1m7qx39rr";
+        url = "https://elpa.nongnu.org/nongnu-devel/raku-mode-0.2.1.0.20250930.115108.tar";
+        sha256 = "1qvsib5w75n31ya153ixiyfklwqxgmrvv2a7zfqqn5ivzlc14ynk";
       };
       packageRequires = [ ];
       meta = {
@@ -4357,10 +4382,10 @@
     elpaBuild {
       pname = "recomplete";
       ename = "recomplete";
-      version = "0.2.0.20250528.3825";
+      version = "0.2.0.20250913.225149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20250528.3825.tar";
-        sha256 = "1cip3dy8klcy1hsw2w3wx9lhzpf6inya430japh798drn0k3vi7j";
+        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20250913.225149.tar";
+        sha256 = "0ghkkigd0kh4kwf8wlviaxcmbzvgdbz67vd8qhlm978b48pqpbb5";
       };
       packageRequires = [ ];
       meta = {
@@ -4531,10 +4556,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "97.0.0.20250728.23846";
+      version = "97.0.0.20251007.170238";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-97.0.0.20250728.23846.tar";
-        sha256 = "1jvhzhvs0zfx3ygzrm9ixw10wmdv0fy9s3g236kbdrlkc94lddrc";
+        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-97.0.0.20251007.170238.tar";
+        sha256 = "1r0bnwg0li1caq8q29hz9f25y8mpkq5iqx5gnd86il58wwx13r96";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4573,10 +4598,10 @@
     elpaBuild {
       pname = "scroll-on-drag";
       ename = "scroll-on-drag";
-      version = "0.1.0.20240421.80350";
+      version = "0.1.0.20250913.225149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-drag-0.1.0.20240421.80350.tar";
-        sha256 = "0yvz2349ii06r69q2a40qw7grxviqfj9bpm36pjb7wzc46bywl23";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-drag-0.1.0.20250913.225149.tar";
+        sha256 = "1igxyz906bgbrx1g0jc4xv43jfhfb0lwilg0nw05mbd1qajv8q1d";
       };
       packageRequires = [ ];
       meta = {
@@ -4594,10 +4619,10 @@
     elpaBuild {
       pname = "scroll-on-jump";
       ename = "scroll-on-jump";
-      version = "0.2.0.20250712.131709";
+      version = "0.2.0.20250913.225149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250712.131709.tar";
-        sha256 = "1x38322dlcfjyj1jy1gmyvc6wwp6idnc802mjc3a4g3yzqjb64iq";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250913.225149.tar";
+        sha256 = "057pc5rfd6ighm87jsgbivlgs52vhczp6c1bz6rjrhfqrajhdw6c";
       };
       packageRequires = [ ];
       meta = {
@@ -4658,10 +4683,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31snapshot0.20250817.234725";
+      version = "2.31snapshot0.20250918.225852";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250817.234725.tar";
-        sha256 = "12jaqyly9y0yvamvm26qgzcx3pqrais581dd50jc4vkfs2s2x0ig";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250918.225852.tar";
+        sha256 = "0bpn15a6a8fvr3ycjngqkg5wqkcv95fbkf8s3zr72xv8ys5zlk61";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4679,10 +4704,10 @@
     elpaBuild {
       pname = "sly";
       ename = "sly";
-      version = "1.0.43.0.20250522.230625";
+      version = "1.0.43.0.20250930.91309";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sly-1.0.43.0.20250522.230625.tar";
-        sha256 = "13y1h93bf4bmz0mwrwhk6nd4skvcpjw9x0jl1ga2xx1ja6wf81s5";
+        url = "https://elpa.nongnu.org/nongnu-devel/sly-1.0.43.0.20250930.91309.tar";
+        sha256 = "0fg0prfy7jp0g5cs0czv8a6i4n29lbz8961h7ybpdn8i5s2mpasd";
       };
       packageRequires = [ ];
       meta = {
@@ -4722,10 +4747,10 @@
     elpaBuild {
       pname = "solarized-theme";
       ename = "solarized-theme";
-      version = "2.0.4.0.20250222.142943";
+      version = "2.0.4.0.20250913.45124";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.0.4.0.20250222.142943.tar";
-        sha256 = "0m8wxvm9a501w4pfc1an4i99h0wv6hpfk1yizh8yjw0y3y8fz606";
+        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.0.4.0.20250913.45124.tar";
+        sha256 = "0cjsz6a14d0zz4r93653d5imvgwpl9xchvr5snbkr8s359fs5icx";
       };
       packageRequires = [ ];
       meta = {
@@ -4764,10 +4789,10 @@
     elpaBuild {
       pname = "spell-fu";
       ename = "spell-fu";
-      version = "0.3.0.20250712.131907";
+      version = "0.3.0.20250913.225149";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20250712.131907.tar";
-        sha256 = "1v9ahhwapqg4a7v82ipx2rcfk9ibrbrsapqk3b3md552j4fdrwzp";
+        url = "https://elpa.nongnu.org/nongnu-devel/spell-fu-0.3.0.20250913.225149.tar";
+        sha256 = "03c7ivc3wmcbwhwyca52naxjwlbsnzzwws8x4cfpydngfrbrfgrb";
       };
       packageRequires = [ ];
       meta = {
@@ -4793,6 +4818,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/sqlite3.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  standard-keys-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "standard-keys-mode";
+      ename = "standard-keys-mode";
+      version = "1.0.0.0.20250905.172556";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/standard-keys-mode-1.0.0.0.20250905.172556.tar";
+        sha256 = "1vxzb1a5qmafs3n9a74fkyb888qk3q1zfm61ywjjsfs7bj4z87fg";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/standard-keys-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -4887,17 +4933,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      seq,
     }:
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.4.0.0.20250615.100102";
+      version = "9.4.0.0.20250922.71205";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.4.0.0.20250615.100102.tar";
-        sha256 = "13b7vbkhb8zw4x3inpfpdhaakgvp6msm1p377dmhpjddz3ngf3l5";
+        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.4.0.0.20250922.71205.tar";
+        sha256 = "1ydsnrdschridpm72228v690024l95bl97hp1l8x5qyxhyg147js";
       };
-      packageRequires = [ seq ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/swift-mode.html";
         license = lib.licenses.free;
@@ -5154,10 +5199,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20250816.45809";
+      version = "0.2.1.0.20250911.3703";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250816.45809.tar";
-        sha256 = "03j1lcrsx14qm4m7k6h56aka7r94gzp7c97jpm404fwnn9zdrib8";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250911.3703.tar";
+        sha256 = "06wjzpgd0525xb8xq968p78y319hy4jxk97kxjdy3cbcf368s58w";
       };
       packageRequires = [ ];
       meta = {
@@ -5197,10 +5242,10 @@
     elpaBuild {
       pname = "tuareg";
       ename = "tuareg";
-      version = "3.0.2snapshot0.20250227.215734";
+      version = "3.0.2snapshot0.20250910.140516";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.2snapshot0.20250227.215734.tar";
-        sha256 = "1ngkjn7dr2k61w5vv8qjgjj8wwc9674px7w1hc8539f7nplf7i71";
+        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.2snapshot0.20250910.140516.tar";
+        sha256 = "0m9xid4s6qqdw8vlpgzsf2lc877shf7dvfxk8b9bhiva56dhrqfw";
       };
       packageRequires = [ caml ];
       meta = {
@@ -5239,10 +5284,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.2.0.20250807.11325";
+      version = "0.12.2.0.20250906.143855";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20250807.11325.tar";
-        sha256 = "1j28vzijhn7aqr3h8pjslixbz38j97zgvx3f86myi2ag5l8k615g";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20250906.143855.tar";
+        sha256 = "1qi73s1r6ld6l31xf3sa9ml52zlcpwp2wr5m2w76i1bcwylgnaad";
       };
       packageRequires = [ ];
       meta = {
@@ -5302,10 +5347,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7.0.20250611.33234";
+      version = "0.7.0.20250918.1702";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20250611.33234.tar";
-        sha256 = "0nzm5y4diim3di2kyaxamgbibni0vrd59d92f3fi7wyxcwb0v8dw";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20250918.1702.tar";
+        sha256 = "19ir40rg2zrmr2f1dfkxk304vhg1rv9bg8g5a0pn5j2qlgwcn5kb";
       };
       packageRequires = [ ];
       meta = {
@@ -5365,10 +5410,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.6.3.0.20250505.230743";
+      version = "2.7.0.0.20250925.121619";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20250505.230743.tar";
-        sha256 = "1cl39911k73cz5qbllyy82jw7hhbd6dly3s4p0kfnmav461b3qcp";
+        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.7.0.0.20250925.121619.tar";
+        sha256 = "0ymr57mwd6k9xia62dqwjxmywlhc5y7vnfc5ag8z9j232znshllp";
       };
       packageRequires = [ ];
       meta = {
@@ -5388,10 +5433,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.0snapshot0.20250629.80737";
+      version = "8.3.0snapshot0.20250922.112745";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250629.80737.tar";
-        sha256 = "0vv7chilnsrig15asv0iy916vmvksbyhxasvlldykq9z3w4r6abi";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250922.112745.tar";
+        sha256 = "1p1jyqwb1m0rxkpyr69yzkjjfv4yj1x3gfk8h5xizjcqisxckpaa";
       };
       packageRequires = [
         cl-lib
@@ -5412,10 +5457,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.21.0.20250714.65721";
+      version = "17.3.22.0.20250827.131545";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.21.0.20250714.65721.tar";
-        sha256 = "0v4jcv0lcm4gds8m086f79wpbd0d64i0y1cf8z5rvrx8psf93wpc";
+        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.22.0.20250827.131545.tar";
+        sha256 = "1qlkdzcm8y3aa3wsh53da7360gavfz3rsvin022581sq05bwys5z";
       };
       packageRequires = [ ];
       meta = {
@@ -5523,10 +5568,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.5.0.20250811.205345";
+      version = "3.4.6.0.20250901.161817";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.5.0.20250811.205345.tar";
-        sha256 = "0y4gm4dw0nwcq7m2n68ysk4sqrr2bbn4m8skgl6m66iag9av58j0";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.6.0.20250901.161817.tar";
+        sha256 = "1387wiakkxw2vpdp07sj1d3dy8vbk1113jmmp980swpd1gm4hfmy";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5633,10 +5678,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.4.20250825201039.0.20250825.201812";
+      version = "28.7.20250917123258.0.20250917.123752";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.4.20250825201039.0.20250825.201812.tar";
-        sha256 = "12z8ygjsyw1faa3b2j9s0fsnkil5rzik35k3k4dwyvzvdrmm8m5n";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.7.20250917123258.0.20250917.123752.tar";
+        sha256 = "03hx3z023xv467zwmgz9g2k0ps2vvd95fs1n6f8msdv5f2sxysx9";
       };
       packageRequires = [ ];
       meta = {
@@ -5762,10 +5807,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20250812.82048";
+      version = "0.0.8.0.20250915.80705";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250812.82048.tar";
-        sha256 = "0wdcd7v40zgzh5zh5y17vzkwh028grzq93w65hhr42qq2g85rqy8";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250915.80705.tar";
+        sha256 = "0dz5gaja4zkq2vdamq2msqyxp8j59m131cm8mgjwz4jikcxg600b";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -678,6 +678,27 @@
       };
     }
   ) { };
+  cond-let = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cond-let";
+      ename = "cond-let";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/cond-let-0.1.1.tar";
+        sha256 = "1s1gzmn2xa76hbk0q60gznsj0p8kfn1b4fzijdkqdrvindmc4ymw";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/cond-let.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   consult-flycheck = callPackage (
     {
       consult,
@@ -1230,10 +1251,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.5";
+      version = "3.6.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.5.tar";
-        sha256 = "0ab6m1c32j3rp577v8qb4k542fjgpvvkcgjvzfcc56fwb9d6xfy0";
+        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.6.tar";
+        sha256 = "0wb1d5cm2gsjarqb9z06hx7nry37la6g5s44bb8q7j2xfd11h764";
       };
       packageRequires = [ ];
       meta = {
@@ -1251,10 +1272,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.1";
+      version = "4.3.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.1.tar";
-        sha256 = "0lqawas0zdrri1csy6vh25wffsxipwc642xzgxwrgxb4v3ga32zn";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.2.tar";
+        sha256 = "0yl5j35r3s3z4pnxpk6hx2a8piw110rgc67zz3nmkp8ppzkz9h86";
       };
       packageRequires = [ ];
       meta = {
@@ -1833,10 +1854,10 @@
     elpaBuild {
       pname = "flymake-pyrefly";
       ename = "flymake-pyrefly";
-      version = "0.1.6";
+      version = "0.1.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/flymake-pyrefly-0.1.6.tar";
-        sha256 = "06z8hkivi2k24yk8bqkgcm52al5jfz82kwjhzbc3j0aaickmacnm";
+        url = "https://elpa.nongnu.org/nongnu/flymake-pyrefly-0.1.8.tar";
+        sha256 = "19h8lmwk4p3lq985d0sqv1b9s6g04dazl31bc0n0y90ksl6ab5f5";
       };
       packageRequires = [ ];
       meta = {
@@ -2217,10 +2238,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.5";
+      version = "1.4.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.5.tar";
-        sha256 = "0m4z6hvm6zf90lbdhkny8fcj4k1y9bqwcxj4ikv51xhz03604l4d";
+        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.6.tar";
+        sha256 = "0hxvdm8578pl5f7fb2xi46a9arfr97cyybizk6yi17p82nz6s9g7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2418,10 +2439,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.8.5";
+      version = "0.9.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.8.5.tar";
-        sha256 = "1zxmbp6b0ldycniciz592v28j3by7niz7m60rilpr97hzl5v56nl";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.tar";
+        sha256 = "1vnnizqb60sipim7fllv5hvwd9xjsp08wyn1gnhn8j91yv90hlqb";
       };
       packageRequires = [
         compat
@@ -2591,10 +2612,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.3.2";
+      version = "1.3.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.3.2.tar";
-        sha256 = "0hc34lr24gjviqmlghaidv71mjmvvv4mpzb87z5a0mqkz9y0a2ds";
+        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.3.4.tar";
+        sha256 = "1z0bl88w9gf53cfmnfq0iqq2hqm2bmy6wl8fwydvayn77lr5x72h";
       };
       packageRequires = [ ];
       meta = {
@@ -2614,10 +2635,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.5";
+      version = "4.0.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-4.0.5.tar";
-        sha256 = "1dbkpyq42f4gl9mc4aqjwdddmn800pga8dpvzky3qpns0q7i1d6g";
+        url = "https://elpa.nongnu.org/nongnu/helm-4.0.6.tar";
+        sha256 = "1nnkhffns1yj24slfln5rywqdw514jfklys3g5kmrl90i9apd5cp";
       };
       packageRequires = [
         helm-core
@@ -2639,10 +2660,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.5";
+      version = "4.0.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.5.tar";
-        sha256 = "0l0z0lq78fha77g1a7iz4zlmidw0c3ri6b4kwrc3jm8cn218q87v";
+        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.6.tar";
+        sha256 = "0b39k4wwl3sjw5c19g36a0lsxiascrqw23cf3hgksrpzp3amipbz";
       };
       packageRequires = [ async ];
       meta = {
@@ -2985,10 +3006,10 @@
     elpaBuild {
       pname = "j-mode";
       ename = "j-mode";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/j-mode-2.0.1.tar";
-        sha256 = "0kk29s3xqad72jxvzzbl4b4z8b4l7xx1vyfcbsj8ns8hv8cip3l3";
+        url = "https://elpa.nongnu.org/nongnu/j-mode-2.0.2.tar";
+        sha256 = "109fy5r3hfz15qdsrmdr6iik4w1kzn2pz7077xrd4mbi7gw5ggdx";
       };
       packageRequires = [ ];
       meta = {
@@ -3070,10 +3091,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.4";
+      version = "1.4.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.4.tar";
-        sha256 = "05i3n7kd5aj0rwxva21ri108w1hjsmgjgv5004r3ngim73h1qlw3";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.5.tar";
+        sha256 = "0c847ailkfa46f6p4d9j6fg485cj8pwd208ynxz5sx5my4gqfnbw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3113,10 +3134,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/llama-1.0.0.tar";
-        sha256 = "1awxli95p2wwddij7nyjlivcknnxz5j19i65zr9l8awj199scnlx";
+        url = "https://elpa.nongnu.org/nongnu/llama-1.0.1.tar";
+        sha256 = "1aldq3waibplzc2m1qfhf58rmi6h3wfgghmdk6q5ixx2y1gml1vq";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3280,6 +3301,7 @@
   magit = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3292,13 +3314,14 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.3.8";
+      version = "4.4.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.3.8.tar";
-        sha256 = "03m2b155xanm9mjj886na7j9bky7a4f2lay4mm6i0r60adsz26nm";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.4.2.tar";
+        sha256 = "0l0fvf4gx4xj7474h5k00p4aa33y7z7x9lgy41vxi47vbifki2yk";
       };
       packageRequires = [
         compat
+        cond-let
         llama
         magit-section
         seq
@@ -3314,6 +3337,7 @@
   magit-section = callPackage (
     {
       compat,
+      cond-let,
       elpaBuild,
       fetchurl,
       lib,
@@ -3323,13 +3347,14 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.3.8";
+      version = "4.4.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.3.8.tar";
-        sha256 = "0h2l769ailf48an78cbrnmxsnpzhaklw23lq2lby3n2wm5d1gmn3";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.4.2.tar";
+        sha256 = "00324rd8r0pcdpgls1m0awjbms68fglsi045b8zrk6q6ahz1v08x";
       };
       packageRequires = [
         compat
+        cond-let
         llama
         seq
       ];
@@ -3371,10 +3396,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.2.tar";
-        sha256 = "146ds0wzw7l1irn5had926y5irqa1j5cld5s0pfmvyh18zjzn9bg";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.3.tar";
+        sha256 = "07snrvsbwvzky8b8whwy3qwwdzj84bfr23c2m11b5sskkgjykvy0";
       };
       packageRequires = [
         persist
@@ -3828,10 +3853,10 @@
     elpaBuild {
       pname = "org-superstar";
       ename = "org-superstar";
-      version = "1.5.1";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/org-superstar-1.5.1.tar";
-        sha256 = "1v6v7a0frgxlywfq6g4mdl6sz448k2ql7j4j4f1wrll33mr7gx8g";
+        url = "https://elpa.nongnu.org/nongnu/org-superstar-1.7.0.tar";
+        sha256 = "1c52kpsj52zswjyv35b6pdd41y4a8hkm1rww3zmrdm80h05sifz0";
       };
       packageRequires = [ org ];
       meta = {
@@ -3899,10 +3924,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.3";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.3.tar";
-        sha256 = "0iy12sl2qwgh30c5ycxgc38yv8kx6cjcj9x3akq88y5zwqqswvm9";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.5.tar";
+        sha256 = "0k24rg1pfajqnagd2yljsccs66si56d7s4aybq9jd086f4wx3fcq";
       };
       packageRequires = [
         compat
@@ -4147,10 +4172,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.58";
+      version = "0.60";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pg-0.58.tar";
-        sha256 = "1h5arpkm9gchn3igv6zzrip0pc9qb0ib0gfsj59svarxa3nvmssn";
+        url = "https://elpa.nongnu.org/nongnu/pg-0.60.tar";
+        sha256 = "06jlr38jbxnmmgqqic1n6d22sx0kfszv9awh3597lsvx044ix48j";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4296,10 +4321,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250711.83643";
+      version = "1.0.20250830.122523";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250711.83643.tar";
-        sha256 = "0qcsk00f0wfcz2h2kqckhb7yw66gw1cpcygmjri5bhnis1irzkki";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250830.122523.tar";
+        sha256 = "0bxinraaj2cnhd6x1sgps36k5vir57l4jn0x5rlndv4lsb2bp18c";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4811,6 +4836,28 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/sqlite3.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  standard-keys-mode = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "standard-keys-mode";
+      ename = "standard-keys-mode";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/standard-keys-mode-1.0.0.tar";
+        sha256 = "1c673y9xaw3i09ihhx7qbixm7rvyynxkv304wafrv7aflrzqranj";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/standard-keys-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -5405,10 +5452,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.6.3";
+      version = "2.7.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.6.3.tar";
-        sha256 = "0agxixxlv3lnsng8jk7y6x1kzzvx3sw5m3mhl8gr4i1didgxc37n";
+        url = "https://elpa.nongnu.org/nongnu/visual-fill-column-2.7.0.tar";
+        sha256 = "1xv42kzmizhr7k35xw08zib71anrif3gsbzc566gvl7yqpjd30zm";
       };
       packageRequires = [ ];
       meta = {
@@ -5426,10 +5473,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.21";
+      version = "17.3.22";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/web-mode-17.3.21.tar";
-        sha256 = "0yqaszrkllfgp0ph7rvjhz35wqzi4bas0qw70d49vaxq4z7bikzg";
+        url = "https://elpa.nongnu.org/nongnu/web-mode-17.3.22.tar";
+        sha256 = "0218wkngd59k73860zi458qabv4cbnc2150fcj7sn1i4im7f3crf";
       };
       packageRequires = [ ];
       meta = {
@@ -5537,10 +5584,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.5";
+      version = "3.4.6";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.5.tar";
-        sha256 = "1bwrn24kqc612ddjl9rpvwkdb1igsqrlmmf1fnad1zza8d09s5iz";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.6.tar";
+        sha256 = "1l3sdfd6k6baw87jgz25f7rlgwgi15f2nj51cfgjy6kkgf5ag48s";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5647,10 +5694,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.4.20250825201039";
+      version = "28.7.20250917123258";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.4.20250825201039.tar";
-        sha256 = "19vdcmimk3f8g14bjmk0wvlm0jq50r36gnc39ilxlbm84ybyrpl6";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.7.20250917123258.tar";
+        sha256 = "1d4r112via671f2x0db1ssxsbhi1w24zklgik3wgz619ng7al2ry";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -8926,11 +8926,14 @@
   "repo": "lapislazuli/blue.el",
   "unstable": {
    "version": [
-    20251009,
-    1324
+    20251010,
+    1137
    ],
-   "commit": "67b058ca787bb173e0ae8becdf217e611759d36d",
-   "sha256": "00jx7mc3hg4887xsq3zsphna32qsy4jlqxiyn2py6ar36i6ngs9a"
+   "deps": [
+    "magit-section"
+   ],
+   "commit": "6f2162a0a8a94f76c22beeffa8b10f36579cc0d0",
+   "sha256": "1viiqaij9dbkn3qnbnwvq660swgzhnf2cn0rc662zk4ldhb88vqx"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -494,15 +494,15 @@
   "repo": "atilaneves/ac-dcd",
   "unstable": {
    "version": [
-    20210428,
-    1556
+    20250925,
+    946
    ],
    "deps": [
     "auto-complete",
     "flycheck-dmd-dub"
    ],
-   "commit": "56d9817159acdebdbb3d5499c7e9379d29af0cd4",
-   "sha256": "0p5cjs156ac1x3fsxnb4kc6bd4z09kdkwkyav9ryw5nkrdzv0bd6"
+   "commit": "b95dfc61b9f2597e17f9a4a59b1745afd46a02d6",
+   "sha256": "05ky8qxmqy18mvibz37a2ddaskl318md3b4f14jdbvlvqlwsndxc"
   },
   "stable": {
    "version": [
@@ -1920,14 +1920,14 @@
   "repo": "minad/affe",
   "unstable": {
    "version": [
-    20250128,
-    839
+    20250921,
+    1712
    ],
    "deps": [
     "consult"
    ],
-   "commit": "a1607fbc66789408128e12c9224b6a6c51d12bcb",
-   "sha256": "166v7d120hbk6vczj1iam85xivk6wwpvga8m0vxgcii19issh5b3"
+   "commit": "10fc401cf2d35bafb7220b9456af7dbfd064e1f2",
+   "sha256": "1ga1zrwh5xfvmmr3sfbzmh6k8wmvca1mb0hqqwmpj9q9i1s76c0c"
   },
   "stable": {
    "version": [
@@ -2223,8 +2223,8 @@
   "repo": "tninja/aider.el",
   "unstable": {
    "version": [
-    20250826,
-    400
+    20250910,
+    525
    ],
    "deps": [
     "magit",
@@ -2232,8 +2232,8 @@
     "s",
     "transient"
    ],
-   "commit": "f7d467fe6497d8cd8a3b4267f5f4bc93e5c669ef",
-   "sha256": "17s0q7wl5psnrx4j832kir34vwfpphjfi6s3jjgpsp649gwqnpgq"
+   "commit": "7fc7041524f960bac46098dfcd23d096f8c7f0b9",
+   "sha256": "1cwhmizknq31v5mdj173wsqzvf4cp272hff93mwiq21xc4dqsca6"
   },
   "stable": {
    "version": [
@@ -2259,16 +2259,16 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20250817,
-    701
+    20250927,
+    502
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "cdee470ee5aa5c81364799fa46f9dbd5ef588663",
-   "sha256": "04zhi6k9ljxs7g61s825bzkwdnwx68bz78m43vf2njbdl0x6dph7"
+   "commit": "c6cb54d58aa5434ee39db77fde3945e078559f00",
+   "sha256": "0lknlkjrpml5pgkj84qc9bdyc3yh5ii85cffswsawb13xgbvww0x"
   },
   "stable": {
    "version": [
@@ -2964,10 +2964,10 @@
  },
  {
   "ename": "amber-glow-theme",
-  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
-  "sha256": "0mrs42zih9x22lf6hjanh5xhw59mf5ivn4dqajdrngb7wvlm4c63",
+  "commit": "106fea07ef7cb988cad2260792a844b680abde79",
+  "sha256": "0dxmqs1sa5wzdkzqk562awyifsz10jsjcs4v7x5fy398v7m3z4hs",
   "fetcher": "github",
-  "repo": "madara123pain/unique-emacs-theme-pack",
+  "repo": "Umer-Arif/unique-emacs-theme-pack",
   "unstable": {
    "version": [
     20250305,
@@ -3378,11 +3378,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20250723,
-    920
+    20250930,
+    1609
    ],
-   "commit": "0a889b50922af6b1fb5086ceaa344b3201e8547e",
-   "sha256": "1xrp8pjaq278k7rfw8r91yn18zv247qwk91zk3wyrvhazjf6vr17"
+   "commit": "17d56b130e7422054a84e4d286b315801d9cc4f0",
+   "sha256": "0ipknpb1wnh3gzqd4h5hy1a407b74791v4qkh5h1mq13fqlgx04b"
   }
  },
  {
@@ -4642,11 +4642,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20250826,
-    517
+    20251005,
+    634
    ],
-   "commit": "59f6ee68eb9bed8de12d71ca78a11dd8effbc2aa",
-   "sha256": "1ja7i4yfan83dan6vvpzywca6yh4ip9an76xhcb2s30270wmvnrk"
+   "commit": "31cb2fea8f4bc7a593acd76187a89075d8075500",
+   "sha256": "1rfanavyv4x34xh5rlvh11m3ssrifzcm6l2vip02hgawih8yijqv"
   },
   "stable": {
    "version": [
@@ -4740,6 +4740,35 @@
    ],
    "commit": "d2f5becc9850c26aa71fb581f9fc389eac740f52",
    "sha256": "1rk3zpbp7nxia7xiwj8yhji497za8npsl6w17848g29gj6hkgyji"
+  }
+ },
+ {
+  "ename": "async1",
+  "commit": "94dfbb83fdc560b7e08bb19ae1fd6572bf8c4892",
+  "sha256": "01lascwyg0w6zk15lnz67njp2x86pdw66cv8hvxdw7pj0vzk9j4v",
+  "fetcher": "github",
+  "repo": "Anoncheg1/emacs-async1",
+  "unstable": {
+   "version": [
+    20250929,
+    1752
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "ab8786693f7750f65fbfea07702fece812c57248",
+   "sha256": "0kcgg653bvw9vdvimr1jir04cpgn2iigdjzh763jg8rz6xrjx5gm"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "3f945d84c8d937d714824e29f992ea92f7db241d",
+   "sha256": "01s1kxk6ia4nyiq6ikq8n2qg3lmyk8aql3w16xgb35ccrhkfn7v7"
   }
  },
  {
@@ -5230,9 +5259,9 @@
  },
  {
   "ename": "auth-source-xoauth2",
-  "commit": "8ba0273c8aa2a50b9dc9b8312b860d94dfd808d5",
-  "sha256": "0g06240ix4gzw3fb74jcadiq7nissi20i1vsbzhkx35j10mv7wn3",
-  "fetcher": "github",
+  "commit": "7089cfa31fc9f10d510536aea9426a4fb283e656",
+  "sha256": "1dzzav4956nnkrjnarpnr2n7nf6dw17pvggy5nr8b9kqrmjqi4gq",
+  "fetcher": "codeberg",
   "repo": "ccrusius/auth-source-xoauth2",
   "unstable": {
    "version": [
@@ -5293,20 +5322,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20250815,
-    2130
+    20250901,
+    1341
    ],
-   "commit": "a11a3f717b0951b4ea1f2e1be5719fd496a07204",
-   "sha256": "0i4z0vgyd19bwjw3p37784rhny4n3svfja4zcw9dczp538a4b4wg"
+   "commit": "20744a681ba5f0584695973a5ece3a794026ff76",
+   "sha256": "10kjl3cvkq024a3kh30s6l0x326cbm6nz6904zkafxjz4lbrryln"
   },
   "stable": {
    "version": [
     2,
-    0,
-    7
+    1,
+    0
    ],
-   "commit": "b9e5df6f6d3f57263d6b22f2401f776380a37778",
-   "sha256": "1ndqm7b2mnrsb0rqigghzjqvk39gj8pjg4nhz8bapvrywb5s5zjk"
+   "commit": "20744a681ba5f0584695973a5ece3a794026ff76",
+   "sha256": "10kjl3cvkq024a3kh30s6l0x326cbm6nz6904zkafxjz4lbrryln"
   }
  },
  {
@@ -5607,20 +5636,20 @@
   "repo": "LionyxML/auto-dark-emacs",
   "unstable": {
    "version": [
-    20250823,
-    106
+    20251006,
+    358
    ],
-   "commit": "8d3f559c832be55857b1bbe4388feb8037a842e4",
-   "sha256": "0d9wsc2lbx7icpgg0rfwyp8iqkg99q1mpwczc5b2qawmpf1bdaj4"
+   "commit": "a71e791e47d09c5bf4bcbc2bbd7300b71ff72f1a",
+   "sha256": "1jmh27fkf1pivavv0qwwbb1fhdaycj3gpbbgsd917flsp6pfw55x"
   },
   "stable": {
    "version": [
     0,
     13,
-    6
+    7
    ],
-   "commit": "8d3f559c832be55857b1bbe4388feb8037a842e4",
-   "sha256": "0d9wsc2lbx7icpgg0rfwyp8iqkg99q1mpwczc5b2qawmpf1bdaj4"
+   "commit": "a71e791e47d09c5bf4bcbc2bbd7300b71ff72f1a",
+   "sha256": "1jmh27fkf1pivavv0qwwbb1fhdaycj3gpbbgsd917flsp6pfw55x"
   }
  },
  {
@@ -6268,9 +6297,9 @@
  },
  {
   "ename": "avy-act",
-  "commit": "b93be7815442e11a9b8176c4a068a46c3ac72002",
-  "sha256": "1xd72lqmlyli94qkrbs64mzwd48id6m571b4vm0sqz4sbbyhs2j8",
-  "fetcher": "gitlab",
+  "commit": "3b9f769d4d65b9d5461fc50d0b65686656bea785",
+  "sha256": "12prplkmd7zsvy3psgcirwjrg9k42yh8csbjh9pb4809cmw8h6vd",
+  "fetcher": "codeberg",
   "repo": "nameiwillforget/avy-act",
   "unstable": {
    "version": [
@@ -6698,28 +6727,28 @@
   "repo": "tarsius/backline",
   "unstable": {
    "version": [
-    20250601,
-    1005
+    20250901,
+    1339
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "5141cc9852ee254ae07b8014027758413d9d4bdc",
-   "sha256": "1g0ckbnr481qipd72jjwqkj1x3222689j125bs6bwy52njpklq6a"
+   "commit": "49ff6466633d14850a7d58eaa4c026c7764cd424",
+   "sha256": "08fzzm69rym32jnfb4k4rwp9sv64jcyxj8rf313i7pjqkzn3czd3"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "5141cc9852ee254ae07b8014027758413d9d4bdc",
-   "sha256": "1g0ckbnr481qipd72jjwqkj1x3222689j125bs6bwy52njpklq6a"
+   "commit": "49ff6466633d14850a7d58eaa4c026c7764cd424",
+   "sha256": "08fzzm69rym32jnfb4k4rwp9sv64jcyxj8rf313i7pjqkzn3czd3"
   }
  },
  {
@@ -6963,11 +6992,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20250810,
-    148
+    20250914,
+    123
    ],
-   "commit": "196f6b9f7c58cb439ed7b0d59c76b1ad737569e0",
-   "sha256": "06yl4x94j1mgiqiadnd22hxyq3yfi1skbbh2f80bpfla27bb1p1y"
+   "commit": "3c41bbd9bb315d39a56b9ab4fa7dc06c7a8a8639",
+   "sha256": "0ljk7vhzisjr1if8lilvy07wi91jnfsdxi4lgk945kzdgmbwxcja"
   },
   "stable": {
    "version": [
@@ -7582,11 +7611,11 @@
   "repo": "Beluga-lang/Beluga",
   "unstable": {
    "version": [
-    20250823,
-    858
+    20250930,
+    700
    ],
-   "commit": "bdc1897d7070c341b1fa317288a79005b7f5b8c2",
-   "sha256": "0yvzd09pdnxs00dy0s2045l98sdnb47bcx7qy604rriyl024zrah"
+   "commit": "820615cc4758086eb7641f62340a3ab93a689303",
+   "sha256": "0i1jgjdv5vsmbryx3qk2a02l7186qd8pmd8ikhz9qmzkxhfmsw45"
   }
  },
  {
@@ -7860,19 +7889,19 @@
   "repo": "kristjoc/bible-gateway",
   "unstable": {
    "version": [
-    20250724,
-    853
+    20251008,
+    1132
    ],
-   "commit": "5f86dd2768950c213f03292e9ee7d2ee652c18fc",
-   "sha256": "1sbc5hd4n3whgi0m1jdvkl4xj4awspq1wjwi6z4m8hyf9mbsj3gd"
+   "commit": "fb79e01beb9b3499c230da034f9eb1f8639a8139",
+   "sha256": "01s7vw8z0h0v3yczhli7h82hab1i6jc7ljfn5zxz21r52ir6g3vq"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
-   "commit": "5f86dd2768950c213f03292e9ee7d2ee652c18fc",
-   "sha256": "1sbc5hd4n3whgi0m1jdvkl4xj4awspq1wjwi6z4m8hyf9mbsj3gd"
+   "commit": "fb79e01beb9b3499c230da034f9eb1f8639a8139",
+   "sha256": "01s7vw8z0h0v3yczhli7h82hab1i6jc7ljfn5zxz21r52ir6g3vq"
   }
  },
  {
@@ -8677,28 +8706,28 @@
   "repo": "Artawower/blamer.el",
   "unstable": {
    "version": [
-    20240918,
-    2113
+    20251001,
+    620
    ],
    "deps": [
     "async",
     "posframe"
    ],
-   "commit": "8a79c1f370f7c5f041c980e0b727960462c192ba",
-   "sha256": "089y8jyn78hx8pzv1q9iz94fh5b61j2jzqjnr6r91xa0s3b7kmq9"
+   "commit": "aa9b22d4e847d15a5c4659c0407aa8bf4242cc94",
+   "sha256": "0ar711chafxvk5fdkv61hqhc8fcd3cjaxyqkml9xq0jyk13k77qd"
   },
   "stable": {
    "version": [
     0,
-    9,
-    4
+    10,
+    0
    ],
    "deps": [
     "async",
     "posframe"
    ],
-   "commit": "8a79c1f370f7c5f041c980e0b727960462c192ba",
-   "sha256": "089y8jyn78hx8pzv1q9iz94fh5b61j2jzqjnr6r91xa0s3b7kmq9"
+   "commit": "d06e1b8907f0bb5d603c76323dbcd8b00a014062",
+   "sha256": "1ycpb3q0waq0bdi5nvd856k31772xaq82d1i2gpbdwqnxl4x7ivb"
   }
  },
  {
@@ -8890,6 +8919,21 @@
   }
  },
  {
+  "ename": "blue",
+  "commit": "41aa9db6807cf988a19820398a28be78589f03a8",
+  "sha256": "0xk9xxjzn6693f88v1541949zph42k7p6jznvaigk8l67128yxis",
+  "fetcher": "codeberg",
+  "repo": "lapislazuli/blue.el",
+  "unstable": {
+   "version": [
+    20251009,
+    1324
+   ],
+   "commit": "67b058ca787bb173e0ae8becdf217e611759d36d",
+   "sha256": "00jx7mc3hg4887xsq3zsphna32qsy4jlqxiyn2py6ar36i6ngs9a"
+  }
+ },
+ {
   "ename": "bluesound",
   "commit": "e28ec7b3785728171cb6fec7874a0bf6925b87bf",
   "sha256": "04kj86i28l4ri4d3pimm633jic3r6w006ydy95lha9xsm62sd74r",
@@ -8932,6 +8976,30 @@
    ],
    "commit": "1fefbc46d10d5398ecca93aa18ef1af3fc1f44b4",
    "sha256": "0298hjdgx03y028pql6z3jcym47ji10hv66zydn1kicsjds0r45l"
+  }
+ },
+ {
+  "ename": "bmp",
+  "commit": "299e39ac1dd36586b41b53afd094a11a4aadd154",
+  "sha256": "0fjjrl8q05kr9dx53i5rcqc8wh6lkzi6x23yz9hiv8y2296py00b",
+  "fetcher": "sourcehut",
+  "repo": "lepisma/bmp",
+  "unstable": {
+   "version": [
+    20251005,
+    2032
+   ],
+   "commit": "8f4fe653ee49860d764b789919bbd46a4a9d3768",
+   "sha256": "1lqknrg1nprllvzz5cpm4lxfl5dqm5jpynv0xqjy37b9l4ddzdj4"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    2
+   ],
+   "commit": "63aeacf69a12aa8b47ae4d9e2d859e5d1c954012",
+   "sha256": "03aq32m8sn56m992nsm1jbd7rix8iap1y93fv98797n0fqiqfdb0"
   }
  },
  {
@@ -9178,11 +9246,11 @@
   "repo": "ideasman42/emacs-bookmark-in-project",
   "unstable": {
    "version": [
-    20250611,
-    333
+    20250921,
+    813
    ],
-   "commit": "ea732ab234faee6db75371d5993d9b479da3d66d",
-   "sha256": "19pin8mwrj5bgic5lsvpkn5l76i5q4qd9z70zhskwzm8gf8dnjn3"
+   "commit": "a15821d3acb5c010a0a309ddd5d957ea6a56a4e4",
+   "sha256": "0mmvxhk2gck861hs85883s43gfi7mc4az8f6c6z4gz41whdhwy71"
   }
  },
  {
@@ -9265,28 +9333,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20250812,
-    1354
+    20251006,
+    1814
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "cedcf302193a64f58f78e85924b36624dc61eafd",
-   "sha256": "07rrz2yqapdvx353kfgp8y4611kxsbj2r37j9cq1l5kw0a30sqzl"
+   "commit": "5b192d8d1a426402b98a2e2e3342c4b73477fbcc",
+   "sha256": "1ppys1bc24ia4qq608wn93w13489a558ia87bz32biiqj4yhmpqg"
   },
   "stable": {
    "version": [
     4,
     2,
-    0
+    2
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "bcec39d4f78b6f2145172d390ffd39f4e5bc74fe",
-   "sha256": "0c1irizwpwqicrhprq84mr7lwvagddl2iiy18hpljaf8jqq9ajpv"
+   "commit": "5b192d8d1a426402b98a2e2e3342c4b73477fbcc",
+   "sha256": "1ppys1bc24ia4qq608wn93w13489a558ia87bz32biiqj4yhmpqg"
   }
  },
  {
@@ -9492,11 +9560,11 @@
   "repo": "ideasman42/emacs-bray",
   "unstable": {
    "version": [
-    20250607,
-    702
+    20250920,
+    932
    ],
-   "commit": "94067be7d07b23a546d7669c374bec95e9482a18",
-   "sha256": "1b2inacqpq0y67sm0xq7f1kippgvk4lyg39cnd6y1rpqh8vxxjn8"
+   "commit": "75e671b07a501889b7d68da3c81d6bd86b817614",
+   "sha256": "03szhjpbxch22xxyhppfl00p5s17bbx23pmkwgcv7hihkncnvi64"
   }
  },
  {
@@ -9980,11 +10048,11 @@
   "repo": "ideasman42/emacs-buffer-name-relative",
   "unstable": {
    "version": [
-    20250611,
-    322
+    20250913,
+    2251
    ],
-   "commit": "6e9e74776f06ddab76f7e3536bff144921cbd334",
-   "sha256": "1i6was1mkh2ycbmsqdi32cj2g5qhwmzbwgxbw23kssvdpxmp6lg6"
+   "commit": "f59cd8c0ecf6670da1d2a1468240d3f81663884b",
+   "sha256": "04iqprrb1s2m9v958g26s5dm8b9p15aqai2941hbw7ffj91b5zx8"
   }
  },
  {
@@ -9995,16 +10063,14 @@
   "repo": "countvajhula/buffer-ring",
   "unstable": {
    "version": [
-    20250507,
-    1635
+    20251004,
+    347
    ],
    "deps": [
-    "dynaring",
-    "ht",
-    "s"
+    "dynaring"
    ],
-   "commit": "7359c523d2ae222137602907d37852d102394c5a",
-   "sha256": "0vvyrbmw5pr1my5m93pm2wh1vg5li0zvcvhddn1km3kywhk5p98p"
+   "commit": "3d7ee2020aff07506e16220f86b6521af814c282",
+   "sha256": "0xav9kw41v417n7km21qxgnaahd7n8iakflslgp4lv70lhmrl8jn"
   },
   "stable": {
    "version": [
@@ -10059,20 +10125,20 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20250822,
-    1932
+    20250911,
+    2238
    ],
-   "commit": "a5f4a6a00ebb0af979c8b122c3a0122a9dedc070",
-   "sha256": "1s4xqzs895cgwqk8m33d9imq87wc39qm8c1rp5652nzi8h5iv2xw"
+   "commit": "68552751bcfd049e72a5b81b3077b121ec7a7d01",
+   "sha256": "1m0ymnpn5haa2xg7dh4j5nqsix86gg21z1jxd93kj75ivk6r11m6"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "0856afa78d415ec1124ab792a844a97b7d7a2f47",
-   "sha256": "0gmka4xikri5830g0qcn686bhn1w69nzsaf2siz5v7d6lq2k7mj4"
+   "commit": "28def905e7d01fb24369b104e1bd1d7bdac8811c",
+   "sha256": "1rj83kkbcyfjpk61x8av0zf2xq86irwspw9qgxvvl68nj3s0zhrd"
   }
  },
  {
@@ -10176,11 +10242,11 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20250805,
-    1623
+    20250822,
+    1931
    ],
-   "commit": "775e258d7480daebb06073ada76eebc4c979f509",
-   "sha256": "1j2n3738mqfr2g3hy4swcdzlzj50dmawq2n06ln1s03giq54p05k"
+   "commit": "5f169b301e04d183500261825bb7af76a35b7ad0",
+   "sha256": "1v3i9fzklq7j5440xb9jsgrbywzkdsrx3pih328ba44d4h7sj4yq"
   },
   "stable": {
    "version": [
@@ -10764,6 +10830,21 @@
   }
  },
  {
+  "ename": "cacao-theme",
+  "commit": "449b10104d15211ffa2e73fed3d3dd9ceb4b1cf7",
+  "sha256": "1zgjqiyj495ayr876n7v4aj07i92mimqng42fpacfirmxs0lsspx",
+  "fetcher": "github",
+  "repo": "Michael-Garibaldi/cacao-theme",
+  "unstable": {
+   "version": [
+    20250928,
+    1909
+   ],
+   "commit": "50d2e703e316fc04ed4e2205f3ef99621fc4ff31",
+   "sha256": "1sxmav51827x5zyllqwkh9z1rd19a1sajsh2pd0j01mfqh27z107"
+  }
+ },
+ {
   "ename": "cache",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "15pj7f4n0lk8qqsfafdj19iy0hz4xpfcf2fnby7ziq2dldyqrax9",
@@ -11092,8 +11173,8 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20250725,
-    1429
+    20250913,
+    1233
    ],
    "deps": [
     "dash",
@@ -11103,8 +11184,8 @@
     "s",
     "transient"
    ],
-   "commit": "320c28254c6f8d4c35ea5d4c7f91210a7a1a9bee",
-   "sha256": "0ahzif99wb935sbivgqy2ra9c6ff1r1p2p6m47cmslhsycb09y2y"
+   "commit": "99a234167a092bc0017d11c814f0b8c0da53a107",
+   "sha256": "0jkhaf5h2qcqz8nvw80wj0xjazdpm2l9n0d5a41p20gnz54rhkbd"
   },
   "stable": {
    "version": [
@@ -11294,14 +11375,14 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20250807,
-    2138
+    20250920,
+    843
    ],
    "deps": [
     "compat"
    ],
-   "commit": "97641dcd1ebca1007badd26b2fb9269b86934c22",
-   "sha256": "1w7pym65a2p63fiv5fqmsvxx6nbxr96a1inldzpjqq5qndgaksgw"
+   "commit": "e687d4dbf4a8d07a2f1a19b5ca676828038eff31",
+   "sha256": "1b511xh76br5ycq6z3yjs4la96vpyjjcndkf5gnv27w9pm938clv"
   },
   "stable": {
    "version": [
@@ -11622,26 +11703,26 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20250817,
-    2347
+    20251006,
+    2105
    ],
    "deps": [
     "transient"
    ],
-   "commit": "5e004a06eef3b66865b785bca51512cdb89ff6a9",
-   "sha256": "0dlhb04l0i71ivsz9mgrphx9mk6qldbihpvkijpqs01h5q2swd83"
+   "commit": "f0ec7e600db38e9e7c0b46de48eac032dbf9845d",
+   "sha256": "18j89l5ivrv1aki4kyc9ww2gm5h5wzx79c2f84k7v9hxvh46d9n8"
   },
   "stable": {
    "version": [
     2,
-    8,
-    4
+    9,
+    1
    ],
    "deps": [
     "transient"
    ],
-   "commit": "5e004a06eef3b66865b785bca51512cdb89ff6a9",
-   "sha256": "0dlhb04l0i71ivsz9mgrphx9mk6qldbihpvkijpqs01h5q2swd83"
+   "commit": "f0ec7e600db38e9e7c0b46de48eac032dbf9845d",
+   "sha256": "18j89l5ivrv1aki4kyc9ww2gm5h5wzx79c2f84k7v9hxvh46d9n8"
   }
  },
  {
@@ -11652,28 +11733,28 @@
   "repo": "kickingvegas/casual-avy",
   "unstable": {
    "version": [
-    20241217,
-    1931
+    20250830,
+    2115
    ],
    "deps": [
     "avy",
     "casual"
    ],
-   "commit": "6716c12e9b7ba8325dab05d55c1ea5cc2b9a44f1",
-   "sha256": "0p4ljzgcr51wpcfs4r0nnpv4rgaivzcq4lbcyr9sfvgqhr1yr271"
+   "commit": "c5bc8e9d57a843f75e6125f097550414af3d5ec7",
+   "sha256": "0zi4s8gk352yhnrdsbg48c7hg3yamaqs4x34ldd9kfrzrasmb7fl"
   },
   "stable": {
    "version": [
     2,
     0,
-    1
+    2
    ],
    "deps": [
     "avy",
     "casual"
    ],
-   "commit": "6716c12e9b7ba8325dab05d55c1ea5cc2b9a44f1",
-   "sha256": "0p4ljzgcr51wpcfs4r0nnpv4rgaivzcq4lbcyr9sfvgqhr1yr271"
+   "commit": "c5bc8e9d57a843f75e6125f097550414af3d5ec7",
+   "sha256": "0zi4s8gk352yhnrdsbg48c7hg3yamaqs4x34ldd9kfrzrasmb7fl"
   }
  },
  {
@@ -11774,11 +11855,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20250715,
-    754
+    20250910,
+    2247
    ],
-   "commit": "d070e926504b81dd9b8cdbf90604b5268e7e17b5",
-   "sha256": "0xcqmyr5nq4zb7q5qkplrsp126h7rhgxxj2plsn3qmggryhdrdr2"
+   "commit": "09b9b785014e74f8e2ba24f29f806f1c0a65ad54",
+   "sha256": "0v7wzmslnqadxja52ygxjwimrhk9l4vw8n21yvk4gpcb66whjyip"
   },
   "stable": {
    "version": [
@@ -12098,17 +12179,17 @@
  },
  {
   "ename": "centered-window",
-  "commit": "b46e83f2ea2c4df1ef343c79c7e249605c9639b3",
-  "sha256": "12xwwbqi48f3b3x4xddrf8n6l90kv4pmy4l5waixcigcx1vwj2r8",
+  "commit": "2dbcb69f603a94b6abc196d45ec5d2fb2ddc1344",
+  "sha256": "19x2wr2hvf1cpbpg6gzhcns3s9xz6ky1bngm5mjz018z3bfw6n4f",
   "fetcher": "github",
-  "repo": "anler/centered-window-mode",
+  "repo": "nullvec/centered-window-mode",
   "unstable": {
    "version": [
-    20220125,
-    804
+    20250921,
+    2101
    ],
-   "commit": "80965f6c6afe8d918481433984b493de72af5399",
-   "sha256": "0zmq84gvkyj20l9gv5wwraa6zis2vk7hadagkmyqg1w6vs25n2mh"
+   "commit": "701f56cd1d2b68352d29914f05ca1b0037bb2595",
+   "sha256": "0nz615jh7p8hm3p2l28warfw3lxwc594nl2njywq0bsgn3pw7vdf"
   }
  },
  {
@@ -12263,7 +12344,7 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20250817,
+    20250921,
     807
    ],
    "deps": [
@@ -12271,8 +12352,8 @@
     "s",
     "yaml-mode"
    ],
-   "commit": "7a1d5825d5d875c1f816ab233c977fd9cc8726dc",
-   "sha256": "06gjgpp8yrblglz8rxq80459zw37i6w0x53kc0nrkf85xwqwird1"
+   "commit": "b8f914d1d5f0b0343e44a50a44c2a0520a90628a",
+   "sha256": "1j0idikby2s23xyg016vhn5y4jzxhk34vck2v3bk95mf3rsjpn11"
   },
   "stable": {
    "version": [
@@ -12536,28 +12617,28 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20250825,
-    1527
+    20251005,
+    1215
    ],
    "deps": [
     "shell-maker",
     "transient"
    ],
-   "commit": "cda5d96d9b01b28cff527ff1134a2df5e9a2731a",
-   "sha256": "04lx5qlw5srbr2rhd0w3z6ikvwcbzsyz623k4rw6yr4ps82dfgyp"
+   "commit": "1a86193a519b1429b14972da49be20beb446affc",
+   "sha256": "1x4f7cis50vsvhmwrkg89l2vjs22pzcy9lwr5jslw0ms3hdzky1n"
   },
   "stable": {
    "version": [
     2,
-    26,
+    30,
     2
    ],
    "deps": [
     "shell-maker",
     "transient"
    ],
-   "commit": "9bf591aa58f5bce7d3b01c505f5608e31820950f",
-   "sha256": "1irwv2fcyj0nf086p29pgyyk1pdbq6c8pczxacfsax0xjmxzyzpx"
+   "commit": "c5b9394fed338eb5bb129590aa29edb14f6d9ba7",
+   "sha256": "0jyhcy27g4dpcd49a2f23smmnxjsvbdzpa71207svillrgiafg8f"
   }
  },
  {
@@ -13223,8 +13304,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20250806,
-    1944
+    20250902,
+    1530
    ],
    "deps": [
     "clojure-mode",
@@ -13235,8 +13316,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "ff44b5b6f5ecb4bc3407fdc07eb54a3e8dc663fd",
-   "sha256": "05sa88kp3pg53harnxk83z54q0qs61icq9xf9871hyxb317hrlqk"
+   "commit": "af63db156a89fc77a35b0f8a3c1ccddcfbf9af84",
+   "sha256": "16l6d0iznmxdpwifdm2xsdnbg74w4jshaj82x5qw1k4cncfyna0d"
   },
   "stable": {
    "version": [
@@ -13457,14 +13538,14 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20250713,
-    1752
+    20250929,
+    1724
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a0aada8cbb381228c80d98b81ebdec30012c512e",
-   "sha256": "055143h804dh58j5xa9q9l0vhb41fbpfaxg3lwz0iilgjazs5xx7"
+   "commit": "754a59fa06bdbf03cc47567c04c97ee49d8aa1f1",
+   "sha256": "1x7rq9pc8xg2c72fyvifpj2zimcqzfrxqprhw60hk1g4x2ygvk99"
   },
   "stable": {
    "version": [
@@ -13716,8 +13797,8 @@
   "repo": "andras-simonyi/citeproc-el",
   "unstable": {
    "version": [
-    20250819,
-    1700
+    20250912,
+    1154
    ],
    "deps": [
     "compat",
@@ -13729,8 +13810,8 @@
     "s",
     "string-inflection"
    ],
-   "commit": "f5217b9fdbcb41a0381ecf92108390fc843090dd",
-   "sha256": "1z3admj8xf73azk4hd8yp75ldwla5zl0n4a4syndk6wqn18vgc7f"
+   "commit": "9f16f2eee4586404b88a7b8cf46e1c158477bc33",
+   "sha256": "1nabgdifrbdn5mj7srjqz1slsfccjh22zjaz9bmkdr1x859b0gaj"
   },
   "stable": {
    "version": [
@@ -13944,8 +14025,8 @@
   "repo": "yuya373/claude-code-emacs",
   "unstable": {
    "version": [
-    20250723,
-    1154
+    20250919,
+    1908
    ],
    "deps": [
     "markdown-mode",
@@ -13953,14 +14034,14 @@
     "transient",
     "vterm"
    ],
-   "commit": "f62dfe4c570c92fceaf628c5749b240a5fd9330d",
-   "sha256": "1z2xq2qmy92nzsgrr2xfjljww5rgzj41yzpipsvqzg1ws6rvd1zs"
+   "commit": "56cccf63709b305bfd74ab72f20bd9d3b12f7d09",
+   "sha256": "0hvmvp5yq0pidb5mry68pc0lirz3b61cyh25am60432xdkq2pv74"
   },
   "stable": {
    "version": [
     0,
-    6,
-    0
+    7,
+    1
    ],
    "deps": [
     "markdown-mode",
@@ -13968,8 +14049,8 @@
     "transient",
     "vterm"
    ],
-   "commit": "f62dfe4c570c92fceaf628c5749b240a5fd9330d",
-   "sha256": "1z2xq2qmy92nzsgrr2xfjljww5rgzj41yzpipsvqzg1ws6rvd1zs"
+   "commit": "56cccf63709b305bfd74ab72f20bd9d3b12f7d09",
+   "sha256": "0hvmvp5yq0pidb5mry68pc0lirz3b61cyh25am60432xdkq2pv74"
   }
  },
  {
@@ -14086,11 +14167,11 @@
   "repo": "NicholasBHubbard/clean-kill-ring.el",
   "unstable": {
    "version": [
-    20230115,
-    2153
+    20250926,
+    1623
    ],
-   "commit": "d05fa7ee97e760d21d533261c7b63eecf223f612",
-   "sha256": "0s0r65byg66fq4q9jqral4m2d616sfxla5k75zrmyxx3h5152n4r"
+   "commit": "60172fc644d68c55b1c15c7fe1a09a63589a1d43",
+   "sha256": "0sxfx0nr8v82ibdy55xbpq063hmw2pq78pc84464fpr35gw3yz26"
   }
  },
  {
@@ -14780,11 +14861,11 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20250815,
-    441
+    20251003,
+    2051
    ],
-   "commit": "32490c80fad7d27367b08d967e8184f75b4ca19e",
-   "sha256": "0zn6ajk7fkd6w7306bd3l4v7zqjj58czinqdk5bdjbgbapnh9rs7"
+   "commit": "08b1c3b961f4284d9718dfcdaa9cb7e8b5b42b27",
+   "sha256": "0ffdycwz6nsckhx6wbdzg6kp3m283y1cfy02hcxwhswcmj0r56lr"
   },
   "stable": {
    "version": [
@@ -14839,28 +14920,28 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20250815,
-    1802
+    20250913,
+    1926
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "08194fb97deb3a83863da7731cb316aa62058f22",
-   "sha256": "0yj3sbcwdk6g4fivma6zdqkvj5wsagx2kid05jgj7zpiyq3wgqgv"
+   "commit": "f5dd024c47b792dac499dac94c906af60044d2ad",
+   "sha256": "0b0a9x669148l83s54jkb0vvwqch1dhfg917f80b1rmqn8nx9rd4"
   },
   "stable": {
    "version": [
     2,
-    2,
-    2
+    3,
+    0
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "05a2b048fd4e5c90aa971479cb9e71cf9aeba2bf",
-   "sha256": "0qk9g2f966iy534k0rbkgbz120psk3hvvw7hn720ym22rlbf214b"
+   "commit": "80e91c557331225b5c4b420ec6f283ac3c40bbac",
+   "sha256": "1vfanw02di8lgvbiijzbgm5rd8w1yzfd81srygacfbzp34diqvcy"
   }
  },
  {
@@ -15033,20 +15114,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20250805,
-    1455
+    20250930,
+    1448
    ],
-   "commit": "2a2c2e0b2658f7c07e00fcf649882fd5578c2fc1",
-   "sha256": "05apsrvsnc4qjh230ym9mdmip8lv209947rw743h4kxch02pxld2"
+   "commit": "11f3f34077ba6fc1a2be6fe0f1ae542ebf884675",
+   "sha256": "092vx75c232y8yng0j97xds0f8lhiw98b18jz3cj1s67kjhf0fsd"
   },
   "stable": {
    "version": [
     4,
     1,
-    0
+    2
    ],
-   "commit": "2a2c2e0b2658f7c07e00fcf649882fd5578c2fc1",
-   "sha256": "05apsrvsnc4qjh230ym9mdmip8lv209947rw743h4kxch02pxld2"
+   "commit": "11f3f34077ba6fc1a2be6fe0f1ae542ebf884675",
+   "sha256": "092vx75c232y8yng0j97xds0f8lhiw98b18jz3cj1s67kjhf0fsd"
   }
  },
  {
@@ -15395,6 +15476,30 @@
    ],
    "commit": "c4757e73e845895e8368fe621fa2bb2bd5a6d49c",
    "sha256": "0yg2v8q7w5siyrq5jfsdjm8a4jx9mqlqyw6k69snsj95kzgj11g6"
+  }
+ },
+ {
+  "ename": "codex-cli",
+  "commit": "b4899a8b40b9691ccd07d98ff6609a97118dbd72",
+  "sha256": "1jqhgi0glva20mg01412na7l2b371q63jc5wli11n4hllxb0759y",
+  "fetcher": "github",
+  "repo": "bennfocus/codex-cli.el",
+  "unstable": {
+   "version": [
+    20250913,
+    1900
+   ],
+   "commit": "172d62381851d82860186a56da6f936f40180b3f",
+   "sha256": "1p9k7pa868hpl9zr9xa1c1mcsmirsslcabx4hay3pwl90raq0nlq"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
+   ],
+   "commit": "172d62381851d82860186a56da6f936f40180b3f",
+   "sha256": "1p9k7pa868hpl9zr9xa1c1mcsmirsslcabx4hay3pwl90raq0nlq"
   }
  },
  {
@@ -16107,14 +16212,14 @@
   "repo": "ddoherty03/commify",
   "unstable": {
    "version": [
-    20230616,
-    1042
+    20240131,
+    1455
    ],
    "deps": [
     "s"
    ],
-   "commit": "35e2438eb7feeb28273c4920376fcf296cc83283",
-   "sha256": "117jkip4waw1vb4rqdg94wncqmza5p6b2x102xkcqhn4nf7f8vw7"
+   "commit": "1245bfe420e92b4274bce3421ee59ea201e72aaa",
+   "sha256": "0ikbplbv8wbx22v3syh9ghvp9qi12i02wlkn2m6isjp4vhi0fqjs"
   }
  },
  {
@@ -16155,20 +16260,19 @@
   "repo": "mekeor/communinfo",
   "unstable": {
    "version": [
-    20250726,
-    2115
+    20250927,
+    28
    ],
-   "commit": "feda0794ba63e407089c7f134e52a92f58d070b8",
-   "sha256": "16nrlkdpzsg0xb9ybl9hqayldfx4cqc5g8317ah8n02vv8w4jby4"
+   "commit": "a562535f385f1ff7a154b01047e4e2c9efc2dd65",
+   "sha256": "05ys67rbhgb6kral9fhl51y4qp3h4k059nk5j6lgksa0hnby99x7"
   },
   "stable": {
    "version": [
-    0,
     1,
-    4
+    0
    ],
-   "commit": "179b6a7bd75837f12d496949b0e7a09373c2ad80",
-   "sha256": "02myabw9mb8q86hnb8ngvd179xxim0x7818f2pi3lw19lfbgic75"
+   "commit": "a562535f385f1ff7a154b01047e4e2c9efc2dd65",
+   "sha256": "05ys67rbhgb6kral9fhl51y4qp3h4k059nk5j6lgksa0hnby99x7"
   }
  },
  {
@@ -16179,11 +16283,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20250805,
-    1525
+    20250911,
+    129
    ],
-   "commit": "ca045bc54411f274779057d94a1807efe7f8d2a6",
-   "sha256": "10lazdsydnnxrndp925sh3zah9nn38sbq4dhr4h0pkhr884wk69j"
+   "commit": "03bedfce7623c69dde08d85abdf0ceb2a89a274c",
+   "sha256": "19h05cc0vvzzia1czn341a3yrg3nygjxhf4d67p7lz66bz7ks3zp"
   },
   "stable": {
    "version": [
@@ -18076,11 +18180,11 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20250825,
-    1926
+    20250905,
+    2104
    ],
-   "commit": "298d9fbe552972ed9a678fc41ed9a2452a313a29",
-   "sha256": "0214k5vhf141wg6jbjirrzmx67kdrgs6qrvgphr5brasa85n2ydg"
+   "commit": "59b03b6ff55b3f07d9b42739cf35ac0de7775a99",
+   "sha256": "1jiwv7jxr92x832z76mpfhxahmxrb84kfc1j7478y064vk55axya"
   },
   "stable": {
    "version": [
@@ -18100,11 +18204,11 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20250101,
-    2156
+    20250831,
+    1542
    ],
-   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
-   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
+   "commit": "d111f99303ceb0354e37e2a5cd7f504d19f105f7",
+   "sha256": "0cng5wlbca6ry31v8ff6q1rdj1cpcgyjnrkr9wkwb0i9ld6aypj6"
   },
   "stable": {
    "version": [
@@ -18212,8 +18316,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20250417,
-    2126
+    20250928,
+    1426
    ],
    "deps": [
     "eldoc",
@@ -18221,14 +18325,14 @@
     "plz",
     "seq"
    ],
-   "commit": "171cbde72993956e46cc478ecc98825997450140",
-   "sha256": "15w171fhh0khvsr02z2c110w818hmrzjpmpn1lazw7s0nq8a8mf5"
+   "commit": "9e32e10b13a53b1fbf5471c34e4c0ea7a5db9057",
+   "sha256": "0gmf0q8s4n4x5v3nj0yanmc5nrjcca4049h7xg5dvd3250y0a1ar"
   },
   "stable": {
    "version": [
     0,
-    6,
-    1
+    7,
+    0
    ],
    "deps": [
     "eldoc",
@@ -18236,8 +18340,8 @@
     "plz",
     "seq"
    ],
-   "commit": "862d3508e31f5d3ee0142414717d229e30bac477",
-   "sha256": "10qpqglv2vd1cnpd08nvhqhrdllnak5d6dqb0nnm1cq7fzkwyj16"
+   "commit": "9e32e10b13a53b1fbf5471c34e4c0ea7a5db9057",
+   "sha256": "0gmf0q8s4n4x5v3nj0yanmc5nrjcca4049h7xg5dvd3250y0a1ar"
   }
  },
  {
@@ -18324,15 +18428,15 @@
   "repo": "Carl2/conan-elisp",
   "unstable": {
    "version": [
-    20231016,
-    830
+    20250919,
+    1412
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "80d17373cb6c3dc7952c538efd9f94a7f564ffec",
-   "sha256": "1zn9jvdnrs6brgrsmzkmnmlcvvsdyf1in2jrrx6yzz953i7dnz11"
+   "commit": "0c3cca9e832e837a037f8c88438cca979891b131",
+   "sha256": "0alb6vjr4xwi9bzh7bwxcrhgf45gbl3bbpa2kdgikahsgz7zbpdf"
   }
  },
  {
@@ -18373,20 +18477,20 @@
   "repo": "tarsius/cond-let",
   "unstable": {
    "version": [
-    20250823,
-    1715
+    20250903,
+    1646
    ],
-   "commit": "7d3d9c6b28fadaa48f2015df4169c666dd9986dd",
-   "sha256": "11zar4q6364dykbga3akhfdvcmm1dxnc570nlnryc5irnsv80nbx"
+   "commit": "79a16e1f2428f0f79f03250b987bc79cd37a029e",
+   "sha256": "1hsxl42dysbrkmgnbd954zjv28cms73r7nask5ip4f07qzgaj1gi"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
-   "commit": "8cb8733112d00ad8d24cb1f2f7a7845448c31819",
-   "sha256": "07csd39xb5816y7944v4bcl0hv3pm8vnfqwcc84g7ijpwpip8rfc"
+   "commit": "79a16e1f2428f0f79f03250b987bc79cd37a029e",
+   "sha256": "1hsxl42dysbrkmgnbd954zjv28cms73r7nask5ip4f07qzgaj1gi"
   }
  },
  {
@@ -18620,25 +18724,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20250821,
-    1739
+    20251006,
+    1037
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c8bbb3f1e2fbbdcca773498e2db168c0929c3434",
-   "sha256": "1in3qiqlfzcwib34dd01v6a5y5h84p2nr94bn7gi32mw9p9b3z8m"
+   "commit": "ce965a04223336665fa82df797455b7317181fc6",
+   "sha256": "059ijmf0v1mbkg4g6n0c878lh4rad4mzy831dqdws9p2h1aq1pi8"
   },
   "stable": {
    "version": [
     2,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "770c43117aad6add1ca8532207618b7e90aec1fe",
-   "sha256": "1vgvs1ymssh5gv7xwnv9bksmgr3i5zqzqhyxz5x8ygj6fxfv2f12"
+   "commit": "098462a6321a15afd4ae33fa8083658145332d9c",
+   "sha256": "0yvb73d2rp728pkaz6d9k1ka64za47bx7jrnx6isf057g17p9di7"
   }
  },
  {
@@ -18807,16 +18911,16 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20250216,
-    2144
+    20250831,
+    924
    ],
    "deps": [
     "consult",
     "eglot",
     "project"
    ],
-   "commit": "b71499f4b93bfea4e2005564c25c5bb0f9e73199",
-   "sha256": "1xx5g4z4l0kanf2mh3f798gw8ydfzbx15wfyqrnhwhiljz796xis"
+   "commit": "d7296fef3f9c4280229df51f32fc0b5db2392c22",
+   "sha256": "1x5v82zrjqlckshy4sjpkwkj6mqqk6njiz00z68n1a8383f1jlik"
   },
   "stable": {
    "version": [
@@ -18841,15 +18945,15 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20250216,
-    2144
+    20250831,
+    925
    ],
    "deps": [
     "consult-eglot",
     "embark-consult"
    ],
-   "commit": "b71499f4b93bfea4e2005564c25c5bb0f9e73199",
-   "sha256": "1xx5g4z4l0kanf2mh3f798gw8ydfzbx15wfyqrnhwhiljz796xis"
+   "commit": "d8b444aac39edfc6473ffbd228df3e9119451b51",
+   "sha256": "043qdk744knnkimjzr8f1wza12gg4jv7yfs1z4aardixfx75i9jg"
   },
   "stable": {
    "version": [
@@ -18873,15 +18977,15 @@
   "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20250724,
-    1511
+    20250923,
+    1114
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "86dcb0bf2897be0f2b915ade96b1915ab23c3ee9",
-   "sha256": "01vidxcmh8zxw8bixp4bwnmrsblrpq72k3pmhjpdd9d9vvg2jg3x"
+   "commit": "062e223bc6cf5f2126d7a107a35069c33c018c36",
+   "sha256": "0g30317fhjy3n4vgjc1m556h9fxayswzbbrriy2irc40fbxyrx91"
   },
   "stable": {
    "version": [
@@ -18922,8 +19026,8 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250730,
-    2355
+    20250915,
+    2043
    ],
    "deps": [
     "consult",
@@ -18931,21 +19035,22 @@
     "ox-gfm",
     "yaml"
    ],
-   "commit": "f76011cafdfb5ab3cff5c93865e4db21713d67cb",
-   "sha256": "11f5bikazp32yap76vqmp6ij0wnvg9hkp4bia31f3gba4hpf6ys2"
+   "commit": "699af6c2b179c6a7888352e78413b7e3f76ae6ba",
+   "sha256": "1brv97np4l3cfby88izwdqc4k1h6ikbx5h08i01j858bkpzkwbnz"
   },
   "stable": {
    "version": [
-    2,
-    6
+    3,
+    0
    ],
    "deps": [
     "consult",
     "markdown-mode",
-    "ox-gfm"
+    "ox-gfm",
+    "yaml"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   }
  },
  {
@@ -18956,29 +19061,31 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250714,
-    2249
+    20250906,
+    1805
    ],
    "deps": [
     "consult",
     "consult-gh",
-    "embark-consult"
+    "embark-consult",
+    "which-key"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   },
   "stable": {
    "version": [
-    2,
-    6
+    3,
+    0
    ],
    "deps": [
     "consult",
     "consult-gh",
-    "embark-consult"
+    "embark-consult",
+    "which-key"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   }
  },
  {
@@ -18989,29 +19096,60 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250714,
-    2249
+    20250906,
+    1805
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   },
   "stable": {
    "version": [
-    2,
-    6
+    3,
+    0
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
+  }
+ },
+ {
+  "ename": "consult-gh-nerd-icons",
+  "commit": "58ff01a26d03936eb8f51d433d565443623f47ba",
+  "sha256": "1d5pf868nfpv87kmwp9rjaw0cyqbp152bdcmr0wr0531cb24d3wf",
+  "fetcher": "github",
+  "repo": "armindarvish/consult-gh",
+  "unstable": {
+   "version": [
+    20250915,
+    2241
+   ],
+   "deps": [
+    "consult-gh",
+    "nerd-icons"
+   ],
+   "commit": "feba9c563f3919401c89dd4008d23ae0896c47ce",
+   "sha256": "123nyka78j2851rbyyrhak0jvhzjy833ccqgy7gpc0qa2lbrld1r"
+  },
+  "stable": {
+   "version": [
+    3,
+    0
+   ],
+   "deps": [
+    "consult-gh",
+    "nerd-icons"
+   ],
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   }
  },
  {
@@ -19022,29 +19160,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250714,
-    2249
+    20250906,
+    1805
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   },
   "stable": {
    "version": [
-    2,
-    6
+    3,
+    0
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "82834b0b2e21903f15cbb6427d1fd12c30e16b88",
-   "sha256": "09yriq68kcm4x0haig1vxlsnrbx2b1y7y2ws6k8fnds3ja175cy2"
+   "commit": "2b625a0331c9a92c67fef8ea2e694b28d5006421",
+   "sha256": "1p9lcjrzwxgscxpy0x992g8sxy6h3mcin1vffxf6nx28akwz13in"
   }
  },
  {
@@ -19275,15 +19413,15 @@
   "repo": "Qkessler/consult-project-extra",
   "unstable": {
    "version": [
-    20250729,
-    1123
+    20250926,
+    603
    ],
    "deps": [
     "consult",
     "project"
    ],
-   "commit": "0cdcf7fc04711417ee1e05e9aec21488732438fe",
-   "sha256": "0zmj2ld0qm7kk4f8q646k11ivswgrn7yvhlhyxlmpazhi892qmp6"
+   "commit": "8067e2c0ca29432514dabfb47a45cf1132a03789",
+   "sha256": "18y1f3z7l563pbnn67fs8jz3dsr04gpgyi1ijshpq40c7ncsnpmf"
   },
   "stable": {
    "version": [
@@ -19636,16 +19774,16 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20250630,
-    1059
+    20250916,
+    500
    ],
    "deps": [
     "editorconfig",
     "f",
     "jsonrpc"
    ],
-   "commit": "4f51b3c21c42756d09ee17011201ea7d6e18ff69",
-   "sha256": "04w96rx2d4w858w9x76r2dqh4aqr940p60s95npk5jml8nr7ww76"
+   "commit": "c42c18e346e1ff8399eb30d40527e593f614e4d3",
+   "sha256": "0rnk2nk1qq6pky40g2wjbm1qhcvbgdfamvryfs74rdm57cvarwf1"
   },
   "stable": {
    "version": [
@@ -19670,8 +19808,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20250825,
-    810
+    20250909,
+    1505
    ],
    "deps": [
     "aio",
@@ -19683,8 +19821,8 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "86ce56c00babbad06641ead5dfa9264bb00908bc",
-   "sha256": "0mm29m8sjvkmmdcka44zsp7ydd4wcsbchwkwgp5c541bpcgsbdpx"
+   "commit": "15cf30010274f48a18fbacdc79062c06901a227e",
+   "sha256": "1s7401wbwfljk5yq82vxxaianq8r3qga9f4gn4dbfb3ikcnm7pvr"
   },
   "stable": {
    "version": [
@@ -19855,14 +19993,14 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20250611,
-    2329
+    20250923,
+    1250
    ],
    "deps": [
     "compat"
    ],
-   "commit": "53aa6c85be72ce220a4321487c535295b0de0488",
-   "sha256": "1f2hz1970f5ifd5p6lbxdi4krgxgvxrr477f6vbqakqj07bk9jps"
+   "commit": "d6cc682c15b594f2bc9f55196a382a5fda7a7fc6",
+   "sha256": "1rllxij3nhy9did3nyxy52dy5isvapgj9s20mfs8k5nfca27l86z"
   },
   "stable": {
    "version": [
@@ -20833,10 +20971,10 @@
  },
  {
   "ename": "cppinsights",
-  "commit": "b7c4c978d3b82366911488e27d64af7cf864e7e2",
-  "sha256": "03pmjw3kjykmxrf71vs1hrnb9qzmmwacqbwnxb25a2gpwzx110hj",
+  "commit": "8fccc1e7a88546259efec961525040fc48620158",
+  "sha256": "0p5mcmn7p1jrk4x6r35wwb5rm30xgd257ln62yg4b2znmx5f1xzb",
   "fetcher": "github",
-  "repo": "chrischen3121/cppinsights.el",
+  "repo": "ignity21/cppinsights.el",
   "unstable": {
    "version": [
     20250519,
@@ -21275,6 +21413,21 @@
   }
  },
  {
+  "ename": "crystal-point",
+  "commit": "35884c7a79a991b6a40996e5679204d848b1fd1d",
+  "sha256": "17x3lv4n36lz4pmv74plgb8mvid9h7zdss1qa06wbix73zmp3yq0",
+  "fetcher": "github",
+  "repo": "laluxx/crystal-point",
+  "unstable": {
+   "version": [
+    20250915,
+    1107
+   ],
+   "commit": "bd7b9aca2f6153dd7d4bf3c74e4d138c77dcc748",
+   "sha256": "19d3mciyjbs6mb3xw742qpbh3s8x2l9kq03k6djn0mzffb14sx4f"
+  }
+ },
+ {
   "ename": "csgo-conf-mode",
   "commit": "2298e3f840da549707ec3270c8303f4f63a674dc",
   "sha256": "0djx6jraqlh9da2jqagj72vjnc8n3px2jp23jdy9rk40z10m5sbr",
@@ -21694,26 +21847,26 @@
   "repo": "rtrppl/cuckoo-search",
   "unstable": {
    "version": [
-    20250512,
-    821
+    20251004,
+    1847
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "b4688f81942255579b5e5fd2c879b9af1627dd45",
-   "sha256": "016nmm03g8a1fg99byhcj5zp70jjg8v7cyp7rv6mfqw7b5n276qh"
+   "commit": "3c9840c4a3fe5cfe0c203ed4657324af8e5bb32f",
+   "sha256": "0qdd2ybr3bbxzm23dzjvddr5aywjjdd2x6vgd64h3gibvk8fbbha"
   },
   "stable": {
    "version": [
     0,
     2,
-    5
+    6
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "b4688f81942255579b5e5fd2c879b9af1627dd45",
-   "sha256": "016nmm03g8a1fg99byhcj5zp70jjg8v7cyp7rv6mfqw7b5n276qh"
+   "commit": "3c9840c4a3fe5cfe0c203ed4657324af8e5bb32f",
+   "sha256": "0qdd2ybr3bbxzm23dzjvddr5aywjjdd2x6vgd64h3gibvk8fbbha"
   }
  },
  {
@@ -21923,6 +22076,21 @@
   }
  },
  {
+  "ename": "custom-keymap",
+  "commit": "0f26e98f9dffe3e18f4c7dea175b1fc9c6c53ea7",
+  "sha256": "0n4vfnln5q70ivs8ryg3300rv8msd8aab20pss5zjdnvb3hr4wnq",
+  "fetcher": "github",
+  "repo": "viandant/custom-keymap",
+  "unstable": {
+   "version": [
+    20250906,
+    1450
+   ],
+   "commit": "d8db247fd8ce47bc9ecc7f75c4074fc4f82c4119",
+   "sha256": "146pia8hhhji32zm4nf7xszq9jvj4cprg0sgh9z1z3dchr1pmww7"
+  }
+ },
+ {
   "ename": "cwl-mode",
   "commit": "2309764cd56d9631dd97981a78b50b9fe793a280",
   "sha256": "0x8akxxmphpgsc2m78h6b0fs6vvcfvmi1q2jrz8hwlmai8f7zi9j",
@@ -22058,14 +22226,14 @@
   "repo": "ideasman42/emacs-cycle-at-point",
   "unstable": {
    "version": [
-    20250611,
-    328
+    20250913,
+    2251
    ],
    "deps": [
     "recomplete"
    ],
-   "commit": "3a635cdb6e0f106370ec762c8382b5cfc33690e7",
-   "sha256": "14ldsrzng49lp4prii3ilxc7ak3l9378ncjgj3m2ycf9lmn0w6wh"
+   "commit": "c390803221816319ae6edcea470d12a4849606af",
+   "sha256": "0yd2x7fhn5fw0yb462y5ih6p6bg1sjz8cs48mjhnqr06p6h4jp0a"
   }
  },
  {
@@ -22452,8 +22620,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20250406,
-    2127
+    20251004,
+    452
    ],
    "deps": [
     "bui",
@@ -22466,8 +22634,8 @@
     "posframe",
     "s"
    ],
-   "commit": "68357594a615cb3af833346e869f10b2de260406",
-   "sha256": "0hq29ia2x62lhd1zz7gnicr10ck1m9cymgc4ii9n35zl6aai382f"
+   "commit": "6c74027e39fca229eeb1d0d59698219ae7d0aa41",
+   "sha256": "0pja86dc2dsk18vh5bqsrv9f7g1yl73cqp5sgdwdgr5zpbsxkc94"
   },
   "stable": {
    "version": [
@@ -22718,17 +22886,17 @@
  },
  {
   "ename": "daselt",
-  "commit": "435b7cdd91b08fbb47bcfaa0ade99819957ba1a1",
-  "sha256": "19ymip7hv6d0ww60f3iwlr3kj4hvn19d8ll1p0irc5a1s6xgdn1v",
-  "fetcher": "gitlab",
+  "commit": "3b9f769d4d65b9d5461fc50d0b65686656bea785",
+  "sha256": "1zsrqyjgf9blswj7wx7d67wx11m2yy9pnzb1ik41abw8iqr0rx40",
+  "fetcher": "codeberg",
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20250816,
-    2150
+    20250915,
+    2057
    ],
-   "commit": "f2fb095ee01f2464dcfda2155b60c68dc7d06d41",
-   "sha256": "04qpf2fx2jpbs6qs90aiwcnq8fal1mn2h6ml9bxc8ddyg1s5ldgr"
+   "commit": "6dca1e898050d517ad55732b2600f98f5004fa42",
+   "sha256": "14hgw0crbql7bbib1s1911plpkyspqh3mxsxwga4wfsp1x8hnqkf"
   }
  },
  {
@@ -23528,11 +23696,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20250731,
-    454
+    20250921,
+    944
    ],
-   "commit": "d604cea39e3fbf47fe3b96bf910d83ad6d61ca43",
-   "sha256": "0zsa610j961g0jjbxkjhy6v75hn5xd29wgs29q95djv1cwb1gp12"
+   "commit": "02175c87d908e2fc0860dae7eacf4a2ffbe80f27",
+   "sha256": "09qgwrky5wqpmfm4q0m27a4gfd246bjdw02cr7frhib3ppnvkaz3"
   }
  },
  {
@@ -23946,15 +24114,16 @@
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20250618,
-    1002
+    20251005,
+    853
    ],
    "deps": [
     "dash",
-    "denote"
+    "denote",
+    "denote-regexp"
    ],
-   "commit": "9d9a6399551d707cd45606a1fdf54d3abfd43859",
-   "sha256": "02v67rafjw904wd2dagnqpif767jb3xrsrjq82sph6dqf1dc8k6i"
+   "commit": "dad35045cf5f30e5ecce1c87b5241ce27793936d",
+   "sha256": "1vbjs7h5rdfsll2qzvbpk3kk3pklpjh0wwh2i1c0zm730pzgg5mg"
   },
   "stable": {
    "version": [
@@ -24050,14 +24219,14 @@
   "repo": "hsolg/emacs-departure-times-norway",
   "unstable": {
    "version": [
-    20250427,
-    852
+    20250921,
+    1626
    ],
    "deps": [
     "persist"
    ],
-   "commit": "11448dfe9f03c1e839d398a4d406984139bb0c40",
-   "sha256": "0nps5asnzajv1aayxrz1hr5aqlc9ljnzmilqbrcqvwl4ky96wl5r"
+   "commit": "3b0559bc55099cb025df63715ed9029885b64c39",
+   "sha256": "0ksnlm7ms3limppkcbv7bzsy2igdsqc2y094pflk4h7xay9k7p6r"
   }
  },
  {
@@ -24421,25 +24590,25 @@
   "repo": "minad/dicom",
   "unstable": {
    "version": [
-    20250604,
-    850
+    20251008,
+    1041
    ],
    "deps": [
     "compat"
    ],
-   "commit": "33ef616725fb65270aecda68362caf1eaf8cbe07",
-   "sha256": "00w7sr6mfhkd2zkp91zq7vhk2v4ypg99gjrh2x1dqbd4vrh79rff"
+   "commit": "df5acfbb5d1211515d2dfec141fd063be35bff16",
+   "sha256": "1fbiajyp5d074kg48w2kg30wz8png0b9scgabbplkmjsm3swnpyw"
   },
   "stable": {
    "version": [
-    0,
-    6
+    1,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "33ef616725fb65270aecda68362caf1eaf8cbe07",
-   "sha256": "00w7sr6mfhkd2zkp91zq7vhk2v4ypg99gjrh2x1dqbd4vrh79rff"
+   "commit": "3c5e750ff63cbd80d328738f93975eee4b537505",
+   "sha256": "15xi5c6qp6k941zh0axb0xlgb596mqf52gvd23r50s4njpllbsqz"
   }
  },
  {
@@ -24536,11 +24705,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20250611,
-    510
+    20250913,
+    2251
    ],
-   "commit": "b5fc7fa7cea4e51dd201306a168d908a6d95c52a",
-   "sha256": "1niil7znxjjq3hm8ysmiqhp1v9mipgicd2giax5g8vw4mcjnv28x"
+   "commit": "1ae63be2381d97afcf63c5dbf07ed9310aa3d707",
+   "sha256": "12gpq6ga2977lh5h1x37qwc97vwq8qk6m4izq6ja762iq6wqp12g"
   }
  },
  {
@@ -24551,11 +24720,11 @@
   "repo": "ideasman42/emacs-diff-at-point",
   "unstable": {
    "version": [
-    20240421,
-    858
+    20250922,
+    2326
    ],
-   "commit": "bdd507b940e57a110e0e7d31834987924abc05b2",
-   "sha256": "0iilqa0638h2dawq95wxmmrn738c0h6swv84k8z7nbywgi5jdi81"
+   "commit": "ecc81b4af98acc06cae3e593d83e74fd51f5b9f8",
+   "sha256": "0m27lwjhn9hywydyxvslhf1g1hax3nbw61j4b5imvrlnn5plj7q1"
   }
  },
  {
@@ -24566,14 +24735,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20250731,
-    209
+    20251008,
+    2241
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f3408d5004627e685b5a4a3a454a9a92ef182432",
-   "sha256": "01g1718222hnlfd7jimvw0qhllmqv5k0vvcd9fffj5is4qzj7c9g"
+   "commit": "74bfb7069dd51d2df57ff7ab6686b40e36bb0ed0",
+   "sha256": "0mni00skryyyjky5a467bz7bm4c1lkwsmc2n4yfp3r2xn0mp4h78"
   },
   "stable": {
    "version": [
@@ -24689,16 +24858,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20250801,
-    1425
+    20250930,
+    718
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "d149a37c93d492a29073451cf07c86fc42b335fe",
-   "sha256": "14d8ayckwm0n5xsdbbbqa0kv2iffvzg58kaaj029fspscvgwv2ix"
+   "commit": "63d31f62617da25b9c77afd0fe88b26e095d506d",
+   "sha256": "105q2477lwhfzhrgpc6nhjxax868nv28k8kif2q27djsh9i37wh4"
   }
  },
  {
@@ -24805,10 +24974,10 @@
  },
  {
   "ename": "dilbert",
-  "commit": "7fb785715c05adaa7551b27f4eaca2b704bf1a86",
-  "sha256": "1bsz4qmjy9hvpgrxpbz94v2yv0xvh1v8fik1pldv72bl4jkvifvl",
+  "commit": "9ca5d080a255a04c36673e88097b83ebcb852954",
+  "sha256": "0ydciz7bnkvk70yr8z9hbg95py3w4p3rkx0355m6b8zypabc41fk",
   "fetcher": "github",
-  "repo": "DaniruKun/dilbert-el",
+  "repo": "danirukun/dilbert-el",
   "unstable": {
    "version": [
     20211118,
@@ -25128,6 +25297,21 @@
    ],
    "commit": "16afdbbd91b451fab44c68c8f7d0b810f5283f28",
    "sha256": "14zgkzwjydahrpz2rz5iww13r4x4fdpf8im4g0nffvb3pqvsbz7f"
+  }
+ },
+ {
+  "ename": "directory-slideshow",
+  "commit": "0a95e9717e491cf07d07d2cabc9a44d1e7c2925d",
+  "sha256": "0vzw7sjcpyrc8mjwyl6qbj4swdkz442m2blrq9aa4gg1z0d09p30",
+  "fetcher": "github",
+  "repo": "Duncan-Britt/directory-slideshow",
+  "unstable": {
+   "version": [
+    20250828,
+    1527
+   ],
+   "commit": "2b18d6bd1b74d7eb481da584d14f93e01e02362f",
+   "sha256": "09gvm3q3azr3z9pd2hivj2711g10fhnjaw5rxkg34fz88swxjvs7"
   }
  },
  {
@@ -25984,14 +26168,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20250806,
-    44
+    20250928,
+    618
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "0f534d81871889bfd5cfff9202351ad1768f4d38",
-   "sha256": "1fxc5adwnm1pwq910ck7q8ri2xnn99727xhpy6l4vy3247bj5dmg"
+   "commit": "009558fcce67bd1120b9285cceae15bdc6dfcef2",
+   "sha256": "0xj6zn08d30nm9lbmnv6192ywnxl7nlvp4y8cndgsqzncahfv3c6"
   },
   "stable": {
    "version": [
@@ -26258,11 +26442,11 @@
   "repo": "jart/disaster",
   "unstable": {
    "version": [
-    20250302,
-    1549
+    20250828,
+    2224
    ],
-   "commit": "5b7f7b06ecffa474535afb34cca3e348c59de71d",
-   "sha256": "0xjicvdy5m14g6h1iaswcm202l51kdj7fyyfj6xq5xhf4jnkkq55"
+   "commit": "0299c129d4153e3a794358159737c3ff9d155654",
+   "sha256": "135izi0a4q3pki6mqrcgrgf5p79vaa88ji6cldmma7xws99ldsqv"
   },
   "stable": {
    "version": [
@@ -26478,26 +26662,26 @@
   "repo": "aurtzy/disproject",
   "unstable": {
    "version": [
-    20250822,
-    2145
+    20251007,
+    310
    ],
    "deps": [
     "transient"
    ],
-   "commit": "5ab01bdfd3732db4aafe934da3665abf57a036f4",
-   "sha256": "00brlzg8s33gh0hi5i0w8y6gwax7ds0v3l51ww38csvyha5jgbw2"
+   "commit": "c2b14a5e1b1e9173b5089102a737e4ed110cd2b6",
+   "sha256": "14q4cvr0kq6c072fiv8bl9dzkw409bjcr7s9h85jf1lnvjj1v446"
   },
   "stable": {
    "version": [
     2,
-    1,
+    2,
     0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "4cd9d4041f17826dd577bf777e5226c0b55f0f35",
-   "sha256": "17691mi013pp1l39dmgzil6kq3nl0dqnqmwsba5j1j3dbfzm9i42"
+   "commit": "de25aad37999c14fa232b8f0b9cac8954037a1df",
+   "sha256": "17ffcfm4qxjvnmy95yczk18mngiy13pbq7avzrhrh44p3d53b5ss"
   }
  },
  {
@@ -26926,11 +27110,11 @@
   "repo": "ideasman42/emacs-doc-show-inline",
   "unstable": {
    "version": [
-    20250209,
-    607
+    20250913,
+    2251
    ],
-   "commit": "2c23259d400d618018952581a22db5bdbac4768d",
-   "sha256": "1pgqx1wykq57p3gf3j51cx17cxwj1pxv18n3qbrigi0hdqmldh8s"
+   "commit": "4c43aac0867af455d9aee341480725e8bbcd7569",
+   "sha256": "01id3zxbsa0lc37q0ipr789570qnrn352wrr8prf8yi7zk36qkf6"
   }
  },
  {
@@ -27394,16 +27578,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20250729,
-    216
+    20250925,
+    241
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "cb703c217e8eb4d6f853da7fca9f1be91d985642",
-   "sha256": "1hmdnv3a0zp60ngfpgcy0vwldj8f0r30pcqjm9ywv2a3ik5vgnwi"
+   "commit": "1efbd4f784a13e4ada0ddbf2b4c68b57c03b4f4d",
+   "sha256": "1qdzgl5vvil1lfvarv931762vy9bv3kq4v8fa16rk34rdb93wk79"
   },
   "stable": {
    "version": [
@@ -27428,14 +27612,14 @@
   "repo": "elken/doom-modeline-now-playing",
   "unstable": {
    "version": [
-    20250810,
-    1114
+    20250906,
+    630
    ],
    "deps": [
     "doom-modeline"
    ],
-   "commit": "bb6f7111ac703962d3acdb1a42b499e7037699da",
-   "sha256": "03wx7xkshw4ycpqgfn0ihzwwz88jcr0lis9hybyzdpjymq4aq1mc"
+   "commit": "aff9417faaf5f1945b9ad95f27fa777bbcf269f7",
+   "sha256": "0z7xsrm30dmi359hzairy94md0jmas0q9n939zy4yv708xykbxpj"
   },
   "stable": {
    "version": [
@@ -27458,14 +27642,14 @@
   "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20250614,
-    958
+    20250924,
+    2042
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3152c60bb55365ebd3b042a40aa68c9b756667f7",
-   "sha256": "02ivxhzf9pb12viqprb3izy7r42y60axyna7400j70xnqsrrvvfi"
+   "commit": "376cf4bdd7d296a3da94aa9a6c68761e7c38a252",
+   "sha256": "0ii2c64dwwvrr0nd78a7csin92wvy2mwvgzzqgxjiky8czrk4g6d"
   },
   "stable": {
    "version": [
@@ -27565,6 +27749,30 @@
   }
  },
  {
+  "ename": "double-press",
+  "commit": "c412d2dc975d87f8fb38821e8a677f6cf979a683",
+  "sha256": "1a9h31xp5wwvaibv904ijw9r4jpnxsvcmhdzvwyxl1nn49j08irx",
+  "fetcher": "github",
+  "repo": "k-talo/double-press.el",
+  "unstable": {
+   "version": [
+    20250916,
+    1005
+   ],
+   "commit": "380f7f1cab9045c9ef56b4b40c241037dc2c58d0",
+   "sha256": "0y80mg4yf719nf5w6d028mydw7lbwxqdlzql59dd5mskrl0z7361"
+  },
+  "stable": {
+   "version": [
+    3,
+    0,
+    1
+   ],
+   "commit": "35fc8b41f015992c2b4ccf6bac0b820258b774f0",
+   "sha256": "075wdj4gjwd83shn315788h9rn896i0nh72r0rrsjd38h9h425y8"
+  }
+ },
+ {
   "ename": "double-saber",
   "commit": "19f5c0195ad9b278a7aaa3fd8e70c0004cc03500",
   "sha256": "0zsmyvlxm3my3xbj7m38539vk2dl7azi1v7jb41kdiavj2cc55zg",
@@ -27645,6 +27853,24 @@
   }
  },
  {
+  "ename": "doxymacs",
+  "commit": "717e40f78ad8d89e9130f9aec409ef811471ab30",
+  "sha256": "0jpzk4nbma1wi8ysc0ji0cicad0c1241h9qvrwcnj11v210cbh9y",
+  "fetcher": "github",
+  "repo": "pniedzielski/doxymacs",
+  "unstable": {
+   "version": [
+    20250909,
+    48
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "869b378b724e4bf4b7e4976e2b8a549d744fc1d2",
+   "sha256": "0gj5afbz5iqzk287mpg7290azgzfg7ssmzzxxx17d4h3jd97mw6w"
+  }
+ },
+ {
   "ename": "dpaste",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0wrfy9w0yf5m15vmhg4l880v92cy557g332xniqs77ab0sga4vgc",
@@ -27685,14 +27911,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20250826,
-    835
+    20250912,
+    823
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "9b0fc3d97ee5e859ec13d6ba5df67c31d5693c2a",
-   "sha256": "1dmf2iqf343s8slhgnwyfs1qb6nc5jwa5igqmlbh3kb6jdjqp5gp"
+   "commit": "38f1fb20892dbb7c0e5ab6e23b7dee1f3fd926b3",
+   "sha256": "1w0q1j4l0ajyil39hy0w6cppn7nksif04wqw6wi9wk8jdxvqy9nl"
   },
   "stable": {
    "version": [
@@ -28215,10 +28441,10 @@
    "version": [
     3,
     20,
-    1
+    2
    ],
-   "commit": "84b524ad0b337a95e44a7c307b1c237d20075272",
-   "sha256": "1v5jkirw0js6bmcl79f4i9dqwa83k2sqixq7ay6mq89g9a49qalx"
+   "commit": "1e54fd3f450aae7fb41ffb6b7c8b7a5aed754777",
+   "sha256": "1z4ji0jwwwxsx0ffw0klnkvaql8m2mqyi9h308y23waaf8dr3g94"
   }
  },
  {
@@ -28372,11 +28598,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20250218,
-    1720
+    20251008,
+    1304
    ],
-   "commit": "4b077432a94873e5f505c8f569743cfd984eebb1",
-   "sha256": "031icdbca6f9j453h07hwmxl0jc4i370lpn2y6lcqhqv4fw5c1lz"
+   "commit": "1f40c468fd5bf5241276347ea785b7f3082d8260",
+   "sha256": "1imybvlr2wc6zg9r8c8bymra9l2089db2pjlb6lbri59g2byi79f"
   },
   "stable": {
    "version": [
@@ -29027,30 +29253,28 @@
   "repo": "masasam/emacs-easy-hugo",
   "unstable": {
    "version": [
-    20250701,
-    2138
+    20250908,
+    2343
    ],
    "deps": [
-    "popup",
     "request",
     "transient"
    ],
-   "commit": "649aa56b1f7a2fc096aedc417316ef4ec0082957",
-   "sha256": "1fndy1w6a3dqlfjrghjlqrjpdbaaj434ljzm4qnkcdr1pfr85jiy"
+   "commit": "ee4a6d2ee65d90c0c1739bc688d08f7b855a6b8a",
+   "sha256": "0hvw9hwc0q0lj5gksgaijm6j9w0w8s5mj1721k7121l66h9c0c8n"
   },
   "stable": {
    "version": [
     3,
-    11,
-    61
+    12,
+    62
    ],
    "deps": [
-    "popup",
     "request",
     "transient"
    ],
-   "commit": "649aa56b1f7a2fc096aedc417316ef4ec0082957",
-   "sha256": "1fndy1w6a3dqlfjrghjlqrjpdbaaj434ljzm4qnkcdr1pfr85jiy"
+   "commit": "ee4a6d2ee65d90c0c1739bc688d08f7b855a6b8a",
+   "sha256": "0hvw9hwc0q0lj5gksgaijm6j9w0w8s5mj1721k7121l66h9c0c8n"
   }
  },
  {
@@ -29061,26 +29285,26 @@
   "repo": "masasam/emacs-easy-jekyll",
   "unstable": {
    "version": [
-    20211217,
-    2311
+    20250830,
+    1006
    ],
    "deps": [
     "request"
    ],
-   "commit": "7f19af310162464956f2bc4c38c6b7e95cb20321",
-   "sha256": "0l8yb3mwzd6kjnz1lnxx55ns0w6vv3cy9wda26hwr6d6hdms34xy"
+   "commit": "4e85bb4568f87e08a93d7c5c82898a8e98109669",
+   "sha256": "0vzr86c5hxn4qk1zyvrk5dak1dl43vakslv2kz2k3052jalbk7y9"
   },
   "stable": {
    "version": [
     2,
-    6,
+    7,
     30
    ],
    "deps": [
     "request"
    ],
-   "commit": "7f19af310162464956f2bc4c38c6b7e95cb20321",
-   "sha256": "0l8yb3mwzd6kjnz1lnxx55ns0w6vv3cy9wda26hwr6d6hdms34xy"
+   "commit": "4e85bb4568f87e08a93d7c5c82898a8e98109669",
+   "sha256": "0vzr86c5hxn4qk1zyvrk5dak1dl43vakslv2kz2k3052jalbk7y9"
   }
  },
  {
@@ -29168,17 +29392,17 @@
  },
  {
   "ename": "easysession",
-  "commit": "3e9ed8efcc22219b1d4fb804521a47670b7668d3",
-  "sha256": "0k540y7vp5cb378fh3nn15f29551rj1b47dw4ambjn8gl0c0x7jq",
+  "commit": "983fd80302a8a75c2ba5e00a919ae3ff51bd24b6",
+  "sha256": "01p8cc34w7wqvr8dpcb120gjqv9br1wnyy0ha99x8c0yas587k2j",
   "fetcher": "github",
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20250825,
-    59
+    20250911,
+    225
    ],
-   "commit": "e4aff5d98219dc0abac426fe9301cc0a4d737c5d",
-   "sha256": "17bn3h0sng6b2qjndw4ijh9z241ms1y94vk7khk91jwzizyxdnz7"
+   "commit": "3a7e3882bb0a09f58aebfdc16c53924d5f8b66a5",
+   "sha256": "0ffrcls3wnviam2fh7dyyhlzkb09jqapclq153sjb57j950b8ajs"
   },
   "stable": {
    "version": [
@@ -29263,15 +29487,15 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20250805,
-    1747
+    20250909,
+    1036
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "248e9274804a656a13abc50214963586113a2158",
-   "sha256": "1bfkmfwadj9dg9dfnqj9nrcj6qqv9wnnfn34gl33526k77lmfhxm"
+   "commit": "72686b4d045dcbdb794e56c8ba60a77eed52ee83",
+   "sha256": "07sl4myxvqqdyj6fgybiz93dw9yba1wkhy3f99mz3fv8hyr06jjr"
   },
   "stable": {
    "version": [
@@ -29361,8 +29585,8 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20250826,
-    353
+    20251009,
+    1404
    ],
    "deps": [
     "compat",
@@ -29370,8 +29594,8 @@
     "f",
     "markdown-mode"
    ],
-   "commit": "c74568ad2a7d1360542adec36125fa6f330908cb",
-   "sha256": "146dw38ihcqwavzir4pjsxll29xxv92pw5ijgnqhs5ds83skckp9"
+   "commit": "a7e9fe25af8fd8827399f2a83744a00156cbc256",
+   "sha256": "00smlfls8zdmlgcb55wn65afd68gyrn91szp4r4vc2mbmcqla04j"
   },
   "stable": {
    "version": [
@@ -29391,17 +29615,25 @@
  },
  {
   "ename": "ecb",
-  "commit": "d13240ac4002fdb2580a7d5ea9058e52d3509917",
-  "sha256": "103vqgngvl7f8mc5g8nzkncfraljkx6l7kiinqw5xbjljdip7xvy",
+  "commit": "2c6a3827d340171319d1186f1d4c4b95eaee4cb8",
+  "sha256": "1fmzfv1fdjnbybw3mi0b9vzmdvpb5g17ngiy3akscss3a3m1m6hx",
   "fetcher": "github",
-  "repo": "Atomlogik/ecb",
+  "repo": "ecb-org/ecb",
   "unstable": {
    "version": [
-    20170728,
-    1921
+    20250930,
+    1739
    ],
-   "commit": "1330a44cf3c171781083b0b926ab7622f64e6e81",
-   "sha256": "0nx1blkvnzrxd2l7ckdihm9fvq5vkcghf6qccagkjzk4zbdalz30"
+   "commit": "a1694bb856784fcd9edf1020ca3a40a924a403f5",
+   "sha256": "1nvcbi3gp4h4pm88b4938pp3d7qklsxcqqvl1s62lv05dwvraczn"
+  },
+  "stable": {
+   "version": [
+    2,
+    52
+   ],
+   "commit": "0c318f1167ef8d7cf940dcdca7b27ff448707fe0",
+   "sha256": "0wxn96vx9x57ppyxcsg46vabjr11f9pm3f164bd79rb3i248g49n"
   }
  },
  {
@@ -29835,11 +30067,11 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20250809,
-    139
+    20250905,
+    724
    ],
-   "commit": "0c2d853aff146fa3dad4fa6a0a2c05a4b6bc47e6",
-   "sha256": "1wirij6izii6xmjsvas0fis7lvyv93pxs041kycmm04qdqn1rnrv"
+   "commit": "4af10445fcdf1c9dfa7af4f9e5bec59e8a759d6f",
+   "sha256": "1lik1xwq5jlmrnyk03zmladkqk9mmxbrgxn25rzhm51idylfgvqf"
   },
   "stable": {
    "version": [
@@ -30468,11 +30700,11 @@
   "url": "https://forge.tedomum.net/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20250215,
-    2014
+    20251003,
+    1847
    ],
-   "commit": "6e697ad705f792f63667b28a23d0e188dff14178",
-   "sha256": "0vgr9vxjm6zp468qw2zr7pgl91xrckhdvkp9syv2gqqa5c6kp2dr"
+   "commit": "0f0ebce80f0feb718b84115b05ed45ec5dfe5b81",
+   "sha256": "1wxl9d9gk5ssdglsd35j0xv0arv3jd050pkna5q5f4vs8464gxl5"
   },
   "stable": {
    "version": [
@@ -30605,15 +30837,15 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20250813,
-    22
+    20251006,
+    437
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "f2c52383fe58802807436994709a6f453354690a",
-   "sha256": "0qlg1lksj6cy9fj0ag4c5vr0561j8p52si5hbm571xh40f4pjays"
+   "commit": "48f6188a6c7661ef8b5094d434b8c6b442d8d7de",
+   "sha256": "13j6y37aksfdpdckw166im0fh45jv9vv9kxjs6248nmcxy0vc1ya"
   },
   "stable": {
    "version": [
@@ -30792,20 +31024,20 @@
   "repo": "meedstrom/el-job",
   "unstable": {
    "version": [
-    20250606,
-    1931
+    20251008,
+    1626
    ],
-   "commit": "6520508920acca44be090bd655ad943751e20ef1",
-   "sha256": "0acyk63052vsii7xnfp6l4n1s4063lprapp662p4p660wk559fnr"
+   "commit": "4d58724cfe98fab1613d95629a155147532e00fd",
+   "sha256": "00jy2b5bj30qaaaxpp99fhbi6jz2r0xm1fl0z4ggh84v7dx9dhy4"
   },
   "stable": {
    "version": [
     2,
-    4,
-    8
+    5,
+    3
    ],
-   "commit": "6520508920acca44be090bd655ad943751e20ef1",
-   "sha256": "0acyk63052vsii7xnfp6l4n1s4063lprapp662p4p660wk559fnr"
+   "commit": "6d72fdde4a62183a8870d467c80f6ff98bfe7ec1",
+   "sha256": "1y4cdf1kafrhf24jbhw2f8415n1x22hczy2di6ysr3mv4im0nvsr"
   }
  },
  {
@@ -31118,6 +31350,30 @@
   }
  },
  {
+  "ename": "elchacha",
+  "commit": "793c41064ad95dfd25dcf21ce2c373390461c099",
+  "sha256": "0gmn8v12j2pk7zx199dcb2acgbwfi3n1ma9590160xzqdr1lbifq",
+  "fetcher": "github",
+  "repo": "KeyWeeUsr/elchacha",
+  "unstable": {
+   "version": [
+    20250922,
+    1827
+   ],
+   "commit": "e6e71b8b25eafefd23c33d0d9cb820c4eb646ff6",
+   "sha256": "1f2nvfh2cdbb34x0smf1xlnwf8nw7mw3jng70ghkyjy7881s1f3x"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    4
+   ],
+   "commit": "e6e71b8b25eafefd23c33d0d9cb820c4eb646ff6",
+   "sha256": "1f2nvfh2cdbb34x0smf1xlnwf8nw7mw3jng70ghkyjy7881s1f3x"
+  }
+ },
+ {
   "ename": "elcontext",
   "commit": "12bcb0bfc89c1f235e4ac5d7e308e41905725dc6",
   "sha256": "1firdsrag7r02qb3kjxc3j8l9psvh117z3qwycazhxdz82z0isw7",
@@ -31196,11 +31452,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20250707,
-    823
+    20251009,
+    1510
    ],
-   "commit": "3f1c0befad5a70cf51ca38131cfa1f6fa287cbf6",
-   "sha256": "02swww902hj2kp3d9njs48iiz486vs4984nn1bv0giy7mwxvmwjw"
+   "commit": "cc3237983a9cbd2f1af20c5ae99ecb0a77f42361",
+   "sha256": "15m2580y6dyxa88b17jv22b1iqijibkspajsbk2s4gchid89rhy2"
   }
  },
  {
@@ -31235,11 +31491,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20250729,
-    132
+    20250920,
+    125
    ],
-   "commit": "8c5104f06700b774b8af76d77a440e334fbc03e9",
-   "sha256": "0hk716pym15crmnviwikwrdqzhs74widjlz5zrp5107klqgxicwn"
+   "commit": "fead2cef661790417267e5498d4d14806e020f99",
+   "sha256": "0nxc0qyx1lz8z9qhkchhmb1n4sfwxi86flwylmxrjq4dvza2p072"
   },
   "stable": {
    "version": [
@@ -32014,11 +32270,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20250611,
-    2328
+    20251002,
+    1141
    ],
-   "commit": "c4cd57b2599ec82a4363ae322aa734e34a719404",
-   "sha256": "1m7yrhphsm9s1xkhyd94pbdyxbh3iyr5z9bj8pnbp4pccb76xfcd"
+   "commit": "6f5936074bb3e44437957cef1f5405898a60309c",
+   "sha256": "1vchi3qf3w0fdxy8nim3gpzn6zlaxma7v05n2y7kwmxd1i7iy7cq"
   }
  },
  {
@@ -32095,20 +32351,17 @@
  },
  {
   "ename": "elisp-depmap",
-  "commit": "2db07414d2d39b2d40a2ae91491032844b82d801",
-  "sha256": "1pd9r1f78nhzpbakjbkvhp43ip6dh3a293dnnk4d4xrm8lfzb9hh",
-  "fetcher": "gitlab",
+  "commit": "82b7a4248b33bc0bbfe9b16bd90447229a3de4c2",
+  "sha256": "08qjrc3vrn18apnb856qd2m0wzza8755fbh8ly9nh58dlbjhkkd7",
+  "fetcher": "github",
   "repo": "mtekman/elisp-depmap.el",
   "unstable": {
    "version": [
-    20220223,
-    1131
+    20250919,
+    1240
    ],
-   "deps": [
-    "dash"
-   ],
-   "commit": "15909462e3f7daf445d3cecf402ee16c7e3263ed",
-   "sha256": "0l08xy83b3avjjaydys7f25rr0l4ifh6awl8dyy6ww6wvrz7sd4c"
+   "commit": "65afa5316506666888c0fb073505eb7e7c62c893",
+   "sha256": "0758c9v1fz9lcfhwlj47z64s2m256av56klh6ly8sjprdx7jrnjk"
   }
  },
  {
@@ -32119,14 +32372,14 @@
   "repo": "laurynas-biveinis/elisp-dev-mcp",
   "unstable": {
    "version": [
-    20250722,
-    1502
+    20251004,
+    1154
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "45ae39151b66b9bfaa6382b01820a7762ab23ade",
-   "sha256": "09pp594b19svzwq9f748mqfcp9prvppbdmld43sd6g78w92y8dzx"
+   "commit": "05bc3ca843ebbb243c22d2a44ea2fb47884f35e6",
+   "sha256": "03yv2p9jwqc1qv0ydb3v6qs4f408dpbs3jfm6whs1pb4n9g94b8q"
   },
   "stable": {
    "version": [
@@ -32351,6 +32604,38 @@
   }
  },
  {
+  "ename": "elkee",
+  "commit": "ffcc6cd8b3c819ebeb64d2ac7e2c0b40e59e3fa7",
+  "sha256": "03gzpwrwmgpmyzcwg0b7nxh4qdl5s3a1351rrpls61rm79f1i7hx",
+  "fetcher": "github",
+  "repo": "KeyWeeUsr/elkee",
+  "unstable": {
+   "version": [
+    20250928,
+    2333
+   ],
+   "deps": [
+    "elchacha",
+    "kaesar"
+   ],
+   "commit": "9caf0b086e6b4f8132163620a709de7b260b5ace",
+   "sha256": "1nfgd3zp9pypwj3sxks3w5dc9wfzv9abz6g70wh557p8v88nria9"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "elchacha",
+    "kaesar"
+   ],
+   "commit": "9caf0b086e6b4f8132163620a709de7b260b5ace",
+   "sha256": "1nfgd3zp9pypwj3sxks3w5dc9wfzv9abz6g70wh557p8v88nria9"
+  }
+ },
+ {
   "ename": "ellama",
   "commit": "fce51577c24bdd80f72a1fe7abaf4ed9118324fe",
   "sha256": "0iz11dz0jxz5jpy8b0wrw5rziwcxmzvjy6whqvlsn9dbm7s9r7vs",
@@ -32358,8 +32643,8 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20250801,
-    1740
+    20250918,
+    1606
    ],
    "deps": [
     "compat",
@@ -32367,14 +32652,14 @@
     "plz",
     "transient"
    ],
-   "commit": "018c2151d1f231a3e3a15a5e99cf39157d758ee4",
-   "sha256": "0ik9sw4fh0caj85601an609wkfvmwdmj2g3rbm620mnd3202kwdy"
+   "commit": "2857f85b8f10eb587afb8cb3da1d96cb236b2856",
+   "sha256": "1q89z24vfj9r8x6rqcbif3nk987m7hh17n3jyk59q3iwivbgrpbd"
   },
   "stable": {
    "version": [
     1,
     8,
-    2
+    7
    ],
    "deps": [
     "compat",
@@ -32382,8 +32667,8 @@
     "plz",
     "transient"
    ],
-   "commit": "018c2151d1f231a3e3a15a5e99cf39157d758ee4",
-   "sha256": "0ik9sw4fh0caj85601an609wkfvmwdmj2g3rbm620mnd3202kwdy"
+   "commit": "4fa24686efab65b27487428d5f92057304d1445f",
+   "sha256": "14f4mwkjsldygvv232d3ivkggizm3ccyrgyd01hymfmv6xazj155"
   }
  },
  {
@@ -32540,20 +32825,20 @@
   "repo": "sp1ff/elmpd",
   "unstable": {
    "version": [
-    20240902,
-    1520
+    20250910,
+    327
    ],
-   "commit": "db808e58993310a01419649985b2f732b1067e9e",
-   "sha256": "0qikw0ayvdcckapl8873fpg08a5wvxfs23r3djpgfqyn26lkc2xw"
+   "commit": "a68563fa3e3b09fcdaf4b9f070542f8cfa257067",
+   "sha256": "0kyw7j2zi2ji07hmpiyrpnyfmdrficinyjnvp7cnrphai925gj92"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "db808e58993310a01419649985b2f732b1067e9e",
-   "sha256": "0qikw0ayvdcckapl8873fpg08a5wvxfs23r3djpgfqyn26lkc2xw"
+   "commit": "89d8b514ed940d7a9452a804158fe6604ec6016f",
+   "sha256": "16fg699zgy14yl3ymqq2cqbpplb9prsqvi550rx69zbq7sq24bp0"
   }
  },
  {
@@ -32740,20 +33025,20 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20250306,
-    1504
+    20250929,
+    1422
    ],
-   "commit": "972a069f240f071a79da23c98d3519df45bb5851",
-   "sha256": "0jv3v8pbncrnniz7wphp7gzlp9vbc2ib8psn2bhil2jhc2s6kj59"
+   "commit": "dcdeb86f7ae633e252f9ef8a73d3458e87c1ab12",
+   "sha256": "15cgqzzfjikq4spsmf7mmhvrd6igcsv75d9mdsxl5j6zhq784hh8"
   },
   "stable": {
    "version": [
     3,
     6,
-    4
+    6
    ],
-   "commit": "a1c5fbf16b528fb67d087437d44d66e9edc99664",
-   "sha256": "0pkgk7608w31kvdjid54xfrc5zrbrzwi98wrglwl07s429xlbai2"
+   "commit": "dcdeb86f7ae633e252f9ef8a73d3458e87c1ab12",
+   "sha256": "15cgqzzfjikq4spsmf7mmhvrd6igcsv75d9mdsxl5j6zhq784hh8"
   }
  },
  {
@@ -33122,30 +33407,28 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20250807,
-    1142
+    20250901,
+    1600
    ],
    "deps": [
     "compat",
-    "llama",
-    "seq"
+    "llama"
    ],
-   "commit": "2b965671ad1d7f5391e48169393492e314e487e8",
-   "sha256": "1lyzv2361h467jhv8928jzg8kg61zfg4ibxp2zr9r88chxgvqml1"
+   "commit": "fc2d5a232c1efca8a35b086d4f94a7bd8ca290c2",
+   "sha256": "1dw470giapm07k9gw7xi2xl2r7rz930h2fjx247vmyyh1d1ndv6q"
   },
   "stable": {
    "version": [
     2,
-    2,
-    3
+    3,
+    0
    ],
    "deps": [
     "compat",
-    "llama",
-    "seq"
+    "llama"
    ],
-   "commit": "fec8743eea83ed716ffac7659142ddfdd23d9e39",
-   "sha256": "16qmfwpl7bs8mrgmlii8jkkwzckmrm220w0z008bcjpc1wn9l5l7"
+   "commit": "fc2d5a232c1efca8a35b086d4f94a7bd8ca290c2",
+   "sha256": "1dw470giapm07k9gw7xi2xl2r7rz930h2fjx247vmyyh1d1ndv6q"
   }
  },
  {
@@ -33186,11 +33469,11 @@
   "repo": "tecosaur/emacs-everywhere",
   "unstable": {
    "version": [
-    20250609,
-    1444
+    20250925,
+    1637
    ],
-   "commit": "4ec16c12ce1eef3c35b5ebb9ddadd928b907f823",
-   "sha256": "1jqs227xib3vj0iiq3x0r1xv86ax09hnfidild8c6xcpdgjw89z0"
+   "commit": "10bf72a616eae8c4c89025bfebb062f761c869f7",
+   "sha256": "0scl2kjgyxr0clbhnwkbwgmygngli641a7gk2vm0hrb3dqbxbf6h"
   }
  },
  {
@@ -33240,20 +33523,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20250601,
-    1009
+    20250901,
+    1544
    ],
-   "commit": "ced062890061b6e4fbe4d00c0617f7ff84fff25c",
-   "sha256": "0khnln4p4d8fcwx02zp3j6x002x2ik0hs0jxf17xif9b8p2rri3c"
+   "commit": "3e015ab99e061f3967a154683f068ce6553f168a",
+   "sha256": "0j2x6incalwfzwri3lisw5by78w3k2vfhmpdhclq5qzjw7bm126v"
   },
   "stable": {
    "version": [
     4,
     3,
-    1
+    2
    ],
-   "commit": "ced062890061b6e4fbe4d00c0617f7ff84fff25c",
-   "sha256": "0khnln4p4d8fcwx02zp3j6x002x2ik0hs0jxf17xif9b8p2rri3c"
+   "commit": "3e015ab99e061f3967a154683f068ce6553f168a",
+   "sha256": "0j2x6incalwfzwri3lisw5by78w3k2vfhmpdhclq5qzjw7bm126v"
   }
  },
  {
@@ -33556,14 +33839,14 @@
   "repo": "marcoxa/emc",
   "unstable": {
    "version": [
-    20250609,
-    606
+    20251001,
+    1740
    ],
    "deps": [
     "delight"
    ],
-   "commit": "78bbc27964571567cef5e2e78d852d0e46f600e7",
-   "sha256": "06qpfx8kcipqss42kn31a4drryd333sm7yzf7s41h3n7b31mq0f6"
+   "commit": "03c991ccc940c8b744f3a08b962f67eef33e6a4c",
+   "sha256": "1vvpmy42k8rgc533n1d3bqgim1vnay0cvd19w311024rvzbpj8rf"
   }
  },
  {
@@ -33631,16 +33914,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20250731,
-    1547
+    20251002,
+    1442
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "e3824b81b11ac71b9bb0993a3a3d3647b923a377",
-   "sha256": "04dviyvpwwpxdx3fmm0kasz1wcralwazfsnqb5gn5hadg0j70kmg"
+   "commit": "99ebaae9f180dd6b2e5be363e709efa1da0014d6",
+   "sha256": "1x0lja7k2vn3dhnmhg3gvhiv6yid899k26f79c7slwfs0sl680yc"
   },
   "stable": {
    "version": [
@@ -34042,28 +34325,28 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20250824,
-    2051
+    20250907,
+    1847
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "e2000ef35eb4954109199408e947b57538c206e3",
-   "sha256": "03a9xyzdq9ym1aqzfrqjl4g7ycsba4nqlaa63qmxc2flvyky9hj8"
+   "commit": "731b986bb2181f7376ab1a8f01abfd3affb5e20d",
+   "sha256": "0knqzgmh76w1cp6cgxnbpk54bb1saf31myai3kznyx9k7ir4hmhb"
   },
   "stable": {
    "version": [
-    4,
-    9,
+    5,
+    0,
     0
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "ee29a3ea6459f68100e6365ac150a220b8c80700",
-   "sha256": "16xplsbiv1ybaws3n7xlysyqgx78haa9m260r4z8w5zfvl0h0lxz"
+   "commit": "825d4e87176c5fc9d1bf099926f4514c9d06e69d",
+   "sha256": "02qvac61v6fxgv8pjbbakn3z3xf1x6358gca7nil9k9jv9xq12ng"
   }
  },
  {
@@ -34208,11 +34491,11 @@
   "repo": "zenspider/enhanced-ruby-mode",
   "unstable": {
    "version": [
-    20250610,
-    2139
+    20251001,
+    2056
    ],
-   "commit": "ad18cf208afd828a65d707f075d64bb3e4c1509d",
-   "sha256": "0wbq18f3a598xi5dl2r5484713dcdlf378yc604jc0gyj27ykrpk"
+   "commit": "cec9ea862ef196113ef19b16e347a522bc8fdd88",
+   "sha256": "1nlg4fqra591fn1h5f2kpk1lamcj2r6mm6qg2fgbxb237abkqhfi"
   },
   "stable": {
    "version": [
@@ -34230,15 +34513,15 @@
   "repo": "jamescherti/enhanced-evil-paredit.el",
   "unstable": {
    "version": [
-    20250526,
-    1717
+    20250909,
+    2222
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "5cef5a157e2223552742a16335841e713cf0b277",
-   "sha256": "142sx7c0j7f9i19bb87lcdsqanhhqqcg863zw9lqslnndsnypczg"
+   "commit": "995b37e0eb5d4993c1491a8b80dd2d1094eaccfc",
+   "sha256": "1a76vdn0wfk7nvmnj2fl9rbg888y2r6956b4j1rmzjq0hsrfr8hf"
   },
   "stable": {
    "version": [
@@ -34407,15 +34690,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20250728,
-    1241
+    20250917,
+    915
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "189bafea47c3110ec897c1c5bc1558fbcc407b85",
-   "sha256": "0ddp1b5ql7rlcdv1mrcdjwm5lz9flxsfd44ffjjf2wmijym9p9pl"
+   "commit": "de1ae6e538764f74659f358b04af0d84fa0fef42",
+   "sha256": "0j5kwg6x1kr9ybzhc0rwrbmq35zmsk09svx39pmw2byl39d8fhb3"
   },
   "stable": {
    "version": [
@@ -34551,8 +34834,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20250601,
-    1044
+    20250901,
+    1551
    ],
    "deps": [
     "closql",
@@ -34560,14 +34843,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "bc9a6018f07dc3e5e1bd2139d08d1dd1af92eea8",
-   "sha256": "1a4a56whm2m576mm2pzvvhnf2jkix8dg73wamgj8gn2m8b1591i3"
+   "commit": "b6922f112dd0b523df0e2da49b4cc9327b1085ba",
+   "sha256": "0j3abhk3vhbpx2m2hgsafij24a9f55kza9fcy54vh81rh3c15q97"
   },
   "stable": {
    "version": [
     4,
-    0,
-    7
+    1,
+    0
    ],
    "deps": [
     "closql",
@@ -34575,8 +34858,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "bc9a6018f07dc3e5e1bd2139d08d1dd1af92eea8",
-   "sha256": "1a4a56whm2m576mm2pzvvhnf2jkix8dg73wamgj8gn2m8b1591i3"
+   "commit": "b6922f112dd0b523df0e2da49b4cc9327b1085ba",
+   "sha256": "0j3abhk3vhbpx2m2hgsafij24a9f55kza9fcy54vh81rh3c15q97"
   }
  },
  {
@@ -34587,30 +34870,30 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20250823,
-    1655
+    20250901,
+    1606
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "b62b1d5da52cc31b34ffd563e8a6b97cfa9e4d01",
-   "sha256": "0rcbjlsxpfm7b2y0cprbzf63gli7sn8rgfj72f8bnngqdmyz6zcz"
+   "commit": "9c588b4f678f488826fc2707ebdae1ae297f1b76",
+   "sha256": "18hx3909cirrqq4nnxl4zyr322131ybm10lqbacgxlxcvbb8v6j1"
   },
   "stable": {
    "version": [
     1,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "d9e58d467c40bf71794f8eee758a83ab0e1933db",
-   "sha256": "1hymzfc2qydjhdhdisd3ba1bqajl7vpn4acdwk9xykip02bnxsfa"
+   "commit": "9c588b4f678f488826fc2707ebdae1ae297f1b76",
+   "sha256": "18hx3909cirrqq4nnxl4zyr322131ybm10lqbacgxlxcvbb8v6j1"
   }
  },
  {
@@ -34640,6 +34923,25 @@
    ],
    "commit": "fd906d3f92d58ecf24169055744409886ceb06ce",
    "sha256": "0d3z5z90ln8ipk1yds1n1p8fj9yyh2kpspqjs7agl38indra3nb4"
+  }
+ },
+ {
+  "ename": "eplotly",
+  "commit": "6bc3ec3f49d275db37c09ea2151d665fde050ed0",
+  "sha256": "1wsd0nbh37gp50dxg7kd4a4zqa26br82a2hdw4xz0x5f440vn168",
+  "fetcher": "codeberg",
+  "repo": "GioBo/eplotly",
+  "unstable": {
+   "version": [
+    20250910,
+    2140
+   ],
+   "deps": [
+    "f",
+    "jack"
+   ],
+   "commit": "2b509457bd8bfeea1e906f8db222f9e1fe8e4c4e",
+   "sha256": "1ma3cwfa0zlc567clf4z0pfxz8l3q0lys43ly4rzp47f9lzd4qar"
   }
  },
  {
@@ -35309,20 +35611,19 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20250717,
-    731
+    20250827,
+    800
    ],
-   "commit": "d04f6a0b261cf23e316e48e2febe14b30c592dc5",
-   "sha256": "0hqljgbhw7yx9hbpd2k0sdvr1psp4aq56wn3d8qa1q0pqpn6zqp3"
+   "commit": "ed8445a63861f510d21e27c9122e4fafa8039d9d",
+   "sha256": "11f2kslkcbln9w0wlp1wvcx6nybp97ijf6wnv7l9pflw61521jq6"
   },
   "stable": {
    "version": [
     28,
-    0,
-    2
+    1
    ],
-   "commit": "d04f6a0b261cf23e316e48e2febe14b30c592dc5",
-   "sha256": "0hqljgbhw7yx9hbpd2k0sdvr1psp4aq56wn3d8qa1q0pqpn6zqp3"
+   "commit": "34316363201de07437e14e79ef559fde7becb0ee",
+   "sha256": "1aby8zips3s7x2h6pjndvx0dasdccnrq81sgxdgy7nfw7rkga7dd"
   }
  },
  {
@@ -36415,11 +36716,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20250725,
-    847
+    20251003,
+    2044
    ],
-   "commit": "b8341e9a4e343ca6bf8b5038359a204a09b454c5",
-   "sha256": "1y180i5bkmzla6rp53674a59wbfz2f4ikbwqi50ca6vh81v6i877"
+   "commit": "282d1cd6b401183cd0f50f5336140a03a1193300",
+   "sha256": "1x5qjrj816sbjnfz10zms3ay2cgg0mxmj7mlm3k5zmng10wqxy4f"
   },
   "stable": {
    "version": [
@@ -37119,16 +37420,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20250812,
-    1023
+    20250929,
+    1650
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "nadvice"
    ],
-   "commit": "334a636621577e77f834bca0c6ecdcec67c6ff1e",
-   "sha256": "1a10912xzq6wixyf9n0fh05ngavd9cg6m1rb3n2b1ivlnpzv21pv"
+   "commit": "b06f644bdb5b06c6ac46c11b0259f15ac9ffd5da",
+   "sha256": "0cpavshhfh1xhq611qjmb8svhz9lf0qbvqjhc5s2v8i11yh48mdw"
   },
   "stable": {
    "version": [
@@ -37321,15 +37622,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20250821,
-    203
+    20251007,
+    813
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "faed16f485bf15c95f4544fbb249b5f07c0007fc",
-   "sha256": "0r56ixnfraazmbicy38hjy1i2cljz5y8and5nnc5s2vzan52zsz8"
+   "commit": "00e71118ab43d8eebf619c8ac00d165b21b9c1e7",
+   "sha256": "16yrp140hnij647jnqxi73ny7y78qnasf2ihgdr6bf43vpzkzw13"
   },
   "stable": {
    "version": [
@@ -37633,15 +37934,15 @@
   "repo": "jam1015/evil-god-toggle",
   "unstable": {
    "version": [
-    20250529,
-    2015
+    20251006,
+    2259
    ],
    "deps": [
     "evil",
     "god-mode"
    ],
-   "commit": "2c381a3ee82e41a787944992ae11a8b52e6a6d87",
-   "sha256": "0qmfv8g5yz19qsxss9bjg1snc989h69slsk5x6vfdpv3kwl3k72y"
+   "commit": "ea5f09b8903fcc111f986b87b5b6b25af8c496a0",
+   "sha256": "1c0x5y70fzwj7389vgaajkb0wj0ganddlamnfb2sygmh4k6b83i7"
   },
   "stable": {
    "version": [
@@ -38946,11 +39247,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20250724,
-    607
+    20250908,
+    352
    ],
-   "commit": "4ca5dffbd3f81361c85203bde44328ad2128d33a",
-   "sha256": "1j00ajpffkd0zzq9xszp0s21zw82ps2jfa00zb2ipg7v2vafkgqj"
+   "commit": "211525baed0ee02201a56bc35cc4366d8e23cc35",
+   "sha256": "06szqafqj71vwirid1sza6p7z8c87pj86pbfim99vsalgp9mq2cl"
   },
   "stable": {
    "version": [
@@ -39424,11 +39725,11 @@
   "repo": "purcell/exec-path-from-shell",
   "unstable": {
    "version": [
-    20240411,
-    859
+    20250922,
+    1413
    ],
-   "commit": "72ede29a0e0467b3b433e8edbee3c79bab005884",
-   "sha256": "15cjwvfv5xdhbym4ms71zdkng4381d3hsdk3kvvx2kycxff52rih"
+   "commit": "59631fc475678ca299cc9503c1e48e87404b0b80",
+   "sha256": "1ijdzdml1fk6dmq8knb3xdfaxfgnfjd70im01076wv326wh0ajc1"
   },
   "stable": {
    "version": [
@@ -40796,11 +41097,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20250725,
-    200
+    20250906,
+    306
    ],
-   "commit": "a1ad6354b7c66bfa43f5bf117cf4e41bc33da64c",
-   "sha256": "1n27gv470cj5l4r34bgnib3wjwlprh32iv6xlg3ghlwk3hflpda4"
+   "commit": "2624b5cd6dc8b9b535d031f8c256081271245c62",
+   "sha256": "0703sps6sa5jf0hxwsxadlcmcr80bjvm3y9n894lqd6qw07zdjrm"
   },
   "stable": {
    "version": [
@@ -40931,15 +41232,15 @@
   "repo": "Artawower/file-info.el",
   "unstable": {
    "version": [
-    20240621,
-    653
+    20250930,
+    920
    ],
    "deps": [
     "browse-at-remote",
     "hydra"
    ],
-   "commit": "36fb3469a4d1c9d803e9d13e7e2e9582ced3043f",
-   "sha256": "1cd6m5acclfwzqpnrnqz08gm52jfjg7m137l005g9hn3vwlbc3bj"
+   "commit": "ac8c0fecde9491d8626d54667c99e4e5dcfa4128",
+   "sha256": "1kq38zj71svvh319a3sif8nckj6phxb06733gg11aax04kygwb5l"
   },
   "stable": {
    "version": [
@@ -41302,8 +41603,8 @@
   "repo": "LaurenceWarne/finito.el",
   "unstable": {
    "version": [
-    20250209,
-    1956
+    20250907,
+    1936
    ],
    "deps": [
     "async",
@@ -41314,8 +41615,8 @@
     "s",
     "transient"
    ],
-   "commit": "7dc99cc22053038777bdff06d34db323047976bb",
-   "sha256": "1v30q9vm6lz8gkipi1s5b0w40yprsw34bif6bjrpcjh8hzq6kcyk"
+   "commit": "be1c866c288bb0d92a24f8b5d4b64ea4d70355ef",
+   "sha256": "0cxnfi17p56lgy7qvqpqnnjdlc0ddbd2riln081g7x7301z44lc7"
   },
   "stable": {
    "version": [
@@ -41474,20 +41775,26 @@
   "repo": "Anoncheg1/firstly-search",
   "unstable": {
    "version": [
-    20240804,
-    955
+    20250904,
+    5
    ],
-   "commit": "d2f58ef2411f664617e8164a1c8d036541f57cef",
-   "sha256": "035sh3nbdjdg7mg69mrykgz4gfy3rf5i70d2yraznazbzyab7nx9"
+   "deps": [
+    "compat"
+   ],
+   "commit": "509cb483e68caf8e6ecd0f171330b91eff430583",
+   "sha256": "01lkhbgb8a4hbzxiny3hfdxpg1qzpmxrp06bx9szw9yjf9qmbnw5"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    4
    ],
-   "commit": "2045d990509074a8151c8a27db50e477d254aa31",
-   "sha256": "1xaddr6zgnif4gng8sdqfsxckh2k35yblpn3mirz6zw7iyd46zs3"
+   "deps": [
+    "compat"
+   ],
+   "commit": "1b5555f2de25bddb7d57d2aa8144f59759e48dac",
+   "sha256": "0n764wd2bi2wvd1h6l1n0hlff8lvf4q68n7bznkxbk4nrsaw9jy7"
   }
  },
  {
@@ -41960,15 +42267,15 @@
   "repo": "emacsmirror/flim",
   "unstable": {
    "version": [
-    20250621,
-    1317
+    20251004,
+    2059
    ],
    "deps": [
     "apel",
     "oauth2"
    ],
-   "commit": "f586caed9251f4bf9e6798a267c5e03e22c608db",
-   "sha256": "0hz380wsjyyrbcx1a92bm57fs680c935bv6zhdz9ag3b3xiwprzm"
+   "commit": "b16b10600efb518425ec796bbf15f64aaa97d998",
+   "sha256": "1phfmmmm9bmapk36m7h800iq3bvfxpg76h9dq8z45q4n6kalmadn"
   }
  },
  {
@@ -43282,14 +43589,14 @@
   "repo": "weijiangan/flycheck-golangci-lint",
   "unstable": {
    "version": [
-    20250407,
-    559
+    20250910,
+    1938
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "14bf143ea7ae190544326576a156de9c915a4751",
-   "sha256": "1d61prv2zkss604k51751l26mmrp6rs9li9c62bmddmvdp0jrx7x"
+   "commit": "38cc30eb8b3056260993bd085f5ae6bc90af177f",
+   "sha256": "0ac8rfbpb434qvlh2prb3sil4nwvnf51z2zx14cmqfjn70yphxiv"
   }
  },
  {
@@ -43378,25 +43685,25 @@
   "url": "https://git.umaneti.net/flycheck-grammalecte/",
   "unstable": {
    "version": [
-    20230605,
-    1035
+    20251001,
+    2010
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "76aca865992d828af54d77c1cf9a70663747e080",
-   "sha256": "0vsf0zsqqfaarwq1k34kg5sqgywzr6dklqv093imm9q6ys18p8c4"
+   "commit": "4b50d794a88d31c43023bed78f1815673f0c8890",
+   "sha256": "1bv6g3y39ifcyxynmwk619hkfl643s3pa4qrmy7m440dndfqjzxf"
   },
   "stable": {
    "version": [
     2,
-    4
+    5
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "76aca865992d828af54d77c1cf9a70663747e080",
-   "sha256": "0vsf0zsqqfaarwq1k34kg5sqgywzr6dklqv093imm9q6ys18p8c4"
+   "commit": "4b50d794a88d31c43023bed78f1815673f0c8890",
+   "sha256": "1bv6g3y39ifcyxynmwk619hkfl643s3pa4qrmy7m440dndfqjzxf"
   }
  },
  {
@@ -44231,15 +44538,15 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250522,
-    350
+    20250930,
+    1139
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "206573c8de58654384823765dcca636c9e35e909",
-   "sha256": "12qzjy3zz0lk439y0y9gl5pirzlf52li3lbyjjmq7lq6yg30qzxm"
+   "commit": "07ef7531f2ec73b90a965ac865cca8c96086f9de",
+   "sha256": "1myzqbd00892a604kg88bxglk0w6valdvmaybsixapr5wgg2sbri"
   },
   "stable": {
    "version": [
@@ -45100,20 +45407,20 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20250502,
-    19
+    20250920,
+    1926
    ],
-   "commit": "64cd28ad98aa6c0474dca7100f34098b38d25185",
-   "sha256": "1h16525z7r6wscn6lc1pwiz7yl3n5l6vkxzwsj4z6dwfdjcwbrad"
+   "commit": "fcd15eafd96afa35f4b3d52f320d949d110bf573",
+   "sha256": "0gan9yanaa6s4llxgqibx4wr04s4kdbxkippndsjcv9q9n9dpdqh"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
-   "commit": "df15c34ee9c7926fb34278630c92c377e9edc6e0",
-   "sha256": "1w3dvcc32xbi1cla2wbfhpr638gky978c2ms8vi9x8dy669x11rf"
+   "commit": "fcd15eafd96afa35f4b3d52f320d949d110bf573",
+   "sha256": "0gan9yanaa6s4llxgqibx4wr04s4kdbxkippndsjcv9q9n9dpdqh"
   }
  },
  {
@@ -45228,15 +45535,15 @@
   "repo": "mohkale/flymake-collection",
   "unstable": {
    "version": [
-    20250531,
-    1243
+    20250831,
+    1353
    ],
    "deps": [
     "flymake",
     "let-alist"
    ],
-   "commit": "40e4f36dfa46ecbc621e7b161db4ff5b5079fdb4",
-   "sha256": "1g49978lkinr5hyn01z4kfzyai6dkalwxajgmv45xdxnl3p3n06g"
+   "commit": "909d98d9ec70c2baa5467634ec37181a058f2548",
+   "sha256": "0082l6ia1p08y86qr1vz6i76gmcpliba7lzm9akr6nlzr5s2d8g0"
   },
   "stable": {
    "version": [
@@ -46177,14 +46484,14 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250522,
-    350
+    20250930,
+    1139
    ],
    "deps": [
     "phpstan"
    ],
-   "commit": "206573c8de58654384823765dcca636c9e35e909",
-   "sha256": "12qzjy3zz0lk439y0y9gl5pirzlf52li3lbyjjmq7lq6yg30qzxm"
+   "commit": "07ef7531f2ec73b90a965ac865cca8c96086f9de",
+   "sha256": "1myzqbd00892a604kg88bxglk0w6valdvmaybsixapr5wgg2sbri"
   },
   "stable": {
    "version": [
@@ -46372,14 +46679,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20250707,
-    1557
+    20250928,
+    1825
    ],
    "deps": [
     "project"
    ],
-   "commit": "1074f358736ace68d0eefa9cd7727ebed0de7c00",
-   "sha256": "1gw3yva3by1hia1wyb2z5fz08hccf0jjfyb73p3lr7jvcbk3zkbz"
+   "commit": "fed03d99366bb4666dd0ed101572b093f1a55b09",
+   "sha256": "1b6k6lr483kq9nhs2wkndz7x7qscfwmadnnhsdvlmqdn9mrp3jf6"
   }
  },
  {
@@ -46613,14 +46920,14 @@
   "repo": "konrad1977/flyover",
   "unstable": {
    "version": [
-    20250708,
-    1611
+    20250917,
+    528
    ],
    "deps": [
     "flymake"
    ],
-   "commit": "dbbc13f67c427ca771137937105c256fa5989c64",
-   "sha256": "18irzq3yzbrm6mpwn90xfav5gi0g2v6x9bm0sxy96gz9ap2k4k63"
+   "commit": "f94a1f4956f8410ff42715315091c79dd340138e",
+   "sha256": "0f0aiinp68k9fifanywa2cpk0dgbccrwxa3sbcdd1icb5skaz8v6"
   }
  },
  {
@@ -47344,8 +47651,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20250824,
-    742
+    20251007,
+    1152
    ],
    "deps": [
     "closql",
@@ -47360,21 +47667,21 @@
     "transient",
     "yaml"
    ],
-   "commit": "2fb110bd9a3e272056886b5538d72024c2d41282",
-   "sha256": "13nrgkvggl0wikizc7yv35niqygp05klfzj2xjyc66rz7f1ggimj"
+   "commit": "54a33e91aed1ce30f083b01b2ffee54ec1311313",
+   "sha256": "0hd8gllkmbn6ac2dk0ilfd43nl3l7sdsf3x7jkl07algnskngr2j"
   },
   "stable": {
    "version": [
     0,
-    5,
-    3
+    6,
+    1
    ],
    "deps": [
     "closql",
     "compat",
+    "cond-let",
     "emacsql",
     "ghub",
-    "let-alist",
     "llama",
     "magit",
     "markdown-mode",
@@ -47382,8 +47689,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "a31859547a1ea5e2acbab67b6b64f90134e2a156",
-   "sha256": "1vr7qrrcj2vdh5h3w43jzqym33ax58218jq3idjrr8wnlh7vdj18"
+   "commit": "34e7b77602b2018f64bd7e38314a0a2cb4a32227",
+   "sha256": "18ayhf3q433abkp2dwyc3arlbvadsr7bjh3j52figy0k2bi3ixhh"
   }
  },
  {
@@ -47630,11 +47937,11 @@
   "repo": "gmlarumbe/fpga",
   "unstable": {
    "version": [
-    20250724,
-    1527
+    20251002,
+    1238
    ],
-   "commit": "f31ced6ae7c037f01c1c384e07cd0ffa6de22e5a",
-   "sha256": "07fgpmc88i6gz3vh3wr60hwhczrxxxi33173ncvhnz93j80zf8vm"
+   "commit": "8e5f44d73d9bec693b9882113fa34827a5b4c2b1",
+   "sha256": "0n7l45gyi7a048vh3bp1692z596yqk6f0yz0lvfqpvldnrgf9n54"
   },
   "stable": {
    "version": [
@@ -47784,26 +48091,26 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20250815,
-    1806
+    20250901,
+    1607
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c9a630aea2713a7111e4423426d868383ab7073f",
-   "sha256": "1qpiyq85jkvmn784r7k6x1jnpsg9nic3zc1awkp4lm80c2dn707c"
+   "commit": "f65d85397d6a87c4d5ef42a4c6c78cbfafe9d12d",
+   "sha256": "0nnncybd3hcz87m61fdnkvyw6akglsyyna6xxsbxwbjp4skqybbr"
   },
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c1a3bb14ebd302db14b0530acfa08fef9f69ac2c",
-   "sha256": "1hq80igrnr8p9z1a9ml681487lkfbr1wa549h4lq62cv91z5mrf5"
+   "commit": "f65d85397d6a87c4d5ef42a4c6c78cbfafe9d12d",
+   "sha256": "0nnncybd3hcz87m61fdnkvyw6akglsyyna6xxsbxwbjp4skqybbr"
   }
  },
  {
@@ -49003,14 +49310,14 @@
   "repo": "emacs-geiser/geiser",
   "unstable": {
    "version": [
-    20250810,
-    1346
+    20250922,
+    2344
    ],
    "deps": [
     "project"
    ],
-   "commit": "c8b862f00e208f2c09bf2a2b2436af0a466a2531",
-   "sha256": "12dyy2fdsd0ymm3l415lb37ij2146c271xski533dh9vmmqmzvna"
+   "commit": "43b9a034aa12d0fd9f27cfdbe7d35affaaf9c19b",
+   "sha256": "07z38plzi5fpsq1r522acgdjbi36hh1i3cdjvg7rdxxlxgmjb0w9"
   },
   "stable": {
    "version": [
@@ -49708,28 +50015,28 @@
   "repo": "anticomputer/gh-notify",
   "unstable": {
    "version": [
-    20250215,
-    2257
+    20251002,
+    1943
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "eb14b84d10d23be80a1e48f3d74c4f8ff144adf8",
-   "sha256": "0a170rdh80c33spkss97sbhp6bwr76hdslig893h9gr874kbk6z2"
+   "commit": "63ebc8c2127fac5fd69b5aa293f558ede82b3c5a",
+   "sha256": "1fihyswz4zp0ddby6wsv08q8n65nplhjmbxcgnynkbp2k0b3zh2n"
   },
   "stable": {
    "version": [
     2,
     1,
-    1
+    5
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "eb14b84d10d23be80a1e48f3d74c4f8ff144adf8",
-   "sha256": "0a170rdh80c33spkss97sbhp6bwr76hdslig893h9gr874kbk6z2"
+   "commit": "63ebc8c2127fac5fd69b5aa293f558ede82b3c5a",
+   "sha256": "1fihyswz4zp0ddby6wsv08q8n65nplhjmbxcgnynkbp2k0b3zh2n"
   }
  },
  {
@@ -49847,31 +50154,30 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20250823,
-    2101
+    20251006,
+    1821
    ],
    "deps": [
     "compat",
     "llama",
     "treepy"
    ],
-   "commit": "8d6f6e5d949f0afdd56c61f6f88936b68e976786",
-   "sha256": "05rb3i74wvf34w27pxcpspianj7mxlgqiqa73xbv3rzc9g8hbiy0"
+   "commit": "6dc4ff700fc515157131b2106a17bb667579d449",
+   "sha256": "1p88q8g3a0qqd2rakpg03p945y88cmb9c93sihh77ya5r477glh0"
   },
   "stable": {
    "version": [
-    4,
-    3,
-    2
+    5,
+    0,
+    1
    ],
    "deps": [
     "compat",
-    "let-alist",
     "llama",
     "treepy"
    ],
-   "commit": "97a07691efad6fc16bc000a35be80d4f8dae251a",
-   "sha256": "0xy3kjfl7zpqypxk7dv14yppvdrim5qg1676hnnacyskglmvxgkv"
+   "commit": "6dc4ff700fc515157131b2106a17bb667579d449",
+   "sha256": "1p88q8g3a0qqd2rakpg03p945y88cmb9c93sihh77ya5r477glh0"
   }
  },
  {
@@ -50197,6 +50503,21 @@
    ],
    "commit": "cef196abf398e2dd11f775d1e6cd8690567408aa",
    "sha256": "1n6x69z1s3hk6m6w8gpmqyrb2cxfzhi9w7q94d46c3z6r75v18vz"
+  }
+ },
+ {
+  "ename": "git-bug",
+  "commit": "08e49319a49e820bc91ce35588156a82eecfd23c",
+  "sha256": "06c2d5p9qdfjz2wm39xk3rawydvnwwx6cxiz950s6jvdmf2p6j43",
+  "fetcher": "github",
+  "repo": "WillForan/emacs-git-bug",
+  "unstable": {
+   "version": [
+    20251001,
+    25
+   ],
+   "commit": "b29eba066f61e3ee3a0c751f4d9958e3be19d56d",
+   "sha256": "1i14zw1794g37wil9i4aszbcp1nflw1d2dcm09f9xiqclja7vnrz"
   }
  },
  {
@@ -50572,26 +50893,26 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20250531,
-    2217
+    20250901,
+    1608
    ],
    "deps": [
     "compat"
    ],
-   "commit": "27af84f31ed022267b7108ad10ea286631f88e88",
-   "sha256": "0fzln0j41vjclz1gygn61dgsyfslx2aw4g8fxblp56a0d5y9hz7q"
+   "commit": "7063d66857023e6c010cecac52de67c0baa77fb7",
+   "sha256": "0k73855kzl2hj0lsr68gmbmabxjm5pxwciybbz0pr3j67s3i7r82"
   },
   "stable": {
    "version": [
     1,
     4,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "27af84f31ed022267b7108ad10ea286631f88e88",
-   "sha256": "0fzln0j41vjclz1gygn61dgsyfslx2aw4g8fxblp56a0d5y9hz7q"
+   "commit": "7063d66857023e6c010cecac52de67c0baa77fb7",
+   "sha256": "0k73855kzl2hj0lsr68gmbmabxjm5pxwciybbz0pr3j67s3i7r82"
   }
  },
  {
@@ -51474,11 +51795,11 @@
   "repo": "gleam-lang/gleam-mode",
   "unstable": {
    "version": [
-    20250412,
-    1910
+    20251006,
+    1500
    ],
-   "commit": "8e981614536f0e36fb14721a9fae8bf72c287a40",
-   "sha256": "0xspx3hpiw21pqcqpp82ngxzsdbc209cbp7yjl5i1j5rwj6d09r7"
+   "commit": "bd4a0ea995cab2bd2676d04ff155eccd306f835d",
+   "sha256": "0xlkk8akh2jycs5ja91mzgcigngk1c6cb33lk4i9dnyy51mbw9rl"
   }
  },
  {
@@ -51732,8 +52053,8 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20250815,
-    1346
+    20251001,
+    707
    ],
    "deps": [
     "compat",
@@ -51741,8 +52062,8 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "2a3119cf2998a6a625e27846c09b281b3239e722",
-   "sha256": "0wys6wnnkh5p5x44lswkmzign284zhpj3bs8a0af1xfq84bdi1bk"
+   "commit": "e8b36d20064b5e4337083d6ee90e4513fcd7790e",
+   "sha256": "1bz5pgpp4visd7xspmn2ig1kqvv3wz20d2k4vcnsk75b1akfmzks"
   },
   "stable": {
    "version": [
@@ -52755,11 +53076,11 @@
   "repo": "minad/goggles",
   "unstable": {
    "version": [
-    20250101,
-    919
+    20250921,
+    1713
    ],
-   "commit": "d71e85ff8d9e7f8966e4cccece3efa545afc41da",
-   "sha256": "1pvgfhy8a1cmip9vx31lbdm4957hz4gsj2a875gvc8xfl2y4dc3r"
+   "commit": "6f87a700137c838568966bc8099dc15786897c32",
+   "sha256": "0jxvp11q4c18w8k7m4vi6sn0nx5wphf5wlq6mxvx34zk1pmw3scn"
   },
   "stable": {
    "version": [
@@ -53141,14 +53462,14 @@
   "repo": "chmouel/gotest-ts.el",
   "unstable": {
    "version": [
-    20250107,
-    1017
+    20250923,
+    702
    ],
    "deps": [
     "gotest"
    ],
-   "commit": "ede3685388e76ed379b184cc62275bcdf819f104",
-   "sha256": "1lpy33d65cdxk6sqpsirijmyng7h5v4a397q11h16br14vpx47i8"
+   "commit": "edbc8dcd14fa037cd91e08896027fcd6331aca7c",
+   "sha256": "1siaj2f7jbvkf5a5fk5h5j56sm27vkxp0913kjkygcjhigkdi0lw"
   }
  },
  {
@@ -53402,11 +53723,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20250807,
-    2036
+    20250929,
+    1735
    ],
-   "commit": "4c9f9eb6279381a9b9f4863f7ac35f15f07fd2cf",
-   "sha256": "1c7q3vq0lixlp2bf4w1mgxhrhfxl5hxi17hw0hy19cnyy37sqis2"
+   "commit": "bd10b618af9b50a678bd992eb8a22a64053e2134",
+   "sha256": "0cbaclbycg2ng03c4h3zlg3x43q9b1985cpknjbyqnhb81zl059m"
   }
  },
  {
@@ -53473,29 +53794,28 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20250824,
-    610
+    20251007,
+    257
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "7bb353a582d11ce210bb0a5b77c53de564c28e67",
-   "sha256": "0zqbrdadpnrrcv33c3p9drg6rch66br9czqg4kjjynl4bf2gx6g5"
+   "commit": "4275350d7769fb8fdd09353e3e6d991b05c7a673",
+   "sha256": "1iil8q9nhm34dsf31qm83v3lv9rij3rcaakma9hpnphipzzws7hi"
   },
   "stable": {
    "version": [
     0,
     9,
-    8,
-    5
+    9
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "a5af15c770b66a61d0609a736e1db37495655559",
-   "sha256": "0ix0k9dv91mbibwih1s5wzx9hj5nkr3cz799m6gb52vpwf9gixg7"
+   "commit": "81618f24e2190568ea745dca82ba50267eed321a",
+   "sha256": "00f391gaf0pnin6qncpnxl5yj0j089d1rdblwgv5cf3mkid9w8gj"
   }
  },
  {
@@ -53973,11 +54293,11 @@
   "repo": "ppareit/graphviz-dot-mode",
   "unstable": {
    "version": [
-    20250715,
-    1358
+    20250925,
+    1226
    ],
-   "commit": "2c7ba85d19cbed4984d0cab31aa33800ffa89f78",
-   "sha256": "0vw5dc4z9pfp6a2m431sszlfvspf5zykb924bbx90awmxfz1h2fx"
+   "commit": "516c151b845a3eb2da73eb4ee648ad99172087ac",
+   "sha256": "05faf6x5fsjy77k576xdwqnxbpcjlhl5bp8snvsbm6y8ac7wz2ml"
   },
   "stable": {
    "version": [
@@ -54750,8 +55070,8 @@
   "repo": "guix/emacs-guix",
   "unstable": {
    "version": [
-    20250525,
-    1711
+    20250914,
+    1923
    ],
    "deps": [
     "bui",
@@ -54760,8 +55080,8 @@
     "geiser",
     "transient"
    ],
-   "commit": "66b935020d93cdbbff0b0ed3b1d2195724a46821",
-   "sha256": "1pm1nyy1r704wjg4hfdrrxlf1mn327wk0vkghwy8wsp4f84j5j7d"
+   "commit": "324987fb4a3e67c6f0f565b6605b8fce559f60ee",
+   "sha256": "1bg8sy20rdpdv1vzim494jwrmd63rd1mn8v94rkdijs9a2cakdkq"
   }
  },
  {
@@ -55386,6 +55706,30 @@
   }
  },
  {
+  "ename": "hare-mode",
+  "commit": "59c72e31c3751e74321c23c12d6b7479684f92c8",
+  "sha256": "1qypqpwm6f5x3xmrf5a6kc53q5qrkqc90afidl85yfp767lsa9iq",
+  "fetcher": "sourcehut",
+  "repo": "grafov/hare-mode",
+  "unstable": {
+   "version": [
+    20251002,
+    1915
+   ],
+   "commit": "bd7e2e8b1437a45b60d6dc053ef26f47ec1436db",
+   "sha256": "0l31q53h3spw5g5fwa238dryxs563644gzgv1gcpshjda8dnmibf"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "bd7e2e8b1437a45b60d6dc053ef26f47ec1436db",
+   "sha256": "0l31q53h3spw5g5fwa238dryxs563644gzgv1gcpshjda8dnmibf"
+  }
+ },
+ {
   "ename": "harpoon",
   "commit": "1b8efde9e17f716c518a0cfe8e65ba57cf662b48",
   "sha256": "006b5919zdjbzfl0jdagnmalz5zapp4bj9l2fxphzn6isyw807r0",
@@ -55531,11 +55875,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20250519,
-    1154
+    20250930,
+    1728
    ],
-   "commit": "2e08ba771ffdc46d082b2285c534afdb12efb941",
-   "sha256": "13fkwdapnl1fcpvgjc725y1sdyg1dqmhjbs0hb9j60givdwq2m29"
+   "commit": "bd89438b0e6e6b6877d635699e265da85e85ca06",
+   "sha256": "0mkxrizxnvl1xdxhxdv01bpqjancbw4vshp69rdhvsiv7gm27nwv"
   },
   "stable": {
    "version": [
@@ -55805,11 +56149,11 @@
   "repo": "hdf5-viewer/hdf5-viewer",
   "unstable": {
    "version": [
-    20250625,
-    519
+    20250901,
+    33
    ],
-   "commit": "0700e660579012ab20650d337ccf8c40700d83b9",
-   "sha256": "15ksiyg0x3i6plhhrdrql55jmr43xjydglyxg86lpxfqb3xjcxn7"
+   "commit": "cd934811721a36e63cea45fffbf4b3459ad60e15",
+   "sha256": "0qzbcizc8s3izrpcscm478910i9v4iwpjb5pm305azfsfb0gnmq3"
   }
  },
  {
@@ -55874,11 +56218,11 @@
   "repo": "mgmarlow/helix-mode",
   "unstable": {
    "version": [
-    20250731,
-    1425
+    20250921,
+    1802
    ],
-   "commit": "32e01acddc582ae9eb27eabda974ce12996a9bb8",
-   "sha256": "12frkqmv0qbs4rqxdazki6xvhdb6ykr4xsrzk8ljlj19dniawhd8"
+   "commit": "1b78a854a2181bbfac8296433c606b2419ded77c",
+   "sha256": "1x5c5zrc7xrxjwpdn61hfy49s7cxqxm87i3a73m5056bp6gpi30r"
   },
   "stable": {
    "version": [
@@ -55913,28 +56257,28 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250823,
-    300
+    20251005,
+    614
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "be88ccd4d16340a64280cbca2e7fd2839721fb0a",
-   "sha256": "080bv3mhf407i7lmaffswxnc80wz78kfp0ijylgmv7hsxxp80hc3"
+   "commit": "ea0dd8639bd6dcac3b1c34228598f3d4555115a0",
+   "sha256": "0lzpx4l9lcdkpacpqnhaahsj1r9i3jgagjlb1biwbv827z46ayl9"
   },
   "stable": {
    "version": [
     4,
     0,
-    5
+    6
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "01ae48a989cdc8665692d5a18c5a386ba0a646ed",
-   "sha256": "1prdbck7m9qlb18v33dkkyba30ld9y1d414xzvfn1avnl3icnm32"
+   "commit": "f12e7dd3132724cc294e79b55291a2c967a8fe5c",
+   "sha256": "0bcwy60wqfhxvxkhc0rl7bkasf0y1pm5kwg90qh9y23ri69z08zx"
   }
  },
  {
@@ -56724,26 +57068,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250821,
-    349
+    20251005,
+    539
    ],
    "deps": [
     "async"
    ],
-   "commit": "4773888c5b5d65fb469be4ec789a9dfd795cb028",
-   "sha256": "0brhlssa5hzsviknhynqllmh8fk0p07vma7i1xmgqkam7skvnpag"
+   "commit": "193164eb010d133185d737784f9451be3ca8e578",
+   "sha256": "1f775ykxckcnax5zf3gzl00kd0y71zwrk2slcpynw1gpcw3fd9ml"
   },
   "stable": {
    "version": [
     4,
     0,
-    5
+    6
    ],
    "deps": [
     "async"
    ],
-   "commit": "01ae48a989cdc8665692d5a18c5a386ba0a646ed",
-   "sha256": "1prdbck7m9qlb18v33dkkyba30ld9y1d414xzvfn1avnl3icnm32"
+   "commit": "f12e7dd3132724cc294e79b55291a2c967a8fe5c",
+   "sha256": "0bcwy60wqfhxvxkhc0rl7bkasf0y1pm5kwg90qh9y23ri69z08zx"
   }
  },
  {
@@ -58065,14 +58409,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20250629,
-    1321
+    20250916,
+    1233
    ],
    "deps": [
     "helm"
    ],
-   "commit": "04680c2d605283b53b81facf002daaa6ccb5d700",
-   "sha256": "1y5a3vm372i9wz5phq9fsf27bryddw189k23aqrpvkyzf4bjizba"
+   "commit": "fcf49200204c90444e2938f00fd147a4a1e89f4a",
+   "sha256": "179dy6772ns9mhil6bfcwdcl6xdyb12zwhk8jlq7l3yiv6kcpgjw"
   },
   "stable": {
    "version": [
@@ -58872,28 +59216,28 @@
   "repo": "bbatsov/helm-projectile",
   "unstable": {
    "version": [
-    20250814,
-    1150
+    20250902,
+    830
    ],
    "deps": [
     "helm",
     "projectile"
    ],
-   "commit": "41bc1c1973a1528f9ae974701d42e3deccce5cbe",
-   "sha256": "094aky23kzwhw9qa4cfyaa6w1146jywcg7f0dgwy0lf1wwrir91l"
+   "commit": "0ffb6b5f09c1d65d721c1111ebfa6cec0ba63234",
+   "sha256": "19zafd0l2mcd53q83bd2mxinadzsp90q5znfcm9fq0m88lpcmg94"
   },
   "stable": {
    "version": [
     1,
-    3,
-    2
+    4,
+    0
    ],
    "deps": [
     "helm",
     "projectile"
    ],
-   "commit": "53acfb64914bfcdb27a745827705493ef6345b52",
-   "sha256": "0rbp5d7v4vy3s21yys9bqip78w43jfhdv65y891al13r3886b2hs"
+   "commit": "0ffb6b5f09c1d65d721c1111ebfa6cec0ba63234",
+   "sha256": "19zafd0l2mcd53q83bd2mxinadzsp90q5znfcm9fq0m88lpcmg94"
   }
  },
  {
@@ -60958,14 +61302,11 @@
   "repo": "mihaimaruseac/hindent",
   "unstable": {
    "version": [
-    20241128,
-    1601
+    20250909,
+    1613
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "beafb2610fb9a724bdd78339375e6673d46c23fe",
-   "sha256": "1hx0sj5afy0glxr3lfr6hvnk0iphmfnfg3wilx2s013a5v0drmxc"
+   "commit": "e841f55c37abf6865309083b93eb6214eb100cea",
+   "sha256": "1sp7dzrngn6jhcy020w1akph849cw1rihz1ql5vc48r7c3wrsyz8"
   },
   "stable": {
    "version": [
@@ -61065,11 +61406,11 @@
   "repo": "kimim/emacs-hippo-theme",
   "unstable": {
    "version": [
-    20230626,
-    1439
+    20250929,
+    1221
    ],
-   "commit": "ab04264f651807fd41617bca0216c2b2e6cdb79f",
-   "sha256": "1ligj4frj4zl490byyzbxqrpwqjak45vgzgs5rl8p731m7rksg2v"
+   "commit": "8eb27d6bf632bb466d242334adfbbe9c027dd8c5",
+   "sha256": "11n84sa079lpq7d2pkmd4nhvys2zifj0y0vsgiy9ja6yg91fhrc5"
   }
  },
  {
@@ -61200,11 +61541,11 @@
   "repo": "ideasman42/emacs-hl-block-mode",
   "unstable": {
    "version": [
-    20250113,
-    1242
+    20250913,
+    2251
    ],
-   "commit": "4823c96d0a0d21e73fcf7a6cfcceba693d84e87d",
-   "sha256": "128y26v9gn2hg1pdniw0r8a63z7n6iz0wazb9d6688ac32wxy719"
+   "commit": "fdb50b4d2048e238d1e039969ff40de00118bf77",
+   "sha256": "0w51sq8x32y1rf49cns3q0c1nzvdln1wjq7mm5hpp7xljygm7c6v"
   }
  },
  {
@@ -61233,11 +61574,11 @@
   "repo": "ideasman42/emacs-hl-indent-scope",
   "unstable": {
    "version": [
-    20250611,
-    330
+    20250918,
+    35
    ],
-   "commit": "643827712a41e8ff17e71573c87be1ffddcc2a90",
-   "sha256": "01bxrkzgn8ay3vg7gakyqg083i6fypa6dy2kh2a4r4540ylj41c3"
+   "commit": "a6511fde03b771a89f949b05e7eecd751cd261f8",
+   "sha256": "0f8jwl60wbh6rq2dzjli2lhqsifpyp0ggavzkvld82gnvnzy9vxj"
   }
  },
  {
@@ -61248,14 +61589,14 @@
   "repo": "8dcc/hl-printf.el",
   "unstable": {
    "version": [
-    20250121,
-    1818
+    20250926,
+    1624
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8b16339f96bc33ab471fd8d6e7861e867000b9d9",
-   "sha256": "06sjbj0cy6k27kyvhfd30jr94l5sd493zkf0w4046szny5ixczk4"
+   "commit": "f2f534efaa1788b66a50a8e811c19d48275f26f4",
+   "sha256": "1hf0nlmlpvn5x34z8li4f5arb3nyg1n5zq348ahxzxdwz2hrlaaw"
   }
  },
  {
@@ -61266,11 +61607,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20250611,
-    323
+    20250923,
+    2251
    ],
-   "commit": "7146a61ef27e52279e80b436537f19248fda2235",
-   "sha256": "0vy7x85lhhhig34a9nmqcd2jilx28qi13815g3wizznsrnyqzzaj"
+   "commit": "51a78d2e19899e981b041023157e1aa2c15138ed",
+   "sha256": "0xzc5lbmagkqhr36p9nfqxsshckrbd04d0jzgx29yxji8q9z4mgg"
   }
  },
  {
@@ -61303,26 +61644,26 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20250801,
-    947
+    20251006,
+    1811
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b8be53068b3469572d66cfedc540f4130901a3da",
-   "sha256": "0ih6hm364kiqxma9f5y3pm5bz9gq7s0nywb2prizlay43bkdg5rv"
+   "commit": "2e9504511aa393686f44a36716c1d2ebdc5def1f",
+   "sha256": "1gzrlf151hbascalch8mar2l7ppgax7l6633ikw79g3ygf37fbrd"
   },
   "stable": {
    "version": [
     3,
-    8,
-    5
+    9,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b8be53068b3469572d66cfedc540f4130901a3da",
-   "sha256": "0ih6hm364kiqxma9f5y3pm5bz9gq7s0nywb2prizlay43bkdg5rv"
+   "commit": "2e9504511aa393686f44a36716c1d2ebdc5def1f",
+   "sha256": "1gzrlf151hbascalch8mar2l7ppgax7l6633ikw79g3ygf37fbrd"
   }
  },
  {
@@ -61720,14 +62061,14 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20250805,
-    1210
+    20251005,
+    1120
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "15ef80bc6ed46447027b59769be16108a0fc4a9e",
-   "sha256": "1dmjcbwcghyppqrg383pkric5mjhrz95f7wlm8lxq8k6zkynm1hp"
+   "commit": "d1431c9e678de6e0c179b2a2bf405e8804472fee",
+   "sha256": "0r4sw6wlapdsvjpnsiahwpx3hhx9kgkfjbaid5567whwj7fs1hsj"
   },
   "stable": {
    "version": [
@@ -62347,11 +62688,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20250819,
-    1241
+    20251007,
+    2220
    ],
-   "commit": "818553046b39f3485d1f9f3636153c3151fd430a",
-   "sha256": "1pvyvxhbibmzrs51f068a9rqx90ll6mi2ag060m6gibhapqgaai1"
+   "commit": "4b58147274b7488322873da47951c2d8d57b006a",
+   "sha256": "0b04vqj9xmh3h2c2aw8x7kbam8pr6smjsriyx27gnfjajaw2bx1q"
   },
   "stable": {
    "version": [
@@ -62530,10 +62871,10 @@
    "version": [
     3,
     1,
-    0
+    1
    ],
-   "commit": "430e035e842fb9afe58d76a96d0a49504746f620",
-   "sha256": "0y268282bmg97r9vhpn1bhhpbrxql3wmjpn3cvm37bf002ivmrqy"
+   "commit": "4004a9ca832ce1a8e3ece4a639a11fcccf9066ec",
+   "sha256": "1bj749hp8bcmn6vmgff5nz69bidplvvsb1028q9xjfgm5a5f3k55"
   }
  },
  {
@@ -62601,11 +62942,11 @@
   "repo": "Stebalien/i3bar.el",
   "unstable": {
    "version": [
-    20241025,
-    1417
+    20250913,
+    1829
    ],
-   "commit": "2e8df32559bad0a77ef87daa13d0740c5328a50a",
-   "sha256": "0sa08gp39cjmdac11mp7ckwm3igy61bfiybrghqdkdh8sm1by5ih"
+   "commit": "75a81e8100884f679378db52a660b3963f2dbede",
+   "sha256": "12carbz9znnijzyc84hvvljhv8zybwzgk42nd57g5iqc637vmhhf"
   }
  },
  {
@@ -62857,6 +63198,21 @@
   }
  },
  {
+  "ename": "ical-form",
+  "commit": "fc039304840e7a2e503364cac5bed8997e56243b",
+  "sha256": "1xd5kcjjkvrrffzrlcdbqcn3ssgyyhvjfvvlcnapksrg638v2i9d",
+  "fetcher": "github",
+  "repo": "haji-ali/maccalfw",
+  "unstable": {
+   "version": [
+    20250921,
+    1717
+   ],
+   "commit": "af8eb956f0e6e10cc209c6d663d28d35cbfb6344",
+   "sha256": "1i6ihqpws0s7knx68r0cs8z99apyljlqzmv5zzbvbrqj7srwq8d3"
+  }
+ },
+ {
   "ename": "iceberg-theme",
   "commit": "dec6f24b215de80a4c12856bd1ad4dc26c33f47e",
   "sha256": "021v5rpmmk2bym46w9hs5ckyajqv41qf2l2183ybqfc679mkbym8",
@@ -63041,11 +63397,11 @@
   "repo": "ideasman42/emacs-idle-highlight-mode",
   "unstable": {
    "version": [
-    20240421,
-    647
+    20250922,
+    1330
    ],
-   "commit": "531be0c2d6dc13c525138c1c9a0f59ac42268f58",
-   "sha256": "1vklsfac0m6wm9mlb7pdrwr0b559qgyvndbkl6221b3dvz0jnb96"
+   "commit": "6fa320d2cc67786c72d82e0372089087bdd74938",
+   "sha256": "1zzg11kdmpprljjr46lkf844hxi0hswqvyaqsbgr20ks4cm8812z"
   }
  },
  {
@@ -63459,15 +63815,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20250825,
-    758
+    20251006,
+    819
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "da5c22f43622112de9e54d8ef9d3ee324d6973f9",
-   "sha256": "11693qh2wp14dwzrkz672m1mz67j7k44saxvpcm91a815m6kpxv5"
+   "commit": "ca1e5fdca371650cd8efcb2762e07b27fe4c1b90",
+   "sha256": "1y3z5avc9j2p6cb8r24gijl9vx0l2s2xwfmma6k535bfym863567"
   },
   "stable": {
    "version": [
@@ -64334,6 +64690,30 @@
   }
  },
  {
+  "ename": "indentinator",
+  "commit": "c792c9b20bd362ffc33e3997c49e865f28fac760",
+  "sha256": "028vmxhhgvf28pzhriach5m87hhlgl70x70hwcj0d8w120fkpm70",
+  "fetcher": "github",
+  "repo": "xendk/indentinator.el",
+  "unstable": {
+   "version": [
+    20250901,
+    1740
+   ],
+   "commit": "65322a28f01485234a7489fe1267186b33c0a63e",
+   "sha256": "0vlz54iaw84vr628nr8b8hpwffzmdvr9hncjq43wpvzkib1apnhs"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "96f569f917ff662638a6b2eb54d4fd5f4e731246",
+   "sha256": "137gdl08hg78ryc4qi01prv5r0wwp1wjsxys0cjm6lj93pv26vcw"
+  }
+ },
+ {
   "ename": "indian-ext",
   "commit": "04e29d1a745d46ff32ccd9ee787ce1fe92786ec6",
   "sha256": "07mny5rd2bmj1v260zfs4imp795lw4gnwr06pcx0s1ml2km1a2k2",
@@ -64821,20 +65201,20 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20250504,
-    336
+    20250920,
+    1803
    ],
-   "commit": "53c8f3edcc8779bb0f4cafb75fd627becaf2856a",
-   "sha256": "12kh731vbdn4yp20c3zb8nx8bklh0b4amdnlybb3ww3sjax41h4f"
+   "commit": "89e009898dca46e07fed5fb313eb7bcdeb9d9714",
+   "sha256": "01jcgrqlwwihvdv0bm1lddlm933czgdnas7rbxhr5zvdys9gfimz"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "1c59f2106e7a945291309b2342aebcb87b91117f",
-   "sha256": "1d2ha86nc9s8rfi6l8m8c97afilnz4vwwsj5ssdph0j215ixvvml"
+   "commit": "89e009898dca46e07fed5fb313eb7bcdeb9d9714",
+   "sha256": "01jcgrqlwwihvdv0bm1lddlm933czgdnas7rbxhr5zvdys9gfimz"
   }
  },
  {
@@ -65229,6 +65609,25 @@
   }
  },
  {
+  "ename": "insta-pocket",
+  "commit": "6a6ae63d8a4d22aa35ad4ff3f137a67af4ada005",
+  "sha256": "1n9k8h966ygmb4jkz0259cz8a7pf57iqqgx76c77a3jp9aw1i0hv",
+  "fetcher": "github",
+  "repo": "thanhvg/emacs-insta-pocket",
+  "unstable": {
+   "version": [
+    20250921,
+    2201
+   ],
+   "deps": [
+    "oauth",
+    "tablist"
+   ],
+   "commit": "33a735c3c5060b5e322aa4eb4e24665c01c3ba4b",
+   "sha256": "05pwzlxmhz19wmkp07prhx21bi7f9mk9gq8ifhqm1fhfjnzml1sk"
+  }
+ },
+ {
   "ename": "instapaper",
   "commit": "a187008942c14dc09f7952a3c5b2e320553cb5c9",
   "sha256": "1lcrwf2ymlfkvn00djxdr0sd7cjbp2sjdszs3sfmsxffaqzmy9ap",
@@ -65426,11 +65825,11 @@
   "repo": "mekeor/iosevka-theme",
   "unstable": {
    "version": [
-    20240621,
-    2151
+    20250919,
+    2228
    ],
-   "commit": "1f17b9cdb48021a0ac1369d9622742e0f5442c9d",
-   "sha256": "0gv79s2v0g5vjqg5xlbxhlqrg7fjymch4skgrnz0ni21h4m9c6gk"
+   "commit": "bef8c3ec7979937cfdde3054ce5fed2146bc3f87",
+   "sha256": "03nx5z9x0hbiaayv7qyihlsy63cmrgw5bcbjra6il2h4n0jidgg8"
   },
   "stable": {
    "version": [
@@ -66946,11 +67345,11 @@
   "repo": "zellio/j-mode",
   "unstable": {
    "version": [
-    20240920,
-    1706
+    20251003,
+    805
    ],
-   "commit": "62d373b9d0926f191f42c747a2364cf8dacf0fa1",
-   "sha256": "09pxzk9njizgiaj1gdcwfd9yak75byvmczc6vh9xyiqd8rwkr29r"
+   "commit": "1365e5a3fe772609685b3787bbd2960331c1a02f",
+   "sha256": "017niqdsys2b6qhyja2nqa9k124qqb069k524b1nlwiz1fkzxcwk"
   },
   "stable": {
    "version": [
@@ -67780,14 +68179,14 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20250802,
-    207
+    20251007,
+    1659
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4c18ce95ced42639f8ef8c47a264c8c37b8b6caa",
-   "sha256": "13kldga8bk4dydc6xvnqdbg69r2wp8aiahlvsg4q4lbakw7mqg0x"
+   "commit": "618e1a5c7ad8aa5a0b219436d3f998f3394415f5",
+   "sha256": "044kqnnpjkchi83jz4y3s2qici5p65yvy60wfiybj1an14vqb877"
   },
   "stable": {
    "version": [
@@ -67809,8 +68208,8 @@
   "repo": "unmonoqueteclea/jira.el",
   "unstable": {
    "version": [
-    20250824,
-    1519
+    20251006,
+    1744
    ],
    "deps": [
     "magit-section",
@@ -67818,14 +68217,14 @@
     "tablist",
     "transient"
    ],
-   "commit": "98bc0cc66ede34793c535a8afd526f42e32b0753",
-   "sha256": "1dsjwr5swrlyjiac9vnxn9dpndqq00pq25mafpzy152wpvnpv3h1"
+   "commit": "865e97d9085be8fbb86e2c4ae749c72d8b79178e",
+   "sha256": "0zfv21249chxry5w72yhmmgk0ja0ljd8akzf9zlz0mn8zqqmsch3"
   },
   "stable": {
    "version": [
     2,
-    7,
-    2
+    10,
+    0
    ],
    "deps": [
     "magit-section",
@@ -67833,8 +68232,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "98bc0cc66ede34793c535a8afd526f42e32b0753",
-   "sha256": "1dsjwr5swrlyjiac9vnxn9dpndqq00pq25mafpzy152wpvnpv3h1"
+   "commit": "865e97d9085be8fbb86e2c4ae749c72d8b79178e",
+   "sha256": "0zfv21249chxry5w72yhmmgk0ja0ljd8akzf9zlz0mn8zqqmsch3"
   }
  },
  {
@@ -67940,11 +68339,11 @@
   "repo": "necaris/jjdescription.el",
   "unstable": {
    "version": [
-    20250423,
-    2333
+    20251007,
+    1951
    ],
-   "commit": "ef3c337cb82e58b3a9a9b0394e84c883a35ab795",
-   "sha256": "0r8wr1ddjwiramj48mxmx12h6w78igl48xnskgvavjxc458laxa7"
+   "commit": "883a3b9d5a400495f0b7ec87220633ad0502c894",
+   "sha256": "0mn0nl2mfh27hqr32z4zb5bc3k6j79vnrq1waqcip01v1g7p7hwp"
   }
  },
  {
@@ -68019,11 +68418,11 @@
   "repo": "SebastianMeisel/journalctl-mode",
   "unstable": {
    "version": [
-    20240219,
-    2115
+    20250922,
+    1323
    ],
-   "commit": "631d10a5c8f466c94c38c3cd7410a27026f5f822",
-   "sha256": "1p3mgza73yls8f7v063jb49z0ylmvni4v812abqvvvrn5q396286"
+   "commit": "c5a6127ad831fa95a8e3b3fa207a011435ae887b",
+   "sha256": "13j0a8n10w41qz2vddjb4i6v0vn3k4f9b2pm1hasjmdw3a7lk9m3"
   },
   "stable": {
    "version": [
@@ -68103,11 +68502,11 @@
   "repo": "ljos/jq-mode",
   "unstable": {
    "version": [
-    20250113,
-    1214
+    20250929,
+    1127
    ],
-   "commit": "eeb86b4d5ad823e97bd19979fcb22d0aa90ff07b",
-   "sha256": "1pcrx8vdb4vvvgg8x2jlw7dd1qs6zzmcc90v89bsx3bsv5vanarp"
+   "commit": "39acc77a63555b8556b8163be3d9b142d173c795",
+   "sha256": "1i8wlgkfafbcdxi3gwv5l173h3m0sp76v0qp25gxin4hklhgbad3"
   },
   "stable": {
    "version": [
@@ -69080,8 +69479,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20250310,
-    1739
+    20250910,
+    703
    ],
    "deps": [
     "dash",
@@ -69090,8 +69489,8 @@
     "s",
     "spinner"
    ],
-   "commit": "cacf52e4c8db76706e6aa336d38746d15a2b6fe2",
-   "sha256": "07057mydg5smbq82xyhiybjmnidca1kp62m7zmgshakshxx1kwwh"
+   "commit": "7b50882f5aec33aa9c120f89c2e604f71bdd7a26",
+   "sha256": "08q44hp2g6v69frfczh4d6mhjd1k3jzmnnyd9mv55vp2kcc35xgy"
   },
   "stable": {
    "version": [
@@ -69353,11 +69752,11 @@
   "repo": "leon-barrett/just-mode.el",
   "unstable": {
    "version": [
-    20240424,
-    1809
+    20250828,
+    1824
    ],
-   "commit": "4c0df4cc4b8798f1a7e99fb78b79c4bf7eec12c1",
-   "sha256": "0lxx22hp1j7q6cjr5ryiymkf7d70pcn5blihrd45h0h5swjx85fl"
+   "commit": "310f437296173e4659c80490fcdb7ebafbac1665",
+   "sha256": "0bjpz0p13rgj3fmydxr34lghwd4vhcgkh7lxqp9a1rv2kdpar2qn"
   },
   "stable": {
    "version": [
@@ -69377,11 +69776,11 @@
   "repo": "leon-barrett/just-ts-mode.el",
   "unstable": {
    "version": [
-    20250328,
-    2115
+    20250828,
+    1824
    ],
-   "commit": "9660d8f7ed48351ca594316d665f9cbbed803388",
-   "sha256": "1821xdznd1mh30nz5hj889shd0i28h545l2yjwgyiji9rgvdcbwi"
+   "commit": "f4fb841f93222fcefccabd641281553b4c8d9d6e",
+   "sha256": "1mmp6pkwcwmwfz2k5g19rbi9yfjrsih4yz4ajz63k1y0g7fxn8lb"
   }
  },
  {
@@ -69392,8 +69791,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20250703,
-    1538
+    20250909,
+    422
    ],
    "deps": [
     "f",
@@ -69401,8 +69800,8 @@
     "s",
     "transient"
    ],
-   "commit": "c126a60a21dbc71151f17819df500d150d9b273e",
-   "sha256": "1pl9z69jq08d9hd53459g5xck13f032ibc22bxh2v880v33ik2gj"
+   "commit": "8096ebd602f374936be2c14cbc6b2e7768c3fccf",
+   "sha256": "0mfp5aj6m2rmyfff3rw4rh1zgisphvz3lp8msx1pwznnfzab5wpi"
   },
   "stable": {
    "version": [
@@ -69761,11 +70160,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20250719,
-    2252
+    20250909,
+    1307
    ],
-   "commit": "fa426fb20966c9fde9cbf70e16172472756db492",
-   "sha256": "1dmz9hw2q783kz93icxhy5ak8bmz4ynfcn7y1rsk1n237w3hzgzm"
+   "commit": "78d1cd9acf7617f5641854c7dcc05d9285ec0cd3",
+   "sha256": "0xw2na9dlaa5k2v80vyq5rjc3lxa74j7gakyd2h0zwdq307yhy7s"
   }
  },
  {
@@ -69840,15 +70239,15 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20250820,
-    1822
+    20251007,
+    1241
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "119b6a5d1f909ee5d3bb140cfdbefe151e0da2df",
-   "sha256": "0fx4wxp6ysqh42czlngbvwhnpnis0kl5kryvj0p3xpmjzv46z46f"
+   "commit": "a0570401fa08fb6f3843e574d28823a8e079e943",
+   "sha256": "0qf5slf6ibi38v460wzbfm8sklpkzzq7hcb46dw13hiq2qmbkc1l"
   },
   "stable": {
    "version": [
@@ -69862,6 +70261,30 @@
    ],
    "commit": "4b64a70625c1640d369392e9a79cdfd534b8e4be",
    "sha256": "00cav4pj69m1kv46y8lcgrb71jfjw6s5sqnnllp0fq5hqdxnmcw1"
+  }
+ },
+ {
+  "ename": "kaomel",
+  "commit": "722f12296e2bbfef6089fce12e55cdc9063f467f",
+  "sha256": "1d32ly048xlk00vjfsxd026x16wzsxfz963iraspr7bjglhzvwf8",
+  "fetcher": "github",
+  "repo": "gicrisf/kaomel",
+  "unstable": {
+   "version": [
+    20250923,
+    1958
+   ],
+   "commit": "9476f16a72e61f08f403cb4dbe860e39f1856c7a",
+   "sha256": "04k36fjd165isbbb5vz0nl945k0b73z62hs271ivp74z6f8nfafg"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "a1a596e3c907457ea1e773b499c49b96fb93038a",
+   "sha256": "1adjjhmvv2rwcnxxwkm81vzc8f52yypbakshh52v0991lymm3kg8"
   }
  },
  {
@@ -70258,26 +70681,26 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20250531,
-    2219
+    20250901,
+    1610
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6570b73c4d726d18d6ee48a46494b6ff35aacea6",
-   "sha256": "1r57crwq6if56rscf9hvni4zq7bhb7cdvf31ir9j6qyqcdjnhgc1"
+   "commit": "f23f6823710c4d194cbdb5f1a0532d1d6fe0d968",
+   "sha256": "0w8kvizrzml85j7m8c3nb8a9sp8nvx0l2xwv3f0zr2nald0vsd6c"
   },
   "stable": {
    "version": [
     1,
     4,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6570b73c4d726d18d6ee48a46494b6ff35aacea6",
-   "sha256": "1r57crwq6if56rscf9hvni4zq7bhb7cdvf31ir9j6qyqcdjnhgc1"
+   "commit": "f23f6823710c4d194cbdb5f1a0532d1d6fe0d968",
+   "sha256": "0w8kvizrzml85j7m8c3nb8a9sp8nvx0l2xwv3f0zr2nald0vsd6c"
   }
  },
  {
@@ -70361,14 +70784,14 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20250531,
-    2219
+    20250913,
+    1926
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5acd65f35aa12303e3ea1f205c368e82f0fa89c3",
-   "sha256": "100vc8a7llgpi350yldw1g00rymlda92ns1ljglpgvqkq4g1czib"
+   "commit": "9b98459e39d5f9f8d14371c47f7070fc99dbbc68",
+   "sha256": "0s3dqqd2hxyb07lfpm5yd38ycr16m9nac8x3i5g6w1860q3357w4"
   },
   "stable": {
    "version": [
@@ -70553,20 +70976,20 @@
   "repo": "hperrey/khalel",
   "unstable": {
    "version": [
-    20250612,
-    503
+    20250910,
+    946
    ],
-   "commit": "a8ea2706e5dce6d3d31ba58176dd1b8873dac04e",
-   "sha256": "1ivy61r48xs8dxh2p9wsyidcyn1n04n4w4s3gph1pkyr4ad1n6wl"
+   "commit": "f7cdb3246d193a518b3a4ca7381ffb6ed8087fcf",
+   "sha256": "06h5272kmg0ykf0zqdy2qwhlzszqsw176l1brk04bg8xyc3a4384"
   },
   "stable": {
    "version": [
     0,
     1,
-    14
+    15
    ],
-   "commit": "a8ea2706e5dce6d3d31ba58176dd1b8873dac04e",
-   "sha256": "1ivy61r48xs8dxh2p9wsyidcyn1n04n4w4s3gph1pkyr4ad1n6wl"
+   "commit": "f7cdb3246d193a518b3a4ca7381ffb6ed8087fcf",
+   "sha256": "06h5272kmg0ykf0zqdy2qwhlzszqsw176l1brk04bg8xyc3a4384"
   }
  },
  {
@@ -70607,15 +71030,15 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20250823,
-    1912
+    20250916,
+    917
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "00c5aec614316f1356f450f388dee101a1a4960c",
-   "sha256": "0jka8ic1rqgz2g5s0yz2kfbk65j0djai90fv5058k8q67b03hm6k"
+   "commit": "6ac2280e4117421c1c162a4a0a2ecfa16351dc36",
+   "sha256": "148ixdxncw39nnagznvmiihzxj0vrcwjk5xrixgi6yk57qfyfvn6"
   },
   "stable": {
    "version": [
@@ -70862,14 +71285,14 @@
   "repo": "mew/kixtart-mode",
   "unstable": {
    "version": [
-    20250806,
-    1656
+    20250916,
+    1957
    ],
    "deps": [
     "eldoc"
    ],
-   "commit": "ddf0c3b207e5695fbc80fe45374db29f5ea18211",
-   "sha256": "078asawps4ydpzpcxv1a26yjbm6401k0xsisbbl85s5spv67a244"
+   "commit": "863f0a42b6d865341cebb43fdcb3e0feb0048b5e",
+   "sha256": "0rida9ii6bis4rd8hknqilaijsbpcxi48amv2cb83bp7p98sqr4k"
   },
   "stable": {
    "version": [
@@ -71133,11 +71556,11 @@
   "repo": "aimebertrand/kql-mode",
   "unstable": {
    "version": [
-    20250126,
-    2159
+    20250925,
+    1437
    ],
-   "commit": "e7504518e0febabeef48b165aab75c905e6dd81a",
-   "sha256": "1g6clq23nrigvigr2v0adr6j3pkq6srxqg8ya6zr4sdasl7s7ags"
+   "commit": "6ea203a6f21332eeab33875908da01607740947d",
+   "sha256": "143icqwyczjgj9k9wwji10viyz569gs2s4x6vq8z6xri79fqjhn5"
   },
   "stable": {
    "version": [
@@ -71263,8 +71686,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20250713,
-    1542
+    20251009,
+    310
    ],
    "deps": [
     "dash",
@@ -71272,8 +71695,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "9218d91b1085a4cdb240377c335142909df6a9e3",
-   "sha256": "08ijjmpyj58wpwc7js3a5gxxsdzm4vlkb9m2smy1xnllzqh0ikm9"
+   "commit": "48a2dabac24921c89e95039d1a8e5a52568baa02",
+   "sha256": "08y4jq0c7cql187bai1ws64icsiq91lfz1d0d1mvxs7yn2xmjvsq"
   },
   "stable": {
    "version": [
@@ -71554,8 +71977,8 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20250722,
-    1903
+    20250827,
+    5
    ],
    "deps": [
     "async-await",
@@ -71565,14 +71988,14 @@
     "request",
     "s"
    ],
-   "commit": "85f66f35f3dbd6d21828aa42647204ed8d70aebb",
-   "sha256": "1xdgkhz1b7x5pwgkn4ykzc436g80m6rjq88zs6y79mcllh6w925n"
+   "commit": "a29b3ccadeab31b6582fedd0e35e5bf46c96fc64",
+   "sha256": "1c8nmj7m0c3j1pdrp7dgcx0kfv9vrjsam0vw4b82k7pxl3k3dcc7"
   },
   "stable": {
    "version": [
-    2,
-    4,
-    0
+    3,
+    0,
+    1
    ],
    "deps": [
     "async-await",
@@ -71582,8 +72005,8 @@
     "request",
     "s"
    ],
-   "commit": "5c95bd829cfd9ad610bcbbc0d3f8ef8bee4e152c",
-   "sha256": "1hv56dpbi2p5fxd5gc2n3qf2cynym7zkb4kjsn83r43wv8v54l4s"
+   "commit": "a29b3ccadeab31b6582fedd0e35e5bf46c96fc64",
+   "sha256": "1c8nmj7m0c3j1pdrp7dgcx0kfv9vrjsam0vw4b82k7pxl3k3dcc7"
   }
  },
  {
@@ -71772,10 +72195,10 @@
  },
  {
   "ename": "langtool-ignore-fonts",
-  "commit": "570bde6b4b89eb74eaf47dda64004cd575f9d953",
-  "sha256": "0fgj0807mq8izii4yx1187gdn2ybr2g5pdp9628sfssm9a3v8iv2",
+  "commit": "1f0d54307cf768673ea9d7e25acc7d9d510c7b69",
+  "sha256": "0jrnidm7g8i3ph84a4jgbdkavqaj1lg6kfnywp91qsw9bgrfj6d0",
   "fetcher": "github",
-  "repo": "cjl8zf/langtool-ignore-fonts",
+  "repo": "cjrl/langtool-ignore-fonts",
   "unstable": {
    "version": [
     20210526,
@@ -71868,20 +72291,20 @@
   "repo": "PillFall/languagetool.el",
   "unstable": {
    "version": [
-    20230325,
-    507
+    20250924,
+    1813
    ],
-   "commit": "b136d531129eb488dc4134784e34c4afedcb0c2f",
-   "sha256": "18rynn9gv7kwaivp836lkkllrc51h6yn64x4r279fg1w4psrq94b"
+   "commit": "fa3c08c369bf53f3311f1f365b54271cf126e4dd",
+   "sha256": "1s1cgjy8k0xygkdwzvq27818rv7ahn73ag06wnqk2gg15a8f36d9"
   },
   "stable": {
    "version": [
     1,
     3,
-    0
+    1
    ],
-   "commit": "b136d531129eb488dc4134784e34c4afedcb0c2f",
-   "sha256": "18rynn9gv7kwaivp836lkkllrc51h6yn64x4r279fg1w4psrq94b"
+   "commit": "8e697f43d1a55356983c93be2a0f314dcf86ca20",
+   "sha256": "05iva433xr403xaq16gvrja02s3vnjg5hk7h699dcqnmf899qsla"
   }
  },
  {
@@ -72925,11 +73348,11 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20250422,
-    932
+    20250917,
+    1957
    ],
-   "commit": "d84b1d8b435a517b7daf70d341784245fde1e8c0",
-   "sha256": "1y52vgfwy7qqyz1cnm82l9i0nr6658j3cnmwnnrzsj052272lyw6"
+   "commit": "802f5593b83c680bd5152d3b3f98ca184eb481a7",
+   "sha256": "1aj3k1qcmfklfl8ipgnpghql8g4zjn442nsing1cb83cbjpj2gxa"
   },
   "stable": {
    "version": [
@@ -73174,20 +73597,20 @@
   "repo": "mpdel/libmpdel",
   "unstable": {
    "version": [
-    20250623,
-    533
+    20250922,
+    938
    ],
-   "commit": "8ed0b79cf6527468471e683b7b2a68aeedd37170",
-   "sha256": "0gyk359z3qhjfwgg5p8sgcbsjg1k62hwr2fyzmshbdc6031ay7rz"
+   "commit": "f2cb01c8d004b5fbfa937579e899035a47d2a5f2",
+   "sha256": "1indy1y31g68i3a4j6nbx3idybn5b11bjvlx9vkibraf622s2bls"
   },
   "stable": {
    "version": [
     2,
-    0,
+    1,
     0
    ],
-   "commit": "e7d35ba9254ead1516133f182a01f6161ae26388",
-   "sha256": "03bavca89cf7dsjmg7hb48qnvca41ndiij33iw5yjjhbq1zyj8r4"
+   "commit": "f2cb01c8d004b5fbfa937579e899035a47d2a5f2",
+   "sha256": "1indy1y31g68i3a4j6nbx3idybn5b11bjvlx9vkibraf622s2bls"
   }
  },
  {
@@ -73494,14 +73917,33 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20241219,
-    2051
+    20250911,
+    57
    ],
    "deps": [
     "avy"
    ],
-   "commit": "826993a0ab736ab09f53a0623fb44edf2182b07c",
-   "sha256": "00grv36l98fzz0iabc2li19k9wf9k9dmsg0lq5p7qnjfizshyzrp"
+   "commit": "8fda5dcb9caff5a3c49d22b82e570ac9e29af7dd",
+   "sha256": "1v1zrw4fzqsgc3n6aqdsw438svmadwhxi6dg3miagxkpnjirgd8n"
+  }
+ },
+ {
+  "ename": "linkin-org",
+  "commit": "76fce39ba1c9cee9fce9d28e675ee776f0ee354e",
+  "sha256": "0l62qbjx9b79fpnkbvx65rp265nsw9db4hdxsv3d3sqzc8n9jidb",
+  "fetcher": "github",
+  "repo": "Judafa/linkin-org",
+  "unstable": {
+   "version": [
+    20251004,
+    1303
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "7d18f48c611db1f97d8ef86a5efa23a76058bf5e",
+   "sha256": "0x92a64wd1qxhp9l0310ng1zaji03znx1z2x7290asvnzssmbr28"
   }
  },
  {
@@ -74351,26 +74793,26 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20250808,
-    1023
+    20250901,
+    1544
    ],
    "deps": [
     "compat"
    ],
-   "commit": "bf586c02ddf5cf2eb0bab468b99436018887bbec",
-   "sha256": "0lxpxbw10hmcc211l8w0rxl23j0y3naklwmj611a1d1ksx1s4skc"
+   "commit": "ec1d4ef02f5572fc5aff3f62d3e7ef791f444456",
+   "sha256": "13f5crs3sc0k5v64mhbg1415q9hm92f43ba53avacxjjzk7gzad4"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0cc2daffded18eea7f00a318cfa3e216977ffe50",
-   "sha256": "0yp1k70pgi45k8gb7xn229g1dzmwnijabvzxgrwacp02n7v1piyh"
+   "commit": "ec1d4ef02f5572fc5aff3f62d3e7ef791f444456",
+   "sha256": "13f5crs3sc0k5v64mhbg1415q9hm92f43ba53avacxjjzk7gzad4"
   }
  },
  {
@@ -74509,15 +74951,15 @@
   "repo": "tanrax/lobsters.el",
   "unstable": {
    "version": [
-    20250817,
-    1829
+    20250827,
+    2008
    ],
    "deps": [
     "request",
     "visual-fill-column"
    ],
-   "commit": "9d4bd2c67ca324ea402897cb629312add53279c3",
-   "sha256": "08vjn3ay3g215fc4dzlnhygf70gacliz83xizgc3p6k2fyv4y491"
+   "commit": "d061e1b0d4fe27c7751509da61396681d335e69f",
+   "sha256": "042qhc3qg3lzcicq9b5z0b5650a9c3d71db5w2bnwbydph25m97h"
   }
  },
  {
@@ -74581,20 +75023,20 @@
   "repo": "csmclaren/loco",
   "unstable": {
    "version": [
-    20250822,
-    1459
+    20250917,
+    1458
    ],
-   "commit": "b0955516ed13a288a9c2671050c1e25bd64e1b91",
-   "sha256": "0asznx04w7m0iq6npfwvbkd6xrmw4bfb7sxr4ijzwnbj5i2xbdcm"
+   "commit": "eb9f89221d10b946482a79493d63a6fac15fb9fc",
+   "sha256": "1g9nqyvgkf2k6qzssafc0w1k935hmzvs512080wpv80jgqx0nd34"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    5
    ],
-   "commit": "b0955516ed13a288a9c2671050c1e25bd64e1b91",
-   "sha256": "0asznx04w7m0iq6npfwvbkd6xrmw4bfb7sxr4ijzwnbj5i2xbdcm"
+   "commit": "eb9f89221d10b946482a79493d63a6fac15fb9fc",
+   "sha256": "1g9nqyvgkf2k6qzssafc0w1k935hmzvs512080wpv80jgqx0nd34"
   }
  },
  {
@@ -74994,8 +75436,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20250810,
-    1948
+    20251008,
+    156
    ],
    "deps": [
     "compat",
@@ -75003,8 +75445,8 @@
     "seq",
     "stream"
    ],
-   "commit": "3c6beb610fded397088d616c1cc3cf6c90c8e568",
-   "sha256": "0z6y81p81nj7ryc95imyd5z54zxsgpj1i5w0c2lli69yjjbyzb5r"
+   "commit": "218c241c5ef0742de89cc63258545dca84facf8e",
+   "sha256": "0dzrbf2xis2bczxd5ha9zabadh935c113lh527rh0gz2dm4qjw14"
   },
   "stable": {
    "version": [
@@ -75608,8 +76050,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20250822,
-    625
+    20251002,
+    2344
    ],
    "deps": [
     "dash",
@@ -75620,8 +76062,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "c0cafd07ea7e0a2d82fcd0680eb36da10356d700",
-   "sha256": "0v7xvldx0px9jnlncbk3g76dwl464m1fzhrhjsbjdpzz4ay7p5pj"
+   "commit": "aec6ae4186afec395d89008764dbccbb73633fd3",
+   "sha256": "118va4wc0yncr6a1qzw8w6vw5459w850wyz38krv6gmm5igcjccy"
   },
   "stable": {
    "version": [
@@ -75740,16 +76182,16 @@
   "repo": "emacs-lsp/lsp-pyright",
   "unstable": {
    "version": [
-    20250301,
-    131
+    20250905,
+    136
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "b4cee81af46274303f2cb9b75de9fc8ddcba04d9",
-   "sha256": "1l65kh188886y06402d8v2989r6n69wxcr2hfzwb0400g3fzda9m"
+   "commit": "3756ff971797ae04fc43ca29c66ba4d854eff038",
+   "sha256": "0pd9g8asags5sqj8h77r9k6yn0xj8da4604zva0vqj5plzq81ral"
   },
   "stable": {
    "version": [
@@ -75937,15 +76379,15 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20250425,
-    326
+    20251009,
+    810
    ],
    "deps": [
     "f",
     "lsp-mode"
    ],
-   "commit": "294121ada4feb4f4ad4d1a8b2dc69de89d518d31",
-   "sha256": "18p7kg2sx4vmasapgsq45650yckji7xhvnl9bw571359y31y9hq7"
+   "commit": "cdd0325a6a571e51f6c7d1cbc198c7a7ea4a194a",
+   "sha256": "1a159pbq5x2w3id815ln103prdvyg8kbcmzr2r2cag8aa24hvs91"
   },
   "stable": {
    "version": [
@@ -76567,30 +77009,30 @@
   "repo": "reinierkof/magik-company",
   "unstable": {
    "version": [
-    20250822,
-    1442
+    20250922,
+    1311
    ],
    "deps": [
     "company",
     "magik-mode",
     "yasnippet"
    ],
-   "commit": "db00024a7212dc6af674a9ce27c1a15a29d484e8",
-   "sha256": "0g09bgxjd4cbd01b56g54j3x2qxpzs9klp9w9qwp698fy2lhirmm"
+   "commit": "f11e7054fc9038ab34eae1702bbc0fb30fa34246",
+   "sha256": "1a5bmh45xqixyv59m9sb5604ji7zdc728linwm5s36zgvdssqpi0"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "company",
     "magik-mode",
     "yasnippet"
    ],
-   "commit": "db00024a7212dc6af674a9ce27c1a15a29d484e8",
-   "sha256": "0g09bgxjd4cbd01b56g54j3x2qxpzs9klp9w9qwp698fy2lhirmm"
+   "commit": "f11e7054fc9038ab34eae1702bbc0fb30fa34246",
+   "sha256": "1a5bmh45xqixyv59m9sb5604ji7zdc728linwm5s36zgvdssqpi0"
   }
  },
  {
@@ -76601,15 +77043,15 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20250821,
-    1048
+    20251006,
+    1327
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "4f2db98631de71f9078a001e6efba7c048acd2f1",
-   "sha256": "0s525p67v81s9a8fws3v836vsv2myxmxgrcmzzzkz7nkhqkm7wd1"
+   "commit": "069a1d630f63f6822607c59ae171ad7be6219631",
+   "sha256": "0mv12nihkwpqirmz5br1rczqnkr50ln4b3dw60kp0s4lc4054fkp"
   },
   "stable": {
    "version": [
@@ -76633,8 +77075,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250826,
-    651
+    20251006,
+    1840
    ],
    "deps": [
     "compat",
@@ -76645,25 +77087,26 @@
     "transient",
     "with-editor"
    ],
-   "commit": "a47b5098c812b7a7932df802378cb754e3ad8639",
-   "sha256": "0nzsz3x0hnxg4y1wf3pag3dmrihpb6zbdpb7wkcas5mcxm55pnrr"
+   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
+   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
   },
   "stable": {
    "version": [
     4,
-    3,
-    8
+    4,
+    2
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama",
     "magit-section",
     "seq",
     "transient",
     "with-editor"
    ],
-   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
-   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
+   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
+   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
   }
  },
  {
@@ -77099,8 +77542,8 @@
   "repo": "emacsorphanage/magit-p4",
   "unstable": {
    "version": [
-    20250519,
-    522
+    20250902,
+    311
    ],
    "deps": [
     "cl-lib",
@@ -77109,8 +77552,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "53b077672b05216c7f164b86514c3ee0d6dd7e90",
-   "sha256": "10iwm6wk3fpbvjsjji8ppyjsvgxdhd0fniw969clyv15kfb554d2"
+   "commit": "19c54db7423ef87a3688b0ac1e882c2341efee84",
+   "sha256": "0xrkjzf0h5kff0fvi4i0jzv8w33xkgknbb395fg9ik7g2qdrrn6k"
   },
   "stable": {
    "version": [
@@ -77240,8 +77683,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250826,
-    651
+    20251006,
+    1840
    ],
    "deps": [
     "compat",
@@ -77249,22 +77692,23 @@
     "llama",
     "seq"
    ],
-   "commit": "a47b5098c812b7a7932df802378cb754e3ad8639",
-   "sha256": "0nzsz3x0hnxg4y1wf3pag3dmrihpb6zbdpb7wkcas5mcxm55pnrr"
+   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
+   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
   },
   "stable": {
    "version": [
     4,
-    3,
-    8
+    4,
+    2
    ],
    "deps": [
     "compat",
+    "cond-let",
     "llama",
     "seq"
    ],
-   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
-   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
+   "commit": "b828afbb4b45641998fb6483a08effb1efb214e1",
+   "sha256": "0lsxldyjv2h69657pgrblhkxq8fvc0xdwlwpfmd09pb8zawygh2g"
   }
  },
  {
@@ -77388,8 +77832,8 @@
   "repo": "alphapapa/magit-todos",
   "unstable": {
    "version": [
-    20240927,
-    52
+    20250928,
+    1611
    ],
    "deps": [
     "async",
@@ -77401,13 +77845,14 @@
     "s",
     "transient"
    ],
-   "commit": "bd27c57eada0fda1cc0a813db04731a9bcc51b7b",
-   "sha256": "0q3rplkvd4ny02zpnrzkfhflg8yx7zq2brq15c603f2yjiwiy7xl"
+   "commit": "7294a95580bddf7232f2d205efae312dc24c5f61",
+   "sha256": "16kfqgg3rzimhmvs2glsikv60an4b7393ypnq834acmbnql6z27x"
   },
   "stable": {
    "version": [
     1,
-    8
+    8,
+    1
    ],
    "deps": [
     "async",
@@ -77419,8 +77864,8 @@
     "s",
     "transient"
    ],
-   "commit": "4c17b73355ad0f6537bec5776154ee7465a4c2f8",
-   "sha256": "0rjr5q73609bs8gx2h5lp7c7bk5nkplfqfd56ifwdrdzdfzn5khy"
+   "commit": "cebcbb8fed2ffcca6c42a9e0338fe129aad4dbc9",
+   "sha256": "0wv64ihg90yfkzg1aayslq630704wlci39zdxcp3s2fn0fqr26zg"
   }
  },
  {
@@ -77926,14 +78371,25 @@
   "repo": "countvajhula/mantra",
   "unstable": {
    "version": [
-    20250706,
-    1916
+    20250920,
+    129
    ],
    "deps": [
     "pubsub"
    ],
-   "commit": "da8a4fcd96340deb908c4c416bbe2b621f5b55d3",
-   "sha256": "1pfb2i8p436q25xwqb6x30kkiv2n4i0bmljs89nbbv2rqwpm8mhz"
+   "commit": "ad46c9d7fdcd50d771f129fd458f85bf6e28dd9d",
+   "sha256": "0fa2apkjbdza282n5qhyjp3by4yhcmg8cqskg7qpas241bd2sfn5"
+  },
+  "stable": {
+   "version": [
+    0,
+    2
+   ],
+   "deps": [
+    "pubsub"
+   ],
+   "commit": "ad46c9d7fdcd50d771f129fd458f85bf6e28dd9d",
+   "sha256": "0fa2apkjbdza282n5qhyjp3by4yhcmg8cqskg7qpas241bd2sfn5"
   }
  },
  {
@@ -78040,25 +78496,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20250824,
-    834
+    20251006,
+    1126
    ],
    "deps": [
     "compat"
    ],
-   "commit": "30e6813c8142ef8cb45e6f9bdd23ead1c80b9b2e",
-   "sha256": "0j80bbjy4axljlqa2rfjdf66bghmmsibrmvscx1bx62jcqjia4gj"
+   "commit": "18d2d02cdb6689d7d08cd6c41b497117eeeba728",
+   "sha256": "05cd4r1y13kidcavjzf543b3wq49i16qcy1jhdllmw1iva7b2d42"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6e3412ce57b9c87c2d66bc8814aa1a3fdb2e929f",
-   "sha256": "1grn94v5pidb9wk2vgxx5n3fmhcgx9i14lrwm5clvsvncysy7zhg"
+   "commit": "cb3a69c039cf3b4ab007a72f802fc5f4699e8120",
+   "sha256": "1x4x0v0cqhk8kpp4nngkdavs383aacd5xxzc1pvgchvmqhck70hy"
   }
  },
  {
@@ -78542,28 +78998,28 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20250801,
-    1032
+    20251006,
+    1740
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "3e05dc0952c9d34d918e629a80492462adb7aa15",
-   "sha256": "13rx2r3kwr30p3p1px66ay5djvcn1503jqvkaaf9h6g97jfbj6bm"
+   "commit": "9319d0647755e1d9dfc081241bfcb2ef3ec96be3",
+   "sha256": "1hyvbz0cxlqr1gpmjs4rh0cf3n7k66zhc2algrhhf5p5i21fp89h"
   },
   "stable": {
    "version": [
     2,
     0,
-    2
+    3
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "2959ec90ed5813be3efd3b1942815d911c41a416",
-   "sha256": "0msg2nkvcz5v67c6m0z91g5442nl1i3drg3gwfsajj0sh9m4f5mr"
+   "commit": "9319d0647755e1d9dfc081241bfcb2ef3ec96be3",
+   "sha256": "1hyvbz0cxlqr1gpmjs4rh0cf3n7k66zhc2algrhhf5p5i21fp89h"
   }
  },
  {
@@ -78701,19 +79157,20 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20250605,
-    1434
+    20251001,
+    1413
    ],
-   "commit": "0c2cf1da3dbee9c82f924c31dface78771319996",
-   "sha256": "1iha55l59pranpwrdnhsg1wwjfg86a2wsk5s66png4q887b04sas"
+   "commit": "aca9a75c24848e95a2f11894d4ef2efc539bf588",
+   "sha256": "0m9ryzigzlksc2h8vwvl2ahh92a1215apzlihlhbcsc4r9b1j738"
   },
   "stable": {
    "version": [
-    6,
-    2
+    7,
+    0,
+    1
    ],
-   "commit": "390bca3fd9ac440e6c3dcdc524e77c7590423f08",
-   "sha256": "1dfv6f05v7i7966q39knilqjnz1rif4zg6cdk31sy6h8prc6arc3"
+   "commit": "243e9d42060fa3d6246de8c193ceb1766fcd2a96",
+   "sha256": "06xya55gd54bpggn4krgqszz3w8ahqbhv3a069xdzb156lpciziq"
   }
  },
  {
@@ -78955,14 +79412,14 @@
   "repo": "lizqwerscott/mcp.el",
   "unstable": {
    "version": [
-    20250727,
-    749
+    20250928,
+    1200
    ],
    "deps": [
     "jsonrpc"
    ],
-   "commit": "4708c5849ce4ddb632016eca662a7405bfa642d4",
-   "sha256": "11x3jscm4iggyy926aidiv95lrbcncngbvivsybvzjvbhdxhb65h"
+   "commit": "b9782bb80027c13a84ae3ffff1e363a674ed6cf1",
+   "sha256": "148lsxpcka4rf5z62y6wis91vdimbivsp0b2ia8kcym8d9k2jy3m"
   }
  },
  {
@@ -78973,11 +79430,11 @@
   "repo": "laurynas-biveinis/mcp-server-lib.el",
   "unstable": {
    "version": [
-    20250728,
-    457
+    20251008,
+    1443
    ],
-   "commit": "062a3078122171fffd1c1fc8ec64b114acd1cba2",
-   "sha256": "10xv6fap9605lns1nzbagdj2lby3si9d16nq5smcbrwfzx4a910j"
+   "commit": "b4cba156e179b4c95aa18b965c48ef3de4838c63",
+   "sha256": "05v6nrj4j80vzx9aa4q9nicf09mn0hdfjljfxlm9c32b37hyhfn9"
   },
   "stable": {
    "version": [
@@ -79118,20 +79575,35 @@
   "repo": "hexmode/mediawiki-el",
   "unstable": {
    "version": [
-    20250805,
-    316
+    20250914,
+    2305
    ],
-   "commit": "2f116ce0931f7966fefe75a1fca5552d6552ddb1",
-   "sha256": "1g0z8q2231760bxc5m6yp0r9isdcjdf3f9vkbm940avcwv9l2khv"
+   "commit": "e0e45e73be527d75127b31746998824115dcf6a5",
+   "sha256": "1bp9120mbhn2x9636axpajijp878rj738aqynr1fq44a25afxyjz"
   },
   "stable": {
    "version": [
     2,
     4,
-    7
+    8
    ],
-   "commit": "2f116ce0931f7966fefe75a1fca5552d6552ddb1",
-   "sha256": "1g0z8q2231760bxc5m6yp0r9isdcjdf3f9vkbm940avcwv9l2khv"
+   "commit": "0bfeb0daba0c0b65281ae7e65b64ea5744d51626",
+   "sha256": "0qgydr8ll1g0d28yy7p8k2sij7769bxx4fhd7c0s5c8cg7mrl666"
+  }
+ },
+ {
+  "ename": "meep",
+  "commit": "1bf900741e64b381f2c310e845b14c0311e0023f",
+  "sha256": "046m817gqlcqldbm4aai32382k3f4a5qxf8zrdicpn5845574rfg",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-meep",
+  "unstable": {
+   "version": [
+    20251008,
+    1123
+   ],
+   "commit": "d455ee7b2466054b1249e951b733f0fd14820bb8",
+   "sha256": "07gvvk19zs1l65wxaxbk8qmpbrc9zvr138flxzmaq3vy3whp4zf4"
   }
  },
  {
@@ -79337,11 +79809,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20250722,
-    2059
+    20250904,
+    1606
    ],
-   "commit": "3309d64c436209649a5106fa3a3dd019de4d3a64",
-   "sha256": "00mgx7jcb8cvsajww271syklyrrjc7wn9hdmqn3n9jxi46381428"
+   "commit": "ff5315b3b2ebc9a37414cbd2f2a3378162f9953a",
+   "sha256": "1l6m3vbbqg11nyr51zl3yqz5d61rl60ccrr43p00pagrpql9sacn"
   },
   "stable": {
    "version": [
@@ -79593,10 +80065,10 @@
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
-   "commit": "70c35d7a303a66cada554c89d02ebd97d45c2a06",
-   "sha256": "0hlqvq3j4f6g16nj3bm2wbkncn8hv8c8iqd0sch3w80wwqnr622y"
+   "commit": "c8f4fbf075bb5db2bc0872afe02af2edac075e4e",
+   "sha256": "135glcrnbr7wmrygrngsxpma8bxajpxlanbkvk08v92p7ar6a21j"
   }
  },
  {
@@ -79852,11 +80324,11 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20250815,
-    36
+    20251007,
+    3
    ],
-   "commit": "a162361aab27e63a886ceff21349425d6da24c86",
-   "sha256": "0bggaf64bzmi336z7ai5xr0zxywfwv7ck3nlw3s5fwdfgr5l7py0"
+   "commit": "3984ef39d4ed7bf763ab9d064a1a46fb9ba9db5a",
+   "sha256": "0vd26xpxb397qjdfqdjfhp0klk7dqam180hnppffmaq2rm6lbpdc"
   },
   "stable": {
    "version": [
@@ -79931,20 +80403,20 @@
   "repo": "purpleidea/mgmt",
   "unstable": {
    "version": [
-    20250131,
-    552
+    20250925,
+    516
    ],
-   "commit": "e40819d617f8403a7487e3e6d740e8b3ee5c92ef",
-   "sha256": "01a0ssin2ryl60fw66vjwrmncrks1yddi0qj6cnvaflvl2g8vxqq"
+   "commit": "6a7b3d5fa9c50d923a088b1e353f975de5077e4d",
+   "sha256": "0vlm9xp670i8z0y0cnbj2bg0wbrvc2jzpf1h77bmyahfy2yg3yql"
   },
   "stable": {
    "version": [
+    1,
     0,
-    0,
-    27
+    0
    ],
-   "commit": "e40819d617f8403a7487e3e6d740e8b3ee5c92ef",
-   "sha256": "01a0ssin2ryl60fw66vjwrmncrks1yddi0qj6cnvaflvl2g8vxqq"
+   "commit": "6a7b3d5fa9c50d923a088b1e353f975de5077e4d",
+   "sha256": "0vlm9xp670i8z0y0cnbj2bg0wbrvc2jzpf1h77bmyahfy2yg3yql"
   }
  },
  {
@@ -79955,14 +80427,14 @@
   "repo": "yoshinari-nomura/mhc",
   "unstable": {
    "version": [
-    20250423,
-    342
+    20250904,
+    940
    ],
    "deps": [
     "calfw"
    ],
-   "commit": "2b22bc6c2041170df40e96b718d4b99a8330e3e3",
-   "sha256": "1pfv0nx4qisbsfd7pl8fd1rgjfi0p7cin6vjrx5k4fsj9ah29pcm"
+   "commit": "2e5e6260363744f124bd0ca22ac7d5962e32fd87",
+   "sha256": "0lj3hjxiqp0k4znp94wrfw7r6q4bvhj0l6998bh4sk046f54216s"
   },
   "stable": {
    "version": [
@@ -80139,21 +80611,6 @@
    ],
    "commit": "1663054ce266ed25e47ec707c19f619d33225903",
    "sha256": "1lgh38pcjnq3va0vcs0rrl0nrf8j6x0fpdwyv3xghskazwsvrxbg"
-  }
- },
- {
-  "ename": "mindre-theme",
-  "commit": "c554027d8124cdf30b3cfa8e8fe0034802d03b31",
-  "sha256": "1v847sywniw6zdv2h1hgsr2fjarnn61rj2ny8xkddi9rwzzi7zfd",
-  "fetcher": "github",
-  "repo": "erikbackman/mindre-theme",
-  "unstable": {
-   "version": [
-    20240610,
-    2131
-   ],
-   "commit": "cbecece36988f83b7e355a3fcf5229f2494f3688",
-   "sha256": "1xhql4wy7r5f8bx4k1293gawbw83agf1s6va073q1pxqd94rjk6y"
   }
  },
  {
@@ -80435,17 +80892,17 @@
  },
  {
   "ename": "minimal-theme",
-  "commit": "6f26b8281f9bd05e3c8f2ef21838275711e622c9",
-  "sha256": "01dar95l7wjjqhbsknvsfbpvv41ka7iqd1fssckz18lgfqpb54bs",
+  "commit": "2dbcb69f603a94b6abc196d45ec5d2fb2ddc1344",
+  "sha256": "1y4jfniz1ggdvr4xp93lfbafsw77d0fbj6j170wz7gblxwhwqxpp",
   "fetcher": "github",
-  "repo": "anler/minimal-theme",
+  "repo": "nullvec/minimal-theme",
   "unstable": {
    "version": [
-    20190113,
-    2132
+    20250921,
+    2102
    ],
-   "commit": "063b4d8ca33d55d04c341f0b2b777ec241a3e201",
-   "sha256": "0lvg7iym6sxhgl4ab9a6x8c2mh2d32vkf0033bs3vphx657gra6l"
+   "commit": "4382db5c4afc3beab0a356f8867bf480bddc5273",
+   "sha256": "1l2d4jrlkqgpz46r1l86d5qmxgm90165c1yy02w4c645kq8fz8yq"
   }
  },
  {
@@ -80531,11 +80988,11 @@
   "repo": "AjaiKN/minizinc-ts-mode",
   "unstable": {
    "version": [
-    20241227,
-    1909
+    20250831,
+    753
    ],
-   "commit": "0c01f72a6c767bb47ed6c01b70a5f6021fe191cb",
-   "sha256": "1mx0pxmzqjl65clhfxa1m7h65m6bckki24p0pzrk11v0j18l16xj"
+   "commit": "c449cde23b8101c589a4cce20b01ea1933978be0",
+   "sha256": "1cywp5pj3vp243lasmpiz96hlds2wrw9k1257dz15598wfh25msa"
   }
  },
  {
@@ -80600,15 +81057,15 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20250819,
-    2310
+    20250915,
+    517
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "3d0a2aca430313bd6c311c6530ec8d43f9a68937",
-   "sha256": "06d1g3ahb8ar2mr68flb99z2nkbnhyaqiv1skp20j24bgk1sz01l"
+   "commit": "2d9d2ad7768adf26fa54a8fdd8f6d78197a259f1",
+   "sha256": "1577ikw6wwx3m07lwwx6rccyz563c4l82ygfnkndhrp38nmzrzfm"
   },
   "stable": {
    "version": [
@@ -80671,15 +81128,14 @@
   "repo": "eki3z/mise.el",
   "unstable": {
    "version": [
-    20250804,
-    517
+    20250910,
+    1021
    ],
    "deps": [
-    "inheritenv",
-    "llama"
+    "inheritenv"
    ],
-   "commit": "9c7e891ddbe5726fd26943f4abed9fee800aac18",
-   "sha256": "0as4r1z6shn4i9gvvwri20vw2v4jxn33ss6mv8xv8jhxdg64rys9"
+   "commit": "60ef63466d07417a9ef956af363baae39c9ddf34",
+   "sha256": "1f0kshl9hkx5ssdkygiymgkgm6cvmmm8zrjkziqvlzy5kn01nmym"
   },
   "stable": {
    "version": [
@@ -81158,26 +81614,26 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20250815,
-    1335
+    20250901,
+    1611
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a3f9adf892908dac0fcb2a000934d824c599ab67",
-   "sha256": "02qg29sz07ywjbf8q9d29n6n7j0f8kl5psnb23d2md3f2czg49pv"
+   "commit": "001f14805830a4f9bc9fc263a0487ebe5acc3e92",
+   "sha256": "1048ynr3j1f5pnwp61j506nv55ff09iq6nz15jpdgd6rwncwb4r7"
   },
   "stable": {
    "version": [
     1,
-    4,
-    5
+    5,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0cb356097366e25dc9a4c95811a8a21a40b9de56",
-   "sha256": "17q8pxb8x90ghqha70r7mkdr540a6mw6l1j1dcvy9bw51hyfk5rx"
+   "commit": "001f14805830a4f9bc9fc263a0487ebe5acc3e92",
+   "sha256": "1048ynr3j1f5pnwp61j506nv55ff09iq6nz15jpdgd6rwncwb4r7"
   }
  },
  {
@@ -81188,11 +81644,11 @@
   "repo": "ideasman42/emacs-mode-line-idle",
   "unstable": {
    "version": [
-    20240801,
-    1318
+    20250918,
+    51
    ],
-   "commit": "f1224688be854183ebe939876f6ac8372d3e9679",
-   "sha256": "1042ma7c6hbb2shi2m834c7aajk2qbygxdl4fhnp20ipf1gqchbw"
+   "commit": "9275f772db735215f121edcd4498810fa90ea8d4",
+   "sha256": "0rrj86m5pg3mfqmvdvnbcyn5cvdi375yhv8qq89n112s9gy8zsqj"
   }
  },
  {
@@ -81356,11 +81812,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20250718,
-    410
+    20251007,
+    415
    ],
-   "commit": "f4e67c80c94fcae23f87517902a10eccc8ad99d6",
-   "sha256": "16k99i1rvw7x5hp4sgvhz2crmim8g8bzj8hkiqrfgzmb8hjr7hsm"
+   "commit": "cfa35451719e37ca07fb3734298eb0bbb569b377",
+   "sha256": "1x6xw7ab10i7b29vn5flny4vhhqcm3j2zk9pjxxkkcbk1da72c99"
   },
   "stable": {
    "version": [
@@ -81547,11 +82003,11 @@
   "repo": "ideasman42/emacs-mono-complete",
   "unstable": {
    "version": [
-    20250821,
-    509
+    20250913,
+    2251
    ],
-   "commit": "341f7a5871e8416ee9ebc1527893ecbe7ae6a3c3",
-   "sha256": "0pz44126czm3bajgj7jdbz0vwdgnj142g81whnknlp4d4wbdxzhk"
+   "commit": "6a641e3ece7286a4e84b29313b689b55379670ed",
+   "sha256": "0f1m2py1sgfga1h96q1x7s683ni0rzrbfdg60fxdcmrrk3rr2y6z"
   }
  },
  {
@@ -81718,26 +82174,26 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20250815,
-    1811
+    20250913,
+    1927
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f20101353fb89db8266107b82d3d82d2eead8ed5",
-   "sha256": "1rz2jai5gjs2n7ny6an9d8hbvgkdmvjikk8qvlj0fnx4ysxlar6f"
+   "commit": "293036f57cc97aa7c085c8044d76fca481f0b54b",
+   "sha256": "1sfdjp1qri6gimvbcpk8nlk9r7mjjv8c7ivgaf70vpik2a8d0lrf"
   },
   "stable": {
    "version": [
     1,
     1,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "404400af5415a35b5639dd1bfbc192751e85d737",
-   "sha256": "1m92yac6h4kzswwmjxc3qjhbqcmrgv6243h5zdpqbqrgkc9wmjp6"
+   "commit": "698376065e78201577b371ccd9a340b24cd59331",
+   "sha256": "1kkbsdw4xd3r81slfgqjrjm63qz3hz9a6v24zabs6rlpmlzmps72"
   }
  },
  {
@@ -82278,28 +82734,28 @@
   "repo": "mpdel/mpdel",
   "unstable": {
    "version": [
-    20250704,
-    1510
+    20250922,
+    929
    ],
    "deps": [
     "libmpdel",
     "navigel"
    ],
-   "commit": "3ef97e161329d37b1e02eefaae6a92dd970195a1",
-   "sha256": "1vfk8lp0x5hs6pqg2y1dcgl9zpvcii06rxwbbwnj4621hpjy6dck"
+   "commit": "006ccab29492cda567112be76e84e40e51d1f70b",
+   "sha256": "1i7ymg0ls984vjmzjz0sbg280i47c6j79vr725x94xdpj6ci35qr"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "libmpdel",
     "navigel"
    ],
-   "commit": "365b2661e56165c53eadd28d3e0a5f9d594412c7",
-   "sha256": "00ajjb9iawva3g7i1y6bz4d4ny3cv5rby6vgkwiy2xkprzxi8900"
+   "commit": "006ccab29492cda567112be76e84e40e51d1f70b",
+   "sha256": "1i7ymg0ls984vjmzjz0sbg280i47c6j79vr725x94xdpj6ci35qr"
   }
  },
  {
@@ -82344,26 +82800,26 @@
   "repo": "sp1ff/mpdmacs",
   "unstable": {
    "version": [
-    20240917,
-    310
+    20250917,
+    32
    ],
    "deps": [
     "elmpd"
    ],
-   "commit": "fca8374804216fb0533b5cbe92199dc4179033db",
-   "sha256": "0g2fyrl2sbdf1hp09cx5waqm500q3jnyiqm90544yn8cvzzavc95"
+   "commit": "e11d46925ce711de37352fb0a243a2cb55f873a3",
+   "sha256": "03r6lq7kzjxc1bz4wr1yw30knm6ivb6l3b06ag38xax160qphkgb"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "elmpd"
    ],
-   "commit": "fca8374804216fb0533b5cbe92199dc4179033db",
-   "sha256": "0g2fyrl2sbdf1hp09cx5waqm500q3jnyiqm90544yn8cvzzavc95"
+   "commit": "e11d46925ce711de37352fb0a243a2cb55f873a3",
+   "sha256": "03r6lq7kzjxc1bz4wr1yw30knm6ivb6l3b06ag38xax160qphkgb"
   }
  },
  {
@@ -82433,14 +82889,14 @@
   "repo": "lorniu/mpvi",
   "unstable": {
    "version": [
-    20250825,
-    1331
+    20250831,
+    853
    ],
    "deps": [
     "emms"
    ],
-   "commit": "c8f8ca22f156456a231e7c6195c5d7da167ef23d",
-   "sha256": "06mji6gw2hs3zqwf7ik1d4wvdbcw3m50ff0rc7mnj5z8hijf74xr"
+   "commit": "79a7bd0559b38b289e5463331a9f25336453f3aa",
+   "sha256": "1nwa8src13jxrycn10gpkhjcwl6y079bw703g0dgphvswzv38h4j"
   },
   "stable": {
    "version": [
@@ -82786,6 +83242,24 @@
   }
  },
  {
+  "ename": "mu4e-walk",
+  "commit": "cadaa91378dedc460d10761ad4268d829b9ed541",
+  "sha256": "0lrb0i1frqbisvkn88pm60a5jbl9x51i9jmma3aibwgb6nl6r4x6",
+  "fetcher": "codeberg",
+  "repo": "timmli/mu4e-walk",
+  "unstable": {
+   "version": [
+    20250915,
+    637
+   ],
+   "deps": [
+    "mu4e"
+   ],
+   "commit": "f062152e50b6354d122a763947acc6b305dc66ef",
+   "sha256": "0mm20air2k6s1p8ax85jkd3pl244xlhasfz52sadp4kk1aj4s7np"
+  }
+ },
+ {
   "ename": "mu4easy",
   "commit": "10f16723cf6565a0ae0284bf178322b6148b8090",
   "sha256": "1s20ygmdcxf0kzbj2an557lmcgk5qs9809l7068x9q8920g7hxld",
@@ -83095,14 +83569,14 @@
   "repo": "magnars/multiple-cursors.el",
   "unstable": {
    "version": [
-    20250210,
-    1813
+    20251006,
+    2038
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "89f1a8df9b1fc721b1672b4c7b6d3ab451e7e3ef",
-   "sha256": "01ccwbfrnc66ax4bngw1b6k9rzw0m85cm4s0wzk1gkdsc2z647jn"
+   "commit": "9017f3be6b00c1d82e33409db4a178133fb39d47",
+   "sha256": "1j4dd7fc78xjry2z2v4bsrwhmsg78rwdcdh3ipzdyjc6h1b1p3vd"
   },
   "stable": {
    "version": [
@@ -84290,11 +84764,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20250815,
-    814
+    20251008,
+    1720
    ],
-   "commit": "e98b14248fec120cc23c5f3a5aa1128d98156c2c",
-   "sha256": "0162hhvm9cqcxxaj3g918p06kcbhzk2iyy1hckdvagsg7sb24cjn"
+   "commit": "418f137faac926b822582fbce55a74a26e891ec5",
+   "sha256": "0lmyz9qsyv0b1l8a2wjkwmbcx5vagl2widxpffwfziq34a7x3r1w"
   },
   "stable": {
    "version": [
@@ -84314,15 +84788,15 @@
   "repo": "rainstormstudio/nerd-icons-completion",
   "unstable": {
    "version": [
-    20250811,
-    751
+    20250925,
+    1420
    ],
    "deps": [
     "compat",
     "nerd-icons"
    ],
-   "commit": "5625ef374d428e69f96c2f95858c8bc4db6f7679",
-   "sha256": "1mxrdwxs0wxfnm308af9jsgmk6qk91hday7dz4v2k87mljmfgrnn"
+   "commit": "63a6b3f1eb98bb381c86a1658ac401c8967079b8",
+   "sha256": "08p361rh5mv3ng10av1381kzl9s4msdjyca96hsgsh05qwq5pdrf"
   }
  },
  {
@@ -84363,14 +84837,14 @@
   "repo": "rainstormstudio/nerd-icons-dired",
   "unstable": {
    "version": [
-    20250727,
-    1932
+    20250827,
+    1819
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "5df0dd57022d0b3f565e05c5d9b3a8a723236676",
-   "sha256": "1zp41j9ly1b8b82kc0lai98l9m98fvy5xsvzsmv77jff333zam25"
+   "commit": "adf9a2bb5f3f13be7a676923639337f3fcc5d8c3",
+   "sha256": "0x1xmwlfjgbk5kk4bxvgz4ykwwgiwmdbzhgsw49kpzz678a3qzrp"
   }
  },
  {
@@ -84511,6 +84985,21 @@
    ],
    "commit": "f3bba59664e1c4c4ed47f16fa786151272d99a70",
    "sha256": "1a6r7cmxvg83fa285drli2nac9a56kyd2pn4y1vfcg7jiy6czhiw"
+  }
+ },
+ {
+  "ename": "nethack",
+  "commit": "0c8ce6463cc786f8181925ff9291bf5333056673",
+  "sha256": "0k05zjwdd3zlw8apxhx9d7l1n2mdxwcz6bjnr9af9xh06vqvis35",
+  "fetcher": "github",
+  "repo": "Feyorsh/nethack-el",
+  "unstable": {
+   "version": [
+    20250929,
+    1522
+   ],
+   "commit": "8c60ea5891b52273309eb7a77c1230a361912ec5",
+   "sha256": "11xrbmy3gxhl6dqyj6271m1y4hwv6z5b44nlcwzwcj2fwx7sa38s"
   }
  },
  {
@@ -84955,14 +85444,14 @@
   "repo": "ninetyfive-gg/ninetyfive.el",
   "unstable": {
    "version": [
-    20250819,
-    2039
+    20250829,
+    1430
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "6c3b47e4a53ce18e62e7a24f01988ac370d3dfe4",
-   "sha256": "0s2049jga3q28kbd4qrl0rka8d0cn6ii2sk1539wcqp7ickpf4w7"
+   "commit": "e330aa250b05dac98038fe794f9d34ee604f3a58",
+   "sha256": "1mxbw4pz4fmwqsn0ydvisrc7zggg1lzkxblbwngwmljdiy36jsaf"
   }
  },
  {
@@ -85358,8 +85847,8 @@
   "repo": "dickmao/nnreddit",
   "unstable": {
    "version": [
-    20250111,
-    350
+    20250831,
+    1249
    ],
    "deps": [
     "anaphora",
@@ -85369,8 +85858,8 @@
     "s",
     "virtualenvwrapper"
    ],
-   "commit": "c3ce69a8864d8333a390dcb20f78de3ba2c4111f",
-   "sha256": "1n82v2vhrmxg9pcqmxj63wpgk7rn9csbzv2vvgl1vfshh58swkr8"
+   "commit": "4b194b5953e9d4e6d94ce929fc264cd2b9e200a4",
+   "sha256": "066xirwjnx4b21slnz831j4z77vr49nw1cj56h060qm6404glyl2"
   }
  },
  {
@@ -85416,26 +85905,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20250812,
-    1334
+    20251005,
+    1557
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5930b1c6de1b54890c25b1d862071e9274f1b2db",
-   "sha256": "1jcyjchy6w2a57q22mcadf5rbsw58nmhf5z7i3q137z4m5z8mh05"
+   "commit": "d476ffe49674f5885b7d7889ed9fbcdf04685773",
+   "sha256": "1srmqffx5ccyck5aprggj8744g02g3cnj9qp1gk3zbj2lyvacwqp"
   },
   "stable": {
    "version": [
     1,
-    7,
-    9
+    8,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f12c3d9e44c4be099c226114ac95586f4d50df05",
-   "sha256": "1kjdx3g9vpb6yywalrmq475s4mgxy82dvl5iinhdj3rl3zdhjkzh"
+   "commit": "6e641890cd334434d0a0b576401a0f905a5b2f25",
+   "sha256": "01g0f908cqhm87xvyafbjv5fr1cag8msg8cb1dwzrid98ay3f4pk"
   }
  },
  {
@@ -86444,6 +86933,30 @@
   }
  },
  {
+  "ename": "numeri",
+  "commit": "114d6ef46fa39d5abaa3128c1b5fae8c86a7084b",
+  "sha256": "1qk5wijf80plsh8avzyln9l6m49038wq9bzk9bxnk30kkjhq38hl",
+  "fetcher": "github",
+  "repo": "kickingvegas/numeri",
+  "unstable": {
+   "version": [
+    20250907,
+    2357
+   ],
+   "commit": "625694f596d8f54be8ba8f2a8002287f4cd4f6de",
+   "sha256": "1z8m4v3s8dp9rfmkkmhlh9pz2sdhjfdgq09rp2bkkzw6802d9gsd"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "625694f596d8f54be8ba8f2a8002287f4cd4f6de",
+   "sha256": "1z8m4v3s8dp9rfmkkmhlh9pz2sdhjfdgq09rp2bkkzw6802d9gsd"
+  }
+ },
+ {
   "ename": "numpydoc",
   "commit": "e7e20f00482f143ac67589a48f7bc591e075b5da",
   "sha256": "1p2ls9qmbl58p4cyrk4f769blc72lfgbwd3sy4hhkv75m4qj4lws",
@@ -87157,20 +87670,20 @@
   "repo": "isamert/ob-deno",
   "unstable": {
    "version": [
-    20241228,
-    1629
+    20250913,
+    1628
    ],
-   "commit": "fae3e100cc5eed950a52d6cbc93130127ec20830",
-   "sha256": "10qpb0x05jx2ak3wgcp5l1zlljchwybiq0jbajyg5aazli3fhixq"
+   "commit": "d9225ecf2e4e111d75b1a059ec04448bc044f3d2",
+   "sha256": "0w5k49iw5rz92v2qlgvl7bhh2h5kabc9wnbmwpfkd57kdjdz0ykj"
   },
   "stable": {
    "version": [
-    2,
+    3,
     0,
-    1
+    0
    ],
-   "commit": "fae3e100cc5eed950a52d6cbc93130127ec20830",
-   "sha256": "10qpb0x05jx2ak3wgcp5l1zlljchwybiq0jbajyg5aazli3fhixq"
+   "commit": "d9225ecf2e4e111d75b1a059ec04448bc044f3d2",
+   "sha256": "0w5k49iw5rz92v2qlgvl7bhh2h5kabc9wnbmwpfkd57kdjdz0ykj"
   }
  },
  {
@@ -88215,6 +88728,35 @@
   }
  },
  {
+  "ename": "ob-ts-node",
+  "commit": "6dc1fac63bcf210e7c10fd62b44bfade13f582a6",
+  "sha256": "0hd94jny1wkwvnpx52685khw8fhnjccma24j287wf0jgsy8c5cic",
+  "fetcher": "github",
+  "repo": "tmythicator/ob-ts-node",
+  "unstable": {
+   "version": [
+    20250929,
+    1013
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "11e25ba2f73b56af66824f67dac167a0d5ae129e",
+   "sha256": "04j9d213ly3gqvwnsgchq262r5r88rjki1g2zzclawnrvhly7ffi"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "11e25ba2f73b56af66824f67dac167a0d5ae129e",
+   "sha256": "04j9d213ly3gqvwnsgchq262r5r88rjki1g2zzclawnrvhly7ffi"
+  }
+ },
+ {
   "ename": "ob-typescript",
   "commit": "11733cd33add89b541dcc1f90a732833861b10d9",
   "sha256": "1wpy928ndvc076jzi14f6k5fsw8had0pz7f1yjdqql4icszhqa0p",
@@ -88605,20 +89147,20 @@
   "repo": "OCamlPro/ocp-indent",
   "unstable": {
    "version": [
-    20250629,
-    1639
+    20251001,
+    1320
    ],
-   "commit": "12138576832400d7fbe6938258f646ddab314fbd",
-   "sha256": "0lzypyazc2dzmb154q1gpps96lmf00r3r2x3bxml3jd5l4ip2l6z"
+   "commit": "8aeb5cc580106366050de0068c11e20f8a947acc",
+   "sha256": "1zrf8sbh7m828bkj299kb0k3qknhafj7gnpiclc67qrwqxkmnmzg"
   },
   "stable": {
    "version": [
     1,
-    8,
-    2
+    9,
+    0
    ],
-   "commit": "9e26c0a2699b7076cebc04ece59fb354eb84c11c",
-   "sha256": "1dvcl108ir9nqkk4mjm9xhhj4p9dx9bmg8bnms54fizs1x3x8ar3"
+   "commit": "8aeb5cc580106366050de0068c11e20f8a947acc",
+   "sha256": "1zrf8sbh7m828bkj299kb0k3qknhafj7gnpiclc67qrwqxkmnmzg"
   }
  },
  {
@@ -88700,14 +89242,14 @@
   "stable": {
    "version": [
     4,
-    33,
+    34,
     0
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "b115947c3d22b5db39bfed9a43a0bdee112be146",
-   "sha256": "1qgxxydml9bibqiq5sqd4rjvmc8qdvrc136nlngqaan13bxkhfi8"
+   "commit": "20456112467fa6c962b242d1d6d4ddcc66488bd3",
+   "sha256": "16fmsczxzl19042i3qr48x3cynh9dj8kj9xglliq6a67nyz8c548"
   }
  },
  {
@@ -89638,14 +90180,14 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20250728,
-    243
+    20250922,
+    1344
    ],
    "deps": [
     "compat"
    ],
-   "commit": "31812d9252c6cfa7eae8fa04cd40c8b2081e9936",
-   "sha256": "0cgklam29vsfrl70n3cqv1dxbsnpzjylfxabfs9v1yz02q27nggv"
+   "commit": "9cf1c90e2501566ceba59f3220b4630995004efd",
+   "sha256": "04d3121q0k6lcm02f6kxr1r8ix5mi60j1d3qqalbhqb0yzgkvhm6"
   },
   "stable": {
    "version": [
@@ -90292,14 +90834,14 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20250813,
-    918
+    20250918,
+    2242
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "32c0790c7f116d1346e8727374baacd4254c2c27",
-   "sha256": "1xxzdmaal2pyj4a7kv5ai7qp1ql84d9wm47chp339rw476d3xm1w"
+   "commit": "5850ff12e6483299ff379415c099ea40b1180882",
+   "sha256": "0p9v0jvk914zg8xl9ndkcjxan1llgdnmynb3cjwa3nz5ijmm55ab"
   },
   "stable": {
    "version": [
@@ -90788,14 +91330,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20250820,
-    1803
+    20250905,
+    335
    ],
    "deps": [
     "org"
    ],
-   "commit": "532dcbf680dcd8f1b314a19628b71d381c38aee2",
-   "sha256": "05alncn93blpyy317797l182znczrjsb5wnhvn5lg4s5v3fmi3nw"
+   "commit": "41f10b9ab07f267613d77e98ef7a33b1772292b0",
+   "sha256": "1aqvq1wca7csi7mrgy1gvy1lgq6ybi9ap030zwk697hvz8i0d59g"
   }
  },
  {
@@ -91563,20 +92105,20 @@
   "repo": "krisbalintona/org-hide-drawers",
   "unstable": {
    "version": [
-    20250613,
-    507
+    20250924,
+    732
    ],
-   "commit": "995de47ef3652d76d53eed043e50fba9612b77c7",
-   "sha256": "0dfcahd3j6s4jd3gn4wbpk0g5qsxp82p58cfi76y5f0l9sv4q2ip"
+   "commit": "15c8fa7fe5b15e09a751699ce780dde7edf7b5bd",
+   "sha256": "1s1wlhbd0k10p1d93f7vi29jsm2kh2ws7bqwc9r2fjqd0hgcaz8x"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0,
-    2
+    0
    ],
-   "commit": "fe6c2e40d439e1cef518eba97e4f8a02a2eb2592",
-   "sha256": "1l460a4f6lbsa3c93qx0vi1l0lbxy86qx6rbsgf2vydywyrqfifs"
+   "commit": "15c8fa7fe5b15e09a751699ce780dde7edf7b5bd",
+   "sha256": "1s1wlhbd0k10p1d93f7vi29jsm2kh2ws7bqwc9r2fjqd0hgcaz8x"
   }
  },
  {
@@ -91707,30 +92249,30 @@
   "repo": "marcIhm/org-index",
   "unstable": {
    "version": [
-    20240923,
-    1249
+    20250914,
+    850
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "0a0da7babec429422d622095e728d9ae02c50913",
-   "sha256": "14y19r9q1ihi0j1d9si7np9kjdfzkpcr0l9qyk00lqfhywhzbwar"
+   "commit": "77bdcefab4cfc673844e21eaea7b446e40498ef6",
+   "sha256": "1m0x34g9fgmiphaimi617wv67f4npciwsgh2nqsc7yij0rp9hx77"
   },
   "stable": {
    "version": [
     7,
-    4,
-    7
+    5,
+    0
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "0a0da7babec429422d622095e728d9ae02c50913",
-   "sha256": "14y19r9q1ihi0j1d9si7np9kjdfzkpcr0l9qyk00lqfhywhzbwar"
+   "commit": "77bdcefab4cfc673844e21eaea7b446e40498ef6",
+   "sha256": "1m0x34g9fgmiphaimi617wv67f4npciwsgh2nqsc7yij0rp9hx77"
   }
  },
  {
@@ -91917,16 +92459,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20250802,
-    302
+    20251004,
+    1853
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "c7259fa13b8eb99a988b06cdaf3a04f9109904de",
-   "sha256": "0r4chf0gchhwarrr7rnhf0fpgczqgjmcirlw6cdc87x8lyx7as13"
+   "commit": "3f4bc7f984301b458c193c47931e8098eca2189d",
+   "sha256": "0wjhfb8bamcn07f5hzq6gv4m8z8l2cgq8x05dajwkb5gyp34rxm2"
   },
   "stable": {
    "version": [
@@ -92124,15 +92666,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250821,
-    537
+    20250919,
+    1411
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "01d015a3b5935cfd69a6a4fafaf30fd3c5d80643",
-   "sha256": "0hp0h2mqgc0ayr5cgdzmjs440ivz84jr887vw79wh07ga025qydq"
+   "commit": "a1231808b47fa1bdd99a1e0701f139b772fb1352",
+   "sha256": "106j1bcfxjkcv7rjy5xfx7wzhgzy3mlz6j9n8r84ynbfaaz82mvr"
   },
   "stable": {
    "version": [
@@ -92293,28 +92835,28 @@
   "repo": "meedstrom/org-mem",
   "unstable": {
    "version": [
-    20250715,
-    1048
+    20251008,
+    1625
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "a99cd068737caf5d9d6c1ea7444f8a6b3c2e57a7",
-   "sha256": "1nm1avc0hbvhr43vkfw3jssiqyckd7ba6jw0qhvgcvk49df393wf"
+   "commit": "8c057cf3dd463e2d61cc2f95b5c43afa4374dba9",
+   "sha256": "10c94qk4dnjbqw3hw0nfd9fxlrlnvrwwglx0hlgynq4xb9yc63w4"
   },
   "stable": {
    "version": [
     0,
-    18,
-    1
+    23,
+    2
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "a99cd068737caf5d9d6c1ea7444f8a6b3c2e57a7",
-   "sha256": "1nm1avc0hbvhr43vkfw3jssiqyckd7ba6jw0qhvgcvk49df393wf"
+   "commit": "521864ca617a62430553a17b8ed49597ded6ce88",
+   "sha256": "1yrax4qmaqczmpmqd4k19fbqh3lsnf36nc0k0dwya9gr9ibmls3f"
   }
  },
  {
@@ -92420,15 +92962,15 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20250611,
-    2334
+    20250924,
+    1705
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "16bef888cb8e0198dd26f869b85c10c4491a3444",
-   "sha256": "08ddrzqvlckj10b0anhdis6cfx448dw3n027cswklmzx6bj3rmfz"
+   "commit": "6c1c38d87fcaa794b64d847851fc54580c3e3b57",
+   "sha256": "0ws6zjwz5kpy1by8ki0sqgvzdpip5mf93nlpkjzfvhvmrarjnrxx"
   },
   "stable": {
    "version": [
@@ -92656,30 +93198,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20250718,
-    1701
+    20251007,
+    2201
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "c032a0bc238dd8df5a71868cd5c736e258dd9918",
-   "sha256": "1xlxf12g16abizfb0y86kfcyq62v8z538dawmy8sxc0232d41iy7"
+   "commit": "57c57017b42167401d5eed8b62ad3e11f7714c7b",
+   "sha256": "1axqak9ml97jvwlvd6izvricxc9wdm7kf61x7hlfi4wcwd27x46b"
   },
   "stable": {
    "version": [
     3,
-    7,
-    4
+    9,
+    1
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "b5a07fcfb793ffc75dfab04962807b42d7d0b38e",
-   "sha256": "1cxzdyiqan4881m7fpzxym1gkplqlyagl3bj1pwa7a5bswhld40y"
+   "commit": "a9f4236f61bbc3e3f46eeb85666f47527a2ac9d3",
+   "sha256": "0nvi1gjll8qlin2adv556wgd030rzjzdj6wpflldw16m87cff7x0"
   }
  },
  {
@@ -93547,8 +94089,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20250823,
-    1744
+    20251007,
+    2258
    ],
    "deps": [
     "avy",
@@ -93564,8 +94106,8 @@
     "request",
     "s"
    ],
-   "commit": "6a22c20f863b997497b618507adbcc8cb10a9f86",
-   "sha256": "0915v798xvybac3p53gwwf34v8p728s1s5msp29mw8j9n8zzcfbm"
+   "commit": "b7510442d0cd9765b53717fe3a37d7cef33a72d1",
+   "sha256": "1xx2jd1795gaqmi4ryvvc14s7jw6a34a8nrc2k9g5ybk9sx0i2kj"
   },
   "stable": {
    "version": [
@@ -93607,6 +94149,30 @@
    ],
    "commit": "0ec3b6e398ee117c8b8a787a0422b95d9e95f7bb",
    "sha256": "14cs9qg1fszg9gxpkrf74b49avcx4smpr39z7a9k3n2w6v4dn19x"
+  }
+ },
+ {
+  "ename": "org-repeat-by-cron",
+  "commit": "c3909dbc9c556367225d6b2210fd6c167dff60a4",
+  "sha256": "0qdhb11jqf1zcb3dcizr6ymnm2fzb29h92fvk9pz7ilalrgchhcc",
+  "fetcher": "github",
+  "repo": "TomoeMami/org-repeat-by-cron.el",
+  "unstable": {
+   "version": [
+    20250922,
+    610
+   ],
+   "commit": "1bd31d7aa0b372703db0b32c7e4c9fd99b54dc34",
+   "sha256": "1m543520z3ix76ydryg1cdw10x04g094db4iyq22jkkhrbp54v9i"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "1bd31d7aa0b372703db0b32c7e4c9fd99b54dc34",
+   "sha256": "1m543520z3ix76ydryg1cdw10x04g094db4iyq22jkkhrbp54v9i"
   }
  },
  {
@@ -93688,11 +94254,11 @@
   "repo": "unhammer/org-rich-yank",
   "unstable": {
    "version": [
-    20250304,
-    907
+    20250923,
+    919
    ],
-   "commit": "66414a3c8c9de97e23e6d0edfb05abbaaf8d00a9",
-   "sha256": "0p8v2bj3dn9a80ls6bzn3a4lf2d131s284mfs6aab72z1vgf22v2"
+   "commit": "fe2ba1c9d9f1f7943d8f76879a1b2b9b15928147",
+   "sha256": "018vm4yr8s6phdmmvyqav3a6ajrz33373nfvkqqcjal68hlyz4ny"
   },
   "stable": {
    "version": [
@@ -93712,8 +94278,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20250701,
-    528
+    20250927,
+    2243
    ],
    "deps": [
     "dash",
@@ -93721,8 +94287,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "89dfaef38b6caa3027f20f96a551dc8f194ac533",
-   "sha256": "0lxblmbc87ra5wa9rs2y1qd6zmy4ihg6vhkhf9g147vrmpjfp6d3"
+   "commit": "41f9a10be587b47454ca8ef26f6a8247605cbe34",
+   "sha256": "1caxsm6vg04c0vny0bi7sh3zhnabsr2d93xf7i51v17hxz2dhx0c"
   },
   "stable": {
    "version": [
@@ -93780,8 +94346,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20250722,
-    1724
+    20250923,
+    2102
    ],
    "deps": [
     "dash",
@@ -93791,8 +94357,8 @@
     "s",
     "transient"
    ],
-   "commit": "9fb452eed0dc4ac8641d8629e4fa9f9fd0bdf6da",
-   "sha256": "01rjfjd88fpa20nivdinfnnbq5cm0s9madi7xgwqd09x04mqxsw5"
+   "commit": "e51853205fa7129484786a6787f8b6b8a130f6e0",
+   "sha256": "07jxk8q86z0a7mvc15p0dm63lnajkcc7j7d7l9di76k4d0x1vfh3"
   },
   "stable": {
    "version": [
@@ -93818,8 +94384,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20250424,
-    2227
+    20250902,
+    1916
    ],
    "deps": [
     "org-ql",
@@ -93828,8 +94394,8 @@
     "s",
     "transient"
    ],
-   "commit": "72634dadc224786284c7d733f67900f2a514eab2",
-   "sha256": "00v3rwpbwpyn5vjpga2kaxvj044gvhjpz8bzdlf5cif5sjpvy3zx"
+   "commit": "5feceb8f79734a3abcaef9cf2f787d5aa45e750f",
+   "sha256": "0qag1jmv498g6l1axx3d5h2wbvnin9f89qdvzyiillzjrs6rgm1w"
   },
   "stable": {
    "version": [
@@ -94194,15 +94760,15 @@
   "repo": "bohonghuang/org-srs",
   "unstable": {
    "version": [
-    20250818,
-    1726
+    20250921,
+    1133
    ],
    "deps": [
     "fsrs",
     "org"
    ],
-   "commit": "51856d234b8683c3502b5366d0eee512061bce04",
-   "sha256": "1jlva1a5llrsxscg1qfab1a5s3bf6dxkcllhm9d5dgsycb644jyg"
+   "commit": "d5cfa9964da631273af9c57aba444cb877efd14e",
+   "sha256": "0gjkq9kbx3gxwzshh868v3qv8n3kgvnd8pk8rz84n84m0mdlxd26"
   }
  },
  {
@@ -94367,26 +94933,26 @@
   "repo": "integral-dw/org-superstar-mode",
   "unstable": {
    "version": [
-    20230116,
-    1358
+    20250914,
+    1308
    ],
    "deps": [
     "org"
    ],
-   "commit": "29dbbc48ac925f36cc1636b36b4a3ccb3588e17f",
-   "sha256": "0bk7c1hlkdrfhah18i13yi3819m4wv5b5lwpnyg292b4k25p39nj"
+   "commit": "ce6f7f421f995893f72d75ffdfa92964b9bea2e3",
+   "sha256": "0fgxmpv54sm7jcrbpka64l4p7bp57sy07mzrzviz00pss44sqyyi"
   },
   "stable": {
    "version": [
     1,
-    5,
+    6,
     0
    ],
    "deps": [
     "org"
    ],
-   "commit": "9d64c42e5029910153ec74cb9b5747b074281140",
-   "sha256": "12inin2p6pm6vbv3yc06fx343dsp0vp07fjb35w088akhikmqh2a"
+   "commit": "6320fc8be629a2e79b46f2271061d3503f65ff1d",
+   "sha256": "1hz4m3axcnsvwmal0fsr2b3s6wa9gzxd5rkk4r74lmsz36x5yl0h"
   }
  },
  {
@@ -94532,14 +95098,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20250410,
-    1242
+    20250921,
+    154
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "9df9782fc6d68e7271cf164212d0ad37bf6d85f9",
-   "sha256": "1kcxw9mzlx2pw2p6i6ib4ll6dg6h2h9bdd888ahmxdhkdjah78v3"
+   "commit": "54e2e60cd3738072351e6dd7720bc652f5fbbabe",
+   "sha256": "1c2cshdgmk30y2rqnwd4cxm5jkk24rmc9162m5pqijgqmh6f9k0h"
   }
  },
  {
@@ -95072,20 +95638,20 @@
   "repo": "pinoaffe/org-vcard",
   "unstable": {
    "version": [
-    20250823,
-    1318
+    20250828,
+    809
    ],
-   "commit": "d160870fa80b08007ea1a0f6bf1cc35f9ba6db1d",
-   "sha256": "1dbsiihs5rmnk35xqymabjrxprn5jrjf4wjrslb0kvz5ig4vphxq"
+   "commit": "03c504c34e5c31091d971090b249064e332987d7",
+   "sha256": "06w4w3wxsrbv67ssnlpk8sj4jg4qvgc87cyaiin8h9f4az3yivkz"
   },
   "stable": {
    "version": [
     0,
     3,
-    0
+    1
    ],
-   "commit": "d160870fa80b08007ea1a0f6bf1cc35f9ba6db1d",
-   "sha256": "1dbsiihs5rmnk35xqymabjrxprn5jrjf4wjrslb0kvz5ig4vphxq"
+   "commit": "03c504c34e5c31091d971090b249064e332987d7",
+   "sha256": "06w4w3wxsrbv67ssnlpk8sj4jg4qvgc87cyaiin8h9f4az3yivkz"
   }
  },
  {
@@ -95577,30 +96143,30 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20250601,
-    1057
+    20250901,
+    1810
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "224350397df0987f8cdc770eb7f4618eca34a727",
-   "sha256": "0vnqzhvizq3xpcbarcvfdp4m89vxwbzf7dqm3izr1qcqmw2rd1cc"
+   "commit": "8493c248081a9ed71ad6fd61e4d6b48c8a0039ec",
+   "sha256": "1nz9fy4348iha1zbw0v8hzsxv171v5758jilhsn2ksn9nvpkbbyb"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    5
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "224350397df0987f8cdc770eb7f4618eca34a727",
-   "sha256": "0vnqzhvizq3xpcbarcvfdp4m89vxwbzf7dqm3izr1qcqmw2rd1cc"
+   "commit": "8493c248081a9ed71ad6fd61e4d6b48c8a0039ec",
+   "sha256": "1nz9fy4348iha1zbw0v8hzsxv171v5758jilhsn2ksn9nvpkbbyb"
   }
  },
  {
@@ -95611,8 +96177,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20250601,
-    1059
+    20250901,
+    1806
    ],
    "deps": [
     "compat",
@@ -95621,14 +96187,14 @@
     "org",
     "orgit"
    ],
-   "commit": "050590fbc79bc3acd0ab87c0257f6719bff1e33a",
-   "sha256": "02l9l5s8ncv92k2zijgi1jrqfjf24310ydxa8mj3j6m3vz5i0qjv"
+   "commit": "5a0dbe26012b2e7885895f80283ba8974a1e8b38",
+   "sha256": "0cz2bzpkk3sjsjcycbdfykhchghx1mn76qxx3pbr2a7qjh7zfdd4"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
    "deps": [
     "compat",
@@ -95637,8 +96203,8 @@
     "org",
     "orgit"
    ],
-   "commit": "050590fbc79bc3acd0ab87c0257f6719bff1e33a",
-   "sha256": "02l9l5s8ncv92k2zijgi1jrqfjf24310ydxa8mj3j6m3vz5i0qjv"
+   "commit": "5a0dbe26012b2e7885895f80283ba8974a1e8b38",
+   "sha256": "0cz2bzpkk3sjsjcycbdfykhchghx1mn76qxx3pbr2a7qjh7zfdd4"
   }
  },
  {
@@ -95702,16 +96268,30 @@
   "repo": "isamert/orgmdb.el",
   "unstable": {
    "version": [
-    20250104,
-    1911
+    20251009,
+    711
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "04c4ea707b7313c3613517baabeae209e2b08a52",
-   "sha256": "1n24v2nlbr99rl2x2cvxfav7vj51x104myvsfd6cqia661vhrpsy"
+   "commit": "405df0ac4045c9cb794348f95f24a8b8fb777c42",
+   "sha256": "0mqcjf27madg1hyb1l8vsikxzyrbl2cx3n5k19vr63m22j5655p3"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "dash",
+    "org",
+    "s"
+   ],
+   "commit": "4dc658b016f48882730c2cbc2d6de2c39283dbaf",
+   "sha256": "09c3mslhnrqx6xy1js7zckrfc3pk5yvh020bj55845w8knlamjg0"
   }
  },
  {
@@ -95804,11 +96384,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20250824,
-    1449
+    20251009,
+    1306
    ],
-   "commit": "12bcbbe37c883329ad773020fafe90063142abd1",
-   "sha256": "0j20xwxd9jk0xqx2a5khn8pkbjagp1vj17jjrw5l7iw9h9kpkwdv"
+   "commit": "cea1e05009aa6608e1ed627efa1746930d857703",
+   "sha256": "1a0300cwcljswjr5n47dpbas3zi6bl90nanbd7ylvanikaa0gxg7"
   }
  },
  {
@@ -95849,11 +96429,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20250723,
-    1118
+    20250922,
+    545
    ],
-   "commit": "d434bd138726e77f34a0e77d5de8416d6322b9f4",
-   "sha256": "17mka8m6m9v4wmx87mzn4wx1j2yagl59f96clx3vq0fks555sxfr"
+   "commit": "08c0206bbd01cad8eb436f456c91e285e343935f",
+   "sha256": "0wf2j5cf8axyiqk9q738p8gbps576rasnchsgxr3qwm9hgxq5a7q"
   }
  },
  {
@@ -96012,14 +96592,14 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20250404,
-    1131
+    20251008,
+    1041
    ],
    "deps": [
     "compat"
    ],
-   "commit": "72112b358c41d2147122b217d11f272a22f285e4",
-   "sha256": "0fw0hgi2542ivc05dbq07ybr8c2mf8ja0z3f07lnslvn7vn5xp9i"
+   "commit": "b7aa47fbc23711d539705d7a4ad5949f587d173e",
+   "sha256": "0ypx9fvbyhl3i64klg71r979gvd6xz1a4f0dvkannsnldxzg85lp"
   },
   "stable": {
    "version": [
@@ -96285,26 +96865,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20250728,
-    801
+    20250909,
+    2023
    ],
    "deps": [
     "compat"
    ],
-   "commit": "62b6ea6fed5fcc644ff9e3b9cb6cb64d3557814a",
-   "sha256": "1wgcklrf10lkfik5qicim66f95l3f3j667b9mjdmkffjf0gy6rgb"
+   "commit": "fb8e72b924013443ba810ad5347d6ca39f005158",
+   "sha256": "08jpxyabjvicvra757ykmskvdkq332bjwcr8gmqax8bvx0x6qyax"
   },
   "stable": {
    "version": [
     3,
     3,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "33ac081b88dd8318a0bb69a973eef9bbbc3eb5e6",
-   "sha256": "1jfj1q54b62l7xhjvmajrwz1ps547v5z174w9d44yph9b3jqllww"
+   "commit": "fb8e72b924013443ba810ad5347d6ca39f005158",
+   "sha256": "08jpxyabjvicvra757ykmskvdkq332bjwcr8gmqax8bvx0x6qyax"
   }
  },
  {
@@ -96359,11 +96939,11 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20250823,
-    40
+    20250921,
+    2109
    ],
-   "commit": "f588cf965e5dea1102f38aebb9f06baec99254dc",
-   "sha256": "0iapy4wyadds6b5f5187priv3vpvp6gqw3yn9fpx443qwdvxygfw"
+   "commit": "c99cf257ab5c34cb894bdd6238be9dda9fce9e85",
+   "sha256": "0gzxrq57az4d6vk0m3j2j8klig81qckzr57q2m2r7i7zgp6q5xxr"
   },
   "stable": {
    "version": [
@@ -96398,26 +96978,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20250823,
-    1716
+    20250901,
+    1338
    ],
    "deps": [
     "compat"
    ],
-   "commit": "52a674c70923c08cf81ce97a706513ebec55efe6",
-   "sha256": "0x1hm7w6w07rdb12gjcsw416p2bhk7wf4pk720ygl1x3hnrkih9y"
+   "commit": "2e7a99b07108e6cc34da16e33746c770a2c20f32",
+   "sha256": "1bgx8lp7qc6vsd6fb2qh92vwsfjz63ma2jsrch6h042nsnvyvx7s"
   },
   "stable": {
    "version": [
     1,
-    1,
-    4
+    2,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a82db0dfe97cf5948d86a5c40d5e38c1ad710f69",
-   "sha256": "1l4dymnzp97qnd92pr8hd29fi9iyq2v26qlcbnnhbn32znk53r53"
+   "commit": "2e7a99b07108e6cc34da16e33746c770a2c20f32",
+   "sha256": "1bgx8lp7qc6vsd6fb2qh92vwsfjz63ma2jsrch6h042nsnvyvx7s"
   }
  },
  {
@@ -96653,14 +97233,14 @@
   "repo": "anticomputer/ovpn-mode",
   "unstable": {
    "version": [
-    20210403,
-    440
+    20250916,
+    7
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4492098c771d094dd0661a5bc6906f65fb530825",
-   "sha256": "1dqy50mvnffhsmfnrkf6n4xic7699dhx4ky2chmcsr6yly3gvwj1"
+   "commit": "0474294b76f3a7b468c94090352fe71f7aedeebf",
+   "sha256": "1vc2lk9agd8v0i6gnzjrcni3cfqjaqiprv1qr6jjn9scvix5j4wy"
   }
  },
  {
@@ -96784,11 +97364,11 @@
   "repo": "fjesser/ox-beamer-lecture",
   "unstable": {
    "version": [
-    20250407,
-    219
+    20250918,
+    358
    ],
-   "commit": "77546eaf9ac8f94b6079720f1d93c33dbbcc4108",
-   "sha256": "1yhmarx2af98ff43h8lrc9r6p85c6xk4k9l26bv2wkcwpvqgkh54"
+   "commit": "d9cb630ab5d9e5ef58f68216a4b9e472d67eb46e",
+   "sha256": "1sj8hdywwnj60v08d3qx8s7gk5x0q6dw5nc1wqss9yfqjq76b2lw"
   },
   "stable": {
    "version": [
@@ -97147,11 +97727,11 @@
   "repo": "DamienCassou/ox-linuxmag-fr",
   "unstable": {
    "version": [
-    20250825,
-    2001
+    20250907,
+    1103
    ],
-   "commit": "1273146d58ca05f2e43278e9d15787f1b39c70a4",
-   "sha256": "1vfblkihy9ixiv1v76jijsn9n7iwhq1c283ihcnlwxqklbwni8c2"
+   "commit": "67381be882a384e0e0ed810b24556148c0eb6b9f",
+   "sha256": "1wshd4kfd68bsb5rcynv2fs7ss2qdvclxpmhwxg67pl2wj6a834k"
   },
   "stable": {
    "version": [
@@ -97639,14 +98219,14 @@
   "repo": "jmpunkt/ox-typst",
   "unstable": {
    "version": [
-    20250704,
-    1835
+    20250926,
+    1502
    ],
    "deps": [
     "org"
    ],
-   "commit": "5c855902fe11c10292e495501e7f1b4adbb53d16",
-   "sha256": "1ycagrb2valm5wlabknagjbd3xyx1g7lri2j5l5mxb2d709105lk"
+   "commit": "cc7e9665d4eabe0a8e0251408392f9578c7b1dac",
+   "sha256": "05lfwwyfn62599ji2j12c2z0i28dq1qp5g7qgmjiv8bg56lck6z0"
   }
  },
  {
@@ -97973,14 +98553,14 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20250819,
-    1304
+    20250828,
+    1506
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "078f403d57e3056338ef45e37973e7a27297f545",
-   "sha256": "15hbh13prjmavy4563xwaaph9jnmxy3mabwjnj63wa1x5kf4lrzk"
+   "commit": "f990665a1b4ca9eadbfcdb0b2a22fbb819e78ef4",
+   "sha256": "0gkbflngwmig398p44niwf43cx3gjzck9k9ybfci73c8d9kdfqcr"
   },
   "stable": {
    "version": [
@@ -98358,8 +98938,20 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20250225,
-    852
+    20251009,
+    956
+   ],
+   "deps": [
+    "dash",
+    "hydra"
+   ],
+   "commit": "dfe1013e386f0af067c43d187e23254649060e64",
+   "sha256": "09z20z0bng6jfgwgwrcpr6v3qvg47584i2w2hkk3mb637rfqay3r"
+  },
+  "stable": {
+   "version": [
+    2,
+    35
    ],
    "deps": [
     "dash",
@@ -98367,19 +98959,6 @@
    ],
    "commit": "d7f6fa119bb0e883cfd615009d197e4b87916033",
    "sha256": "0dyf0d5qmshbf5zi2kimplj1byrdhm31yx3fr0mvnq5hp076820d"
-  },
-  "stable": {
-   "version": [
-    2,
-    34,
-    1
-   ],
-   "deps": [
-    "dash",
-    "hydra"
-   ],
-   "commit": "bbb687a6ad9d8af07e38910a0bffeb707b334688",
-   "sha256": "1kraah7663cr9lsymqff25ad80nlih94y871byd925nhyl908kfl"
   }
  },
  {
@@ -98612,26 +99191,26 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20250822,
-    1936
+    20250901,
+    1803
    ],
    "deps": [
     "compat"
    ],
-   "commit": "88cbcf779d3c382cf785a540a2134a663b753d7b",
-   "sha256": "0rxrcnpsar1550ihfr6a8qf0cx1p5va14cdx70ykqzfpvcbg5rdw"
+   "commit": "ccbf5f5a61f469e40bc7971e6b033d1ee35bf14d",
+   "sha256": "04b4znak3qzy482byyv4z6i8nnvbg6d7y2jwmicgjpn53qspzsr7"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3804fde5c6da5bd92413e471a2a0c6df224d0946",
-   "sha256": "1fsrbkxanjjrlybxmwhzxn7a6jh73r4hpz5m5zva52p2fb09g387"
+   "commit": "ccbf5f5a61f469e40bc7971e6b033d1ee35bf14d",
+   "sha256": "04b4znak3qzy482byyv4z6i8nnvbg6d7y2jwmicgjpn53qspzsr7"
   }
  },
  {
@@ -98780,11 +99359,11 @@
   "repo": "joostkremers/parsebib",
   "unstable": {
    "version": [
-    20250316,
-    2257
+    20250922,
+    1100
    ],
-   "commit": "7bfde4e4679413424a9a9af099203d5c23e32cd2",
-   "sha256": "180lvlq6xfri1lag85s6478x8cv4iccj6qk2rag9nm19yrhxfh7a"
+   "commit": "4a9df6f1b4f37bbf4f8712eac99c8a25698f1c0e",
+   "sha256": "10qz1d1rj52p3naz8srxxsagi2hl97nfphjyggkn42nx3prpisr6"
   },
   "stable": {
    "version": [
@@ -99615,14 +100194,14 @@
   "repo": "krisbalintona/pdf-meta-edit",
   "unstable": {
    "version": [
-    20250321,
-    2317
+    20250912,
+    1306
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8c2690f070d79e7cb495c0d3e04b48db2a2bbc3e",
-   "sha256": "0nlk2m652jzccy1lcpxmhjhjdcbkikg8nggpdlsscimrf9hid0f6"
+   "commit": "2e12f57480c831f069bcf71fe91c9f52ff06319f",
+   "sha256": "0gim4kzlik13avjgyvwclgkrs4pv4ap7jdn4kn6f19h8fvq4gys8"
   },
   "stable": {
    "version": [
@@ -99960,20 +100539,20 @@
   "repo": "jamescherti/persist-text-scale.el",
   "unstable": {
    "version": [
-    20250822,
-    1937
+    20250915,
+    132
    ],
-   "commit": "d73c195cd2abd3941c50941552349951bcaa1f25",
-   "sha256": "05nv8f98ywnpm7rrkrcf8l68v2kzmcklsr65p3fh0ly0bmcbsc0l"
+   "commit": "235e37b1ca38816b3bb882f7a40bb109e8739ea8",
+   "sha256": "1k2p7z95j331kw77q68151400723c6w4afjgrbgdjfj52przsxrk"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
-   "commit": "84127d1a54ed55e40038b1f12828f4ad26146dfc",
-   "sha256": "0gc3v6j9ggh4av29r41zyndn5jzdjab8240jcs4d1x7ifnyiz7w5"
+   "commit": "235e37b1ca38816b3bb882f7a40bb109e8739ea8",
+   "sha256": "1k2p7z95j331kw77q68151400723c6w4afjgrbgdjfj52przsxrk"
   }
  },
  {
@@ -100087,11 +100666,11 @@
   "repo": "Bad-ptr/persp-mode.el",
   "unstable": {
    "version": [
-    20250814,
-    1552
+    20250830,
+    955
    ],
-   "commit": "82680795b3dbb9f9fb023b1754902f38519d9875",
-   "sha256": "1q43i9m4jqwmzj2k431c697am8kgwd8ydhpc7zl6jvf2hphxxv1d"
+   "commit": "fab4bf76927445d2e431f06e74572acba81f47d5",
+   "sha256": "137nqrkg31pczyqk1mccmk5x42dzq9yy3vzy7hz0mbif20dz4a4h"
   },
   "stable": {
    "version": [
@@ -100354,25 +100933,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20250823,
-    2007
+    20250928,
+    1446
    ],
    "deps": [
     "peg"
    ],
-   "commit": "614617eb2c342feaa91a88caba87107bb5194040",
-   "sha256": "0lk2byk0dydxxaw0k7qfs734dyfi5ya0y9x364qhkkakv9l07j67"
+   "commit": "5063ec8bb8679ba40b1423b6cc1b086cfb735803",
+   "sha256": "056v8phxw87gzkny6hqbibq659qbb00yxl2s9y100l7y1azsvcqs"
   },
   "stable": {
    "version": [
     0,
-    58
+    60
    ],
    "deps": [
     "peg"
    ],
-   "commit": "991bd9429d30b05a351fe2d46e628569ce6b661c",
-   "sha256": "1vzd3wj9nwhnp2whxfy6z6zfig3hr1vm4d0zgzaz1zjwicqiznjn"
+   "commit": "215cec9499d9069b387a4638a00b16c08d1e0c19",
+   "sha256": "143np0qsfk73zzbkpvyj89x135rf9x957yl1wn5psz1x9hp2m195"
   }
  },
  {
@@ -100811,17 +101390,16 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20250519,
-    1806
+    20250930,
+    1244
    ],
    "deps": [
     "async",
     "composer",
-    "f",
     "php-runtime"
    ],
-   "commit": "207366ad4d67921e4da68e1e97a98c7f03bb3ee3",
-   "sha256": "114fbxvakfpjlsylcvvbr39jsxaya4laf52zkm353d25k0icbprs"
+   "commit": "8526ce3b4f49136d2a48e295ee4c72ceefa98f16",
+   "sha256": "05g5v7yghrywg3sqqwlixi4yjkcbd9cczijbnz1j5lh9vaj6ff4g"
   },
   "stable": {
    "version": [
@@ -100845,16 +101423,16 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250522,
-    1315
+    20250930,
+    1139
    ],
    "deps": [
     "compat",
     "php-mode",
     "php-runtime"
    ],
-   "commit": "8a6720a58589cb5c9a1da2b96475440f472932c5",
-   "sha256": "146sw6i7dphk8mfmnf95wpfwi3yx2slkf1m2s9qhvlhvnj246b16"
+   "commit": "07ef7531f2ec73b90a965ac865cca8c96086f9de",
+   "sha256": "1myzqbd00892a604kg88bxglk0w6valdvmaybsixapr5wgg2sbri"
   },
   "stable": {
    "version": [
@@ -100992,11 +101570,11 @@
   "repo": "johanclaesson/picpocket",
   "unstable": {
    "version": [
-    20221101,
-    2104
+    20250830,
+    1131
    ],
-   "commit": "30942846bd8cb95a938a534ed9ed9efeff813b7c",
-   "sha256": "0a6jnnl74z1nr1w4qkllil4vv5k669vkjl5z6zc42b4sb5qrksw7"
+   "commit": "9fafd11824fd81cd884c20ff7243d6a58cea8ff2",
+   "sha256": "1hhxhv7bj2jn7h8j3690zfi1ax4ihxlbrsni4xiz2x7xayl4nk9j"
   }
  },
  {
@@ -101177,10 +101755,10 @@
  },
  {
   "ename": "pine-script-mode",
-  "commit": "287b781147fe41089fa8c76570bc30539e43e5bc",
-  "sha256": "0ihijbcx7m4vhxr1fnfkwjdk6ka1mqzxb8z164yh8yn73qs0saiq",
+  "commit": "6ddeff131f70043ca0a70a71a8e447e265bbcb57",
+  "sha256": "1rp1abf551hml0xgq37zxf9zlrcz9lp3b3myfa5fkpc1s3x0c6zz",
   "fetcher": "github",
-  "repo": "EricCrosson/pine-script-mode",
+  "repo": "darrylhebbes/pine-script-mode",
   "unstable": {
    "version": [
     20250826,
@@ -101207,11 +101785,11 @@
   "repo": "themkat/pink-bliss-uwu",
   "unstable": {
    "version": [
-    20250521,
-    854
+    20250927,
+    1515
    ],
-   "commit": "bfbdd43bb1616d74e4d4ca0ebf43d97053c4b45a",
-   "sha256": "02dhvnhjjfxh085wgxsl8vswrn5r9c8jqinw7xqzrmyhfscdbrx6"
+   "commit": "c57272fd37d2d36e91870b0553de6dc51b1e8ca2",
+   "sha256": "0xkr6n3fhk4s9db5wwzki4g72zxvrx2wsmyfz9sjfvzd532lyg8x"
   }
  },
  {
@@ -101967,14 +102545,14 @@
   "repo": "8dcc/plumber.el",
   "unstable": {
    "version": [
-    20250306,
-    1106
+    20250903,
+    2031
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ddab8a2a81eb9d59c29e2ce19752fbe4fef4f254",
-   "sha256": "0chz9nrghndcg6vlshrciva7x8jivyqr0ywi0hgi3s2qvfpfqbq8"
+   "commit": "6fb863d0c0b6b86fc6e488d4d9b1a2a85822c3de",
+   "sha256": "1k9f6izj5szff15495c4q33jna4hha3pwa4n5y5l9f5alkk0zjvn"
   }
  },
  {
@@ -102782,15 +103360,15 @@
   "repo": "kn66/pomo-cat.el",
   "unstable": {
    "version": [
-    20250819,
-    1022
+    20250914,
+    1145
    ],
    "deps": [
     "popon",
     "posframe"
    ],
-   "commit": "a924765965ecc1a8da684f7691bce553ece6f336",
-   "sha256": "1nc2n62syzf7pwgrr939vbf5jr0j8ik1d8smn3vdvd5fy9fa022b"
+   "commit": "f006de9c1fae681299ba63bbc64176348b62e645",
+   "sha256": "0gd51livwbg30p6syrkr91n5v7km768cvw1xjqjidf0fr6ghddjm"
   }
  },
  {
@@ -104103,6 +104681,24 @@
   }
  },
  {
+  "ename": "procress",
+  "commit": "7af2c4f31c7dd2bb2fb512c59adc289db85a3958",
+  "sha256": "1fqjf8y44m1sy1ps9cqlan1865d69vilb61n7585dpmp8y3p5a8c",
+  "fetcher": "github",
+  "repo": "haji-ali/procress",
+  "unstable": {
+   "version": [
+    20250914,
+    1846
+   ],
+   "deps": [
+    "auctex"
+   ],
+   "commit": "137655ec1193bd1ea1a1ee3362349491c873710a",
+   "sha256": "0i4kgx51vw6kx8v70gdi84kagcm8xz4mbgwx9wz8cxir6yfbkwd9"
+  }
+ },
+ {
   "ename": "prodigy",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0lfxb80jqjnzssjs6l511jcsmhkpzb5rh5czrb16dkqcz0cl5b2p",
@@ -104159,11 +104755,11 @@
   "repo": "ideasman42/emacs-prog-face-refine",
   "unstable": {
    "version": [
-    20250611,
-    331
+    20250913,
+    2251
    ],
-   "commit": "2205eeb6fa0b4e2b71e27a87683a40183a0c829e",
-   "sha256": "1arn29hh8fjycjvgp0iqhjc7mf7sh1p3lk01z4nl0fwmhc6ibh4a"
+   "commit": "c9981a933e2a60ed59b61f1c8134c347010f8cc8",
+   "sha256": "0zbfprcp22m7511rkfa2jbdxm5ygm4wv28kzhw1xfmsw7w8fk2ca"
   }
  },
  {
@@ -104282,11 +104878,11 @@
   "repo": "lucius-martius/project-cmake",
   "unstable": {
    "version": [
-    20250824,
-    2004
+    20250830,
+    1304
    ],
-   "commit": "4a261cef5b7ca406577d3b0eaeabfae88419edeb",
-   "sha256": "1m4pachj26gdbmwbv15d7wshay7qnmaxy6x5nzi9hnvcfhg5v7xs"
+   "commit": "519ca5d7dd490a6b54435841c9fce3d5e3dcc140",
+   "sha256": "1dhs4irm6am24cx20bcrmnxspazm8iwv3kbb755lsx70040gx4b8"
   },
   "stable": {
    "version": [
@@ -104769,8 +105365,8 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20250531,
-    1228
+    20250927,
+    1605
    ],
    "deps": [
     "compat",
@@ -104778,8 +105374,8 @@
     "project",
     "s"
    ],
-   "commit": "8b5f59c12097ca7507d12fef15c8d02f2fd9ab5b",
-   "sha256": "09s0scqy0cyd0mvq0mhd674r28q5m4y61bkhpz1a2rg8s09bvm3v"
+   "commit": "482789397c5e11dbb95438c87ccd0cad3d37a33a",
+   "sha256": "0rlx9n1hmnzk46ml93g6lpv32ivmm7lfbb4mzicnapq7gly41132"
   }
  },
  {
@@ -104809,15 +105405,15 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20241107,
-    2107
+    20250921,
+    1037
    ],
    "deps": [
     "compile-multi",
     "projection"
    ],
-   "commit": "50d4f0ec4edfddd24f7c1c540f299a919aa4c151",
-   "sha256": "0s0bs395cczxq53axii514kjk32kj1rv3x68l16ni8jcys8bdy1w"
+   "commit": "f4b108eeb55c79b201c140bd8fe7f1fcaffd3617",
+   "sha256": "0p9xpbc62rcf9qbcc0rf36hd0z7b6c7apnji4gxdmggmpfaxnhva"
   }
  },
  {
@@ -105021,11 +105617,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20250623,
-    2108
+    20250915,
+    1038
    ],
-   "commit": "999cafbe7320ae887f7eebd441beab7e5b0ae6eb",
-   "sha256": "06ba11lsl0944pg03lq3105s1x7a857lfc1xncbr3fsk57ln815h"
+   "commit": "f33b478d1144d6828dfa0df7f0d7d48da704ea11",
+   "sha256": "0dfd4lpsdjhpp73812i4nb3vkphk4ixmnb9zychv7k2ad6cfhh6p"
   },
   "stable": {
    "version": [
@@ -105134,10 +105730,10 @@
   "stable": {
    "version": [
     32,
-    0
+    1
    ],
-   "commit": "4fbd1111a292d04746c732573025e3251de0bb9c",
-   "sha256": "1hhlpkx16w513wi4l3pr6sy69h9j6bmrcqwkqrpjzljllqzk884j"
+   "commit": "7fcfd66022455635fa29af92987cdc0967efd4f3",
+   "sha256": "0sl3ahj74gpy4dv8xz9sry7kapnh00kpmghz2iqnlw5j40rvbyy1"
   }
  },
  {
@@ -105487,11 +106083,19 @@
   "repo": "countvajhula/pubsub",
   "unstable": {
    "version": [
-    20250616,
-    2221
+    20250905,
+    719
    ],
-   "commit": "7691efbe3a28b4b546486474526c0b5c89a583d7",
-   "sha256": "18bzjcnpd6ps0ncg076a8ghqbydbp4pskskj1smqg46cghh0zaw4"
+   "commit": "84b57d3a3d166b73dfe79acf254fab2938f473f4",
+   "sha256": "0ys6lnrdl6kyqnzhvip1rw39hk998lkm9vwcv3987v818l256yhq"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "84b57d3a3d166b73dfe79acf254fab2938f473f4",
+   "sha256": "0ys6lnrdl6kyqnzhvip1rw39hk998lkm9vwcv3987v818l256yhq"
   }
  },
  {
@@ -105857,11 +106461,11 @@
   "repo": "ideasman42/emacs-py-autopep8",
   "unstable": {
    "version": [
-    20250421,
-    1116
+    20250913,
+    2251
    ],
-   "commit": "69fa9a47c15801172503987237c6043bc92761f5",
-   "sha256": "0n5d7lfgzg7rfj4kxcfp904h66yh73024bhvcwl0k6r6jc8sbvkh"
+   "commit": "a72b83e04dbbeedcc353e19627494de35c74961a",
+   "sha256": "10fw8wc84dld0y651qj96c5v2lg7axcxn2zschfr9m8s95qfn847"
   },
   "stable": {
    "version": [
@@ -106108,11 +106712,11 @@
   "repo": "statmobile/pydoc",
   "unstable": {
    "version": [
-    20250816,
-    1529
+    20250910,
+    2000
    ],
-   "commit": "dbfbe0fc9ac1dfb12a202062b6639a1d335ddc49",
-   "sha256": "120ddz4714h4mv1lwlmqc7gfvzs89a6mxhaiw9kn4bjypp8csafq"
+   "commit": "5e76e74538ac3201ad7a3526ecf16d9ac7e73310",
+   "sha256": "1akkw5wf419j6p1gkqdgkpdbsz9m2gls7pjyzbx6lcg1fh947n2g"
   },
   "stable": {
    "version": [
@@ -106278,14 +106882,14 @@
   "repo": "cor5corpii/pyim-cangjiedict",
   "unstable": {
    "version": [
-    20210617,
-    934
+    20250924,
+    1320
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "d17e3d32a6480939b350a91a915ebe8e6efad819",
-   "sha256": "1bszpqsm15az0wvbgsk012manxnvigbk38qr5iqzkgd4d13yv5fs"
+   "commit": "2742edcfb60328793fc983bd4a0dedc88f550ec1",
+   "sha256": "1nl5wxj6zli1kvl665ychr9wrq1chxdv1m4pzkmcp7rqj7291kwy"
   }
  },
  {
@@ -106762,11 +107366,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20250821,
-    1140
+    20250930,
+    608
    ],
-   "commit": "fcff76c308b4409007c61492e4936e7c0b7d5aee",
-   "sha256": "12xhws04ljqdibfnyl5sn7nl05ndz5a3r2spk8aqvfcwd29zkn4d"
+   "commit": "5aaf8b386aa694429d997c6fd49772b0b359e514",
+   "sha256": "0b6mv1cy5jznpzkxslf1d89k7pk1f3rjpnhb21jx857xqiyid11p"
   },
   "stable": {
    "version": [
@@ -107297,6 +107901,30 @@
   }
  },
  {
+  "ename": "quick-fasd",
+  "commit": "0e21cdaa71631d7968d4891ad64d82be452ecfd1",
+  "sha256": "0n703cf44r2dnwp35c183aqx8wjhvzw40khh662qgzx3dbmw337j",
+  "fetcher": "github",
+  "repo": "jamescherti/quick-fasd.el",
+  "unstable": {
+   "version": [
+    20250915,
+    131
+   ],
+   "commit": "fe0d6c611ec995e2f59b23d45af3b8b28244703b",
+   "sha256": "1fsl6l67jf8fm5h6i5qxqvibzssbiyyjzchq3r5sbqry3d8yx3mk"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "fe0d6c611ec995e2f59b23d45af3b8b28244703b",
+   "sha256": "1fsl6l67jf8fm5h6i5qxqvibzssbiyyjzchq3r5sbqry3d8yx3mk"
+  }
+ },
+ {
   "ename": "quick-peek",
   "commit": "68f59a3048ec6196b138b6584a22ce70baa38284",
   "sha256": "0ivg6v9c535bw2bv636wmkd4sy037j55054bfm31wvvxk99bndwq",
@@ -107334,20 +107962,20 @@
   "repo": "jamescherti/quick-sdcv.el",
   "unstable": {
    "version": [
-    20250313,
-    1703
+    20250923,
+    1446
    ],
-   "commit": "f94099124e4df92b44086c46d59e286f21bfafa8",
-   "sha256": "19ywfnf5ws40h9iv03xibjfk1hfpnb67zf9702px3yg5j1mhr845"
+   "commit": "376d69a914b75091ace06e5b18d777942e66312f",
+   "sha256": "1dilw0j2njq3rgnvv95ly82ayrl33vmq0dalw6crbiia4lni4asc"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    3
    ],
-   "commit": "f94099124e4df92b44086c46d59e286f21bfafa8",
-   "sha256": "19ywfnf5ws40h9iv03xibjfk1hfpnb67zf9702px3yg5j1mhr845"
+   "commit": "376d69a914b75091ace06e5b18d777942e66312f",
+   "sha256": "1dilw0j2njq3rgnvv95ly82ayrl33vmq0dalw6crbiia4lni4asc"
   }
  },
  {
@@ -107575,14 +108203,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20250711,
-    1236
+    20250830,
+    1625
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8a80578405cb1dcce460fd34c23daed4c5f0546b",
-   "sha256": "1mkk7g43ifd0j12nfjhpclq89248ifwf66f5j233ih2rm5x21n69"
+   "commit": "f3952cdebb7d92b65bd6755513b51cf01812032a",
+   "sha256": "1n2ngzlhdc0z5rf7hv5k508j8q4sl7sq80ddgyaz8dyzlkmw1p6h"
   }
  },
  {
@@ -107808,11 +108436,11 @@
   "repo": "Raku/raku-mode",
   "unstable": {
    "version": [
-    20240429,
-    1007
+    20250930,
+    1151
    ],
-   "commit": "14f9b9bba08c0bbb7f3895380d0b1a9feb7a168d",
-   "sha256": "03r858crkxfp2nswsk81ajr8ynqm501a3l6qmbmlk57pb1p2a1py"
+   "commit": "d06baaa2e881470dddb97193713f9f0a278942ad",
+   "sha256": "1y90jz8dhnaba71anzli8i95p76dff2jw8k4404cx1bd17g0m09r"
   },
   "stable": {
    "version": [
@@ -108333,20 +108961,20 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20250826,
-    451
+    20250902,
+    2107
    ],
-   "commit": "c78300c0afaf9328bac66bab083a2f0b8e10fd25",
-   "sha256": "187mkiy8a9zb1zjq645xiidwv6spbbp5nssng745jlm0a5fbib4q"
+   "commit": "a8e95ca9c07480c188733d7e6315147fd6e4ed24",
+   "sha256": "0vg6pkvkpz02b237f1p3qxsrwyc5ar44l73rr04gk368n7a0lnwv"
   },
   "stable": {
    "version": [
     0,
-    31,
+    32,
     2
    ],
-   "commit": "ea0633f7b8cb4478073b3082e01c3a46b2e888b1",
-   "sha256": "1qhdmb1rlj7r3nzhv8ajl90yibgmfjb1x9rjyljgqyfmizrp87lv"
+   "commit": "a8e95ca9c07480c188733d7e6315147fd6e4ed24",
+   "sha256": "0vg6pkvkpz02b237f1p3qxsrwyc5ar44l73rr04gk368n7a0lnwv"
   }
  },
  {
@@ -108856,11 +109484,11 @@
   "repo": "ideasman42/emacs-recomplete",
   "unstable": {
    "version": [
-    20250528,
-    38
+    20250913,
+    2251
    ],
-   "commit": "0e4a2bad35886e31742117eee3d610e13586ac5e",
-   "sha256": "1dasj12k9664s77cxnkbrszy2vkfwd6iz6mrj9xzsq7mjgg5gk58"
+   "commit": "6bf7081c448283974b1be519ef2dc946556d8ddb",
+   "sha256": "1qi05dysmqdfdfsi38gncml4rga1xqkwkw76viic4bc14l86rhm0"
   }
  },
  {
@@ -108971,14 +109599,14 @@
   "repo": "minad/recursion-indicator",
   "unstable": {
    "version": [
-    20250101,
-    924
+    20250921,
+    1714
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8a828f00a42d397639397aa9051fc884eda688d3",
-   "sha256": "06hjn61wsl8xyxsn6878rvprfk54r5pbv12pkf6ijq4mz3iciz8c"
+   "commit": "91140813d5f54f2ab56116914a10d1f7aae65826",
+   "sha256": "1jrkhljpcqmhr3frkrjf0wm6nk9d4dvp41j5i1is2sd0nmcl1s64"
   },
   "stable": {
    "version": [
@@ -109471,17 +110099,17 @@
  },
  {
   "ename": "remember-last-theme",
-  "commit": "26edcdddaf8dc8c9a18d6b007e0d49d04fe4ccca",
-  "sha256": "0pw36f9mchkl1qhaii39zd0vwrydjlijzanv706ai2bl8r7l0ppy",
+  "commit": "2dbcb69f603a94b6abc196d45ec5d2fb2ddc1344",
+  "sha256": "1xl48hmjhyh99nalf12gcz6y9d9kbc6z1hj4qnr95bijcfk8sxvi",
   "fetcher": "github",
-  "repo": "anler/remember-last-theme",
+  "repo": "nullvec/remember-last-theme",
   "unstable": {
    "version": [
-    20170619,
-    2133
+    20250921,
+    2104
    ],
-   "commit": "57e8e2a475ea89316dbb5c4d2ea047f56a2cbcdf",
-   "sha256": "0sb110rb6pnjnvyqn0kji19bhbn8mk4x32yps00aq2g2v9pc1jzr"
+   "commit": "6c180928df64bf825f96241291b90e44f5163032",
+   "sha256": "08wv0ygw7jq05hyhsy7zdlkv0nsr2jbda6a207jpj5gidwd3hv3s"
   }
  },
  {
@@ -109512,11 +110140,11 @@
   "repo": "Reagankm/renpy-mode",
   "unstable": {
    "version": [
-    20250712,
-    1708
+    20250922,
+    1610
    ],
-   "commit": "feba611ed07fe26774f4106fcdbf31c2de28856c",
-   "sha256": "1j5055lwkx87yi2ymb1khs9q2lrixfwh8m239xpwdwp6lk9gv2wi"
+   "commit": "76f75a5fdc217756acdca4897d199d1c0074f61e",
+   "sha256": "17di5q9qyr495j89vbhdba2azxsyldim92i2rlbjhh7hwxf8kwmb"
   }
  },
  {
@@ -109527,11 +110155,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20250824,
-    918
+    20250918,
+    104
    ],
-   "commit": "9cffa91052a0f5a1c7f1ff44c254f33b9350d6b8",
-   "sha256": "0h3xgijyfzpnqx3m7ivnq64znrhjnqnc7wph0653iy1mvig1pxzd"
+   "commit": "1f43805f227e10462fb97d0794779014d2fb7442",
+   "sha256": "0940azgq92148fs1iqxp67bcv3gz071910jrknxf2kp6bxsw5bc4"
   }
  },
  {
@@ -109557,16 +110185,29 @@
   "repo": "countvajhula/repeat-ring",
   "unstable": {
    "version": [
-    20250712,
-    625
+    20250915,
+    2234
    ],
    "deps": [
     "mantra",
     "pubsub",
     "virtual-ring"
    ],
-   "commit": "f2e67a961476a9a871f245f2d7c1df94e51ef721",
-   "sha256": "0wzxw7hxkijhm5mzhsrjdk3l31c3mv62jwx349w1j27hs3dx4pgp"
+   "commit": "04c128149e50827134ecd8e5a5176cd889469175",
+   "sha256": "0c7pzyvfggikgcbjkk1r9hfkbwp9n6nykxwv97g55yck30hbibak"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "deps": [
+    "mantra",
+    "pubsub",
+    "virtual-ring"
+   ],
+   "commit": "0d436ddcf67e698f3afac7c430559ace8e646314",
+   "sha256": "0z2hzfiaq7ml1fj1wnfxy8dx8805iyz0mimskr2x98pa8wvbclbl"
   }
  },
  {
@@ -110017,14 +110658,14 @@
   "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20250817,
-    0
+    20250922,
+    700
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ad97f666b607b1947aae4bcfb5b91fb3b0d97b87",
-   "sha256": "0bamndc9g1l2hv9sm5cfjmhzwnvkg922fhkav7zkxhzmk9v1n0qa"
+   "commit": "757d82eacb997f82c84c4e6eea08a338b0b6afa8",
+   "sha256": "1xdihcridgglr5bj0xsd4a6ywh47380npgkj8d1axi1b4c9aak98"
   }
  },
  {
@@ -110330,11 +110971,11 @@
   "repo": "ideasman42/emacs-revert-buffer-all",
   "unstable": {
    "version": [
-    20240421,
-    836
+    20250913,
+    2251
    ],
-   "commit": "d49462047ebb442d7872f12007380797ee49473c",
-   "sha256": "0qhkvrbhsvw3vwawj47xb23i11i1pkcypcmn4r4fy65qcpzjm12g"
+   "commit": "8bcd18498cae5a61e832bc0f2be997198456d6f1",
+   "sha256": "1g5rrgbjf6hb0v057d90lb4093x2vj0fdb3h3m0cdfv8sv86q7xk"
   }
  },
  {
@@ -110414,28 +111055,28 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20250625,
-    2009
+    20251004,
+    2013
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "7611852b5517212a4f0fdab9cd9ecb0cf3995f08",
-   "sha256": "0vwqwc0ajcrjd20zdynhmwcir5jzj018ihbk8db8lb8ar7yviinz"
+   "commit": "dcd65fd34b5fcd7c28fd83275129a2ebc7fa8f17",
+   "sha256": "0nk8h7a2alxc0yz5v4mxbhyfb0ys4rpwll18gxwjs5yay26l6rrm"
   },
   "stable": {
    "version": [
     2,
-    3,
+    4,
     0
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "9a6bcf7180108a58ed4612aa4e55af13410ac9d0",
-   "sha256": "1adici6hs4ivz7lqhrgdm9g1rz0mgvrsa7pkr2pcx6mg1f0qnlmr"
+   "commit": "b123ac91b86f0ec5479934b0569d9e612fe1e2d5",
+   "sha256": "19vczsw4f36gn0n7gfmq5j919m813rr9s4vg8kjh20ysnl04qqxl"
   }
  },
  {
@@ -111845,11 +112486,11 @@
   "repo": "ideasman42/emacs-run-stuff",
   "unstable": {
    "version": [
-    20250707,
-    1237
+    20250923,
+    2315
    ],
-   "commit": "67776282c7277e1a288c7654f3ced5284d6cd46b",
-   "sha256": "1kgn2ph21h4r1rldnv1yrdhf66sqp1yanpaxvmz2qzhji1ykyj53"
+   "commit": "fea43ee2ac733607c120eb04fd798fa803555c4e",
+   "sha256": "0nmpyax69yw63a5rgwfvfap2a9z2yp6bmimss7j3c0lqwmxkswsw"
   }
  },
  {
@@ -111898,20 +112539,20 @@
   "repo": "Anoncheg/emacs-russian-calendar",
   "unstable": {
    "version": [
-    20250103,
-    307
+    20251005,
+    1815
    ],
-   "commit": "dc5c6db3ab1658d140188609f5e0ecb53bf840a9",
-   "sha256": "1ndxmq4isi3h10fiqbamkrcq8cf73av5bylf3b5wnbyac7hhpipp"
+   "commit": "a768d62a60de911dac28832d88b3e1635cb7f5b6",
+   "sha256": "034kwisg36dixqhhklwmqikjzbj53c73mr9kw7rirv9b3viihb48"
   },
   "stable": {
    "version": [
     0,
-    0,
-    8
+    1,
+    1
    ],
-   "commit": "984f568abcbfa29ec13119c8eb13da365a502327",
-   "sha256": "0dkw1m3gvsl8fw9adqgdbc179xjbqn8r2q9mhsvsjm6z0dqc05m2"
+   "commit": "23bc82093556a2bd045621c9964ba9162aac9937",
+   "sha256": "09609pffp0rr87xqldznjjx5f60h3l9dg266sgiciid34hl0f1m8"
   }
  },
  {
@@ -112373,11 +113014,11 @@
   "repo": "thapakrish/samskritam.el",
   "unstable": {
    "version": [
-    20250815,
-    440
+    20250829,
+    2315
    ],
-   "commit": "07fd19057dc8122c6f7174bcd9b36ce711375385",
-   "sha256": "0j6ara5nsv0ykxihfy78w2ag6p5nammjbpd07iqq4xs4k34fjngi"
+   "commit": "e84358904b93c5c03d00b62f1e6735393d2b3d53",
+   "sha256": "1k2lsgn2zz82qpbz1ym9d69a008q3w5z7szszs1i2pz2cqwp4f91"
   }
  },
  {
@@ -112505,14 +113146,14 @@
   "repo": "jcfk/savefold.el",
   "unstable": {
    "version": [
-    20250817,
-    1933
+    20251002,
+    924
    ],
    "deps": [
     "compat"
    ],
-   "commit": "68ec792ced589f64e747bee4fddaba89339f11ca",
-   "sha256": "1fq083k2783xv4zj7qhpdz147y31ck8c0khqh1n9z6zny5pg2b8x"
+   "commit": "068f67dcfca6653187fe4c208d66a08b1f5e642a",
+   "sha256": "0m75fr6chrk81dfyapgwzw8jpli40w1103ws38s5fzb6sj1di4zm"
   }
  },
  {
@@ -112639,14 +113280,14 @@
   "repo": "openscad/emacs-scad-mode",
   "unstable": {
    "version": [
-    20250728,
-    238
+    20251007,
+    1702
    ],
    "deps": [
     "compat"
    ],
-   "commit": "44b4ac086bd01791ff2ccb25234b4e5d701bc10a",
-   "sha256": "1h86z2qn9q7ww2m7p992fx8abzdffcd3bcp3bmck3c9q2aksjl5j"
+   "commit": "b130730a3123387e69c85cf10633701ea447fa2a",
+   "sha256": "0k77jncalzvhmcdb2nn8j0h4xba8p805xnciid2r93w2dj1swnz6"
   },
   "stable": {
    "version": [
@@ -112812,11 +113453,11 @@
   "repo": "emacs-pe/scihub.el",
   "unstable": {
    "version": [
-    20220913,
-    618
+    20250104,
+    420
    ],
-   "commit": "56aa7205b5f2a6c9821557f9f1b9ff76dc1bb882",
-   "sha256": "1i8dh5dwmdl0vxgrz48qamzxj89zr0sz0ylxvc7qkkbdrs325if8"
+   "commit": "899d9144f7f88925a48257dfee28988628df084d",
+   "sha256": "16vz0i0zfv6fap8dff7fy2x84rmw33kmqabr99c7x92qyjl66g95"
   }
  },
  {
@@ -113090,11 +113731,11 @@
   "repo": "ideasman42/emacs-scroll-on-drag",
   "unstable": {
    "version": [
-    20240421,
-    803
+    20250913,
+    2251
    ],
-   "commit": "f1a39a34f6ba350bcb6fe5927584d6e1cbaf72e5",
-   "sha256": "1igr324vhzl19z7crw5v8g0zc5wznqjdnx1fq3jxqjmq3185a9d6"
+   "commit": "2df06478dc0aee0d4c5f7f4dac340e66cef34d10",
+   "sha256": "0mxcga0dbcb8q6bqqd62vp3pxyawm60zk1z7g2dl4rbbsg63m9hy"
   }
  },
  {
@@ -113105,11 +113746,11 @@
   "repo": "ideasman42/emacs-scroll-on-jump",
   "unstable": {
    "version": [
-    20250712,
-    1317
+    20250913,
+    2251
    ],
-   "commit": "8b108786da855dffd0f1957a0906dd3921e25711",
-   "sha256": "0k5rbkj1z81i0g2wsa854sc5xfmbk2irqzm86jd1z548zf14wr5f"
+   "commit": "6b992a611a0998d3543bd91616121202d5843a06",
+   "sha256": "074d8h1a5yv8l8ccmz8lcyi4pg6gdh17rh00z6ffzqfg4s70pmb5"
   }
  },
  {
@@ -113266,15 +113907,15 @@
   "repo": "sdm-lang/emacs-sdml-mode",
   "unstable": {
    "version": [
-    20250424,
-    2016
+    20251005,
+    2315
    ],
    "deps": [
     "tree-sitter",
     "tree-sitter-indent"
    ],
-   "commit": "36c77e0d5af0165104cf8b7fdb489ae405993d64",
-   "sha256": "116anp92chdm6nn8fynrl2jnvkisq76c6h0257hq6ixg9l1k1xmh"
+   "commit": "75d627413a13d23c8872a474b4dc16d77d0a7a93",
+   "sha256": "0f5dg5z8yvypgzv1f7dcnpp0hlahv5yprwb6jrni3khk9fs6jqm9"
   },
   "stable": {
    "version": [
@@ -113803,28 +114444,28 @@
   "repo": "abailly/sensei",
   "unstable": {
    "version": [
-    20220530,
-    1226
+    20250831,
+    1341
    ],
    "deps": [
     "projectile",
     "request"
    ],
-   "commit": "3538990de9ab57154e3da08d10fbd2c6228d87b8",
-   "sha256": "1f7q7s0ajrpgaa78j3zrff5dr1p2j82kgpvpal2lgqns4947m726"
+   "commit": "3129584a6b4b57cbf0e4769dcb8efcc21d8bc821",
+   "sha256": "108vsqv49xf8310fprghzm5v3dkh78p83yrr47z6kag3g85jg1ih"
   },
   "stable": {
    "version": [
     0,
-    43,
-    3
+    45,
+    2
    ],
    "deps": [
     "projectile",
     "request"
    ],
-   "commit": "3538990de9ab57154e3da08d10fbd2c6228d87b8",
-   "sha256": "1f7q7s0ajrpgaa78j3zrff5dr1p2j82kgpvpal2lgqns4947m726"
+   "commit": "3129584a6b4b57cbf0e4769dcb8efcc21d8bc821",
+   "sha256": "108vsqv49xf8310fprghzm5v3dkh78p83yrr47z6kag3g85jg1ih"
   }
  },
  {
@@ -114527,20 +115168,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20250820,
-    939
+    20251008,
+    1308
    ],
-   "commit": "b33eed1f939d107c01d4c1f7cfd50d76078f715e",
-   "sha256": "1hflmj6fnbbrnbbvrmjr7w9vbckx5hxsxx5h91yklmw8vy0xpn5l"
+   "commit": "ceb6915a0fc2ba3cfc6f1a5fc3bf1a0860bdd36e",
+   "sha256": "04mc23adxv6grkx7cm940hq17an4lj6jnvdhy5w1i0w8jx3884sw"
   },
   "stable": {
    "version": [
     0,
-    80,
-    1
+    82,
+    2
    ],
-   "commit": "d5748939c7209f927a4e563f03ad8a94cf5f802b",
-   "sha256": "1bcca4mg07rjb8x8875cggmhd1nxj0filb6qkfhq196rcsq7yckn"
+   "commit": "61cb4f7ddcdbb8d337812cd78aedccf6392f49b7",
+   "sha256": "1v65gbrw2kczj952j2xx1fvq7sfnxgm6xgdgmz82ydgj3sbrfg44"
   }
  },
  {
@@ -114818,11 +115459,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20250710,
-    340
+    20250917,
+    433
    ],
-   "commit": "cfe8e90591ec3271cb901cc34b68f2ca3d858c1f",
-   "sha256": "10ww6djgb5s2ghknvhx9yl210iawkhp1ll80ls5lvmk7vph6bnay"
+   "commit": "058fa307293287e9232219007893cb56abb2c4b3",
+   "sha256": "0ww933jv7cbsjkc0mx33yzs2cnqpkq0df3zi14yk7znpzh89mix1"
   },
   "stable": {
    "version": [
@@ -115065,15 +115706,15 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20250807,
-    649
+    20250923,
+    958
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "5571cc62635628c8661f123b6d4a8335cb0ff8a1",
-   "sha256": "1skxyy87c6iwfqc0rwjls5vg2m43m3qfmzdyl1pgsjs9p1njp06b"
+   "commit": "6d5b730c09cbbb070abadab1b2039677b74e3c62",
+   "sha256": "18ksyr57ca5sdrngi16rskpffjys73qlx7dka58mrcvl8pbdpndy"
   },
   "stable": {
    "version": [
@@ -115329,11 +115970,11 @@
   "repo": "ideasman42/emacs-sidecar-locals",
   "unstable": {
    "version": [
-    20250611,
-    320
+    20250918,
+    217
    ],
-   "commit": "332c2c0d2e6c4c07f9b4fa91f5900e648f153212",
-   "sha256": "14dv8bz5z0am0wgsr34xfcqdikgmbw7q9skbbxv23sg86z7j8zl2"
+   "commit": "94fc39a75a53e44de8639204455ccc7bf374d7fc",
+   "sha256": "09j404hjsyadgr0z48n0b82bf2ilvfh0h8n17d3gri7p9znjzhci"
   }
  },
  {
@@ -115975,10 +116616,10 @@
  },
  {
   "ename": "siri-shortcuts",
-  "commit": "f3a67195c63059fbc2d2714b540505bb9cde49d1",
-  "sha256": "04fnzv6sq5mbj5difddbchvp7sgz48qrhs5izhl5w1si5q2ds5ri",
+  "commit": "ca5b60aecdf7acf7bfa32f7e1d767aedf367cf9a",
+  "sha256": "1fvjxf6dqm2jfcaavj4m1lqjc0ai5lnd9bkyfidds9aw8vzy0dm7",
   "fetcher": "github",
-  "repo": "DaniruKun/siri-shortcuts.el",
+  "repo": "danirukun/siri-shortcuts.el",
   "unstable": {
    "version": [
     20211229,
@@ -116011,8 +116652,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20250801,
-    950
+    20250928,
+    1843
    ],
    "deps": [
     "compat",
@@ -116020,8 +116661,8 @@
     "llama",
     "magit"
    ],
-   "commit": "9c9fc0624308fba0fe0cc112d1e4de21db81803f",
-   "sha256": "06gsl5cr2x73njhxia2xlxdhkdddzv6w7q3asgj1f6xjx50vvc7b"
+   "commit": "600dd0b79881908c08fbf72872f0fa392264d548",
+   "sha256": "0f4pk1js74hwyic9imlmw9axh7jby2rxr6m48gf8bamadcdsvlxq"
   },
   "stable": {
    "version": [
@@ -116062,11 +116703,11 @@
   "repo": "mastro35/sixcolors-theme",
   "unstable": {
    "version": [
-    20250309,
-    1750
+    20250902,
+    1120
    ],
-   "commit": "0c61d87110b1e38337d9dffc63bf29ecb72209d2",
-   "sha256": "03h05yjs0k3s6plvlhf1ys15xy329fzdz4s0khnlbbhxyib6x6zw"
+   "commit": "b0a82b97bf9d7d9ab8f1afcf9481c97da0e23c84",
+   "sha256": "0gwi719wqyp7wd7fca6xfv77l3swqi187azszzjqpcw56sj45hxs"
   }
  },
  {
@@ -116279,8 +116920,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20250819,
-    1012
+    20250924,
+    2025
    ],
    "deps": [
     "alert",
@@ -116292,8 +116933,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "b75ac2a6a65477c2ecc6b989d3f08cc833c8627a",
-   "sha256": "0m32252lv1pwd4i0z7f8ayhq2iwd84f4dmz1c6wb90xly5zc5l65"
+   "commit": "4ad4bb3a2628b2015a591c835566f9348a16b81a",
+   "sha256": "0nmfccpx5cwdhl49q9vccpjzwjbad3c88ijyg6g91h238r19chr4"
   }
  },
  {
@@ -116351,14 +116992,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20250817,
-    2347
+    20250918,
+    2258
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "fe2090079cf933c72c48861582477d1c0c896f6a",
-   "sha256": "19h92mbssx9442dpcy6h0v1x4ipvbq8zx3all6kf7b62vakyrdm4"
+   "commit": "e57ff4278d519bfda9523a30db8d927b84430516",
+   "sha256": "1fphddhncm42fj5962i0ispiky4zli8cfcp3fj16x4x8rfk0spjs"
   },
   "stable": {
    "version": [
@@ -116653,11 +117294,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20250707,
-    823
+    20251009,
+    1510
    ],
-   "commit": "3f1c0befad5a70cf51ca38131cfa1f6fa287cbf6",
-   "sha256": "02swww902hj2kp3d9njs48iiz486vs4984nn1bv0giy7mwxvmwjw"
+   "commit": "cc3237983a9cbd2f1af20c5ae99ecb0a77f42361",
+   "sha256": "15m2580y6dyxa88b17jv22b1iqijibkspajsbk2s4gchid89rhy2"
   }
  },
  {
@@ -116668,11 +117309,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20250522,
-    2241
+    20250930,
+    913
    ],
-   "commit": "f13ceb762c306c77d5e87366713a2a1689bb5113",
-   "sha256": "1kvjazg7mgrraql346409hmf9pi9vf1sg206i7v2ghivqy8splxq"
+   "commit": "3041c402169ab1d2f63cbbe1aae2dc35f0928e1e",
+   "sha256": "1j6wck4kvxk0wvl3m1f4f96wyj9x53alxjjm3bchacpv9rl8dv44"
   },
   "stable": {
    "version": [
@@ -118098,11 +118739,11 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20250222,
-    1429
+    20250913,
+    451
    ],
-   "commit": "5d136736f76c85a83fef737d10ecd32af4d493fd",
-   "sha256": "0nwyax9dikpw4fcplnk0az9k1pk02wnhkadvfp325s7rl2j8y23b"
+   "commit": "65f6772119462f2e91a9d70f0c4e1085bddd29c9",
+   "sha256": "0czcv8q323zgh3vkafwbj0gli9fp8wxcw42m5cimvwh5sqvm1snr"
   },
   "stable": {
    "version": [
@@ -118872,11 +119513,11 @@
   "repo": "ideasman42/emacs-spatial-navigate",
   "unstable": {
    "version": [
-    20240421,
-    908
+    20250915,
+    2339
    ],
-   "commit": "4f85fe3ae4d240a35d3d7edd8b865612024f9dda",
-   "sha256": "0vdqjw2ih7fngqy34wmxszq9bil49l3gnhh2ig6x3ah2wf47g401"
+   "commit": "0fadd12d73dc40cb6fb3574239d6aa37910d1eb0",
+   "sha256": "085hxnmhpgkff37f0rx1ihm17fv8h2sa97xjhx52j5h3cwn8q8pk"
   }
  },
  {
@@ -119027,11 +119668,11 @@
   "repo": "ideasman42/emacs-spell-fu",
   "unstable": {
    "version": [
-    20250712,
-    1319
+    20250913,
+    2251
    ],
-   "commit": "e2eda668f5af063ecc3d97321eda6a50951c87a1",
-   "sha256": "1pqzpwig4zs6rx4cnrizpicmj4dcx1czhw458zfirq4k0m622755"
+   "commit": "b141e2e24e3def0c3c656090cf11705bb34254d1",
+   "sha256": "0zwx03sl1svzwqa4gidipsnlf05rrk05ghc7kqpb6xk8a8s81a3c"
   }
  },
  {
@@ -119543,11 +120184,11 @@
   "repo": "xenodium/sqlite-mode-extras",
   "unstable": {
    "version": [
-    20241017,
-    1030
+    20250827,
+    1317
    ],
-   "commit": "2508fdd94b48517892a409a4cb725ece3bd015b6",
-   "sha256": "0fnd84fm37vkr64gvbdv6knaj2abmpl7p0h2w8ks26hbdb8g4wg0"
+   "commit": "83881ac1298eb15aaded2d579b59d7d9d25e403b",
+   "sha256": "1ngfzymqwybq2dfaa1a0lk3fib5ws5j5w3inxkr5h9wqb4np3dij"
   }
  },
  {
@@ -119643,11 +120284,11 @@
   "repo": "srcery-colors/srcery-emacs",
   "unstable": {
    "version": [
-    20250728,
-    1144
+    20250901,
+    1751
    ],
-   "commit": "a0e3409c97dc24f3468a352a4fcf00ed9923cac7",
-   "sha256": "1lb24j9zgpgxmyynmibvn2mynggb0limd0cpja3jliw2zygw6j15"
+   "commit": "eee86865bb7baa8f015ab57a42d9c12e51b8b6fb",
+   "sha256": "0n0cxfa5bn3pwi7rkvf49mg1hbh54kd097sdgw7ab5kp33aprsj0"
   }
  },
  {
@@ -120242,11 +120883,11 @@
   "repo": "motform/stimmung-themes",
   "unstable": {
    "version": [
-    20241030,
-    823
+    20250915,
+    1420
    ],
-   "commit": "c7fbe9f06fff0fca2f2fc9a448865c6fc1e6ce8a",
-   "sha256": "0b5dn4f1cgldf7a5y22297p42xhhjgqy6gky1dnyj2b5jzyryxyd"
+   "commit": "bb3410593bb7ecf3c4094396f488e5c64efdb051",
+   "sha256": "1783s1sr4jmz5xi5r8s1bfh92rfnqb03ncjglci5q9ahzmcv946k"
   }
  },
  {
@@ -120413,11 +121054,11 @@
   "repo": "akicho8/string-inflection",
   "unstable": {
    "version": [
-    20250823,
-    45
+    20250831,
+    53
    ],
-   "commit": "e56f40737b6925de5c212aaa9485014f42cbdbcd",
-   "sha256": "0m205jdy76ml3dgn2fwrn5lzz3cr0dxcny1iqq74vhq7azn9hvlk"
+   "commit": "67767a8239c23eb91dafc11dd3171ea9e9c6fc7e",
+   "sha256": "0868jms67n9i0m843i2sdgnp5fws1xa7bf38adc40nigjmpdsnid"
   },
   "stable": {
    "version": [
@@ -120512,20 +121153,20 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20250822,
-    1937
+    20250915,
+    112
    ],
-   "commit": "3935581cc5d84aa6134b430c63fff9185a99564c",
-   "sha256": "0777638j29wj9a7r4yc73gjh09ns8lm0ksh450ahldq5x18bwmdf"
+   "commit": "99004e3a2539686e7d714ef4f7290726f3ad6fe3",
+   "sha256": "0k80f1xqwcyaqjcwry54d61in6j8h81kysx6h2z956jj170gxpd2"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    3
    ],
-   "commit": "70eac3a2f99feedcc3fcd03ceb3b2c51b82fb1bf",
-   "sha256": "1b1v3jkvrgk0fcdwgv1gd4fzdksrzmp69ly58ahj7df6frm4am6n"
+   "commit": "99004e3a2539686e7d714ef4f7290726f3ad6fe3",
+   "sha256": "0k80f1xqwcyaqjcwry54d61in6j8h81kysx6h2z956jj170gxpd2"
   }
  },
  {
@@ -120891,8 +121532,8 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20250809,
-    1425
+    20250905,
+    1018
    ],
    "deps": [
     "deferred",
@@ -120900,13 +121541,13 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "11485c5b6008e7dbf405036e1f08d103531517e9",
-   "sha256": "1rpsv6b8wdafizdrc84fwa0xyhsb5v39p8zkwm4fzgd18h57j5jf"
+   "commit": "1051a201dee73ec6374df459e32671085cd6b026",
+   "sha256": "0s8pyqvimc3fdd4cgiyyr9q0c3lhpjqibyznj5jd5j0rm417v44y"
   },
   "stable": {
    "version": [
     3,
-    6,
+    7,
     0
    ],
    "deps": [
@@ -120915,8 +121556,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "11485c5b6008e7dbf405036e1f08d103531517e9",
-   "sha256": "1rpsv6b8wdafizdrc84fwa0xyhsb5v39p8zkwm4fzgd18h57j5jf"
+   "commit": "1051a201dee73ec6374df459e32671085cd6b026",
+   "sha256": "0s8pyqvimc3fdd4cgiyyr9q0c3lhpjqibyznj5jd5j0rm417v44y"
   }
  },
  {
@@ -121186,8 +121827,8 @@
   "repo": "isamert/swagg.el",
   "unstable": {
    "version": [
-    20250413,
-    1409
+    20250913,
+    1822
    ],
    "deps": [
     "compat",
@@ -121196,8 +121837,8 @@
     "s",
     "yaml"
    ],
-   "commit": "841159b8db75fd600c929e7d09c87526d94d0756",
-   "sha256": "1azw1jhnjq0sm7pfyvv74ks7ysz9h32mv6c7wspafczxcp6qwiz7"
+   "commit": "1fe1acf42cd7fe7ffbb56b82a030a53e544b8ff6",
+   "sha256": "1128jfyhp591mqv042wwicir1azyg7fv4azh4y3sffx44ij7n1rk"
   },
   "stable": {
    "version": [
@@ -121212,8 +121853,8 @@
     "s",
     "yaml"
    ],
-   "commit": "747102ae3448e8dcd5209308447375fd0fee4f89",
-   "sha256": "1azagz784g73zrcd092qmc5abk2rc9zq225chp2db2mm0v1bf1c0"
+   "commit": "95b4cbac6b0b2f12da982b768be861e20ae13e61",
+   "sha256": "1ccigx15fzb0w321b91gzlc5bs0nvr7g6da0rwksa9iy5nl36hk2"
   }
  },
  {
@@ -121424,14 +122065,11 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20250615,
-    1001
+    20250922,
+    712
    ],
-   "deps": [
-    "seq"
-   ],
-   "commit": "fc7df7bd906a2bb04aac6e0de47fc7acf33ceed3",
-   "sha256": "1z9ybkjwbdayk8yfclwp0irfy0mn15p6m1mfvv4vrn6ami2wvrsv"
+   "commit": "c2fe47722fcab02a8bd40b443fc11687793591e9",
+   "sha256": "1zxakl1s0c0mddzrvfnik78dfi6lhlxlq28jz9ksn1nh5jl1by46"
   },
   "stable": {
    "version": [
@@ -121454,11 +122092,11 @@
   "repo": "rechsteiner/swift-ts-mode",
   "unstable": {
    "version": [
-    20250115,
-    1906
+    20250915,
+    759
    ],
-   "commit": "43a0be79f9758fc444f5fafdff6023c4c7bf80f7",
-   "sha256": "1bpcgzzllmraaaic0kam78ka9ikx56jz8lkdjijzk3fsgc9jmnh6"
+   "commit": "17806f6f56f09c86c5e70af239bea4313aaaf0b8",
+   "sha256": "04fch8nsngf503qwgn0l53h4nkf4zpss638zdaxxngjgzchz7pih"
   }
  },
  {
@@ -122121,16 +122759,16 @@
   "repo": "vapniks/syslog-mode",
   "unstable": {
    "version": [
-    20250122,
-    2126
+    20250905,
+    2333
    ],
    "deps": [
     "hide-lines",
     "hsluv",
     "ov"
    ],
-   "commit": "b17ad3520bb9ebf0cd2837581dcca0d26559a8c8",
-   "sha256": "1vv251b6bgmk4xvjsdp9k2l8cbzak900wa4valxbpc8zgiy7klm8"
+   "commit": "f167635feae7365574755a7d61a27079c6b40aef",
+   "sha256": "1gqvx6w95480vqb7vmk2lzn44gp2j0iclczbjn3in311rzrlinsr"
   },
   "stable": {
    "version": [
@@ -122452,6 +123090,30 @@
   }
  },
  {
+  "ename": "tabbymacs",
+  "commit": "1aebea30f9bfbf78ec392b118399fc2e45c778e6",
+  "sha256": "05hznszg03rpfphv2v37pn8rl0a8q5m6v45jhnac0s7wpnv27qif",
+  "fetcher": "github",
+  "repo": "Bastillan/tabbymacs",
+  "unstable": {
+   "version": [
+    20251007,
+    1441
+   ],
+   "commit": "b88bac22c923bebbbc7e52f10a25669a7680698c",
+   "sha256": "0yr9wmmqhv1svlf6yhwx8fnzxyxdzr3kil72sys9l8bablnajzg6"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "b88bac22c923bebbbc7e52f10a25669a7680698c",
+   "sha256": "0yr9wmmqhv1svlf6yhwx8fnzxyxdzr3kil72sys9l8bablnajzg6"
+  }
+ },
+ {
   "ename": "tabgo",
   "commit": "80bdcded3f79c12968f4884fabf89cc7380c3bf1",
   "sha256": "0mdlxvim1pgps3mbflmjyp4zxbnlcrh5d7f7p75lrwnjqf44byna",
@@ -122544,14 +123206,14 @@
   "repo": "mclear-tools/tabspaces",
   "unstable": {
    "version": [
-    20250116,
-    229
+    20250920,
+    2116
    ],
    "deps": [
     "project"
    ],
-   "commit": "f552823f51f11d66492f754deb51abd709c08ed9",
-   "sha256": "038il7nvymxh7wryskylz3ma4xl63jjvg6fvdjpa8x4ry60w4z5j"
+   "commit": "d8fceb24064ee8485fdcbcb4cc5de8c9a7d6e0ac",
+   "sha256": "1p5795l2kwh0rm87wqfvssvg7vvplzky3sja906mjz2h2nai0ph3"
   }
  },
  {
@@ -122950,15 +123612,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20250304,
-    1550
+    20251009,
+    1004
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "ff06f58364375c96477561f265e3dbf55a8ad231",
-   "sha256": "0bircjqj2zm67zspsy2r76zygvkxq6y65f3bchlhhhj1rr19kalh"
+   "commit": "f5b48d2a605c1383ddb8522ed315b625115f16a6",
+   "sha256": "12h4jvqzw2s30c1wxd26qa9m8fhpb2nc1ijh05781fkxd7sqrdkr"
   },
   "stable": {
    "version": [
@@ -123038,14 +123700,14 @@
   "repo": "caramelhooves/teleport.el",
   "unstable": {
    "version": [
-    20250110,
-    1250
+    20251009,
+    739
    ],
    "deps": [
     "dash"
    ],
-   "commit": "30bd57e3040b2d7e0a527e47cc773584e3b873a6",
-   "sha256": "0mdwsfmdiji493v276phb8q62znc57mx3ys7xvy3aj57rn0yj2ca"
+   "commit": "0cda2233170109fa87a9ff97a79fb315b039f91e",
+   "sha256": "10dc2asjrj6xk80s3c8xh14yx90pdib4aishziiq31x22a33rnpi"
   }
  },
  {
@@ -123089,25 +123751,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20250823,
-    2003
+    20250920,
+    848
    ],
    "deps": [
     "compat"
    ],
-   "commit": "779d9577ac537534fad4221c96e6c565bb14908a",
-   "sha256": "0nf3jqibg9xnwsfznvsfkd5cjyj2amg705n2bcrbc92plsjfmxnd"
+   "commit": "79e0538f7c273a1ae73ec3f8c77563e38ed31e84",
+   "sha256": "0w9cibpmai4rbfjvjqjqxrizka9z48dx7vh4w2xcic15jywvdrpb"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9fa2c59660fe9473429a51872d3c00e1b95cab86",
-   "sha256": "104wifdqglk6hxs6z3gr6rmxf3hdqsl3y9bvcp3wwm10yqkpnmkx"
+   "commit": "aa0f6fab4013d4661c34f9352531ceac1f0973a8",
+   "sha256": "1a5pk000cy4zgh73hdpw08cwf1qr7cgw4hpj5n0dkprwbw5hhm8s"
   }
  },
  {
@@ -123570,19 +124232,20 @@
   "repo": "milanglacier/termint.el",
   "unstable": {
    "version": [
-    20250824,
-    1809
+    20251004,
+    424
    ],
-   "commit": "0e5ae2c685bf8b45f89fd91dc235ddaf5d4ffbd5",
-   "sha256": "0lp0rinxjlalb2d4lp2sxngwnr3sjdyr90djx97ylrrx7s1g6jax"
+   "commit": "7f908bfe9bbaeb624b44285bebff6b52e0ccebcc",
+   "sha256": "0lq0rn2rzz50znrk0fr36f1b2isz1shygc5xfgi30gxrbxh3a85w"
   },
   "stable": {
    "version": [
     0,
+    1,
     1
    ],
-   "commit": "18f60f732dd91d274a8cbdfa2508aaa922c32708",
-   "sha256": "0mw8sk071ph3s0vcvbkkqd8bwp8n7y3ijnfrfpkklilg3zb0vrqq"
+   "commit": "7d265907a960f7e0fab84a107185228860351f54",
+   "sha256": "1q8c1w7c332cfi8frk2vib8v63sl349nzdj4iay1a9gxhkdgxpbl"
   }
  },
  {
@@ -124111,6 +124774,24 @@
   }
  },
  {
+  "ename": "thanks",
+  "commit": "99862d682838aa49b2d58a250da629d5315906ab",
+  "sha256": "06r6d5fvvcp8lajsljm27ma74rbdflpa928pcj6d45v0frnzfgnl",
+  "fetcher": "github",
+  "repo": "FrostyX/thanks",
+  "unstable": {
+   "version": [
+    20250907,
+    1400
+   ],
+   "deps": [
+    "gh"
+   ],
+   "commit": "7dcc186ea754695694f1ce7159ab8b6a2d663f3c",
+   "sha256": "002s3i2d0zkahs9smhv5mrwihdzxvlzavq9dfbicfrlvyh8knph1"
+  }
+ },
+ {
   "ename": "the-matrix-theme",
   "commit": "aed1e8ffa09b9f8994811da804019b31d5ef3fe6",
   "sha256": "00s6hg0ww5pr789frmpgmn7b6bqirz4hwl0m8sbdf8aii8gv4shi",
@@ -124342,21 +125023,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20250824,
-    1632
+    20251006,
+    1136
    ],
-   "commit": "879208449207e47a4b655e11848979f41a7e4b29",
-   "sha256": "0wabymrm7r1zjcz32sl28yrmgcn96axw8i3ab9aszvxx3alb77fg"
+   "commit": "c35086693e07ca7af8ab09cb89710ba9f929c490",
+   "sha256": "13wshgfd8zd07x3mbkrqija425932mgdgb5ivbnkmsx9s55cjvw4"
   },
   "stable": {
    "version": [
     2025,
-    8,
-    25,
+    10,
+    6,
     0
    ],
-   "commit": "879208449207e47a4b655e11848979f41a7e4b29",
-   "sha256": "0wabymrm7r1zjcz32sl28yrmgcn96axw8i3ab9aszvxx3alb77fg"
+   "commit": "c35086693e07ca7af8ab09cb89710ba9f929c490",
+   "sha256": "13wshgfd8zd07x3mbkrqija425932mgdgb5ivbnkmsx9s55cjvw4"
   }
  },
  {
@@ -124396,6 +125077,25 @@
    ],
    "commit": "6e7564593d7735acc9f3fa670ec6512991cb73a1",
    "sha256": "173zk9nzjds0rkypmaq8xv5qianivgk16jpzgk0msdsn9kjbd8s9"
+  }
+ },
+ {
+  "ename": "ticktick",
+  "commit": "977d9c4fbdea86825272d401d01d5722ed948965",
+  "sha256": "1ixgrzazdm3ahw2f9976laq7j4gsnv37fwd8hp9kaac3hgcffxx4",
+  "fetcher": "github",
+  "repo": "polhuang/ticktick.el",
+  "unstable": {
+   "version": [
+    20250827,
+    2049
+   ],
+   "deps": [
+    "request",
+    "simple-httpd"
+   ],
+   "commit": "edab80659c655af1e1538b3cfbbbe399a428b9c8",
+   "sha256": "038lms98az5m7bpzpmbg2airmkda5wa8wqzrzvfx6x19dna4pfp4"
   }
  },
  {
@@ -124615,11 +125315,19 @@
   "repo": "karthink/timeout",
   "unstable": {
    "version": [
-    20250822,
-    1813
+    20250911,
+    2339
    ],
-   "commit": "0efdd2173cfd84a9f49b721ce7ef685048499905",
-   "sha256": "0j4adn4kir87kqc4j3fd8h3fkdi5c4dnqsy8q22s99p12i2c37v4"
+   "commit": "6d31046c5b1817271a52ab810e5bc635fe7ab3b4",
+   "sha256": "16hzgdm5pq5qwg7w64w1q8kkwv1r9967bpcashcnm7pcwgk7bavk"
+  },
+  "stable": {
+   "version": [
+    2,
+    1
+   ],
+   "commit": "6d31046c5b1817271a52ab810e5bc635fe7ab3b4",
+   "sha256": "16hzgdm5pq5qwg7w64w1q8kkwv1r9967bpcashcnm7pcwgk7bavk"
   }
  },
  {
@@ -124869,6 +125577,29 @@
    ],
    "commit": "7cedeb264a44cd62bcd9c778dca52316d09e07e5",
    "sha256": "0ym6cxglacclk0sgwbnbswwslf8bs6d0drj89nrabnhad15prxgz"
+  }
+ },
+ {
+  "ename": "tintin-mode",
+  "commit": "ecb28c6273cfa6e9705301f94025480614014871",
+  "sha256": "14bciaz086gmcab888z0svwzgv1kl7cn4qk7prm6gkwz16a85aqs",
+  "fetcher": "github",
+  "repo": "lesharris/tintin-mode",
+  "unstable": {
+   "version": [
+    20251001,
+    2003
+   ],
+   "commit": "7820fd9f15bfd0a492b03973621abd81c370babf",
+   "sha256": "0piyi4fj2xlml6rpqi8f5cslk7q7iqlh7fydpvj3jl6bjzrxl0nn"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "commit": "7820fd9f15bfd0a492b03973621abd81c370babf",
+   "sha256": "0piyi4fj2xlml6rpqi8f5cslk7q7iqlh7fydpvj3jl6bjzrxl0nn"
   }
  },
  {
@@ -125227,11 +125958,11 @@
   "repo": "topikettunen/tok-theme",
   "unstable": {
    "version": [
-    20241114,
-    1637
+    20251007,
+    1430
    ],
-   "commit": "fa495ad556079af8efff758d3705dbf22ca64ca1",
-   "sha256": "0abdvzww9lj20jjqygj6sp528dilry4368w2pc88j7whfv1wyp2i"
+   "commit": "c99b30cfb7bbf98479d1236b199308c31ebede76",
+   "sha256": "0hb6hmhha2vn1kkml0477zsnfpi3agkmf0pxynsxng7bjx3h4pld"
   }
  },
  {
@@ -125793,11 +126524,11 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20250421,
-    1753
+    20250831,
+    39
    ],
-   "commit": "9d9f63fd7cf8812797eb0ef77d7969e7387a9eb9",
-   "sha256": "12vq5p3bmqp4gh4s40s8sbz8hs2zczkcl4zfnn7ybr5sc36g1zax"
+   "commit": "254814886cb4fdeba0ab1a9df33f7cbcdc1900cf",
+   "sha256": "0yp1nsx4ncx6b1ss634jlc5pc52g1r6crv6jn6qwgh1kng65xrvx"
   },
   "stable": {
    "version": [
@@ -125943,28 +126674,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20250816,
-    1830
+    20251006,
+    1815
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "07a104aa73b5d5e3168ba6e202ebfb60188af6ed",
-   "sha256": "1rka160jgk1i1bqlizyb46la3gck2i8gb1ywy0r51a3grl2x92rk"
+   "commit": "053d56e4de2dd78bf32f7af7ed5f289a91cdb6ac",
+   "sha256": "0097px3gqvyjiv05bc1gzandfkncx5khhg34999r2a6ffj65xa68"
   },
   "stable": {
    "version": [
     0,
-    9,
-    4
+    10,
+    1
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "aa32e0d66cc389befed7a8e8df9439d92a729daa",
-   "sha256": "1bv4ziz44yn4jnzbi6px55hk5h9cxr8jv2v1cdafc2bs9i11qb3n"
+   "commit": "053d56e4de2dd78bf32f7af7ed5f289a91cdb6ac",
+   "sha256": "0097px3gqvyjiv05bc1gzandfkncx5khhg34999r2a6ffj65xa68"
   }
  },
  {
@@ -125975,14 +126706,14 @@
   "repo": "conao3/transient-dwim.el",
   "unstable": {
    "version": [
-    20221225,
-    1630
+    20251006,
+    339
    ],
    "deps": [
     "transient"
    ],
-   "commit": "cb5e0d35729fc6448553b7a17fc5c843f00e8c1d",
-   "sha256": "03mk0rvi3mn2wbx817swqd5y784k446yh8l4vv892rjb81fchl2g"
+   "commit": "65985faf00f5a0e5e725c4f3f9f4118d19b8ee5a",
+   "sha256": "16ygz5csgcx5ri3qpid3v3kk1wfshf9napli5ymn6g76spp07sam"
   }
  },
  {
@@ -126419,26 +127150,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20250824,
-    1812
+    20251005,
+    2228
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "3d22dcde8574a7991bea412d45d7db71d50ce544",
-   "sha256": "032wljj3qf7lqk8dyzbr24zppyfjjdbljilhlyv5bnxszxgs8wap"
+   "commit": "980deccc43b2a00e9888e04ef6d4935b31b4d92b",
+   "sha256": "1qm02rrxyqib0y008l85nbpf6xi7mmxxshpnjxib029dab29dm3w"
   },
   "stable": {
    "version": [
     0,
     12,
-    301
+    310
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "3d22dcde8574a7991bea412d45d7db71d50ce544",
-   "sha256": "032wljj3qf7lqk8dyzbr24zppyfjjdbljilhlyv5bnxszxgs8wap"
+   "commit": "980deccc43b2a00e9888e04ef6d4935b31b4d92b",
+   "sha256": "1qm02rrxyqib0y008l85nbpf6xi7mmxxshpnjxib029dab29dm3w"
   }
  },
  {
@@ -126515,8 +127246,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20250729,
-    1429
+    20250907,
+    1320
    ],
    "deps": [
     "ace-window",
@@ -126528,8 +127259,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "5fa84199501fd43e5573b1277a2b1699c7473cc1",
-   "sha256": "08wjq7czw9ix9aaz82f7n3x14byv2cc8whmirqjzsp19l29r2qq4"
+   "commit": "05333cc23ca4349cd839cf1c18e1eaef1f6b70ec",
+   "sha256": "0bglrc7lwgv1wmbybbcs7ncnlc5nwa7n3mr1ffhmh37z6srwlba3"
   },
   "stable": {
    "version": [
@@ -127276,14 +128007,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20250228,
-    257
+    20250909,
+    1604
    ],
    "deps": [
     "caml"
    ],
-   "commit": "1600fdad28bdd2c55e52a87e7987713c6d5d1718",
-   "sha256": "0s5nc0pqk9l28gw5sv3wzv9qk7r1p25m1kjmkrnl9agk6f1rck0i"
+   "commit": "de9572f537b71c5e67b6ad676e1f7e42e8180878",
+   "sha256": "0c9cpwbqn1mpyz8gw09n7kffs3rm3v58q0wrzkihbig47cvzj998"
   },
   "stable": {
    "version": [
@@ -128186,11 +128917,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20250611,
-    332
+    20250918,
+    17
    ],
-   "commit": "99d1b5099f432123577c51b6a67210b0c37716e6",
-   "sha256": "0sbijq1gac6dzrv2n2s6pwn96n3gx7bq8d5zsd71nq0635ffbkdq"
+   "commit": "366717d88f77182f780829f2041f1a16ca2970c7",
+   "sha256": "101fq3z33f1742gzrzhwv5x8ig8zj1yqlidmvfgdgqkcmm5a61rl"
   }
  },
  {
@@ -128583,14 +129314,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20250825,
-    917
+    20251005,
+    1159
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "193205f2c08cc905909398ef902ffb2cb49c86cd",
-   "sha256": "04pmkzq3f4sl3xm75dzz6ilsbz2x24cs4rf5rn7zjqlqwzwihgrm"
+   "commit": "c55d942b145df12658116ce174e11ed593b554dc",
+   "sha256": "03xnzngk8jc71qimp4a6zd7mgss1hi6krpdbmcyddpbgx9qs173w"
   }
  },
  {
@@ -129299,11 +130030,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20250716,
-    39
+    20250913,
+    2251
    ],
-   "commit": "2b959be31103ca645c28e45b476e89fe17d23777",
-   "sha256": "133fj5r15sblvdk3vh33jqag32sm4lsic4wk4jd06kanhy9nwjkr"
+   "commit": "a3022c1d4c69de1b51e061288e8f08cab02ef991",
+   "sha256": "1jf232h9cla1nnm2rh673npw73fjgz0sp2dcmjrij50vqsy3kqz2"
   }
  },
  {
@@ -129400,11 +130131,11 @@
   "repo": "kborling/uwu-theme",
   "unstable": {
    "version": [
-    20250416,
-    117
+    20250902,
+    202
    ],
-   "commit": "13baeac7649762d8d0220d954c177c5aeb1d3b1b",
-   "sha256": "0xvdax4w28rpzyb9gy7ixpdyzikfiqax8b5n04dc3xdvjrmiyyyq"
+   "commit": "430e06214e8230357bea8252e8a56c5c1aa8f3eb",
+   "sha256": "175d83yzhv84ib92dxhiy2b4dndiynis60kmcnffbwwb4j5pxra1"
   }
  },
  {
@@ -130113,11 +130844,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20250731,
-    2205
+    20250916,
+    350
    ],
-   "commit": "e818377f2ceddf5670dcd9a32d3de0e8bf82a8f1",
-   "sha256": "14pjrq87nzgh7vm34vdhadbxgblzwc5rb5gsbql7v2lqha898svs"
+   "commit": "3179e53373b9c39845a460474e5483a28c0d22c5",
+   "sha256": "0xwnzskbaladg7646y99rpcq4615l2qjqlrn241gqrk8xjkh78qc"
   },
   "stable": {
    "version": [
@@ -130174,8 +130905,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20250821,
-    1213
+    20251008,
+    2322
    ],
    "deps": [
     "ag",
@@ -130189,13 +130920,13 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "740ce49e9d6f70486acd2aa0952b5f25d8a324fd",
-   "sha256": "19nm5vfmci96n3bc53575m0amrbsbwq345phwz31xh2haqgn1g3f"
+   "commit": "fb7d629688f862e0bdb91986d72bcff2ae7c3e23",
+   "sha256": "1hgplmd9zzikp6wklx4y8svzd7n2i0rmfhphpms0f2zl74ana6c6"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     0
    ],
    "deps": [
@@ -130210,8 +130941,8 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "869ecc0a07ad018f16310055e34c630ece8f549c",
-   "sha256": "19rks3iwa7naqscx7scppk69g7avdwgc3vkgyaxf79dpxx85aa8v"
+   "commit": "fb7d629688f862e0bdb91986d72bcff2ae7c3e23",
+   "sha256": "1hgplmd9zzikp6wklx4y8svzd7n2i0rmfhphpms0f2zl74ana6c6"
   }
  },
  {
@@ -130222,26 +130953,26 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20250812,
-    1617
+    20251008,
+    2041
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "c57897fbb529c6cd768b96d22c54b645cfc6194a",
-   "sha256": "1nnq2a1qjqfn0hkqj4n4r49llqks5krvh6chvi42wyhkpn62i1bg"
+   "commit": "b71a15e1677060bc0a3e7dc180a11a82074a2157",
+   "sha256": "19jzdi4n8qj65wxgfr0simnsy2r90rpac5bgkc5bz7w2vfy7rhk3"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "efcd2207dfb7e5ae3e1fc6d6eeea9b8267ec9ef9",
-   "sha256": "1i6f9ya0zlxf9nv19w1a3akq4bm0lwswflcnl53nrh4qw0p4j0zh"
+   "commit": "b71a15e1677060bc0a3e7dc180a11a82074a2157",
+   "sha256": "19jzdi4n8qj65wxgfr0simnsy2r90rpac5bgkc5bz7w2vfy7rhk3"
   }
  },
  {
@@ -130261,6 +130992,21 @@
    ],
    "commit": "72dd31ef847344d79409503f3c42169041eb3da4",
    "sha256": "04am1kzrimnkl2g1inik5l50i6gr5mafs0jdinvalhrdnbdr45iq"
+  }
+ },
+ {
+  "ename": "verse-mode",
+  "commit": "f40679e2f28ebcb1f27ca29d6ba1ee76b8ba0549",
+  "sha256": "0cvqv83ndmfv0rvsh1ab3wc15anwnpcbs1b1bbv8waw46v6yxsn5",
+  "fetcher": "github",
+  "repo": "sness23/verse-mode",
+  "unstable": {
+   "version": [
+    20250910,
+    2354
+   ],
+   "commit": "d5facb02832e812d47c4354b26c60d2f73097165",
+   "sha256": "1yjk4v3l3rqfdyc0g8njvqblw3rn62d2svkcp7xyfn6296ww73x6"
   }
  },
  {
@@ -130330,25 +131076,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20250824,
-    1017
+    20250908,
+    1638
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5140630c2396623c3d7de85cebba72cfd11b9af5",
-   "sha256": "110m6nkaiakhrlz9bcf56waq4bwy7njdwkwcl7cdfydwysv0r48b"
+   "commit": "488685badfdf49bb750a213f228bdba8e113c7c8",
+   "sha256": "1cc7myy92sc6rks0fp0916cbgfdh5ars0z918cpyfrm0pkingq7x"
   },
   "stable": {
    "version": [
     2,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fcab88ad878e16356c392c99a64f172e7541dd65",
-   "sha256": "089ngnx3avqs0xlf25hmpp2sximdc9wxkq9fvmjf87viiz175k1y"
+   "commit": "488685badfdf49bb750a213f228bdba8e113c7c8",
+   "sha256": "1cc7myy92sc6rks0fp0916cbgfdh5ars0z918cpyfrm0pkingq7x"
   }
  },
  {
@@ -130437,8 +131183,8 @@
   "repo": "gmlarumbe/vhdl-ext",
   "unstable": {
    "version": [
-    20250821,
-    1757
+    20251009,
+    1205
    ],
    "deps": [
     "ag",
@@ -130449,14 +131195,14 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "99a4a17940872e3e122375eff20caf1ee8ef8655",
-   "sha256": "1nl1z4mh7fn3di7gbqgkm33pgcq0axa75svrv6kln1wqymlb7vvn"
+   "commit": "abaeede75309794b6d104af2d387452f148e5ca4",
+   "sha256": "1nh3qi25rlgq701gzxjibx8mplzwps1j4rz6cq65vkbrbzxj16l1"
   },
   "stable": {
    "version": [
     0,
-    6,
-    1
+    7,
+    0
    ],
    "deps": [
     "ag",
@@ -130467,8 +131213,8 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "04c7e7738376af45c6397f08cfafb4f34222af17",
-   "sha256": "1nzh8vk3pp7chk5vnwa5d9ddqvgv95ar2djnjnnhmrk2z79klpg5"
+   "commit": "5a3513d2f26ace017e9fab7141754ff5bdebb0eb",
+   "sha256": "0agiamq7g8zm3blznykbr1kgr09rb133rd4mh9nfc0vfk8i5mabv"
   }
  },
  {
@@ -130479,20 +131225,20 @@
   "repo": "gmlarumbe/vhdl-ts-mode",
   "unstable": {
    "version": [
-    20250721,
-    1616
+    20251008,
+    2052
    ],
-   "commit": "3f9916cda24d014cf02af841fa0e9e0c411e1f56",
-   "sha256": "063d37jjc60kdkb7cx8hfbsrirwccw9jladwbpv86dimc0fqknp5"
+   "commit": "9da613a72aa7caaa32b11f4de6f2e778bfb9376c",
+   "sha256": "0x11sjiy3j43am0clwxsbx7b38pfsl74qgypkc3czs7dh1c5xyrx"
   },
   "stable": {
    "version": [
     0,
     3,
-    1
+    2
    ],
-   "commit": "3f9916cda24d014cf02af841fa0e9e0c411e1f56",
-   "sha256": "063d37jjc60kdkb7cx8hfbsrirwccw9jladwbpv86dimc0fqknp5"
+   "commit": "9da613a72aa7caaa32b11f4de6f2e778bfb9376c",
+   "sha256": "0x11sjiy3j43am0clwxsbx7b38pfsl74qgypkc3czs7dh1c5xyrx"
   }
  },
  {
@@ -130593,20 +131339,20 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20250820,
-    1631
+    20250914,
+    124
    ],
-   "commit": "6fdb71cbb74449d9cc5492159691ee3d2eb42eab",
-   "sha256": "1g718jpilwl831ypq2y8f654453fadn3jqfkg15bkdswgpav8kzg"
+   "commit": "ec339632e0fa52045fc4bdc7fcfaee60d6e8eff1",
+   "sha256": "0cvjx9fw5aznbkw6di450x3hpbk491rl2a4hshxhbm6j5bp5bfjx"
   },
   "stable": {
    "version": [
     1,
     0,
-    8
+    9
    ],
-   "commit": "abf7fb4f83c0dd87fa247c776c5d91963fb785e0",
-   "sha256": "126p9363dqciar2gxj12ipr7gqjbr3l4j0mglaxyk5lbmg98xji6"
+   "commit": "ec339632e0fa52045fc4bdc7fcfaee60d6e8eff1",
+   "sha256": "0cvjx9fw5aznbkw6di450x3hpbk491rl2a4hshxhbm6j5bp5bfjx"
   }
  },
  {
@@ -130737,11 +131483,19 @@
   "repo": "countvajhula/virtual-ring",
   "unstable": {
    "version": [
-    20250522,
-    1957
+    20250920,
+    1541
    ],
-   "commit": "138afec2ce1176ebcf18124294b21428487245de",
-   "sha256": "01cvxng298ln6k071f0l8ggky70z0460sslx3v764jyia9lxkrc6"
+   "commit": "2d53ba23ecdca94801cc88085c7df7346d98e514",
+   "sha256": "0blw37zdvp6rc92qkj5dcadapzx2isizf5y2zyqp4358wpqyfjpn"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "ded8cf97a234d2e9bf5bdaa405aca20659e0d40d",
+   "sha256": "1v986w4d315fmrmr0ik9v0srrsf48pmiwa6cqw0v4s6qdhccvcal"
   }
  },
  {
@@ -130829,11 +131583,11 @@
   "repo": "joostkremers/visual-fill-column",
   "unstable": {
    "version": [
-    20250323,
-    1529
+    20250925,
+    1054
    ],
-   "commit": "30fc3e4ea9aa415eccc873e5d7c4f1bbc0491495",
-   "sha256": "0sy01jx8z229ival3y4bj0jrb3w2ys8kiw3bmy6ssjwbl7xlyxxj"
+   "commit": "a38e3a28e580084749f5adb31a382aba118fa2bd",
+   "sha256": "0dlwbp59dcyikr2p0jyjz9k81la2scskj7wc9w085y1fcf36fpnr"
   },
   "stable": {
    "version": [
@@ -130912,11 +131666,11 @@
   "repo": "szermatt/visual-replace",
   "unstable": {
    "version": [
-    20250719,
-    2051
+    20250913,
+    2103
    ],
-   "commit": "d64e22028d32cebcc9a8b041a62b0f000c60659c",
-   "sha256": "0cd81f0p2x43fxbh0y71y5x88z5lwdr75cmcr41axzh5lyvq5ha3"
+   "commit": "cf6a02fae01d9962862920a6cfe2488df2f76684",
+   "sha256": "1g8idc8lkf5vfnyj68jsivr4gmm9mmgizd5zp13nh52qfi5k2lra"
   },
   "stable": {
    "version": [
@@ -131018,19 +131772,19 @@
   "repo": "k-talo/volatile-highlights.el",
   "unstable": {
    "version": [
-    20250723,
-    2155
+    20250924,
+    1215
    ],
-   "commit": "3952439feb0173745ce36c1fc192c84494186b55",
-   "sha256": "0ykjry3adcc7k6bmhxixr1xykpp83n7m8nwd7kpqhq35f4w8pmfm"
+   "commit": "b1e7754d7b502ef6583a13f2662e515a654f944d",
+   "sha256": "1cljb6vs0c0gffby41cw85jxdvbqnykdz0b3fr08y9nwbhnsiq6w"
   },
   "stable": {
    "version": [
     1,
-    18
+    20
    ],
-   "commit": "11861d7ea1603fca305dd1d0488f7e697c8a7e1e",
-   "sha256": "10vaidj32wbhmjx4chr1zgfzikysns1fqx4gh2iya7cy75likw4m"
+   "commit": "b1e7754d7b502ef6583a13f2662e515a654f944d",
+   "sha256": "1cljb6vs0c0gffby41cw85jxdvbqnykdz0b3fr08y9nwbhnsiq6w"
   }
  },
  {
@@ -131156,11 +131910,11 @@
   "repo": "hardenedapple/vsh",
   "unstable": {
    "version": [
-    20250812,
-    757
+    20250901,
+    1658
    ],
-   "commit": "0746df2fb306e0c3d8dea26899f618c68b6b63e3",
-   "sha256": "0dpn0vy98b0fmyampxb5vc2sc25ybl18z1265j41jgd4pwl82zq1"
+   "commit": "47c35e3062a20418340c8150c8d5ad41c1e7d6b4",
+   "sha256": "0jmlgvm9jw247r4yqw4vyaq5slys5r54h33a183wafb30gvfsbi1"
   }
  },
  {
@@ -131171,11 +131925,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20241218,
-    331
+    20250929,
+    1514
    ],
-   "commit": "f64729ed8b59e46ce827d28222c4087c538de562",
-   "sha256": "0bbkw9l44ir03s8lxbnci0gaaqhgj5wb3rqgj2nygaq0ih4mqvg9"
+   "commit": "adf8d10212d15f9bd5ca62b96c7b423be02ce3c4",
+   "sha256": "1275g9wjqp56ghjgki9pqzb569pp58hcxiy3hy0752pgx0qyaa17"
   }
  },
  {
@@ -131664,8 +132418,8 @@
   "repo": "chenyanming/wallabag.el",
   "unstable": {
    "version": [
-    20250421,
-    1046
+    20251007,
+    1036
    ],
    "deps": [
     "emacsql",
@@ -131673,8 +132427,8 @@
     "request",
     "s"
    ],
-   "commit": "5f4da856ef31bea112c6d0491ee22339c1acd725",
-   "sha256": "19h09yklgm05nkv37325whmj7a3zippvhhzq1p5kqmp9dns7q00g"
+   "commit": "798379d3a7210cb03abe6e470b59c212bb467632",
+   "sha256": "01sp9pvylvcpb30l9iz5xs2pingv1h1hnws3di7q07y6dfzpan9f"
   }
  },
  {
@@ -131762,16 +132516,16 @@
   "repo": "emacsmirror/wanderlust",
   "unstable": {
    "version": [
-    20250629,
-    2048
+    20250907,
+    2201
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "b7d2e84bf3260ea2de7903eab8330538b3423a6e",
-   "sha256": "036jxcb999kgypg52rqd4s0nw5na1vp2r8ksafw1y2w8srky6mms"
+   "commit": "a642423f7fee4a55406501ea896e17c7cf9e3133",
+   "sha256": "0fhpcvgb9g0yk342iqfx4mgygc14xcqmc86yybb8m17amkhs50dd"
   }
  },
  {
@@ -132080,11 +132834,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20250714,
-    657
+    20250827,
+    1315
    ],
-   "commit": "f1f22bc9ce8cc80d7eb00e63d62b78140fae1e54",
-   "sha256": "0gih4vhbkmmyhmv2f8r6abc96cfrf0xgq4dy1sbcadl1plh6n4zs"
+   "commit": "1eb0abb1a9bffbb33db7bbfc6efe5b48bf416d57",
+   "sha256": "19bvi12cm8yyjp545hm9fn2n57k7b0lrvqypd3gij2p8s041cm6r"
   },
   "stable": {
    "version": [
@@ -132226,26 +132980,26 @@
   "repo": "pzel/weblio",
   "unstable": {
    "version": [
-    20240514,
-    1005
+    20250928,
+    1117
    ],
    "deps": [
     "request"
    ],
-   "commit": "952d085fd814b139562ef947c7dcabc31f92341d",
-   "sha256": "1v36x3iyav5i28zp5b1899071xlxawq6ml642258bilhaba2j37a"
+   "commit": "86adae50e51a74149d9805c0446edf10a7f5c3f7",
+   "sha256": "0ka5ndq16sjm0w0mr3xzfxbxbdinv52iyss1mqs096yqnn0lqv31"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
    "deps": [
     "request"
    ],
-   "commit": "952d085fd814b139562ef947c7dcabc31f92341d",
-   "sha256": "1v36x3iyav5i28zp5b1899071xlxawq6ml642258bilhaba2j37a"
+   "commit": "86adae50e51a74149d9805c0446edf10a7f5c3f7",
+   "sha256": "0ka5ndq16sjm0w0mr3xzfxbxbdinv52iyss1mqs096yqnn0lqv31"
   }
  },
  {
@@ -132806,17 +133560,17 @@
  },
  {
   "ename": "white-theme",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "04l5hjhd465w9clrqc4dr8bx8hj4i9dx4nfr9hympgv101bpgy4x",
+  "commit": "2dbcb69f603a94b6abc196d45ec5d2fb2ddc1344",
+  "sha256": "0l74qikpv2ry6i81pc1ylw8f5bibbd3b8l42ygypkv09qan16hpx",
   "fetcher": "github",
-  "repo": "anler/white-theme.el",
+  "repo": "nullvec/white-theme.el",
   "unstable": {
    "version": [
-    20160917,
-    1743
+    20250921,
+    2105
    ],
-   "commit": "e9e6d5b9d43da6eb15e86f5fbc8b1ba83abe8c78",
-   "sha256": "1yqfq1gzkrw79myvj16nfi30ynfyz8yrpbzjcj8nhsc5rfrrmym2"
+   "commit": "7c42cb08425ac7f7e33e8d947a950a55dee3fadf",
+   "sha256": "19nx8i1zcqb58vf8bd2cg81ff0wm4lkjxng31isdika7pc5kdidx"
   }
  },
  {
@@ -133515,26 +134269,26 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20250801,
-    1152
+    20250901,
+    1618
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0a2df46e2831c3b8ddc8f688069f2b4a49898731",
-   "sha256": "081h1l22py0hrix9wdhjm9gnjbw1ijqlahg67wiv41083wg8jmfv"
+   "commit": "87a384a0e59260cca41ca8831d98e195b1ec8ada",
+   "sha256": "1d0y32y934ld60vdyx9hwbvpifmhdmm08066x0ivxqcyw0qyggxg"
   },
   "stable": {
    "version": [
     3,
     4,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0a2df46e2831c3b8ddc8f688069f2b4a49898731",
-   "sha256": "081h1l22py0hrix9wdhjm9gnjbw1ijqlahg67wiv41083wg8jmfv"
+   "commit": "87a384a0e59260cca41ca8831d98e195b1ec8ada",
+   "sha256": "1d0y32y934ld60vdyx9hwbvpifmhdmm08066x0ivxqcyw0qyggxg"
   }
  },
  {
@@ -134242,14 +134996,14 @@
   "repo": "cjennings/emacs-wttrin",
   "unstable": {
    "version": [
-    20240521,
-    2004
+    20250925,
+    1236
    ],
    "deps": [
     "xterm-color"
    ],
-   "commit": "5655b5fd438622581f84eb84c8880f20e11b87ed",
-   "sha256": "1mna2jahwv6kyr832jba4ch3xwx618v4dwhwaxxchv9hzgxpf38g"
+   "commit": "4d8973dcc5c3c3d043011e67c8d4e9d581df6a43",
+   "sha256": "18mrw1g3vix6a1jh0wldlrqjjbd34q3hg2qwwm0jflzdsjlzjkqg"
   },
   "stable": {
    "version": [
@@ -135770,11 +136524,11 @@
   "repo": "mastro35/year-1984-theme",
   "unstable": {
    "version": [
-    20250806,
-    655
+    20250902,
+    1120
    ],
-   "commit": "7d8b5ec7eb9ee364a66cc7c83d6490915543ba1f",
-   "sha256": "10p9xgadmpim8g2i6knxy11imv4hm18zkxn9f04ysv27ipnjx36g"
+   "commit": "d04b9b267085bb3606426dab2e26ea6489b31de3",
+   "sha256": "0ihr07cir07pxlkqzb5yfi0mk1ic6ymg8i3bg4271fr1myifjkd1"
   }
  },
  {
@@ -135785,14 +136539,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20250815,
-    610
+    20250927,
+    411
    ],
    "deps": [
     "compat"
    ],
-   "commit": "bc094600f5b39a7d1f6c6aeb125054fab276fb9a",
-   "sha256": "0b8h63sz4n4al38xdny87dklllm2m1pajppjg74j2sb91gy7fqdv"
+   "commit": "e897ff82307b1003b9bdb88e7594a9df90398d7f",
+   "sha256": "1qi7l606rdiz9i0vd27k9bhnqbwdixw7vjc0frcycxih26dvkvzz"
   },
   "stable": {
    "version": [
@@ -136649,14 +137403,14 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20250618,
-    1627
+    20250915,
+    1207
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "9f86fded13e28c6c9ccf56d417276547bac7e54e",
-   "sha256": "0n6h9k03s7nbpabda0xds5x6g1rhr7jg2igjgs476rzi60pfgcxs"
+   "commit": "8c1f0bd07e88a443e16e6ffd3abd1d3e76e10f35",
+   "sha256": "0ywgb5sf7afyayp0zwkmr7li9kmgry91kmxdq805cpzyv0ng25m7"
   }
  },
  {
@@ -136672,6 +137426,24 @@
    ],
    "commit": "3898b70d6f72da688e086323fa2922f1542d1318",
    "sha256": "1lw7iwc422dj9zcd5bpi2n24zgssjvqc9hgnay4iv3ah0ayvraf6"
+  }
+ },
+ {
+  "ename": "ziggy-mode",
+  "commit": "c4a20d572acd403d4bc6736fe5f5ca5314d27813",
+  "sha256": "1xx56p19sblci62krhx6fkwrv7ifk7mr2kqic8ilnh3nbc8sdg03",
+  "fetcher": "github",
+  "repo": "dcolazin/ziggy-mode",
+  "unstable": {
+   "version": [
+    20250930,
+    4
+   ],
+   "deps": [
+    "reformatter"
+   ],
+   "commit": "07db893782d095b95f304669b7c652f5a7888ddd",
+   "sha256": "1b4mmhzy8a7vgrhnmxwcyn59xw4vwfq7lk9c38pc5pmvbqn3aay5"
   }
  },
  {
@@ -136721,11 +137493,11 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20250405,
-    2035
+    20250908,
+    1240
    ],
-   "commit": "38703add4740e54862e406b44e38269b7d65671d",
-   "sha256": "01yp2a7nd0v82f37b6c1kiaxfpvscg1s0kgswa5wkz5a1x7q02c9"
+   "commit": "302e494324066d63f317b54c4db75d173914c521",
+   "sha256": "10qdia4w31709jk81xcvlyn1ac7zspiawvfx5spr09vff00gbljc"
   },
   "stable": {
    "version": [
@@ -136744,15 +137516,15 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20241006,
-    1334
+    20250905,
+    1921
    ],
    "deps": [
     "zk",
     "zk-index"
    ],
-   "commit": "297ebd0df13c957f4ba9700cafc5466dafacc5cb",
-   "sha256": "0r6frhdpakzjrh6qhcr913jcf95ncbs0rsfdgkrka5d5gkrdds41"
+   "commit": "a634b6ec7af4f16a1ceed9271d2a0dbd9bca8501",
+   "sha256": "1akiid6z812sp1jfwrf3qz4wklc0mdmina4rfj9bfyphiivk4lf6"
   },
   "stable": {
    "version": [
@@ -136775,14 +137547,14 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20250405,
-    2034
+    20250908,
+    1240
    ],
    "deps": [
     "zk"
    ],
-   "commit": "181e2ed7206fd168e8eca315a63e90871bb7562f",
-   "sha256": "03q344pjycp6nz9sraby5r0iscpv6y8pqps6ym60z920scadyyap"
+   "commit": "302e494324066d63f317b54c4db75d173914c521",
+   "sha256": "10qdia4w31709jk81xcvlyn1ac7zspiawvfx5spr09vff00gbljc"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- emacs-overlay commit: c3e2ca282d91c806f1c10ae9387c9631241f21f7
- new failed toplevel builds:
  - [X] emacs.pkgs.procress
  - [x] emacs.pkgs.blue: [upstream report][1]
  - [x] emacs.pkgs.elisp-depmap: [upstream report][2]
  - [ ] emacs.pkgs.sdml-mode

[1]: https://codeberg.org/lapislazuli/blue.el/issues/3
[2]: https://github.com/mtekman/elisp-depmap.el/issues/7

Closes: #449908

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
