### PR TITLE
meowhttp: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16174,6 +16174,12 @@
     githubId = 18228995;
     name = "Matúš Ferech";
   };
+  maukkis = {
+    email = "luna@girlsmell.xyz";
+    github = "maukkis";
+    githubId = 82530388;
+    name = "Luna Laurie";
+  };
   maurer = {
     email = "matthew.r.maurer+nix@gmail.com";
     github = "maurer";

--- a/pkgs/by-name/me/meowhttp/package.nix
+++ b/pkgs/by-name/me/meowhttp/package.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  stdenv,
+  lib,
+  cmake,
+  openssl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "meowhttp";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "maukkis";
+    repo = "meowHttp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/V9k84Cew9IT63DeuOVG/4KxErbQz3x/6579QZ/eU60=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "C++ library to send https and wss requests";
+    homepage = "https://github.com/maukkis/meowHttp";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ maukkis ];
+    license = lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
Added a new package: `meowhttp`.
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
