### PR TITLE
mcpelauncher-{client,ui-qt}: 1.4.0-qt6 -> 1.5.3-qt6

### DIFF
--- a/pkgs/by-name/mc/mcpelauncher-client/fix-cmake4-build.patch
+++ b/pkgs/by-name/mc/mcpelauncher-client/fix-cmake4-build.patch
@@ -1,0 +1,31 @@
+diff --git a/mcpelauncher-errorwindow/CMakeLists.txt b/mcpelauncher-errorwindow/CMakeLists.txt
+index c9a01b9..448b50b 100644
+--- a/mcpelauncher-errorwindow/CMakeLists.txt
++++ b/mcpelauncher-errorwindow/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(mcpelauncher-errorwindow LANGUAGES CXX)
+ 
+diff --git a/mcpelauncher-webview/CMakeLists.txt b/mcpelauncher-webview/CMakeLists.txt
+index 7a6b8fe..af80cbf 100644
+--- a/mcpelauncher-webview/CMakeLists.txt
++++ b/mcpelauncher-webview/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(mcpelauncher-webview)
+ 
+diff --git a/simple-ipc/CMakeLists.txt b/simple-ipc/CMakeLists.txt
+index 2f475e1..09b800a 100644
+--- a/simple-ipc/CMakeLists.txt
++++ b/simple-ipc/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.6)
++cmake_minimum_required (VERSION 3.10)
+ 
+ project(simpleipc LANGUAGES CXX)
+ 
+

--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -26,7 +26,7 @@
 # Bionic libc part doesn't compile with GCC
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "mcpelauncher-client";
-  version = "1.4.0-qt6";
+  version = "1.5.3-qt6";
 
   # NOTE: check mcpelauncher-ui-qt when updating
   src = fetchFromGitHub {
@@ -34,12 +34,15 @@ clangStdenv.mkDerivation (finalAttrs: {
     repo = "mcpelauncher-manifest";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-2YmsxcR4EipnBIBqoM8g6hOCCh1WKooukqXhP/1X6tU=";
+    hash = "sha256-uVtvPeGfiCpXIN1aQzF0nw8qNddIeIjFeoKXJUInqwg=";
   };
 
-  patches = [ ./dont_download_glfw_client.patch ];
+  patches = [
+    ./dont_download_glfw_client.patch
+    ./fix-cmake4-build.patch
+  ];
 
-  # Path hard-coded paths.
+  # Patch hard-coded paths.
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace mcpelauncher-client/src/jni/main_activity.cpp \
       --replace-fail /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open \

--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/fix-cmake4-build.patch
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/fix-cmake4-build.patch
@@ -1,0 +1,51 @@
+diff --git a/axml-parser/CMakeLists.txt b/axml-parser/CMakeLists.txt
+index 633c915..50c5ffb 100644
+--- a/axml-parser/CMakeLists.txt
++++ b/axml-parser/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.10)
+ project(axml_parser)
+ 
+ set(CMAKE_CXX_STANDARD 11)
+diff --git a/mcpelauncher-common/CMakeLists.txt b/mcpelauncher-common/CMakeLists.txt
+index 393162f..b1aefdb 100644
+--- a/mcpelauncher-common/CMakeLists.txt
++++ b/mcpelauncher-common/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.6)
++cmake_minimum_required (VERSION 3.10)
+ 
+ project(mcpelauncher-common LANGUAGES CXX)
+ 
+diff --git a/mcpelauncher-extract/CMakeLists.txt b/mcpelauncher-extract/CMakeLists.txt
+index 164cfc8..1406fc9 100644
+--- a/mcpelauncher-extract/CMakeLists.txt
++++ b/mcpelauncher-extract/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.1)
++cmake_minimum_required (VERSION 3.10)
+ 
+ project(mcpelauncher-extract LANGUAGES CXX)
+ 
+diff --git a/mcpelauncher-ui-qt/CMakeLists.txt b/mcpelauncher-ui-qt/CMakeLists.txt
+index a396838..53693cf 100644
+--- a/mcpelauncher-ui-qt/CMakeLists.txt
++++ b/mcpelauncher-ui-qt/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(mcpelauncher-ui-qt LANGUAGES CXX)
+ 
+diff --git a/playdl-signin-ui-qt/CMakeLists.txt b/playdl-signin-ui-qt/CMakeLists.txt
+index 7f02ff3..c00b1a8 100644
+--- a/playdl-signin-ui-qt/CMakeLists.txt
++++ b/playdl-signin-ui-qt/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(playdl-signin-ui-qt)
+ 
+

--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
@@ -22,11 +22,12 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "mcpelauncher-ui-manifest";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-W97PIb2NTfmqLsIQgrJkOb+8n3fDzlE91sDvgJbNFwY=";
+    hash = "sha256-utL70loiS1itxbX6Pp10dzIIYssNiQOZKfkPYIsXrvU=";
   };
 
   patches = [
     ./dont_download_glfw_ui.patch
+    ./fix-cmake4-build.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/449636
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
