### PR TITLE
kftray: init at 0.27.30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16865,6 +16865,13 @@
       }
     ];
   };
+  lunkentuss = {
+    email = "peter.hansson17@gmail.com";
+    matrix = "@lunkentuss:matrix.org";
+    github = "lunkentuss";
+    githubId = 9850798;
+    name = "Peter Hansson";
+  };
   LunNova = {
     email = "nixpkgs-maintainer@lunnova.dev";
     github = "LunNova";

--- a/pkgs/by-name/kf/kftray/package.nix
+++ b/pkgs/by-name/kf/kftray/package.nix
@@ -1,0 +1,146 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  perl,
+  glib,
+  gtk3,
+  libsoup_3,
+  webkitgtk_4_1,
+  libayatana-appindicator,
+  cargo-tauri,
+  pnpm_9,
+  nodejs,
+  jq,
+}:
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    cargoHash = finalAttrs.cargoDeps.hash or "sha256-/ZGUqCYwuyoS2h0Rt8J4IdvtU7vfXbO461Lg1KBWY0o=";
+    # -Z flags requires nightly version of rust
+    patchCargoToml = ''
+      substituteInPlace Cargo.toml \
+        --replace-fail ', "-Zthreads=4"' "" \
+        --replace-fail 'trim-paths = "all"' "" \
+        --replace-fail ', "trim-paths"' ""
+    '';
+    kftrayBinaries = rustPlatform.buildRustPackage {
+      pname = "kftray-binaries";
+      cargoBuildFlags = [
+        "-p"
+        "kftray-helper"
+        "-p"
+        "kftui"
+      ];
+      inherit (finalAttrs) src version;
+      cargoHash = cargoHash;
+      patchPhase = patchCargoToml;
+      buildInputs = [
+        openssl
+        glib
+        gtk3
+        libayatana-appindicator
+        webkitgtk_4_1
+      ];
+
+      nativeBuildInputs = [
+        pkg-config
+        perl
+      ];
+
+      doCheck = false;
+    };
+  in
+  {
+    pname = "kftray";
+    version = "0.26.7";
+
+    src = fetchFromGitHub {
+      owner = "hcavarsan";
+      repo = "kftray";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-QYFNm5eG4koC9BKkq+Cx8XS8ik6bF4ckBrG6BdWvkOs=";
+    };
+
+    cargoRoot = "./";
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        cargoRoot
+        ;
+      hash = cargoHash;
+    };
+
+    pnpmDeps = pnpm_9.fetchDeps {
+      inherit (finalAttrs) pname version src;
+      fetcherVersion = 1;
+      hash = "sha256-fnv59YLPavC2HvNT2tEftcPKhrWKMIIk+KMCDL4jkmo=";
+    };
+
+    buildInputs = [
+      openssl
+      glib
+      gtk3
+      nodejs
+      libsoup_3
+      webkitgtk_4_1
+      libayatana-appindicator
+    ];
+
+    nativeBuildInputs = [
+      rustPlatform.cargoSetupHook
+      cargo-tauri.hook
+      pnpm_9.configHook
+      pkg-config
+      perl
+      jq
+    ];
+
+    patchPhase = ''
+      ${patchCargoToml}
+
+      # The build script tries to do a copy of kftray-helper, so the following
+      # makes sure kftray-helper binary exists in expected location.
+      mkdir -p target/release
+      ln -s ${kftrayBinaries}/bin/kftray-helper target/release
+
+      # kftray is using the updater plugin. We override the key pair since we
+      # want to update with nix. The following is an random generated key pair
+      # that holds no significance. Should we able to be simplified once
+      # --no-sign flag is available, see
+      # https://github.com/tauri-apps/tauri/pull/14052
+      export TAURI_SIGNING_PRIVATE_KEY="dW50cnVzdGVkIGNvbW1lbnQ6IHJzaWduIGVuY3J5cHRlZCBzZWNyZXQga2V5ClJXUlRZMEl5SkpzS2h6elk5ZTZZVmhMaE4zL2ExWG1kcWlhYmZ0Y0wwRXhyVnNzNUpYb0FBQkFBQUFBQUFBQUFBQUlBQUFBQW50eHlFN1N1bE8yWFk5ZC9rZ1o1elhUclhpay9aS09jN0JBdkE3V3BaeCtoZDhNKy8zSk9WMWtJd2pJamExWmdZcWh2YUZXMUJVamVNUVo5Y3M4OVBlN05LbURuVUNzTHJzUWN3cWhuZnlKbzcyM21iTy8wQ1Y2elgvT1FXYk5ieE1kUzQ1MDE4YjA9Cg=="
+      export TAURI_SIGNING_PRIVATE_KEY_PASSWORD=""
+      jq \
+        '.plugins.updater.pubkey="dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZCNkZFMkJGOTI2QzgxMkMKUldRc2dXeVN2K0p2YXdYZ3BkVVBxWjIzSk9YaGFIQ3MvN3BMZ2NBR05aU1VCbWdxaVROVmRNVWwK"' \
+        < crates/kftray-tauri/tauri.conf.json > tauri.conf.json.tmp
+      mv tauri.conf.json.tmp crates/kftray-tauri/tauri.conf.json
+
+      substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+        --replace-fail \
+        "libayatana-appindicator3.so.1" \
+        "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+    '';
+
+    postInstall = ''
+      ln -s ${kftrayBinaries}/bin/kftui $out/bin
+    '';
+
+    doCheck = false;
+
+    meta = {
+      description = "Kubectl port-forward manager";
+      homepage = "https://github.com/hcavarsan/kftray";
+      license = with lib.licenses; [ gpl3 ];
+      maintainers = [
+        # lunkentuss
+      ];
+      mainProgram = "kftray";
+    };
+  }
+)

