### PR TITLE
Revert "llama-cpp: 6670 -> 6729"

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -75,13 +75,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
-  version = "6729";
+  version = "6670";
 
   src = fetchFromGitHub {
     owner = "ggml-org";
     repo = "llama.cpp";
     tag = "b${finalAttrs.version}";
-    hash = "sha256-CkPLgzSsiCkSIAp4XetUJszt0+WjPRt+9V9SvRogbVU=";
+    hash = "sha256-B4Qog7RLcre8KB9N+aVUZSJwlkHIIcCxR8jySoxbXoQ=";
     leaveDotGit = true;
     postFetch = ''
       git -C "$out" rev-parse --short HEAD > $out/COMMIT


### PR DESCRIPTION
Reverts NixOS/nixpkgs#450798

This bump broke `llama-cpp-vulkan`.

```
Running phase: unpackPhase
unpacking source archive /nix/store/gjrc5vy6q4r0kkslcbvl7cixr1382zy4-source
source root is source
Running phase: patchPhase
applying patch /nix/store/scjhs52g6yvlxh7x30acjjffbrf50skk-disable_bfloat16.patch
patching file ggml/src/ggml-vulkan/CMakeLists.txt
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file ggml/src/ggml-vulkan/CMakeLists.txt.rej
```