### PR TITLE
python3Packages.tree-sitter: run tests by using GH source

### DIFF
--- a/pkgs/by-name/ke/keymap-drawer/package.nix
+++ b/pkgs/by-name/ke/keymap-drawer/package.nix
@@ -1,4 +1,28 @@
 {
-  python3Packages,
+  python3,
+  fetchFromGitHub,
 }:
-python3Packages.toPythonApplication python3Packages.keymap-drawer
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      tree-sitter = super.tree-sitter.overrideAttrs {
+        version = "0.24.0";
+        src = fetchFromGitHub {
+          owner = "tree-sitter";
+          repo = "py-tree-sitter";
+          tag = "v0.24.0";
+          hash = "sha256-ZDt/8suteaAjGdk71l8eej7jDkkVpVDBIZS63SA8tsU=";
+          fetchSubmodules = true;
+        };
+        # keymap-drawer only requires tree-sitter-devicetree grammer, and
+        # the tests fail with numereous TREE_SITTER_LANGUAGE_VERSION
+        # related failures related to other grammers. Hence we disable the
+        # tests altogether, hoping that in the future this python3.override
+        # won't be needed at all.
+        doInstallCheck = false;
+      };
+    };
+  };
+in
+python.pkgs.toPythonApplication python.pkgs.keymap-drawer

--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -3,7 +3,6 @@
 
   buildPythonPackage,
   fetchFromGitHub,
-  fetchPypi,
   pythonOlder,
 
   nix-update-script,
@@ -47,16 +46,7 @@ buildPythonPackage {
     pydantic-settings
     pyparsing
     pyyaml
-    # keymap-drawer currently requires tree-sitter 0.24.0
-    # See https://github.com/caksoylar/keymap-drawer/issues/183
-    (tree-sitter.overrideAttrs rec {
-      version = "0.24.0";
-      src = fetchPypi {
-        inherit version;
-        inherit (tree-sitter) pname;
-        hash = "sha256-q9la9lyi9Pfso1Y0M5HtZp52Tzd0i1NSlG8A9/x45zQ=";
-      };
-    })
+    tree-sitter
     tree-sitter-grammars.tree-sitter-devicetree
   ];
 
@@ -80,5 +70,10 @@ buildPythonPackage {
       MattSturgeon
     ];
     mainProgram = "keymap";
+    # keymap-drawer currently requires tree-sitter 0.24.0
+    # See https://github.com/caksoylar/keymap-drawer/issues/183
+    # top-level package `keymap-drawer` is not broken due to this
+    # incompatibility, thanks to a Python override
+    broken = lib.versionAtLeast tree-sitter.version "0.25.0";
   };
 }

--- a/pkgs/development/python-modules/tree-sitter/default.nix
+++ b/pkgs/development/python-modules/tree-sitter/default.nix
@@ -1,10 +1,18 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
+
+  # tests
+  pytestCheckHook,
+  tree-sitter-python,
+  tree-sitter-rust,
+  tree-sitter-html,
+  tree-sitter-javascript,
+  tree-sitter-json,
 }:
 
 buildPythonPackage rec {
@@ -12,19 +20,43 @@ buildPythonPackage rec {
   version = "0.25.2";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-/kPBWFVdpGcjsotS4FitREGVr9HbPKdyDFmiVFROnCA=";
+  src = fetchFromGitHub {
+    owner = "tree-sitter";
+    repo = "py-tree-sitter";
+    tag = "v${version}";
+    hash = "sha256-MgiVxq9MUaOkNNgn46g2Cy7/IUx/yatKSR1vE6LscKg=";
+    fetchSubmodules = true;
   };
 
   build-system = [ setuptools ];
 
+  nativeCheckInputs = [
+    pytestCheckHook
+    tree-sitter-python
+    tree-sitter-rust
+    tree-sitter-html
+    tree-sitter-javascript
+    tree-sitter-json
+  ];
+
   pythonImportsCheck = [ "tree_sitter" ];
+
+  preCheck = ''
+    # https://github.com/NixOS/nixpkgs/issues/255262#issuecomment-1721265871
+    rm -r tree_sitter
+  '';
+
+  disabledTests = [
+    # Test fails only in the Nix sandbox, with:
+    #
+    #    AssertionError: Lists differ: ['', '', ''] != ['graph {\n', 'label="new_parse"\n', '}\n']
+    "test_dot_graphs"
+  ];
 
   meta = {
     description = "Python bindings to the Tree-sitter parsing library";
     homepage = "https://github.com/tree-sitter/py-tree-sitter";
-    changelog = "https://github.com/tree-sitter/py-tree-sitter/releases/tag/v${version}";
+    changelog = "https://github.com/tree-sitter/py-tree-sitter/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