--- a/pkgs/by-name/kf/kftray/package.nix
+++ b/pkgs/by-name/kf/kftray/package.nix
@@ -1,0 +1,173 @@
+{
+  cargo-nextest,
+  cargo-tauri,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  glib,
+  gtk3,
+  jq,
+  lib,
+  libayatana-appindicator,
+  libsoup_3,
+  nodejs,
+  openssl,
+  perl,
+  pkg-config,
+  pnpmConfigHook,
+  pnpm_10,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_1,
+}:
+let
+  pnpm = pnpm_10;
+in
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    cargoHash = finalAttrs.cargoDeps.hash or "sha256-08k5hhMV2YRKNz/Zp+b0WhUVHYRlX7Rhb3xFQefOTw0=";
+    kftrayBinaries = rustPlatform.buildRustPackage {
+      pname = "kftray-binaries";
+      cargoBuildFlags = [
+        "-p"
+        "kftray-helper"
+        "-p"
+        "kftui"
+      ];
+      inherit (finalAttrs) src version;
+      cargoHash = cargoHash;
+      buildInputs = [
+        openssl
+        glib
+        gtk3
+        libayatana-appindicator
+        webkitgtk_4_1
+      ];
+
+      nativeBuildInputs = [
+        pkg-config
+        perl
+      ];
+
+      doCheck = false;
+    };
+  in
+  {
+    pname = "kftray";
+    version = "0.27.30";
+
+    src = fetchFromGitHub {
+      owner = "hcavarsan";
+      repo = "kftray";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-PELLoATb8T2jXhiUItVhX+cOd1JCXFRgLUagRa8LOFo=";
+    };
+
+    cargoRoot = "./";
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      inherit (finalAttrs)
+        pname
+        version
+        src
+        cargoRoot
+        ;
+      hash = cargoHash;
+    };
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      inherit pnpm;
+      fetcherVersion = 4;
+      hash = "sha256-LdhXmxdorRsMrX+hMtAbt9NiBW1opO2424bpj+J/c8E=";
+    };
+
+    buildInputs = [
+      openssl
+      glib
+      gtk3
+      libsoup_3
+      webkitgtk_4_1
+      libayatana-appindicator
+    ];
+
+    nativeBuildInputs = [
+      rustPlatform.cargoSetupHook
+      cargo-tauri.hook
+      pnpmConfigHook
+      pnpm
+      pkg-config
+      perl
+      jq
+      nodejs
+    ];
+
+    postPatch = ''
+      # kftray is using the updater plugin. We override the key pair since we
+      # want to update with nix. The following is an random generated key pair
+      # that holds no significance. Should we able to be simplified once
+      # --no-sign flag is available, see
+      # https://github.com/tauri-apps/tauri/pull/14052
+      export TAURI_SIGNING_PRIVATE_KEY="dW50cnVzdGVkIGNvbW1lbnQ6IHJzaWduIGVuY3J5cHRlZCBzZWNyZXQga2V5ClJXUlRZMEl5SkpzS2h6elk5ZTZZVmhMaE4zL2ExWG1kcWlhYmZ0Y0wwRXhyVnNzNUpYb0FBQkFBQUFBQUFBQUFBQUlBQUFBQW50eHlFN1N1bE8yWFk5ZC9rZ1o1elhUclhpay9aS09jN0JBdkE3V3BaeCtoZDhNKy8zSk9WMWtJd2pJamExWmdZcWh2YUZXMUJVamVNUVo5Y3M4OVBlN05LbURuVUNzTHJzUWN3cWhuZnlKbzcyM21iTy8wQ1Y2elgvT1FXYk5ieE1kUzQ1MDE4YjA9Cg=="
+      export TAURI_SIGNING_PRIVATE_KEY_PASSWORD=""
+      jq \
+        '.plugins.updater.pubkey="dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZCNkZFMkJGOTI2QzgxMkMKUldRc2dXeVN2K0p2YXdYZ3BkVVBxWjIzSk9YaGFIQ3MvN3BMZ2NBR05aU1VCbWdxaVROVmRNVWwK"' \
+        < crates/kftray-tauri/tauri.conf.json > tauri.conf.json.tmp
+      mv tauri.conf.json.tmp crates/kftray-tauri/tauri.conf.json
+
+      substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
+        --replace-fail \
+        "libayatana-appindicator3.so.1" \
+        "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+    '';
+
+    preBuild = ''
+      # The build script tries to do a copy of kftray-helper, so the following
+      # makes sure kftray-helper binary exists in expected location.
+      mkdir -p target/release
+      ln -s ${kftrayBinaries}/bin/kftray-helper target/release
+    '';
+
+    postInstall = ''
+      ln -s ${kftrayBinaries}/bin/kftui $out/bin
+    '';
+
+    nativeCheckInputs = [
+      cargo-nextest
+    ];
+
+    # The below is equivalent to running the mise test:back task. The mise
+    # test:server task is skipped since it requires docker.
+    checkPhase = ''
+      INSTA_UPDATE=always \
+      cargo \
+        nextest \
+        run \
+        --profile ci \
+        --config-file .cargo/nextest.toml \
+        --locked \
+        --workspace \
+        --all-features \
+        --lib \
+        --bins \
+        --examples \
+        --tests \
+        -- \
+        --skip commands::github::tests::test_import_configs_from_github \
+        --skip commands::httplogs::tests::test_is_editor_available
+    '';
+
+    doCheck = true;
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    meta = {
+      description = "Kubectl port-forward manager";
+      homepage = "https://github.com/hcavarsan/kftray";
+      license = with lib.licenses; [ gpl3 ];
+      maintainers = with lib.maintainers; [
+        lunkentuss
+      ];
+      mainProgram = "kftray";
+    };
+  }
+)


### PR DESCRIPTION
Adds the programs kftray and kftui from [github kftray repository](https://github.com/hcavarsan/kftray).

Relates to https://github.com/NixOS/nixpkgs/issues/316930.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
