### PR TITLE
 picotool: 2.1.1 -> 2.2.0-a4

### DIFF
--- a/pkgs/by-name/pi/picotool/package.nix
+++ b/pkgs/by-name/pi/picotool/package.nix
@@ -6,29 +6,21 @@
   pkg-config,
   libusb1,
   pico-sdk,
-  mbedtls_2,
+  mbedtls,
   versionCheckHook,
   gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "picotool";
-  version = "2.1.1";
+  version = "2.2.0-a4";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "picotool";
     tag = finalAttrs.version;
-    hash = "sha256-WA17FXSUGylzUcbvzgAGCeds+XeuSvDlgFBJD10ERVY=";
+    hash = "sha256-kIB/ODAvwWWoAQDq2cMiFuNWjzzLgPuRQv0NluWYU+Y=";
   };
-
-  postPatch = ''
-    # necessary for signing/hashing support. our pico-sdk does not come with
-    # it by default, and it shouldn't due to submodule size. pico-sdk uses
-    # an upstream version of mbedtls 2.x so we patch ours in directly.
-    substituteInPlace lib/CMakeLists.txt \
-      --replace-fail "''$"'{PICO_SDK_PATH}/lib/mbedtls' '${mbedtls_2.src}'
-  '';
 
   buildInputs = [
     libusb1
@@ -38,11 +30,9 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
-  cmakeFlags = [ "-DPICO_SDK_PATH=${pico-sdk}/lib/pico-sdk" ];
-
-  postInstall = ''
-    install -Dm444 ../udev/99-picotool.rules -t $out/etc/udev/rules.d
-  '';
+  cmakeFlags = [
+    "-DPICO_SDK_PATH=${pico-sdk}/lib/pico-sdk"
+  ];
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Updates picotool to 2.2.0-a4 
 - NOTE: a4 refers to the rp2035-a4 variant (latest) patch that was applied to 2.2.0, NOT that it's alpha 4 :)

Updates to mbedtls3.
 - resolves build issues with mbedtls2 as it used cmake 2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
