### PR TITLE
nixos/nixos-init: add more strict assertions for required config

### DIFF
--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -24,7 +24,15 @@ in
     assertions = [
       {
         assertion = config.boot.initrd.systemd.enable;
-        message = "nixos-init can only be used with systemd initrd";
+        message = "nixos-init can only be used with boot.initrd.systemd.enable";
+      }
+      {
+        assertion = config.system.etc.overlay.enable;
+        message = "nixos-init can only be used with system.etc.overlay.enable";
+      }
+      {
+        assertion = config.services.userborn.enable || config.systemd.sysusers.enable;
+        message = "nixos-init can only be used with services.userborn.enable or systemd.sysusers.enable";
       }
     ];
   };

--- a/nixos/tests/activation/nixos-init.nix
+++ b/nixos/tests/activation/nixos-init.nix
@@ -8,11 +8,9 @@
   nodes.machine =
     { modulesPath, ... }:
     {
-      imports = [
-        "${modulesPath}/profiles/perlless.nix"
-      ];
-      virtualisation.mountHostNixStore = false;
-      virtualisation.useNixStoreImage = true;
+      boot.initrd.systemd.enable = true;
+      system.etc.overlay.enable = true;
+      services.userborn.enable = true;
 
       system.nixos-init.enable = true;
       # Forcibly set this to only these specific values.


### PR DESCRIPTION
Fixes #450765

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
