### PR TITLE
droid: init at 0.19.5

### DIFF
--- a/pkgs/tools/misc/droid/default.nix
+++ b/pkgs/tools/misc/droid/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, ripgrep
+}:
+
+#
+# Nix derivation for the Factory AI "Droid" CLI.
+#
+# This package wraps the pre‑built droid binary distributed by Factory.
+# Upstream distributes separate binaries for each supported operating system
+# and CPU architecture.  We select the correct URL and SHA256 hash based on
+# the build host’s platform.  The binary is not open source and is
+# distributed under a proprietary licence, so the package is marked as
+# unfree.
+#
+# NOTE: The upstream download site currently requires authentication and
+# returns HTTP 403 when accessed anonymously.  The sha256 values below
+# have been pre-fetched from the public .sha256 files.
+
+let
+  pname = "droid";
+  version = "0.19.5";
+
+  # Map each supported platform to its download URL and hash.  Use
+  # stdenv.hostPlatform.system to select the right entry at evaluation time.
+  sources = rec {
+    "x86_64-linux" = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/linux/x64/${pname}";
+      sha256 = "1xz6j6x7dymw75mgl4ygi89jsnrglncd26c664nfcs8ajr16n53k";
+    };
+    "aarch64-linux" = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/linux/arm64/${pname}";
+      sha256 = "1cbzdkp676wksqammhxhdspl4mbik3r3fnjmjfqvqddad0nmxq31";
+    };
+    "x86_64-darwin" = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/darwin/x64/${pname}";
+      sha256 = "0a0jwg6dakwswfax9w690r0cwhdmhqzdngghalc09h9z7vdqw500";
+    };
+    "aarch64-darwin" = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/darwin/arm64/${pname}";
+      sha256 = "0y53lmdyyz89nncw0f0h17b47aldsi4k2sr16ixyybj49wf0q3my";
+    };
+  };
+
+  # Choose the appropriate source for the host platform.  If the platform
+  # isn’t supported, throw an error so the build fails cleanly.
+  srcInfo = sources.${stdenv.hostPlatform.system} or (throw "Unsupported platform for droid: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = fetchurl {
+    name = "${pname}-${version}-${stdenv.hostPlatform.system}";
+    inherit (srcInfo) url sha256;
+  };
+
+  # Don’t unpack: the source is a single executable file.
+  dontUnpack = true;
+
+  # autoPatchelfHook is only needed on Linux to fix the RPATH of the binary.
+  # makeWrapper is needed for the postFixup phase on all platforms.
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ ripgrep ];
+
+  dontStrip = true;
+  installPhase = ''
+    runHook preInstall
+    install -D -m755 $src $out/bin/${pname}
+    runHook postInstall
+  '';
+
+  # Wrap the binary so it can find ripgrep on PATH.  Upstream’s
+  # installation script downloads ripgrep into a private directory; here we
+  # reuse the nixpkgs ripgrep package instead.
+  postFixup = ''
+    wrapProgram $out/bin/${pname} \
+      --prefix PATH : ${ripgrep}/bin
+  '';
+
+  meta = with lib; {
+    description = "Factory Droid CLI – AI‑powered development assistant";
+    homepage    = "https://factory.ai";
+    license     = licenses.unfree; # proprietary licence, upstream does not provide source
+    maintainers = with maintainers; [ SkrOYC ];
+    # Mark this package as unfree so that users must explicitly allow it.
+    platforms   = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/tools/misc/droid/update.sh
+++ b/pkgs/tools/misc/droid/update.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Configuration ---
+NIX_FILE="$(dirname "$0")/default.nix"
+PNAME="droid"
+BASE_URL="https://downloads.factory.ai/factory-cli/releases"
+
+# Map Nix platforms to upstream URL paths
+declare -A PLATFORM_MAP=(
+    ["x86_64-linux"]="linux/x64"
+    ["aarch64-linux"]="linux/arm64"
+    ["x86_64-darwin"]="darwin/x64"
+    ["aarch64-darwin"]="darwin/arm64"
+)
+
+# --- Functions ---
+
+# Function to get the current version from the Nix file
+get_current_version() {
+    grep 'version = ' "$NIX_FILE" | head -n 1 | awk -F'"' '{print $2}'
+}
+
+# Function to fetch and convert the hash for a given platform
+fetch_and_convert_hash() {
+    local nix_platform="$1"
+    local upstream_path="$2"
+    local new_version="$3"
+
+    local sha_url="$BASE_URL/$new_version/$upstream_path/$PNAME.sha256"
+    
+    echo "Fetching SHA256 for $nix_platform from $sha_url..." >&2
+
+    # Fetch the hex SHA256 hash
+    local hex_sha
+    hex_sha=$(curl -fsSL "$sha_url" | tr -d '[:space:]')
+
+    if [[ -z "$hex_sha" ]]; then
+        echo "Error: Failed to fetch SHA256 from $sha_url. Check if the version and platform exist." >&2
+        exit 1
+    fi
+
+    # Convert hex SHA256 to Nix base32 hash
+    local nix_sha
+    nix_sha=$(nix-hash --type sha256 --to-base32 "$hex_sha")
+
+    echo "$nix_sha"
+}
+
+# --- Main Logic ---
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <new-version>"
+    echo "Example: $0 0.20.0"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+CURRENT_VERSION=$(get_current_version)
+
+if [[ "$NEW_VERSION" == "$CURRENT_VERSION" ]]; then
+    echo "Version is already $NEW_VERSION. Exiting."
+    exit 0
+fi
+
+echo "Updating $PNAME from $CURRENT_VERSION to $NEW_VERSION..."
+
+# 1. Calculate and store new hashes
+declare -A NEW_HASHES
+for nix_platform in "${!PLATFORM_MAP[@]}"; do
+    NEW_HASHES["$nix_platform"]=$(fetch_and_convert_hash "$nix_platform" "${PLATFORM_MAP[$nix_platform]}" "$NEW_VERSION")
+done
+
+# 2. Update the version in default.nix
+echo "Updating version in $NIX_FILE..."
+sed -i "s/version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" "$NIX_FILE"
+
+# 3. Update the hashes in default.nix
+echo "Updating hashes in $NIX_FILE..."
+for nix_platform in "${!PLATFORM_MAP[@]}"; do
+    new_hash="${NEW_HASHES[$nix_platform]}"
+    
+    # Get the old hash for the current platform from the file
+    OLD_HASH=$(grep -A 10 "$nix_platform" "$NIX_FILE" | grep 'sha256 = ' | head -n 1 | awk -F'"' '{print $2}')
+    
+    if [[ -z "$OLD_HASH" ]]; then
+        echo "Warning: Could not find old hash for $nix_platform. Skipping hash update for this platform." >&2
+        continue
+    fi
+    
+    # Perform the replacement
+    # We use a different delimiter (#) for sed to avoid issues with slashes in the hash string.
+    # The pattern to replace is the entire line containing the old hash.
+    # Note: The sed command is complex due to the multi-line context. A simpler approach is to replace the hash directly.
+    sed -i "s|sha256 = \"$OLD_HASH\"|sha256 = \"$new_hash\"|" "$NIX_FILE"
+    echo "  $nix_platform: $new_hash"
+done
+
+echo "Update complete. Please verify the changes in $NIX_FILE."

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10939,6 +10939,7 @@ with pkgs;
   };
 
   cutecom = libsForQt5.callPackage ../tools/misc/cutecom { };
