### PR TITLE
go-parallel: init at 0-unstable-2025-12-06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27443,7 +27443,6 @@
     name = "Dmitry Voronin";
     github = "voronind-com";
     githubId = 22127600;
-    keys = [ { fingerprint = "3241 FDAD 82A7 E22D 4279  F405 913F 3267 9278 2E1C"; } ];
   };
   votava = {
     email = "votava@gmail.com";

--- a/pkgs/by-name/go/go-parallel/package.nix
+++ b/pkgs/by-name/go/go-parallel/package.nix
@@ -1,0 +1,28 @@
+{
+  buildGoModule,
+  fetchgit,
+  lib,
+  ...
+}:
+buildGoModule {
+  pname = "go-parallel";
+  version = "0-unstable-2025-12-06";
+  vendorHash = null;
+  src = fetchgit {
+    url = "https://git.voronind.com/voronind/par";
+    rev = "f7c6f2d381956ce51c33dccfb0e5755f15ad378b";
+    sha256 = "mK6z/7v/6NgSisX+BFzuRMJVHRCdiOH/lVLaWd0oAxg=";
+  };
+  postInstall = ''
+    install -D $src/completion.sh $out/share/bash-completion/completions/par
+    install -D $src/man.1 $out/share/man/man1/par.1
+  '';
+
+  meta = {
+    description = "CLI shell parallelisation tool written in Go";
+    homepage = "https://git.voronind.com/voronind/par";
+    license = lib.licenses.mit;
+    mainProgram = "par";
+    maintainers = with lib.maintainers; [ voronind ];
+  };
+}


### PR DESCRIPTION
I also switched to using SSH keys to sign, so I removed my old GPG fingerprint from myself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
