### PR TITLE
nixos/installer: add new options to customize sd-card image creation

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -142,6 +142,15 @@ in
       '';
     };
 
+    rootFilesystemImage = mkOption {
+      type = types.package;
+      default = rootfsImage;
+      description = ''
+        The finished root partition image with all custom fileystem modifications.
+        Used to override the filesystem creator itself.
+      '';
+    };
+
     firmwareSize = mkOption {
       type = types.int;
       # As of 2019-08-18 the Raspberry pi firmware + u-boot takes ~18MiB
@@ -268,11 +277,11 @@ in
             echo "file sd-image $img" >> $out/nix-support/hydra-build-products
           fi
 
-          root_fs=${rootfsImage}
+          root_fs=${config.sdImage.rootFilesystemImage}
           ${lib.optionalString config.sdImage.compressImage ''
             root_fs=./root-fs.img
             echo "Decompressing rootfs image"
-            zstd -d --no-progress "${rootfsImage}" -o $root_fs
+            zstd -d --no-progress "${config.sdImage.rootFilesystemImage}" -o $root_fs
           ''}
 
           # Gap in front of the first partition, in MiB

--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -21,7 +21,7 @@
 with lib;
 
 let
-  rootfsImage = pkgs.callPackage ../../../lib/make-ext4-fs.nix (
+  rootfsImage = pkgs.callPackage config.sdImage.rootFilesystemCreator (
     {
       inherit (config.sdImage) storePaths;
       compressImage = config.sdImage.compressImage;
@@ -125,6 +125,20 @@ in
         Label for the NixOS root volume.
         Usually used when creating a recovery NixOS media installation
         that avoids conflicting with previous instalation label.
+      '';
+    };
+
+    rootFilesystemCreator = mkOption {
+      type = types.oneOf [
+        types.package
+        types.path
+      ];
+      default = ../../../lib/make-ext4-fs.nix;
+      example = ''
+        nixpkgs/nixos/lib/make-btrfs-fs.nix
+      '';
+      description = ''
+        The filesystem creator used for the root partition.
       '';
     };
 


### PR DESCRIPTION
The sd card creation process lacks the ability to choose different filesystem other than ext4. These patches allow you to use another filesystem creator or even swap out the entire root partition creation process entirely. If these new options are unused, it does the same if these options never existed. `default` option value just uses the normal ext4 creation process.

How others might use this I leave open to them. I personally am experimenting with my RPi 3b to replace Ubuntu on it. To actually boot BTRFS for example you might also need to override `uboot` firmware images.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
