### PR TITLE
superfile: 1.3.3 -> 1.6.0

### DIFF
--- a/pkgs/by-name/su/superfile/package.nix
+++ b/pkgs/by-name/su/superfile/package.nix
@@ -6,9 +6,10 @@
   nix-update-script,
   writableTmpDirAsHomeHook,
   exiftool,
+  zoxide,
 }:
 let
-  version = "1.3.3";
+  version = "1.6.0";
   tag = "v${version}";
 in
 buildGoModule {
@@ -19,28 +20,52 @@ buildGoModule {
     owner = "yorukot";
     repo = "superfile";
     inherit tag;
-    hash = "sha256-A1SWsBcPtGNbSReslp5L3Gg4hy3lDSccqGxFpLfVPrk=";
+    hash = "sha256-JETdQ42vGPnpviCAR29BSdBTG+huWRr5syN5NysnAlo=";
   };
 
-  vendorHash = "sha256-sqt0BzJW1nu6gYAhscrXlTAbwIoUY7JAOuzsenHpKEI=";
+  vendorHash = "sha256-d2Yo8fWJ2fj7RJrnktljY6TkEPq6Tnbdh2BM4DIAr0E=";
 
   ldflags = [
     "-s"
     "-w"
   ];
 
-  nativeBuildInputs = [ exiftool ];
+  # TestLayout test does not support parallel testing
+  enableParallelBuilding = false;
+
+  nativeBuildInputs = [
+    exiftool
+    zoxide
+  ];
 
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
-  # Upstream notes that this could be flaky, and it consistently fails for me.
+  preCheck = ''
+    mkdir -p $HOME/.local/share/superfile
+  '';
+
   checkFlags = [
-    "-skip=^TestReturnDirElement/Sort_by_Date$"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Only failing on nix darwin. I suspect this is due to the way
-    # darwin handles file permissions.
-    "-skip=^TestCompressSelectedFiles"
+    "-skip=^${
+      lib.concatStringsSep "$|^" (
+        [
+          # Upstream notes that this could be flaky, and it consistently fails for me.
+          "TestReturnDirElement/Sort_by_Date"
+
+          # Tests fail with
+          # ... `validations failed, error : file panel 1 error : invalid cursor : 0, element count : 0, layout info` ...
+          "TestLayout"
+        ]
+        ++ lib.optionals stdenv.isDarwin [
+          # Only failing on nix darwin. I suspect this is due to the way
+          # darwin handles file permissions.
+          "TestCompressSelectedFiles"
+          "TestFileDelete/Move_to_trash"
+
+          # Fails with directory cleanup
+          "TestZoxide"
+        ]
+      )
+    }$"
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
I can't get `TestLayout` to work. The error seems to indicate that it can't open a virtual terminal in the sandbox.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
