### PR TITLE
LAStools: 2.0.3 -> 2.0.3-unstable-2025-09-15 and fix build with cmake 4

### DIFF
--- a/pkgs/by-name/la/LAStools/drop-64-suffix.patch
+++ b/pkgs/by-name/la/LAStools/drop-64-suffix.patch
@@ -1,13 +1,12 @@
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -32,6 +32,6 @@ endforeach(TARGET)
- foreach(TARGET ${ALL_TARGETS})
- 	target_link_libraries(${TARGET} LASlib)
- 	set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../bin64)
--	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET}64)
-+	set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET})
- 	install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
+@@ -40,6 +40,6 @@ foreach(TARGET ${ALL_TARGETS})
+   set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
+   target_link_libraries(${TARGET} LASlib ${CMAKE_DL_LIBS})
+   set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../bin64)
+-  set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET}64)
++  set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME ${TARGET})
+   install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
  endforeach(TARGET)
--- 
 2.28.0
 

--- a/pkgs/by-name/la/LAStools/package.nix
+++ b/pkgs/by-name/la/LAStools/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     cmake
   ];
 
+  cmakeFlags = [ (lib.strings.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5") ];
+
   meta = with lib; {
     description = "Software for rapid LiDAR processing";
     homepage = "http://lastools.org/";

--- a/pkgs/by-name/la/LAStools/package.nix
+++ b/pkgs/by-name/la/LAStools/package.nix
@@ -5,15 +5,15 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "LAStools";
-  version = "2.0.3";
+  version = "2.0.3-unstable-2025-09-15";
 
   src = fetchFromGitHub {
     owner = "LAStools";
     repo = "LAStools";
-    rev = "v${version}";
-    sha256 = "sha256-IyZjM8YvIVB0VPNuEhmHHw7EuKw5RanB2qhCnBD1fRY=";
+    rev = "718f0032e14499a0fa54f6ecef483ab98a6da286";
+    sha256 = "sha256-j8K6aB7uYWEQtefOj2gPGuplBY61SryKJtdFmoBBv9o=";
   };
 
   patches = [
@@ -29,8 +29,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
   ];
-
-  cmakeFlags = [ (lib.strings.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5") ];
 
   meta = with lib; {
     description = "Software for rapid LiDAR processing";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
