### PR TITLE
phd2: fix build, use system libraries

### DIFF
--- a/pkgs/by-name/ph/phd2/package.nix
+++ b/pkgs/by-name/ph/phd2/package.nix
@@ -2,16 +2,21 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pkg-config,
+  fetchpatch2,
   cmake,
-  gtk3,
-  wxGTK32,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  cfitsio,
   curl,
+  eigen_3_4_0,
   gettext,
   glib,
-  indi-full,
+  gtest,
+  gtk3,
   libnova,
-  wrapGAppsHook3,
+  libusb1,
+  wxGTK32,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,24 +30,42 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-GnT/tyk975caqESBSu4mdX5IWGi5O+RljLSd+CwoGWo=";
   };
 
+  # fixes build error because of missing include
+  # is in masster, should be removed with next release
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/OpenPHDGuiding/phd2/commit/0927de6c8943fae7161457008b989bf72a05c638.patch?full_index=1";
+      hash = "sha256-yo5YdZ4B7jx6p4TqFZc7RJsutsWzeNBUfinFAd8es7E=";
+    })
+  ];
+
   nativeBuildInputs = [
     cmake
+    ninja
     pkg-config
     wrapGAppsHook3
   ];
 
   buildInputs = [
-    gtk3
-    wxGTK32
+    cfitsio
     curl
+    eigen_3_4_0
     gettext
     glib
-    indi-full
+    gtest
+    gtk3
     libnova
+    libusb1
+    wxGTK32
   ];
 
   cmakeFlags = [
+    "-DCMAKE_CXX_STANDARD=17" # needed for gtest
     "-DOPENSOURCE_ONLY=1"
+    "-DUSE_SYSTEM_CFITSIO=ON"
+    "-DUSE_SYSTEM_LIBUSB=ON"
+    "-DUSE_SYSTEM_EIGEN3=ON"
+    "-DUSE_SYSTEM_GTEST=ON"
   ];
 
   # Fix broken wrapped name scheme by moving wrapped binary to where wrapper expects it


### PR DESCRIPTION
Cmake 4 broke the build. Using now the system libraries instead of the bundled ones were possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
