### PR TITLE
qt6.wrapQtAppsHook: don't include qtwayland

### DIFF
--- a/doc/languages-frameworks/qt.section.md
+++ b/doc/languages-frameworks/qt.section.md
@@ -25,15 +25,7 @@ stdenv.mkDerivation {
 
 The same goes for Qt 5 where libraries and tools are under `libsForQt5`.
 
-Any Qt package should include `wrapQtAppsHook` or `wrapQtAppsNoGuiHook` in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
-
-::: {.note}
-
-`wrapQtAppsHook` propagates plugins and QML components from `qtwayland` on platforms that support it, to allow applications to act as native Wayland clients. It should be used for all graphical applications.
-
-`wrapQtAppsNoGuiHook` does not propagate `qtwayland` to reduce closure size for purely command-line applications.
-
-:::
+Any Qt package should include `wrapQtAppsHook` in `nativeBuildInputs`, or explicitly set `dontWrapQtApps` to bypass generating the wrappers.
 
 ## Packages supporting multiple Qt versions {#qt-versions}
 

--- a/pkgs/by-name/dr/drawpile/package.nix
+++ b/pkgs/by-name/dr/drawpile/package.nix
@@ -83,12 +83,7 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
     rustc
     rustPlatform.cargoSetupHook
-    (
-      if buildClient || buildServerGui then
-        qt6Packages.wrapQtAppsHook
-      else
-        qt6Packages.wrapQtAppsNoGuiHook
-    )
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/li/libarchive-qt/package.nix
+++ b/pkgs/by-name/li/libarchive-qt/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    qt6.wrapQtAppsNoGuiHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/li/linyaps/package.nix
+++ b/pkgs/by-name/li/linyaps/package.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     copyDesktopItems
     pkg-config
-    qt6Packages.wrapQtAppsNoGuiHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   postInstall = ''

--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    kdePackages.wrapQtAppsNoGuiHook
+    kdePackages.wrapQtAppsHook
   ]
   ++ lib.optionals (withGstreamer || withOmemo) [
     pkg-config

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -133,20 +133,6 @@ let
           propagatedBuildInputs = [ makeBinaryWrapper ];
           depsTargetTargetPropagated = [
             (onlyPluginsAndQml qtbase)
-          ]
-          ++ lib.optionals (lib.meta.availableOn stdenv.targetPlatform qtwayland) [
-            (onlyPluginsAndQml qtwayland)
-          ];
-        } ./hooks/wrap-qt-apps-hook.sh
-      ) { };
-
-      wrapQtAppsNoGuiHook = callPackage (
-        { makeBinaryWrapper, qtbase }:
-        makeSetupHook {
-          name = "wrap-qt6-apps-no-gui-hook";
-          propagatedBuildInputs = [ makeBinaryWrapper ];
-          depsTargetTargetPropagated = [
-            (onlyPluginsAndQml qtbase)
           ];
         } ./hooks/wrap-qt-apps-hook.sh
       ) { };
@@ -164,6 +150,7 @@ let
     }
     // lib.optionalAttrs config.allowAliases {
       full = throw "qt6.full has been removed. Please use individual packages instead."; # Added 2025-10-21
+      wrapQtAppsNoGuiHook = lib.warn "wrapQtAppsNoGuiHook is deprecated, use wrapQtAppsHook instead" self.wrapQtAppsHook;
     };
 
   baseScope = makeScopeWithSplicing' {

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -77,11 +77,10 @@ else # Only set up Qt once.
     fi
 
     qtPreHook() {
-        # Check that wrapQtAppsHook/wrapQtAppsNoGuiHook is used, or it is explicitly disabled.
+        # Check that wrapQtAppsHook is used, or it is explicitly disabled.
         if [[ -z "$__nix_wrapQtAppsHook" && -z "$dontWrapQtApps" ]]; then
             echo >&2 "Error: this derivation depends on qtbase, but no wrapping behavior was specified."
-            echo >&2 "  - If this is a graphical application, add wrapQtAppsHook to nativeBuildInputs"
-            echo >&2 "  - If this is a CLI application, add wrapQtAppsNoGuiHook to nativeBuildInputs"
+            echo >&2 "  - If this is an application, add wrapQtAppsHook to nativeBuildInputs"
             echo >&2 "  - If this is a library or you need custom wrapping logic, set dontWrapQtApps = true"
             exit 1
         fi


### PR DESCRIPTION
The base windowing integration for Wayland lives in qtbase now, and qtwayland only provides libadwaita decorations, which are only relevant on GNOME-likes without server-side decoration support, and should probably be installed by the appropriate modules.

Drafting for post-25.11 and also we need to figure out how to actually install qadwaita.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
