### PR TITLE
texlive: fix ls-R reproducibility by sorting file listings

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -224,7 +224,7 @@ lib.fix (
 
       postBuild = # generate ls-R database
         ''
-          mktexlsr "$out"
+          mktexlsr --sort "$out"
         '';
     };
 

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.sh
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.sh
@@ -153,7 +153,7 @@ installtl_do_postinst_stuff () {
 
     # make new files available
     tlutils_info "running mktexlsr $TEXMFSYSVAR $TEXMFSYSCONFIG"
-    mktexlsr "$TEXMFSYSVAR" "$TEXMFSYSCONFIG"
+    mktexlsr --sort "$TEXMFSYSVAR" "$TEXMFSYSCONFIG"
 
     # can be skipped if generating formats only
     if [[ -z $__formatsOf ]] ; then
@@ -164,7 +164,7 @@ installtl_do_postinst_stuff () {
         # tlmgr --no-execute-actions paper letter
         # install-tl: "rerun mktexlsr for updmap-sys and tlmgr paper updates"
         tlutils_info "re-running mktexlsr $TEXMFSYSVAR $TEXMFSYSCONFIG"
-        mktexlsr "$TEXMFSYSVAR" "$TEXMFSYSCONFIG"
+        mktexlsr --sort "$TEXMFSYSVAR" "$TEXMFSYSCONFIG"
 
         tlutils_update_context_cache
     fi


### PR DESCRIPTION
## Summary

Fixes #450461 by ensuring bit-by-bit reproducible builds for TeX Live packages.

## Problem

Building TeX Live packages multiple times produced different results due to non-deterministic ordering in the `ls-R` database files (located in `/share/texmf-var/ls-R`). These files are used by Kpathsea for fast file lookups, and their content varied between builds depending on filesystem ordering.

This made it difficult to:
- Detect CI breaches  
- Reproduce builds reliably
- Benefit from content-addressed storage systems

## Solution

The `mktexlsr.pl` script includes a `--sort` flag that ensures deterministic, alphabetically-sorted output. This PR adds the `--sort` flag to all three `mktexlsr` invocations in the TeX Live build process:

1. When generating the texmfdist ls-R database (`build-tex-env.nix`)
2. Initial mktexlsr run for TEXMFSYSVAR and TEXMFSYSCONFIG (`build-tex-env.sh`)
3. Re-run after updmap-sys updates (`build-tex-env.sh`)

## Changes

- `pkgs/tools/typesetting/tex/texlive/build-tex-env.nix`: Add `--sort` flag to mktexlsr call
- `pkgs/tools/typesetting/tex/texlive/build-tex-env.sh`: Add `--sort` flag to both mktexlsr calls

## Upstream Reference

This fix is based on the Debian reproducible builds effort documented in [Debian Bug #1003449](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003449), which addressed the same reproducibility issue in TeX Live.

## Testing

The fix has been tested by building `texlive.combined.scheme-infraonly`. The `--sort` flag is a standard option in `mktexlsr.pl` and has been used successfully in Debian for reproducible builds.

## Impact

This change only affects the ordering of entries in the generated `ls-R` files. The functionality remains identical, but builds will now be reproducible across different filesystems and build environments.