### PR TITLE
indilib: 2.1.5.1 -> 2.1.6; indilib-3rdparty: 2.1.5.1 -> 2.1.6.2

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   bash,
   cmake,
   cfitsio,
@@ -17,22 +18,36 @@
   fftw,
   gtest,
   udevCheckHook,
+  versionCheckHook,
   indi-full,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "indilib";
-  version = "2.1.5.1";
+  version = "2.1.6";
 
   src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-mbY3iDLRcQ+pis26u6pHzB43ureaKH7KYPkV0CwHU/E=";
+    hash = "sha256-0+ZC9NoanBDojYz/ufZUpUQB++vnMcUYtG1UmmVGbTg=";
   };
+
+  # fixes version number. This commit is directly after the tagged commit in master
+  # should be removed with the next release
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/indilib/indi/commit/91e3e35250126887a856e90b6a0a30697fb01545.patch?full_index=1";
+      hash = "sha256-ho1S+A6gTQ9ELy/QE14S6daXyMN+vASFbXa2vMWdqR8=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
     udevCheckHook
   ];
 
@@ -86,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Implementation of the INDI protocol for POSIX operating systems";
     changelog = "https://github.com/indilib/indi/releases/tag/v${finalAttrs.version}";
     license = licenses.lgpl2Plus;
+    mainProgram = "indiserver";
     maintainers = with maintainers; [
       sheepforce
       returntoreality

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -9,7 +9,6 @@
   coreutils,
   cfitsio,
   fetchFromGitHub,
-  fetchpatch,
   gtest,
   libusb1,
   libusb-compat-0_1,
@@ -42,12 +41,13 @@
 }:
 
 let
+  thirdparty_version = "2.1.6.2";
   fxload = libusb1.override { withExamples = true; };
   src-3rdparty = fetchFromGitHub {
     owner = "indilib";
     repo = "indi-3rdparty";
-    rev = "v${indilib.version}";
-    hash = "sha256-+WBQdu1iWleHf6xC4SK69y505wqZ36IUM4xnh1fnc6s=";
+    rev = "v${thirdparty_version}";
+    hash = "sha256-FMvdm7dkOkRlmbPNeQjh0jd+2bOinzW13QPP2NnOr/M=";
   };
 
   buildIndi3rdParty =
@@ -58,7 +58,7 @@ let
       cmakeFlags ? [ ],
       postInstall ? "",
       doCheck ? true,
-      version ? indilib.version,
+      version ? thirdparty_version,
       src ? src-3rdparty,
       meta ? { },
       ...
@@ -551,14 +551,6 @@ in
   indi-astarbox = buildIndi3rdParty {
     pname = "indi-astarbox";
     buildInputs = [ indilib ];
-    # TODO patch already upstream, remove with version > 2.1.5.1
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/indilib/indi-3rdparty/commit/c347000ec227a5ef98911aab34c7b08a91509cba.patch";
-        hash = "sha256-M3b4ySoGJRpfNmBaagjDaeEPKqwaVgRUWaQY626SGBI=";
-        stripLen = 1;
-      })
-    ];
   };
 
   indi-astroasis = buildIndi3rdParty {
@@ -713,15 +705,6 @@ in
       glib
       zlib
     ];
-    # TODO patch already upstream, remove with version > 2.1.5.1
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/indilib/indi-3rdparty/commit/c33c08b50093698e2aa73d73783d96f85df488a9.patch";
-        hash = "sha256-EQ2G9gTexf9FESCAR28f2cwzvH4TOAA8bvyJCxFv/E8=";
-        stripLen = 1;
-      })
-    ];
-
   };
 
   indi-gphoto = buildIndi3rdParty {


### PR DESCRIPTION
Bumped to latest version. Fixes also kstars build failure.
Resolves #449796

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
