### PR TITLE
solvespace: fix cmake4 requiring a minimum version

### DIFF
--- a/pkgs/by-name/so/solvespace/package.nix
+++ b/pkgs/by-name/so/solvespace/package.nix
@@ -90,7 +90,11 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  cmakeFlags = [ "-DENABLE_OPENMP=ON" ];
+  cmakeFlags = [
+    "-DENABLE_OPENMP=ON"
+    # CMake 4 needs a minimum version
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
 
   meta = {
     description = "Parametric 3d CAD program";


### PR DESCRIPTION
CMake4 now requires a minumum version.
```
[~]$ nix run nixpkgs#solvespace
error: Cannot build '/nix/store/ybdhkxqz0wwrlgbfwwq31kndi63ca078-solvespace-3.1.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/wxfbv8vzr3r30f063kq2gc7722g2nvwn-solvespace-3.1
       Last 25 log lines:
       > -- Detecting C compile features - done
       > -- Detecting CXX compiler ABI info
       > -- Detecting CXX compiler ABI info - done
       > -- Check for working CXX compiler: /nix/store/dmypp1h4ldn0vfk3fi6yfyf5yxp9yz0k-gcc-wrapper-14.3.0/bin/g++ - skipped
       > -- Detecting CXX compile features
       > -- Detecting CXX compile features - done
       > -- Performing Test HAS_FILE_PREFIX_MAP
       > -- Performing Test HAS_FILE_PREFIX_MAP - Success
       > -- Found OpenMP_C: -fopenmp (found version "4.5")
       > -- Found OpenMP_CXX: -fopenmp (found version "4.5")
       > -- Found OpenMP: TRUE (found version "4.5")
       > -- found OpenMP, compiling with flags: -fopenmp
       > -- Using in-tree libdxfrw
       > -- Using in-tree mimalloc
       > CMake Error at extlib/mimalloc/CMakeLists.txt:1 (cmake_minimum_required):
       >   Compatibility with CMake < 3.5 has been removed from CMake.
       >
       >   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
       >   to tell CMake that the project requires at least <min> but has been updated
       >   to work with policies introduced by <max> or earlier.
       >
       >   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
       >
       > 
       > -- Configuring incomplete, errors occurred!
       For full logs, run:
         nix log /nix/store/ybdhkxqz0wwrlgbfwwq31kndi63ca078-solvespace-3.1.drv
```

I've added a `cmakeFlag` `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` similar to #449468

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
