### PR TITLE
nfs-ganesha: fix cmake 4 build, tools, and BTRFS detection

### DIFF
--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -87,7 +87,11 @@ stdenv.mkDerivation rec {
   ++ lib.optional useCeph ceph;
 
   postPatch = ''
-    substituteInPlace src/tools/mount.9P --replace "/bin/mount" "/usr/bin/env mount"
+    substituteInPlace src/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 2.6.3)" \
+      "cmake_minimum_required(VERSION 3.10)"
+
+    substituteInPlace src/tools/mount.9P --replace-fail "/bin/mount" "/usr/bin/env mount"
   '';
 
   postFixup = ''

--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    install -Dm755 $src/src/tools/mount.9P $tools/bin/mount.9P
+    install -Dm755 ../tools/mount.9P $tools/bin/mount.9P
   ''
   + lib.optionalString useDbus ''
     # Policy for D-Bus statistics interface

--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -7,6 +7,7 @@
   sphinx,
   krb5,
   xfsprogs,
+  btrfs-progs,
   jemalloc,
   libcap,
   ntirpc,
@@ -77,6 +78,7 @@ stdenv.mkDerivation rec {
     acl
     krb5
     xfsprogs
+    btrfs-progs
     jemalloc
     dbus.lib
     libcap

--- a/pkgs/by-name/nt/ntirpc/package.nix
+++ b/pkgs/by-name/nt/ntirpc/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
       "cmake_minimum_required(VERSION 2.6.3)" \
       "cmake_minimum_required(VERSION 3.10)"
 
-    substituteInPlace ntirpc/netconfig.h --replace "/etc/netconfig" "$out/etc/netconfig"
-    sed '1i#include <assert.h>' -i src/work_pool.c
+    substituteInPlace ntirpc/netconfig.h --replace-fail \
+      "/etc/netconfig" "$out/etc/netconfig"
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/nt/ntirpc/package.nix
+++ b/pkgs/by-name/nt/ntirpc/package.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     "dev"
   ];
   postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 2.6.3)" \
+      "cmake_minimum_required(VERSION 3.10)"
+
     substituteInPlace ntirpc/netconfig.h --replace "/etc/netconfig" "$out/etc/netconfig"
     sed '1i#include <assert.h>' -i src/work_pool.c
   '';


### PR DESCRIPTION
* Fix compatibility with CMake 4 (no upstream patches are currently available). See https://github.com/NixOS/nixpkgs/issues/445447
* Fix patching of the mount.9P utility.
* Add btrfs-progs to allow btrfs subvolume detection.





## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
