### PR TITLE
docker-compose: add plugin support

### DIFF
--- a/pkgs/applications/virtualization/docker/compose.nix
+++ b/pkgs/applications/virtualization/docker/compose.nix
@@ -2,8 +2,15 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  symlinkJoin,
+  extraPlugins ? [ ],
 }:
-
+let
+  pluginsRef = symlinkJoin {
+    name = "docker-plugins";
+    paths = extraPlugins;
+  };
+in
 buildGoModule rec {
   pname = "docker-compose";
   version = "2.39.4";
@@ -18,6 +25,11 @@ buildGoModule rec {
   postPatch = ''
     # entirely separate package that breaks the build
     rm -rf pkg/e2e/
+  '';
+
+  preBuild = lib.optionalString (extraPlugins != [ ]) ''
+    substituteInPlace vendor/github.com/docker/cli/cli-plugins/manager/manager_unix.go \
+      --replace-fail /usr/libexec/docker/cli-plugins "${pluginsRef}/libexec/docker/cli-plugins"
   '';
 
   vendorHash = "sha256-Uqzul9BiXHAJ1BxlOtRS68Tg71SDva6kg3tv7c6ar2E=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes:
```
$ COMPOSE_BAKE=true docker compose build
WARN[0000] Docker Compose is configured to build using Bake, but buildx isn't installed
...
```

Thanks to deep analysis in the issue (#424333), I was able to patch docker compose, so it hopefully can correctly find other plugins now.

Though turns out my docker compose had an unrelated issue, and after fixing that, I tried testing it with and without this fix, and even without the fix, even though it gives a warning, it still used buildx.

Looks like this PR only fixes this warning, but I decided to still create a Draft PR, maybe if someone has actual problems with compose build as a result of this warning, then it can be useful.

Also passing other plugins inside compose plugin seems like a hack, maybe some one has a better idea how to do that.

Resolves #424333

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
