### PR TITLE
chromium,chromedriver: 141.0.7390.65 -> 141.0.7390.76

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "141.0.7390.65",
+    "version": "141.0.7390.76",
     "chromedriver": {
-      "version": "141.0.7390.66",
-      "hash_darwin": "sha256-0LLARLPwlZ3KB5xCq4Yx5S6vtnhVddJ62IdgEy0vp7o=",
-      "hash_darwin_aarch64": "sha256-rLW5FOMNyFEn1Du2VN2sGfWri2erjN7SENa01vA2Vp8="
+      "version": "141.0.7390.77",
+      "hash_darwin": "sha256-lLzkO+PkVPZsnD00Ag/NSmpe7DbYPxHEQgsgqpvFijs=",
+      "hash_darwin_aarch64": "sha256-py6zFm8HhmijU6Z3SP8FO6w/DIIMVyP51jOPpqme0YE="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "b2ec783d2b51a396804a4e3e33f6586be09a4e2d",
-        "hash": "sha256-9jZ7411NThelyL0R5yoLXB0lOkydOI3v6K5ORhjqfF4=",
+        "rev": "d6fcfbb51aac4df61d06692d4a62fd8b9aaf3c3a",
+        "hash": "sha256-PefndHEz3LALHSCsw6tuNiobQVzsTrseUmf4lqnpNpM=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/10/stable-channel-update-for-desktop_9.html

This update resolves a privacy concern around passing urls to AI Mode. See https://chromium-review.googlesource.com/c/chromium/src/+/7023081

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
