### PR TITLE
zenoh-plugin-dds: init at 1.4.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13261,6 +13261,11 @@
     github = "katrinafyi";
     githubId = 39479354;
   };
+  kaweees = {
+    github = "kaweees";
+    githubId = 49963287;
+    name = "Miguel Villa Floran";
+  };
   kayhide = {
     email = "kayhide@gmail.com";
     github = "kayhide";

--- a/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "zenoh-plugin-dds";
+  version = "1.4.0"; # nixpkgs-update: no auto update
+
+  src = fetchFromGitHub {
+    owner = "eclipse-zenoh";
+    repo = "zenoh-plugin-dds";
+    rev = version;
+    hash = "sha256-vSFgxSSbLEwpwPznvy+m66Z5grgmxZiIom/I4p0xris=";
+  };
+
+  cargoHash = "sha256-oMmO4N1EqqpWcujbm8sPPwEzNC1Gy2UdCCRqcgyQqdI=";
+
+  nativeBuildInputs = [
+    cmake
+    rustPlatform.bindgenHook
+  ];
+
+  # Some test time out
+  doCheck = false;
+
+  meta = {
+    description = "Zenoh plugin for DDS";
+    longDescription = "A zenoh plug-in that allows to transparently route DDS data. This plugin can be used by DDS applications to leverage zenoh for geographical routing or for better scaling discovery";
+    homepage = "https://github.com/eclipse-zenoh/zenoh-plugin-dds";
+    changelog = "https://github.com/eclipse-zenoh/zenoh-plugin-dds/releases/tag/${src.rev}";
+    license = with lib.licenses; [
+      epl20
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ kaweees ];
+    platforms = lib.platforms.linux;
+    mainProgram = "zenoh-bridge-dds";
+  };
+}

--- a/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
   cmake,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-dds";
   version = "1.4.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-dds";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-vSFgxSSbLEwpwPznvy+m66Z5grgmxZiIom/I4p0xris=";
   };
 
@@ -22,14 +22,15 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
-  # Some test time out
-  doCheck = false;
+  checkFlags = [
+    "--skip=test_name_that_times_out"
+  ];
 
   meta = {
     description = "Zenoh plugin for DDS";
     longDescription = "A zenoh plug-in that allows to transparently route DDS data. This plugin can be used by DDS applications to leverage zenoh for geographical routing or for better scaling discovery";
     homepage = "https://github.com/eclipse-zenoh/zenoh-plugin-dds";
-    changelog = "https://github.com/eclipse-zenoh/zenoh-plugin-dds/releases/tag/${src.rev}";
+    changelog = "https://github.com/eclipse-zenoh/zenoh-plugin-dds/releases/tag/${finalAttrs.src.rev}";
     license = with lib.licenses; [
       epl20
       asl20
@@ -38,4 +39,4 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.linux;
     mainProgram = "zenoh-bridge-dds";
   };
-}
+})


### PR DESCRIPTION
Add the following plugin for [Zenoh](https://zenoh.io/):

dds for routing Data Distribution Service (DDS)-compliant data

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
