### PR TITLE
OVMF/OVMF-cloud-hypervisor: Add cloud-hypervisor OVMF support for `aarch64`

### DIFF
--- a/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
+++ b/pkgs/by-name/ov/OVMF-cloud-hypervisor/package.nix
@@ -1,7 +1,148 @@
-{ lib, OVMF }:
+{
+  stdenv,
+  nixosTests,
+  lib,
+  edk2,
+  util-linux,
+  nasm,
+  acpica-tools,
+  llvmPackages,
+  fetchFromGitLab,
+  fdSize2MB ? false,
+  fdSize4MB ? secureBoot,
+  secureBoot ? false,
+  systemManagementModeRequired ? secureBoot && stdenv.hostPlatform.isx86,
+  httpSupport ? false,
+  tpmSupport ? false,
+  tlsSupport ? false,
+  debug ? false,
+  # Usually, this option is broken, do not use it except if you know what you are
+  # doing.
+  sourceDebug ? false,
+  projectDscPath ?
+    {
+      x86_64 = "OvmfPkg/CloudHv/CloudHvX64.dsc";
+      aarch64 = "ArmVirtPkg/ArmVirtCloudHv.dsc";
+    }
+    .${stdenv.hostPlatform.parsed.cpu.name}
+      or (throw "Unsupported OVMF `projectDscPath` on ${stdenv.hostPlatform.parsed.cpu.name}"),
+  fwPrefix ?
+    {
+      x86_64 = "CLOUDHV";
+      aarch64 = "CLOUDHV_EFI";
+    }
+    .${stdenv.hostPlatform.parsed.cpu.name}
+      or (throw "Unsupported OVMF `fwPrefix` on ${stdenv.hostPlatform.parsed.cpu.name}"),
+}:
 
-OVMF.override {
-  projectDscPath = "OvmfPkg/CloudHv/CloudHvX64.dsc";
-  fwPrefix = "CLOUDHV";
-  metaPlatforms = builtins.filter (lib.hasPrefix "x86_64-") OVMF.meta.platforms;
-}
+let
+  cpuName = stdenv.hostPlatform.parsed.cpu.name;
+
+  version = lib.getVersion edk2;
+
+  OvmfPkKek1AppPrefix = "4e32566d-8e9e-4f52-81d3-5bb9715f9727";
+
+  debian-edk-src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "qemu-team";
+    repo = "edk2";
+    nonConeMode = true;
+    sparseCheckout = [
+      "debian/edk2-vars-generator.py"
+      "debian/python"
+      "debian/PkKek-1-*.pem"
+      "debian/patches/OvmfPkg-X64-add-opt-org.tianocore-UninstallMemAttrPr.patch"
+    ];
+    rev = "refs/tags/debian/2025.02-8";
+    hash = "sha256-n/6T5UBwW8U49mYhITRZRgy2tNdipeU4ZgGGDu9OTkg=";
+  };
+
+  buildPrefix = "Build/*/*";
+
+in
+
+edk2.mkDerivation projectDscPath (finalAttrs: {
+  pname = "OVMF";
+  inherit version;
+
+  outputs = [
+    "out"
+    "fd"
+  ];
+
+  nativeBuildInputs = [
+    util-linux
+    nasm
+    acpica-tools
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.bintools
+    llvmPackages.llvm
+  ];
+
+  strictDeps = true;
+
+  hardeningDisable = [
+    "format"
+    "stackprotector"
+    "pic"
+    "fortify"
+  ];
+
+  buildFlags =
+    # IPv6 has no reason to be disabled.
+    [ "-D NETWORK_IP6_ENABLE=TRUE" ]
+    ++ lib.optionals debug [ "-D DEBUG_ON_SERIAL_PORT=TRUE" ]
+    ++ lib.optionals sourceDebug [ "-D SOURCE_DEBUG_ENABLE=TRUE" ]
+    ++ lib.optionals secureBoot [ "-D SECURE_BOOT_ENABLE=TRUE" ]
+    ++ lib.optionals systemManagementModeRequired [ "-D SMM_REQUIRE=TRUE" ]
+    ++ lib.optionals fdSize2MB [ "-D FD_SIZE_2MB" ]
+    ++ lib.optionals fdSize4MB [ "-D FD_SIZE_4MB" ]
+    ++ lib.optionals httpSupport [
+      "-D NETWORK_HTTP_ENABLE=TRUE"
+      "-D NETWORK_HTTP_BOOT_ENABLE=TRUE"
+    ]
+    ++ lib.optionals tlsSupport [ "-D NETWORK_TLS_ENABLE=TRUE" ]
+    ++ lib.optionals tpmSupport [
+      "-D TPM_ENABLE"
+      "-D TPM2_ENABLE"
+      "-D TPM2_CONFIG_ENABLE"
+    ];
+
+  buildConfig = if debug then "DEBUG" else "RELEASE";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Qunused-arguments";
+
+  patches = [
+    (debian-edk-src + "/debian/patches/OvmfPkg-X64-add-opt-org.tianocore-UninstallMemAttrPr.patch")
+  ];
+
+  postInstall = ''
+    mkdir -vp $fd/FV
+    mv -v $out/FV/${fwPrefix}.fd $fd/FV
+  '';
+
+  dontPatchELF = true;
+
+  passthru =
+    let
+      prefix = "${finalAttrs.finalPackage.fd}/FV/${fwPrefix}";
+    in
+    {
+      mergedFirmware = "${prefix}.fd";
+      firmware = "${prefix}.fd";
+      # This will test the EFI firmware for the host platform as part of the NixOS Tests setup.
+      tests.basic-systemd-boot = nixosTests.systemd-boot.basic;
+      tests.secureBoot-systemd-boot = nixosTests.systemd-boot.secureBoot;
+      inherit secureBoot systemManagementModeRequired;
+    };
+
+  meta = {
+    description = "Sample UEFI firmware for Cloud Hypervisor and KVM";
+    homepage = "https://github.com/tianocore/tianocore.github.io/wiki/OVMF";
+    license = lib.licenses.bsd2;
+    teams = with lib.teams; [
+      ctrl-os
+    ];
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This MR introduces aarch64 support for the cloud hypervisor flavour of OVMF.
Currently, the OVMF package does not support building a OVMF firmware for cloud hypervisor for the aarch64 architecture, because the output files are different from the standard output files for the QEMU version of OVMF on aarch64 architectures.
No updates to the OVMF package is needed, as the source code is already available in the current package
## Things done
- Changed `pkgs/applications/virtualization/OVMF/default.nix postBuild and postInstall phases to support the `cloud-hypervisor` flavour of OVMF 
- Added aarch64 architecture to the `OVMF-cloud-hypervisor` meta.platforms
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
