### PR TITLE
kodi: 21.2 -> 22.0

### DIFF
--- a/pkgs/applications/video/kodi/addons/addon-update-script/default.nix
+++ b/pkgs/applications/video/kodi/addons/addon-update-script/default.nix
@@ -10,7 +10,7 @@
 { attrPath }:
 
 let
-  url = "http://mirrors.kodi.tv/addons/omega/addons.xml.gz";
+  url = "http://mirrors.kodi.tv/addons/piers/addons.xml.gz";
   updateScript = writeShellScript "update.sh" ''
     set -ex
 

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -18,8 +18,9 @@
   boost,
   avahi,
   lame,
+  exiv2,
   gettext,
-  pcre-cpp,
+  pcre2,
   yajl,
   fribidi,
   which,
@@ -37,7 +38,7 @@
   alsa-lib,
   libGLU,
   libGL,
-  ffmpeg,
+  ffmpeg_8,
   fontconfig,
   freetype,
   ftgl,
@@ -72,7 +73,7 @@
   libcec_platform,
   dcadec,
   libuuid,
-  libcrossguid,
+  crossguid,
   libmicrohttpd,
   bluez,
   doxygen,
@@ -88,7 +89,7 @@
   zlib,
   flatbuffers,
   fstrcmp,
-  rapidjson,
+  nlohmann_json,
   lirc,
   mesa-gl-headers,
   x11Support ? true,
@@ -244,14 +245,14 @@ stdenv.mkDerivation (
   in
   {
     pname = "kodi";
-    version = "21.3";
-    kodiReleaseName = "Omega";
+    version = "22.0a3";
+    kodiReleaseName = "Piers";
 
     src = fetchFromGitHub {
       owner = "xbmc";
       repo = "xbmc";
       rev = "${finalAttrs.version}-${finalAttrs.kodiReleaseName}";
-      hash = "sha256-36wBAqGEDCRZ4t1ygTg03Pyk7Gg9quUTUGD3SBp6nCk=";
+      hash = "sha256-z9MnqMvo2jChmogYOmVz4D42NLgGbmjL19/sRs1AZSI=";
     };
 
     # make  derivations declared in the let binding available here, so
@@ -275,8 +276,9 @@ stdenv.mkDerivation (
       python3Packages.python
       boost
       libmicrohttpd
+      exiv2
       gettext
-      pcre-cpp
+      pcre2
       yajl
       fribidi
       libva
@@ -329,17 +331,17 @@ stdenv.mkDerivation (
       libgcrypt
       libgpg-error
       libunistring
-      libcrossguid
+      crossguid
       libplist
       bluez
       glib
       harfbuzz
       lcms2
       libpthread-stubs
-      ffmpeg
+      ffmpeg_8.dev
       flatbuffers
       fstrcmp
-      rapidjson
+      nlohmann_json
       lirc
       mesa-gl-headers
 
@@ -422,7 +424,7 @@ stdenv.mkDerivation (
       "-DGIT_VERSION=${finalAttrs.version}-${finalAttrs.kodiReleaseName}"
       "-DENABLE_EVENTCLIENTS=ON"
       "-DENABLE_INTERNAL_CROSSGUID=OFF"
-      "-DENABLE_INTERNAL_RapidJSON=OFF"
+      "-DENABLE_INTERNAL_NLOHMANNJ=OFF"
       "-DENABLE_OPTICAL=${if opticalSupport then "ON" else "OFF"}"
       "-DENABLE_VDPAU=${if vdpauSupport then "ON" else "OFF"}"
       "-DLIRC_DEVICE=/run/lirc/lircd"
@@ -496,7 +498,7 @@ stdenv.mkDerivation (
 
     passthru = {
       pythonPackages = python3Packages;
-      ffmpeg = ffmpeg;
+      ffmpeg = ffmpeg_8;
       kodi = finalAttrs.finalPackage;
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10761,18 +10761,15 @@ with pkgs;
   kodiPackages = recurseIntoAttrs (kodi.packages);
 
   kodi = callPackage ../applications/video/kodi {
-    ffmpeg = ffmpeg_6;
     jre_headless = buildPackages.jdk11_headless;
   };
 
   kodi-wayland = callPackage ../applications/video/kodi {
-    ffmpeg = ffmpeg_6;
     jre_headless = buildPackages.jdk11_headless;
     waylandSupport = true;
   };
 
   kodi-gbm = callPackage ../applications/video/kodi {
-    ffmpeg = ffmpeg_6;
     jre_headless = buildPackages.jdk11_headless;
     gbmSupport = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

new `kodi` release is upcoming so here is the WIP PR for anyone interested in testing

- `ffmpeg` bumped from `6` to ~`7`~ `8`
- [pcre-cpp has been dropped](https://github.com/xbmc/xbmc/pull/24128)
- [added exif2 as dependency](https://github.com/xbmc/xbmc/pull/24109)
- [replaced rapidjson with nlohmann_json](https://github.com/xbmc/xbmc/pull/26612)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
