### PR TITLE
sdrpp: 1.1.0-unstable-2024-01-22 -> 1.2.1-unstable-2025-10-09

### DIFF
--- a/pkgs/by-name/sd/sdrpp/cmake4.patch
+++ b/pkgs/by-name/sd/sdrpp/cmake4.patch
@@ -1,0 +1,27 @@
+diff --git a/core/libcorrect/CMakeLists.txt b/core/libcorrect/CMakeLists.txt
+index 7fce281d..b709255f 100644
+--- a/core/libcorrect/CMakeLists.txt
++++ b/core/libcorrect/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.13)
+ project(Correct C)
+ include(CheckLibraryExists)
+ include(CheckIncludeFiles)
+diff --git a/misc_modules/discord_integration/discord-rpc/CMakeLists.txt b/misc_modules/discord_integration/discord-rpc/CMakeLists.txt
+index 1dc1c913..e9924677 100644
+--- a/misc_modules/discord_integration/discord-rpc/CMakeLists.txt
++++ b/misc_modules/discord_integration/discord-rpc/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.2.0)
++cmake_minimum_required (VERSION 3.13)
+ project (DiscordRPC)
+ 
+ include(GNUInstallDirs)
+@@ -11,4 +11,4 @@ file(GLOB_RECURSE ALL_SOURCE_FILES
+ 
+ # add subdirs
+ 
+-add_subdirectory(src)
+\ No newline at end of file
++add_subdirectory(src)

--- a/pkgs/by-name/sd/sdrpp/package.nix
+++ b/pkgs/by-name/sd/sdrpp/package.nix
@@ -69,15 +69,18 @@ stdenv.mkDerivation rec {
   # SDR++ uses a rolling release model.
   # Choose a git hash from head and use the date from that commit as
   # version qualifier
-  git_hash = "27ab5bf3c194169ddf60ca312723fce96149cc8e";
-  git_date = "2024-01-22";
-  version = "1.1.0-unstable-" + git_date;
+  git_rev = "4658a1ade6707dee6f2ae09ba9eb71097223ea93";
+  git_hash = "sha256-UxYAcqOMPQYdUbL2636LpOGbCaxHjLiJhsH62s+0AZU=";
+  git_date = "2025-10-09";
+  version_number = "1.2.1";
+
+  version = "${version_number}-unstable-" + git_date;
 
   src = fetchFromGitHub {
     owner = "AlexandreRouma";
     repo = "SDRPlusPlus";
-    rev = git_hash;
-    hash = "sha256-R4xWeqdHEAaje37VQaGlg+L2iYIOH4tXMHvZkZq4SDU=";
+    rev = git_rev;
+    hash = git_hash;
   };
 
   patches = [ ./runtime-prefix.patch ];
@@ -90,7 +93,7 @@ stdenv.mkDerivation rec {
       --replace "codec2.h" "codec2/codec2.h"
     # Since the __TIME_ and __DATE__ is canonicalized in the build,
     # use our qualified version shown in the programs window title.
-    substituteInPlace core/src/version.h --replace "1.1.0" "$version"
+    substituteInPlace core/src/version.h --replace-fail "${version_number}" "$version"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sd/sdrpp/package.nix
+++ b/pkgs/by-name/sd/sdrpp/package.nix
@@ -83,7 +83,12 @@ stdenv.mkDerivation rec {
     hash = git_hash;
   };
 
-  patches = [ ./runtime-prefix.patch ];
+  patches = [
+    ./runtime-prefix.patch
+    # CMake 4 dropped support of versions lower than 3.5,
+    # versions lower than 3.10 are deprecated.
+    ./cmake4.patch
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Resolves #450446 
See #445447 

Depends on 5ea500c431ef0136bddb8e5fd6282dbe7b5e9794 from #449871 (airspyhf update)

Hey, I've updated SDRPlusPlus to the newest unsable version and fixed the cmake build issue.
I wanted to create a pull request upstream, bet they do not allow code changes in their pull requests, so I added the patch here.
I've bumped the minimum cmake version to 3.13 as this is, what upstream uses.

~I've cherry picked a commit of #449871. I don't know, what happens when this gets merged (regarding merge conflicts etc.).~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
