### PR TITLE
libraspberrypi: fix cmake 4 compatibility

### DIFF
--- a/pkgs/by-name/li/libraspberrypi/cmake-v4.patch
+++ b/pkgs/by-name/li/libraspberrypi/cmake-v4.patch
@@ -1,0 +1,112 @@
+From 260c2039cfeb5efaf94a7b31424679c15e943eb6 Mon Sep 17 00:00:00 2001
+From: SkohTV <contact@skoh.dev>
+Date: Fri, 10 Oct 2025 18:45:27 -0400
+Subject: [PATCH] Increase `cmake_minimum_required` to 3.10
+
+---
+ CMakeLists.txt                                        | 2 +-
+ helpers/dtoverlay/CMakeLists.txt                      | 2 +-
+ host_applications/android/apps/vidtex/CMakeLists.txt  | 2 +-
+ host_applications/linux/apps/dtmerge/CMakeLists.txt   | 2 +-
+ host_applications/linux/apps/dtoverlay/CMakeLists.txt | 2 +-
+ host_applications/linux/apps/gencmd/CMakeLists.txt    | 2 +-
+ host_applications/linux/apps/smem/CMakeLists.txt      | 2 +-
+ interface/vcos/CMakeLists.txt                         | 2 +-
+ middleware/openmaxil/CMakeLists.txt                   | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fe67fc874..ca0de5a3b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ project(vmcs_host_apps)
+ 
+diff --git a/helpers/dtoverlay/CMakeLists.txt b/helpers/dtoverlay/CMakeLists.txt
+index b3bd30f10..9346ddf89 100644
+--- a/helpers/dtoverlay/CMakeLists.txt
++++ b/helpers/dtoverlay/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ # CMake build file for dtoverlay library.
+ # =============================================================================
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 2.8...3.10)
+ 
+ include_directories (${VIDEOCORE_ROOT}
+                      ${VIDEOCORE_ROOT}/helpers
+diff --git a/host_applications/android/apps/vidtex/CMakeLists.txt b/host_applications/android/apps/vidtex/CMakeLists.txt
+index e7206cc83..c6d39051f 100644
+--- a/host_applications/android/apps/vidtex/CMakeLists.txt
++++ b/host_applications/android/apps/vidtex/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ SET(COMPILE_DEFINITIONS -Werror -Wall)
+ 
+diff --git a/host_applications/linux/apps/dtmerge/CMakeLists.txt b/host_applications/linux/apps/dtmerge/CMakeLists.txt
+index d3f7e36c2..951e61c96 100755
+--- a/host_applications/linux/apps/dtmerge/CMakeLists.txt
++++ b/host_applications/linux/apps/dtmerge/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ get_filename_component (VIDEOCORE_ROOT ../../../.. ABSOLUTE)
+ include (${VIDEOCORE_ROOT}/makefiles/cmake/global_settings.cmake)
+diff --git a/host_applications/linux/apps/dtoverlay/CMakeLists.txt b/host_applications/linux/apps/dtoverlay/CMakeLists.txt
+index 97bcadcf9..72afe141f 100755
+--- a/host_applications/linux/apps/dtoverlay/CMakeLists.txt
++++ b/host_applications/linux/apps/dtoverlay/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ get_filename_component (VIDEOCORE_ROOT ../../../.. ABSOLUTE)
+ include (${VIDEOCORE_ROOT}/makefiles/cmake/global_settings.cmake)
+diff --git a/host_applications/linux/apps/gencmd/CMakeLists.txt b/host_applications/linux/apps/gencmd/CMakeLists.txt
+index 0c2c32a4c..f5151ebec 100644
+--- a/host_applications/linux/apps/gencmd/CMakeLists.txt
++++ b/host_applications/linux/apps/gencmd/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ if (WIN32)
+    set(VCOS_PLATFORM win32)
+diff --git a/host_applications/linux/apps/smem/CMakeLists.txt b/host_applications/linux/apps/smem/CMakeLists.txt
+index 0fa8328c9..39907b9a2 100644
+--- a/host_applications/linux/apps/smem/CMakeLists.txt
++++ b/host_applications/linux/apps/smem/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 2.8...3.10)
+ 
+ get_filename_component (VIDEOCORE_ROOT ../../../.. ABSOLUTE)
+ include (${VIDEOCORE_ROOT}/makefiles/cmake/global_settings.cmake)
+diff --git a/interface/vcos/CMakeLists.txt b/interface/vcos/CMakeLists.txt
+index 23a8d724d..7ccb165d9 100644
+--- a/interface/vcos/CMakeLists.txt
++++ b/interface/vcos/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 2.8...3.10)
+ 
+ get_filename_component (VIDEOCORE_ROOT "../.." ABSOLUTE)
+ include (${VIDEOCORE_ROOT}/makefiles/cmake/global_settings.cmake)
+diff --git a/middleware/openmaxil/CMakeLists.txt b/middleware/openmaxil/CMakeLists.txt
+index 3e9c5f9d1..c4cdacab0 100644
+--- a/middleware/openmaxil/CMakeLists.txt
++++ b/middleware/openmaxil/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ # CMake build file for OpenMAX IL.
+ # =============================================================================
+ 
+-cmake_minimum_required (VERSION 2.8)
++cmake_minimum_required (VERSION 2.8...3.10)
+ 
+ if (VIDEOCORE_SIMULATION)

--- a/pkgs/by-name/li/libraspberrypi/package.nix
+++ b/pkgs/by-name/li/libraspberrypi/package.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation {
     hash = "sha512-f7tBgIykcIdkwcFjBKk5ooD/5Bsyrd/0OFr7LNCwWFYeE4DH3XA7UR7YjArkwqUVCVBByr82EOaacw0g1blOkw==";
   };
 
+  patches = [
+    # fix for CMake v4
+    # https://github.com/raspberrypi/userland is archived, so no luck getting this merged
+    ./cmake-v4.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix #450795 
Tracking https://github.com/NixOS/nixpkgs/issues/445447
Worth noting, the original repo https://github.com/raspberrypi/userland got archived recently, so no luck getting this patch merged upstream

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