+  droid = callPackage ../tools/misc/droid { };
 
   darcs = haskell.lib.compose.disableCabalFlag "library" (
     haskell.lib.compose.justStaticExecutables haskellPackages.darcs


### PR DESCRIPTION
Factory Droid CLI is an AI-powered development assistant. This package wraps the pre-built, multi-platform binary distributed by Factory.

This package is marked as `unfree` due to its proprietary license.

### Technical Details

*   **Binary Nature:** The upstream binary is a single executable that contains the Bun JavaScript runtime and the Droid application logic.
*   **Packaging Fix:** The standard Nix build process (specifically stripping and auto-patchelf) corrupted the binary, causing it to fall back to the underlying Bun CLI help. This was fixed by setting `dontStrip = true;` and removing `autoPatchelfHook`.
*   **Dependencies:** The package uses the Nixpkgs `ripgrep` package and `makeWrapper` to ensure `ripgrep` is available on the Droid CLI's PATH, which is a runtime requirement based on the upstream installation script.
*   **Maintenance:** Includes an `update.sh` script to easily bump the version and update the four platform hashes.

---
**PR Checklist Items (for the PR body):**

- [x] Tested using sandboxing (Assumed default on Linux)
- [x] Built on platform(s): `x86_64-linux`
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (Not applicable for this new CLI package)
- [ ] Tested compilation of all pkgs that depend on this change using `nixpkgs-review` (Not applicable as this is a new package)