### PR TITLE
nebula: 1.9.6 -> 1.9.7

### DIFF
--- a/pkgs/by-name/ne/nebula/package.nix
+++ b/pkgs/by-name/ne/nebula/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "nebula";
-  version = "1.9.6";
+  version = "1.9.7";
 
   src = fetchFromGitHub {
     owner = "slackhq";
     repo = "nebula";
     tag = "v${version}";
-    hash = "sha256-klVbLseqIaibcXL83BVjRgY1ziZlxf+w4bRkkPlUnlU=";
+    hash = "sha256-U6PCHRSETkrA/nulTqIn9vvj3zks10kJ1k2syFsPMnM=";
   };
 
   vendorHash = "sha256-oXhq+s5gDKPVClZpOzYi7BaYwcDqbCLBEO5BNGy9LJA=";


### PR DESCRIPTION
- Security
  - Fix an issue where Nebula could incorrectly accept and process a packet from an erroneous source IP when the sender's certificate is configured with unsafe_routes (cert v1/v2) or multiple IPs (cert v2). ([#1494](https://github.com/slackhq/nebula/pull/1494))
- Changed
  - Disable sending recv_error messages when a packet is received outside the allowable counter window.
  - Improve error messages and remove some unnecessary fatal conditions in the Windows and generic udp listener.

Source: https://github.com/slackhq/nebula/releases/tag/v1.9.7

Changes: https://github.com/slackhq/nebula/compare/v1.9.6...v1.9.7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
