### PR TITLE
[Backport release-25.05] victoriametrics: 1.119.0 -> 1.127.0

### DIFF
--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.123.0";
+  version = "1.124.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GUVRMlF94BaZSVfz4Z+IBSpf6WuA5o1WQQmeZAqKZ1g=";
+    hash = "sha256-f0Mf/4cFnJ/3I8z/4UhhNJnSCau9Q7mFfR32lP9/yi0=";
   };
 
   vendorHash = null;
@@ -57,6 +57,10 @@ buildGoModule (finalAttrs: {
     #
     # This appears to be some kind of test server for development purposes only.
     rm -f app/vmui/packages/vmui/web/{go.mod,main.go}
+
+    # Allow older go versions
+    substituteInPlace go.mod \
+      --replace-fail "go 1.24.6" "go ${finalAttrs.passthru.go.version}"
 
     # Increase timeouts in tests to prevent failure on heavily loaded builders
     substituteInPlace lib/storage/storage_test.go \

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.124.0";
+  version = "1.125.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-f0Mf/4cFnJ/3I8z/4UhhNJnSCau9Q7mFfR32lP9/yi0=";
+    hash = "sha256-Xhurksf2BMw+v+4PsKm9o+XO2KfYX9wZTlq/kLLxVYc=";
   };
 
   vendorHash = null;
@@ -60,7 +60,7 @@ buildGoModule (finalAttrs: {
 
     # Allow older go versions
     substituteInPlace go.mod \
-      --replace-fail "go 1.24.6" "go ${finalAttrs.passthru.go.version}"
+      --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"
 
     # Increase timeouts in tests to prevent failure on heavily loaded builders
     substituteInPlace lib/storage/storage_test.go \

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.120.0";
+  version = "1.121.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tU3rRdYpP0uO0SeIuYarHwJu80m/iRVbYtlbON1WeSQ=";
+    hash = "sha256-hCZU6O3synVayg253Cbsonzad3ZBMx1B/yJwBJzU+X0=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.125.1";
+  version = "1.126.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pRYazo13K5mjdwQD3VJcX9Js4xEG9dgz7MbM8HvxWV0=";
+    hash = "sha256-QVeg/F7oPPgSRTi5jcfTj15bD/7fQoPopahpUP9b0UA=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.119.0";
+  version = "1.120.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Gc3B3JmTbINdPJ8PIhcuQhFD+FoxNOskoBEcDoMAUUk=";
+    hash = "sha256-tU3rRdYpP0uO0SeIuYarHwJu80m/iRVbYtlbON1WeSQ=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.125.0";
+  version = "1.125.1";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Xhurksf2BMw+v+4PsKm9o+XO2KfYX9wZTlq/kLLxVYc=";
+    hash = "sha256-pRYazo13K5mjdwQD3VJcX9Js4xEG9dgz7MbM8HvxWV0=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.122.0";
+  version = "1.123.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CpxnCW4+hsc3SQZXMI0pkPnKPvh1GTvCmhg5NkSZbk4=";
+    hash = "sha256-GUVRMlF94BaZSVfz4Z+IBSpf6WuA5o1WQQmeZAqKZ1g=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.121.0";
+  version = "1.122.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hCZU6O3synVayg253Cbsonzad3ZBMx1B/yJwBJzU+X0=";
+    hash = "sha256-CpxnCW4+hsc3SQZXMI0pkPnKPvh1GTvCmhg5NkSZbk4=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaMetrics";
-  version = "1.126.0";
+  version = "1.127.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaMetrics";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QVeg/F7oPPgSRTi5jcfTj15bD/7fQoPopahpUP9b0UA=";
+    hash = "sha256-j0PikCV0VWSfp2rvwssXwvkRGQzFNd6hidZv3bufUuI=";
   };
 
   vendorHash = null;
@@ -60,7 +60,7 @@ buildGoModule (finalAttrs: {
 
     # Allow older go versions
     substituteInPlace go.mod \
-      --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"
+      --replace-fail "go 1.25.1" "go ${finalAttrs.passthru.go.version}"
 
     # Increase timeouts in tests to prevent failure on heavily loaded builders
     substituteInPlace lib/storage/storage_test.go \


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/419388
- https://github.com/NixOS/nixpkgs/pull/423293
- https://github.com/NixOS/nixpkgs/pull/427162
- https://github.com/NixOS/nixpkgs/pull/430982
- https://github.com/NixOS/nixpkgs/pull/434803
- https://github.com/NixOS/nixpkgs/pull/439215
- https://github.com/NixOS/nixpkgs/pull/439957
- https://github.com/NixOS/nixpkgs/pull/443189
- https://github.com/NixOS/nixpkgs/pull/449827
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
