### PR TITLE
Add clang64 toolchain to pkgsCross

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -341,31 +341,48 @@ rec {
   # Windows
   #
 
-  # 32 bit mingw-w64
-  mingw32 = {
+  # mingw-w64 with MSVCRT for i686
+  mingw-msvcrt-i686 = {
     config = "i686-w64-mingw32";
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
   };
 
-  # 64 bit mingw-w64
-  mingwW64 = {
+  # mingw-w64 with MSVCRT for x86_64
+  mingw-msvcrt-x86_64 = {
     # That's the triplet they use in the mingw-w64 docs.
     config = "x86_64-w64-mingw32";
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
   };
 
-  ucrt64 = {
+  # mingw-w64 with UCRT for x86_64, default compiler
+  mingw-ucrt-x86_64 = {
     config = "x86_64-w64-mingw32";
     libc = "ucrt"; # This distinguishes the mingw (non posix) toolchain
   };
 
-  # LLVM-based mingw-w64 for ARM
-  ucrtAarch64 = {
+  # mingw-w64 with UCRT for x86_64, LLVM
+  mingw-ucrt-x86_64-llvm = {
+    config = "x86_64-w64-mingw32";
+    libc = "ucrt";
+    rust.rustcTarget = "x86_64-pc-windows-gnullvm";
+    useLLVM = true;
+  };
+
+  # mingw-w64 with ucrt for Aarch64, default compiler (which is LLVM
+  # because GCC does not support this platform yet).
+  mingw-ucrt-aarch64 = {
     config = "aarch64-w64-mingw32";
     libc = "ucrt";
     rust.rustcTarget = "aarch64-pc-windows-gnullvm";
     useLLVM = true;
   };
+
+  # mingw-64 back compat
+  # TODO: Warn after 26.05, and remove after 26.11.
+  mingw32 = mingw-msvcrt-i686;
+  mingwW64 = mingw-msvcrt-x86_64;
+  ucrt64 = mingw-ucrt-x86_64;
+  ucrtAarch64 = mingw-ucrt-aarch64;
 
   # Target the MSVC ABI
   x86_64-windows = {

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -205,11 +205,12 @@ in
     }
   );
 
-  # Test some cross builds on 32 bit mingw-w64
-  crossMingw32 = mapTestOnCross systems.examples.mingw32 windowsCommon;
-
-  # Test some cross builds on 64 bit mingw-w64
-  crossMingwW64 = mapTestOnCross systems.examples.mingwW64 windowsCommon;
+  # Test some cross builds on various mingw-w64 platforms
+  crossMingw32 = mapTestOnCross systems.examples.mingw-msvcrt-i686 windowsCommon;
+  cross-mingw-msvcrt-x86_64 = mapTestOnCross systems.examples.mingw-msvcrt-x86_64 windowsCommon;
+  cross-mingw-ucrt-x86_64 = mapTestOnCross systems.examples.mingw-ucrt-x86_64 windowsCommon;
+  cross-mingw-ucrt-x86_64-llvm = mapTestOnCross systems.examples.mingw-ucrt-x86_64-llvm windowsCommon;
+  cross-mingw-ucrt-aarch64 = mapTestOnCross systems.examples.mingw-ucrt-aarch64 windowsCommon;
 
   x86_64-cygwin = mapTestOnCross systems.examples.x86_64-cygwin cygwinCommon;
 


### PR DESCRIPTION
Added support for the clang64 toolchain which should be cached. Clang32 should also be added and `ucrtAarch64` should be renamed to fit the scheme, but those are future PRs - as I need this in nixpkgs unstable URGENTLY.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
