### PR TITLE
qt6.qtbase: build with jemalloc

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -161,7 +161,10 @@ let
       qttools = callPackage ./modules/qttools { };
       qttranslations = callPackage ./modules/qttranslations.nix {
         qttools = self.qttools.override {
-          qtbase = self.qtbase.override { qttranslations = null; };
+          qtbase = self.qtbase.override {
+            qttranslations = null;
+            withJemalloc = false;
+          };
           qtdeclarative = null;
         };
       };

--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -39,6 +39,8 @@
   glib,
   harfbuzz,
   icu,
+  withJemalloc ? true,
+  jemalloc,
   libX11,
   libXcomposite,
   libXext,
@@ -115,6 +117,12 @@ stdenv.mkDerivation rec {
     md4c
     double-conversion
   ]
+  ++ lib.optional withJemalloc (
+    jemalloc.override {
+      # pyside explodes otherwise
+      disableInitExecTls = true;
+    }
+  )
   ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [
     libproxy
     dbus
@@ -183,7 +191,6 @@ stdenv.mkDerivation rec {
     gperf
     lndir
     perl
-    pkg-config
     which
     cmake
     ninja
@@ -192,6 +199,7 @@ stdenv.mkDerivation rec {
 
   propagatedNativeBuildInputs = [
     lndir
+    pkg-config
   ]
   # I’m not sure if this is necessary, but the macOS mkspecs stuff
   # tries to call `xcrun xcodebuild`, so better safe than sorry.
@@ -297,6 +305,7 @@ stdenv.mkDerivation rec {
     "-DQT_HOST_PATH=${pkgsBuildBuild.qt6.qtbase}"
     "-DQt6HostInfo_DIR=${pkgsBuildBuild.qt6.qtbase}/lib/cmake/Qt6HostInfo"
   ]
+  ++ lib.optional withJemalloc "-DQT_FEATURE_jemalloc=ON"
   ++ lib.optional (
     qttranslations != null && !isCrossBuild
   ) "-DINSTALL_TRANSLATIONSDIR=${qttranslations}/translations";

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -21,30 +21,30 @@ let
     qtbase
 
     # optional
-    qt3d
-    qtcharts
-    qtconnectivity
-    qtdatavis3d
+    # qt3d
+    # qtcharts
+    # qtconnectivity
+    # qtdatavis3d
     qtdeclarative
-    qthttpserver
-    qtmultimedia
-    qtnetworkauth
-    qtquick3d
-    qtremoteobjects
-    qtscxml
-    qtsensors
-    qtspeech
-    qtsvg
-    qtwebchannel
-    qtwebsockets
-    qtwebview
-    qtpositioning
-    qtlocation
-    qtshadertools
-    qtserialport
-    qtserialbus
-    qtgraphs
-    qttools
+    # qthttpserver
+    # qtmultimedia
+    # qtnetworkauth
+    # qtquick3d
+    # qtremoteobjects
+    # qtscxml
+    # qtsensors
+    # qtspeech
+    # qtsvg
+    # qtwebchannel
+    # qtwebsockets
+    # qtwebview
+    # qtpositioning
+    # qtlocation
+    # qtshadertools
+    # qtserialport
+    # qtserialbus
+    # qtgraphs
+    # qttools
   ];
   qt_linked = symlinkJoin {
     name = "qt_linked";
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     if stdenv.hostPlatform.isLinux then
       # qtwebengine fails under darwin
       # see https://github.com/NixOS/nixpkgs/pull/312987
-      packages ++ [ python.pkgs.qt6.qtwebengine ]
+      packages # ++ [ python.pkgs.qt6.qtwebengine ]
     else
       python.pkgs.qt6.darwinVersionInputs
       ++ [


### PR DESCRIPTION
This currently segfaults pyside somehow, needs more investigation, opening this as a starting point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
