### PR TITLE
lib.teams: Sync from GitHub (members/shortName/scope)

### DIFF
--- a/.github/workflows/team.yml
+++ b/.github/workflows/team.yml
@@ -1,0 +1,81 @@
+name: Teams
+
+on:
+  schedule:
+    # Every Tuesday at 19:42 (randomly chosen)
+    - cron: '42 19 * * 1'
+
+  # Allows manual trigger
+  workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: team-token
+        with:
+          app-id: ${{ vars.OWNER_APP_ID }}
+          private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+          permission-administration: read
+          permission-members: read
+      - name: Fetch source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            ci/github-script
+            maintainers/github-teams.json
+      - name: Install dependencies
+        run: npm install bottleneck
+      - name: Synchronise teams
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.team-token.outputs.token }}
+          script: |
+            require('./ci/github-script/get-teams.js')({
+              github,
+              context,
+              core,
+              outFile: "maintainers/github-teams.json"
+            })
+
+      # Use a GitHub App to create the PR so that CI gets triggered
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: sync-token
+        with:
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - name: Get GitHub App User Git String
+        id: user
+        env:
+          GH_TOKEN: ${{ steps.sync-token.outputs.token }}
+          APP_SLUG: ${{ steps.sync-token.outputs.app-slug }}
+        run: |
+          name="${APP_SLUG}[bot]"
+          userId=$(gh api "/users/$name" --jq .id)
+          email="$userId+$name@users.noreply.github.com"
+          echo "git-string=$name <$email>" >> "$GITHUB_OUTPUT"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ steps.sync-token.outputs.token }}
+          add-paths: maintainers/github-teams.json
+          author: ${{ steps.user.outputs.git-string }}
+          committer: ${{ steps.user.outputs.git-string }}
+          commit-message: "maintainers/github-teams.json: Automated sync"
+          branch: github-team-sync
+          title: "maintainers/github-teams.json: Automated sync"
+          body: |
+            This is an automated PR to sync the GitHub teams with access to this repository to the `lib.teams` list.
+
+            This PR can be merged without taking any further action.
+

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -33,6 +33,7 @@
 /lib/path/*                 @infinisil @hsjobeki
 /lib/fileset                @infinisil @hsjobeki
 /maintainers/github-teams.json @infinisil
+/maintainers/computed-team-list.nix @infinisil
 ## Standard environment–related libraries
 /lib/customisation.nix      @alyssais @NixOS/stdenv
 /lib/derivations.nix        @alyssais @NixOS/stdenv

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -32,6 +32,7 @@
 /lib/asserts.nix            @infinisil @hsjobeki @Profpatsch
 /lib/path/*                 @infinisil @hsjobeki
 /lib/fileset                @infinisil @hsjobeki
+/maintainers/github-teams.json @infinisil
 ## Standard environment–related libraries
 /lib/customisation.nix      @alyssais @NixOS/stdenv
 /lib/derivations.nix        @alyssais @NixOS/stdenv

--- a/ci/github-script/get-teams.js
+++ b/ci/github-script/get-teams.js
@@ -1,0 +1,82 @@
+const excludeTeams = [
+  /^voters.*$/,
+  /^nixpkgs-maintainers$/,
+  /^nixpkgs-committers$/,
+]
+
+module.exports = async ({ github, context, core, outFile }) => {
+  const withRateLimit = require('./withRateLimit.js')
+  const { writeFileSync } = require('node:fs')
+  const result = {}
+  await withRateLimit({ github, core }, async (_stats) => {
+    /// Turn an Array of users into an Object, mapping user.login -> user.id
+    function makeUserSet(users) {
+      // Sort in-place and build result by mutation
+      users.sort((a, b) => (a.login > b.login ? 1 : -1))
+
+      return users.reduce((acc, user) => {
+        acc[user.login] = user.id
+        return acc
+      }, {})
+    }
+
+    /// Process a list of teams and append to the result variable
+    async function processTeams(teams) {
+      for (const team of teams) {
+        core.notice(`Processing team ${team.slug}`)
+        if (!excludeTeams.some((regex) => team.slug.match(regex))) {
+          const members = makeUserSet(
+            await github.paginate(github.rest.teams.listMembersInOrg, {
+              org: context.repo.owner,
+              team_slug: team.slug,
+              role: 'member',
+            }),
+          )
+          const maintainers = makeUserSet(
+            await github.paginate(github.rest.teams.listMembersInOrg, {
+              org: context.repo.owner,
+              team_slug: team.slug,
+              role: 'maintainer',
+            }),
+          )
+          result[team.slug] = {
+            description: team.description,
+            id: team.id,
+            maintainers,
+            members,
+            name: team.name,
+          }
+        }
+        await processTeams(
+          await github.paginate(github.rest.teams.listChildInOrg, {
+            org: context.repo.owner,
+            team_slug: team.slug,
+          }),
+        )
+      }
+    }
+
+    const teams = await github.paginate(github.rest.repos.listTeams, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    })
+
+    await processTeams(teams)
+  })
+
+  // Sort the teams by team name
+  const sorted = Object.keys(result)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = result[key]
+      return acc
+    }, {})
+
+  const json = `${JSON.stringify(sorted, null, 2)}\n`
+
+  if (outFile) {
+    writeFileSync(outFile, json)
+  } else {
+    console.log(json)
+  }
+}

--- a/ci/github-script/run
+++ b/ci/github-script/run
@@ -83,4 +83,16 @@ program
     }
   })
 
+program
+  .command('get-teams')
+  .description('Fetch the list of teams with GitHub and output it to a file')
+  .argument('<owner>', 'Owner of the GitHub repository to label (Example: NixOS)')
+  .argument('<repo>', 'Name of the GitHub repository to label (Example: nixpkgs)')
+  .argument('[outFile]', 'Path to the output file (Example: github-teams.json). If not set, prints to stdout')
+  .action(async (owner, repo, outFile, options) => {
+    const getTeams = (await import('./get-teams.js')).default
+    // TODO: Refactor this file so we don't need to pass a PR
+    await run(getTeams, owner, repo, undefined, { ...options, outFile })
+  })
+
 await program.parse()

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -63,7 +63,7 @@ let
       customisation = callLibs ./customisation.nix;
       derivations = callLibs ./derivations.nix;
       maintainers = import ../maintainers/maintainer-list.nix;
-      teams = callLibs ../maintainers/team-list.nix;
+      teams = callLibs ../maintainers/computed-team-list.nix;
       meta = callLibs ./meta.nix;
       versions = callLibs ./versions.nix;
 

--- a/lib/tests/teams.nix
+++ b/lib/tests/teams.nix
@@ -24,12 +24,16 @@ let
           default = false;
         };
         members = lib.mkOption {
-          type = types.listOf (types.submodule (import ./maintainer-module.nix { inherit lib; }));
+          type = types.listOf (types.submodule ./maintainer-module.nix);
           default = [ ];
         };
         github = lib.mkOption {
           type = types.str;
           default = "";
+        };
+        githubMaintainers = lib.mkOption {
+          type = types.listOf (types.submodule ./maintainer-module.nix);
+          default = [ ];
         };
       };
     };

--- a/lib/tests/teams.nix
+++ b/lib/tests/teams.nix
@@ -31,6 +31,10 @@ let
           type = types.str;
           default = "";
         };
+        githubId = lib.mkOption {
+          type = types.int;
+          default = 0;
+        };
         githubMaintainers = lib.mkOption {
           type = types.listOf (types.submodule ./maintainer-module.nix);
           default = [ ];

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -158,12 +158,16 @@ If the team lists no specific membership policy, feel free to merge changes to t
 > [!IMPORTANT]
 > If a team says it is a closed group, do not merge additions to the team without an approval by at least one existing member.
 
-A corresponding GitHub team can be created by any org member.
+#### Synced GitHub teams
+
+As an alternative to tracking team members in `team-list.nix`, a corresponding GitHub team can be created by any org member and its members subsequently managed directly on GitHub.
 When creating the team it should be created with the `nixpkgs-maintainers` team as parent.
 Once approved, the team will have the right privileges to be pinged and requested for review in Nixpkgs.
 
 > [!TIP]
 > The team name should be as short as possible; because it is nested under the maintainers group, no -maintainers suffix is needed.
+
+After the first [weekly team sync](../.github/workflows/team-sync.yml) with the new team, it's then also possible to link it to the entry in `team-list.nix` by setting its `github` field to the GitHub team name.
 
 # Maintainer scripts
 

--- a/maintainers/computed-team-list.nix
+++ b/maintainers/computed-team-list.nix
@@ -20,6 +20,8 @@ let
     );
 
 in
+# TODO: Consider automatically exposing all GitHub teams under `lib.teams`,
+# so that no manual PRs are necessary to add such teams anymore
 lib.mapAttrs (
   name: attrs:
   if attrs ? github then
@@ -28,6 +30,12 @@ lib.mapAttrs (
         githubTeams.${attrs.github}
           or (throw "lib.teams.${name}: Corresponding GitHub team ${attrs.github} not known yet, make sure to create it and wait for the regular team sync");
     in
+    # TODO: Consider specifying `githubId` in team-list.nix and inferring `github` from it (or even dropping it)
+    # This would make renames easier because no additional place needs to keep track of them.
+    # Though in a future where all Nixpkgs GitHub teams are automatically exposed under `lib.teams`,
+    # this would also not be an issue anymore.
+    assert lib.assertMsg (!attrs ? githubId)
+      "lib.teams.${name}: Both `githubId` and `github` is set, but the former is synced from the latter";
     assert lib.assertMsg (!attrs ? shortName)
       "lib.teams.${name}: Both `shortName` and `github` is set, but the former is synced from the latter";
     assert lib.assertMsg (
@@ -38,6 +46,7 @@ lib.mapAttrs (
     ) "lib.teams.${name}: Both `members` and `github` is set, but the former is synced from the latter";
     attrs
     // {
+      githubId = githubTeam.id;
       shortName = githubTeam.name;
       scope = githubTeam.description;
       members =

--- a/maintainers/computed-team-list.nix
+++ b/maintainers/computed-team-list.nix
@@ -43,6 +43,7 @@ lib.mapAttrs (
       members =
         maintainerSetToList attrs.github githubTeam.maintainers
         ++ maintainerSetToList attrs.github githubTeam.members;
+      githubMaintainers = maintainerSetToList attrs.github githubTeam.maintainers;
     }
   else
     attrs

--- a/maintainers/computed-team-list.nix
+++ b/maintainers/computed-team-list.nix
@@ -1,0 +1,49 @@
+# Extends ./team-list.nix with synced GitHub information from ./github-teams.json
+{ lib }:
+let
+  githubTeams = lib.importJSON ./github-teams.json;
+  teams = import ./team-list.nix { inherit lib; };
+
+  # A fast maintainer id lookup table
+  maintainersById = lib.pipe lib.maintainers [
+    lib.attrValues
+    (lib.groupBy (attrs: toString attrs.githubId))
+    (lib.mapAttrs (_: lib.head))
+  ];
+
+  maintainerSetToList =
+    githubTeam:
+    lib.mapAttrsToList (
+      login: id:
+      maintainersById.${toString id}
+      or (throw "lib.teams: No maintainer entry for GitHub user @${login} who's part of the @NixOS/${githubTeam} team")
+    );
+
+in
+lib.mapAttrs (
+  name: attrs:
+  if attrs ? github then
+    let
+      githubTeam =
+        githubTeams.${attrs.github}
+          or (throw "lib.teams.${name}: Corresponding GitHub team ${attrs.github} not known yet, make sure to create it and wait for the regular team sync");
+    in
+    assert lib.assertMsg (!attrs ? shortName)
+      "lib.teams.${name}: Both `shortName` and `github` is set, but the former is synced from the latter";
+    assert lib.assertMsg (
+      !attrs ? scope
+    ) "lib.teams.${name}: Both `scope` and `github` is set, but the former is synced from the latter";
+    assert lib.assertMsg (
+      !attrs ? members
+    ) "lib.teams.${name}: Both `members` and `github` is set, but the former is synced from the latter";
+    attrs
+    // {
+      shortName = githubTeam.name;
+      scope = githubTeam.description;
+      members =
+        maintainerSetToList attrs.github githubTeam.maintainers
+        ++ maintainerSetToList attrs.github githubTeam.members;
+    }
+  else
+    attrs
+) teams

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -66,6 +66,8 @@
       "adamcstephens": 2071575,
       "ankhers": 750786,
       "gleber": 33185,
+      "minijackson": 1200507,
+      "savtrip": 42227195,
       "yurrriq": 1866448
     },
     "name": "Beam"
@@ -151,7 +153,7 @@
     "name": "crystal-lang"
   },
   "cuda-maintainers": {
-    "description": "All things CUDA and deep learning!",
+    "description": "Maintain CUDA-enabled packages",
     "id": 5704451,
     "maintainers": {
       "ConnorBaker": 3880346,
@@ -159,12 +161,13 @@
       "samuela": 226872
     },
     "members": {
-      "GaetanLepage": 33058747
+      "GaetanLepage": 33058747,
+      "prusnak": 42201
     },
     "name": "cuda-maintainers"
   },
   "darwin-core": {
-    "description": "Maintains core platform support and packages for macOS and other Apple platforms.",
+    "description": "Maintain core platform support and packages for macOS and other Apple platforms",
     "id": 11265438,
     "maintainers": {
       "emilazy": 18535642
@@ -278,11 +281,10 @@
     "name": "darwin-maintainers"
   },
   "documentation-team": {
-    "description": "https://nixos.org/community/teams/documentation",
+    "description": "Maintain nixpkgs/NixOS documentation and tools for building it. https://nixos.org/community/teams/documentation",
     "id": 6590023,
     "maintainers": {
-      "alejandrosame": 1078000,
-      "fricklerhandwerk": 6599296
+      "alejandrosame": 1078000
     },
     "members": {
       "hsjobeki": 50398876,
@@ -323,7 +325,7 @@
     "name": "emacs"
   },
   "enlightenment": {
-    "description": "Maintainers of the Enlightenment Desktop Environment",
+    "description": "Maintain Enlightenment desktop environment and related packages",
     "id": 5937665,
     "maintainers": {
       "romildo": 1217934
@@ -350,7 +352,7 @@
     "name": "exotic-platform-maintainers"
   },
   "flutter": {
-    "description": "",
+    "description": "Maintain Flutter and Dart-related packages and build tools",
     "id": 7718198,
     "maintainers": {
       "RossComputerGuy": 19699320
@@ -372,13 +374,14 @@
     "name": "Freedesktop"
   },
   "geospatial": {
-    "description": "Maintain geospatial packages",
+    "description": "Maintain geospatial, remote sensing and OpenStreetMap software",
     "id": 7084621,
     "maintainers": {
       "imincik": 476346
     },
     "members": {
-      "das-g": 97746,
+      "autra": 1576598,
+      "l0b0": 168301,
       "nh2": 399535,
       "nialov": 47318483,
       "sikmir": 688044,
@@ -404,13 +407,15 @@
     "id": 3806133,
     "maintainers": {},
     "members": {
+      "bobby285271": 20080233,
+      "dasj19": 7589338,
       "hedning": 71978,
       "jtojnar": 705123
     },
     "name": "GNOME"
   },
   "golang": {
-    "description": "",
+    "description": "Maintain Golang compilers",
     "id": 4020424,
     "maintainers": {
       "Mic92": 96200,
@@ -425,16 +430,14 @@
     "name": "golang"
   },
   "haskell": {
-    "description": "The nixpkgs Haskell team",
+    "description": "Maintain Haskell packages and infrastructure",
     "id": 4769723,
     "maintainers": {
       "cdepillabout": 64804,
       "maralorn": 1651325,
-      "peti": 28323,
       "sternenseemann": 3154475
     },
     "members": {
-      "expipiplus1": 857308,
       "wolfgangwalther": 9132420
     },
     "name": "Haskell"
@@ -468,18 +471,18 @@
     "name": "Java"
   },
   "k3s": {
-    "description": "Lightweight Kubernetes maintainer team (k3s)",
+    "description": "Maintain K3s package, NixOS module, NixOS tests, update script",
     "id": 7725877,
     "maintainers": {
       "Mic92": 96200,
       "euank": 2147649,
       "marcusramberg": 5526,
-      "wrmilling": 6162814,
-      "yajo": 973709
+      "wrmilling": 6162814
     },
     "members": {
       "frederictobiasc": 26125115,
-      "superherointj": 5861043
+      "heywoodlh": 18178614,
+      "rorosen": 76747196
     },
     "name": "k3s"
   },
@@ -525,7 +528,7 @@
     "name": "Linux kernel"
   },
   "lisp": {
-    "description": "The nixpkgs Lisp team",
+    "description": "Maintain the Lisp ecosystem",
     "id": 7678368,
     "maintainers": {
       "7c6f434c": 1891350,
@@ -583,7 +586,7 @@
     "name": "loongarch64"
   },
   "lua": {
-    "description": "Deals with lua ecosystem",
+    "description": "Maintain the lua ecosystem",
     "id": 5255750,
     "maintainers": {
       "teto": 886074
@@ -597,7 +600,7 @@
     "name": "lua"
   },
   "lumina": {
-    "description": "Maintainers of the Lumina Desktop Environment",
+    "description": "Maintain lumina desktop environment and related packages",
     "id": 5937661,
     "maintainers": {
       "romildo": 1217934
@@ -620,13 +623,26 @@
     "name": "LXC"
   },
   "lxqt": {
-    "description": "Maintainers of the LXQt Desktop Environment",
+    "description": "Maintain LXQt desktop environment and related packages",
     "id": 5937679,
     "maintainers": {
       "romildo": 1217934
     },
     "members": {},
     "name": "LXQt"
+  },
+  "marketing-team": {
+    "description": "Marketing team [leader=@djacu]",
+    "id": 7709512,
+    "maintainers": {
+      "djacu": 7043297,
+      "tomberek": 178444
+    },
+    "members": {
+      "flyfloh": 74379,
+      "thilobillerbeck": 7442383
+    },
+    "name": "Marketing Team"
   },
   "mate": {
     "description": "Maintainers of the MATE Desktop Environment",
@@ -640,7 +656,7 @@
     "name": "MATE"
   },
   "neovim": {
-    "description": "Maintains neovim ecosystem",
+    "description": "Maintain the vim and neovim text editors and related packages",
     "id": 6748534,
     "maintainers": {
       "GaetanLepage": 33058747
@@ -683,7 +699,7 @@
     "name": "Nix team"
   },
   "nixos-release-managers": {
-    "description": "Team of Release Managers.",
+    "description": "Manage the current nixpkgs/NixOS release",
     "id": 3620128,
     "maintainers": {
       "jopejoe1": 34899572,
@@ -693,7 +709,7 @@
     "name": "nixos-release-managers"
   },
   "nixpkgs-ci": {
-    "description": "Maintaining Nixpkgs CI",
+    "description": "Maintain Nixpkgs' in-tree Continuous Integration, including GitHub Actions",
     "id": 13362067,
     "maintainers": {
       "philiptaron": 43863,
@@ -736,12 +752,11 @@
     "name": "Node"
   },
   "ocaml": {
-    "description": "Maintain the ecosystem around OCaml in Nixpkgs",
+    "description": "Maintain the OCaml compiler and package set",
     "id": 7553013,
     "maintainers": {
       "Alizter": 8614547,
       "romildo": 1217934,
-      "superherointj": 5861043,
       "ulrikstrid": 1607770
     },
     "members": {
@@ -750,7 +765,7 @@
     "name": "OCaml"
   },
   "pantheon": {
-    "description": "Maintainers of the Pantheon desktop",
+    "description": "Maintain Pantheon desktop environment and platform",
     "id": 4786995,
     "maintainers": {
       "davidak": 91113
@@ -767,8 +782,7 @@
     "members": {
       "Ma27": 6025220,
       "aanderse": 7755101,
-      "drupol": 252042,
-      "globin": 1447245,
+      "piotrkwiecinski": 2151333,
       "talyz": 63433
     },
     "name": "php"
@@ -795,15 +809,21 @@
     "name": "postgres"
   },
   "qt-kde": {
-    "description": "Maintain the Qt framework, KDE Frameworks and Applications, and Plasma desktop",
+    "description": "Maintain the Qt framework, KDE application suite, Plasma desktop environment and related projects",
     "id": 4341481,
     "maintainers": {
       "ttuegel": 563054
     },
     "members": {
       "FRidh": 2129135,
+      "K900": 386765,
+      "LunNova": 782440,
+      "NickCao": 15247171,
       "SCOTT-HAMILTON": 24496705,
+      "SuperSandro2000": 7258858,
       "bkchr": 5718007,
+      "ilya-fedin": 17829319,
+      "mjm": 1181,
       "nyanloutre": 7677321,
       "peterhoeg": 722550
     },
@@ -840,7 +860,7 @@
     "name": "RISC-V"
   },
   "rocm": {
-    "description": "AMD ROCm stack and related",
+    "description": "Maintain ROCm and related packages",
     "id": 6921873,
     "maintainers": {
       "mschwaig": 3856390
@@ -853,7 +873,7 @@
     "name": "rocm"
   },
   "rust": {
-    "description": "",
+    "description": "Maintain the Rust compiler toolchain and nixpkgs integration",
     "id": 7304571,
     "maintainers": {
       "Mic92": 96200,
@@ -940,7 +960,7 @@
     "name": "stdenv"
   },
   "systemd": {
-    "description": "systemd on NixOS.",
+    "description": "Maintain systemd for NixOS",
     "id": 3894007,
     "maintainers": {
       "flokli": 183879
@@ -954,7 +974,7 @@
     "name": "systemd"
   },
   "xen-project": {
-    "description": "Maintains the Xen Project ecosystem on Nixpkgs. Members listed as \"Maintainers\" are recipients of Xen Security Advisories sent to xsa@nixos.org.",
+    "description": "Maintain the Xen Project Hypervisor and the related tooling ecosystem. Members listed as \"Maintainers\" are recipients of Xen Security Advisories sent to xsa@nixos.org.",
     "id": 11127725,
     "maintainers": {
       "CertainLach": 6235312,

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -1,0 +1,980 @@
+{
+  "acme": {
+    "description": "Maintain ACME-related packages and modules.",
+    "id": 3806126,
+    "maintainers": {},
+    "members": {
+      "arianvp": 628387,
+      "emilazy": 18535642,
+      "m1cr0man": 3044438
+    },
+    "name": "ACME"
+  },
+  "agda": {
+    "description": "Maintain Agda-related packages and modules",
+    "id": 14416551,
+    "maintainers": {
+      "alexarice": 17208985,
+      "ncfavier": 4323933,
+      "turion": 303489
+    },
+    "members": {
+      "phijor": 10487782
+    },
+    "name": "agda"
+  },
+  "android": {
+    "description": "Maintain Android-related tooling in nixpkgs",
+    "id": 11821955,
+    "maintainers": {
+      "RossComputerGuy": 19699320,
+      "numinit": 369111
+    },
+    "members": {
+      "JohnRTitor": 50095635,
+      "adrian-gierakowski": 330177,
+      "hadilq": 5190539
+    },
+    "name": "Android"
+  },
+  "bazel": {
+    "description": "Maintenance of https://bazel.build/ and related packages",
+    "id": 5468470,
+    "maintainers": {
+      "Profpatsch": 3153638
+    },
+    "members": {
+      "aherrmann": 732652,
+      "avdv": 3471749,
+      "ethercrow": 222467,
+      "groodt": 343415,
+      "kalbasit": 87115,
+      "mboes": 51356,
+      "uri-canva": 33242106
+    },
+    "name": "Bazel"
+  },
+  "beam": {
+    "description": "Maintain BEAM-related packages and modules.",
+    "id": 4502493,
+    "maintainers": {
+      "happysalada": 5317234
+    },
+    "members": {
+      "Br1ght0ne": 12615679,
+      "DianaOlympos": 15774340,
+      "adamcstephens": 2071575,
+      "ankhers": 750786,
+      "gleber": 33185,
+      "yurrriq": 1866448
+    },
+    "name": "Beam"
+  },
+  "bootstrapping": {
+    "description": "coordinates efforts towards bootstrappable builds (see https://bootstrappable.org/)",
+    "id": 9141350,
+    "maintainers": {
+      "zeuner": 2545850
+    },
+    "members": {
+      "philiptaron": 43863
+    },
+    "name": "bootstrapping"
+  },
+  "categorization": {
+    "description": "Maintain the categorization system in Nixpkgs, per RFC 0146. This team has authority over all categorization issues in Nixpkgs. Matrix: https://matrix.to/#/%23nixpkgs-categorization:matrix.org",
+    "id": 11723948,
+    "maintainers": {
+      "7c6f434c": 1891350,
+      "Aleksanaa": 42209822,
+      "GetPsyched": 43472218,
+      "Lyndeno": 13490857,
+      "SigmaSquadron": 174749595,
+      "fgaz": 8182846,
+      "natsukium": 25083790,
+      "philiptaron": 43863,
+      "pyrotelekinetic": 29682759,
+      "tomodachi94": 68489118
+    },
+    "members": {},
+    "name": "Categorization"
+  },
+  "channel-updaters": {
+    "description": "Users who can update the Nixpkgs/NixOS channels",
+    "id": 3475569,
+    "maintainers": {},
+    "members": {
+      "nixos-channel-bot": 56695723
+    },
+    "name": "channel-updaters"
+  },
+  "coq": {
+    "description": "Coq proof assistant and package maintainers",
+    "id": 7617261,
+    "maintainers": {
+      "Alizter": 8614547,
+      "Zimmi48": 1108325,
+      "vbgl": 2612464
+    },
+    "members": {},
+    "name": "Coq"
+  },
+  "cosmic": {
+    "description": "Maintain the COSMIC DE and related packages.",
+    "id": 12734494,
+    "maintainers": {
+      "alyssais": 2768870,
+      "nyabinary": 97130632
+    },
+    "members": {
+      "HeitorAugustoLN": 44377258,
+      "Pandapip1": 45835846,
+      "a-kenji": 65275785,
+      "ahoneybun": 4884946,
+      "drakon64": 6444703,
+      "griffi-gh": 45996170,
+      "michaelBelsanti": 62124625,
+      "thefossguy": 44400303
+    },
+    "name": "COSMIC"
+  },
+  "crystal-lang": {
+    "description": "The Crystal Lang eco-system",
+    "id": 3806663,
+    "maintainers": {
+      "peterhoeg": 722550
+    },
+    "members": {
+      "Br1ght0ne": 12615679,
+      "manveru": 3507
+    },
+    "name": "crystal-lang"
+  },
+  "cuda-maintainers": {
+    "description": "All things CUDA and deep learning!",
+    "id": 5704451,
+    "maintainers": {
+      "ConnorBaker": 3880346,
+      "SomeoneSerge": 9720532,
+      "samuela": 226872
+    },
+    "members": {
+      "GaetanLepage": 33058747
+    },
+    "name": "cuda-maintainers"
+  },
+  "darwin-core": {
+    "description": "Maintains core platform support and packages for macOS and other Apple platforms.",
+    "id": 11265438,
+    "maintainers": {
+      "emilazy": 18535642
+    },
+    "members": {
+      "reckenrode": 7413633,
+      "toonn": 1486805
+    },
+    "name": "darwin-core"
+  },
+  "darwin-maintainers": {
+    "description": "Improve Darwin-support across Nixpkgs and help maintainers without access to Darwin hardware. Apply to join through https://github.com/NixOS/nixpkgs/issues/323144 to keep the process transparent.",
+    "id": 2385202,
+    "maintainers": {
+      "toonn": 1486805
+    },
+    "members": {
+      "0xMRTT": 105598867,
+      "21CSM": 81891917,
+      "Aleksanaa": 42209822,
+      "CorbanR": 1918683,
+      "Emin017": 99674037,
+      "Et7f3": 29592775,
+      "FlameFlag": 57304299,
+      "Guanran928": 68757440,
+      "LnL7": 689294,
+      "Mastermindaxe": 33257997,
+      "Moraxyc": 69713071,
+      "Prince213": 25235514,
+      "Samasaur1": 30577766,
+      "Sciencentistguy": 4983935,
+      "Steven0351": 24440751,
+      "afh": 16507,
+      "azuwis": 9315,
+      "booxter": 90200,
+      "carlossless": 498906,
+      "cideM": 4246921,
+      "cidkidnix": 67574902,
+      "copumpkin": 2623,
+      "devusb": 4951663,
+      "domenkozar": 126339,
+      "donn": 12652988,
+      "dwt": 57199,
+      "eliandoran": 21236836,
+      "emilazy": 18535642,
+      "ethancedwards8": 60861925,
+      "fiddlerwoaroof": 808745,
+      "frogamic": 10263813,
+      "gador": 1883533,
+      "griff": 4368,
+      "groodt": 343415,
+      "gshpychka": 23005347,
+      "hexagonal-sun": 222664,
+      "heywoodlh": 18178614,
+      "iedame": 60272,
+      "isabelroses": 71222764,
+      "jonhermansen": 660911,
+      "juliusrickert": 5007494,
+      "jwiegley": 8460,
+      "kashw2": 15855440,
+      "kevingriffin": 209729,
+      "khaneliman": 1778670,
+      "kloenk": 12898828,
+      "konradmalik": 13033392,
+      "kubukoz": 894884,
+      "lutzmor": 9321736,
+      "magistau": 43097806,
+      "maljub01": 350635,
+      "martinjlowm": 110860,
+      "matteo-pacini": 3139724,
+      "matthewbauer": 19036,
+      "mexisme": 329349,
+      "mikroskeem": 3490861,
+      "mirkolenz": 5160954,
+      "mstone": 412508,
+      "n8henrie": 1234956,
+      "niklaskorz": 590517,
+      "ofalvai": 1694986,
+      "pasqui23": 6931743,
+      "prusnak": 42201,
+      "pupbrained": 33522919,
+      "reckenrode": 7413633,
+      "ryand56": 22267679,
+      "samrose": 115821,
+      "sarahec": 11277967,
+      "shaunsingh": 71196912,
+      "sikmir": 688044,
+      "siraben": 8219659,
+      "siriobalmelli": 23038812,
+      "starcraft66": 1858154,
+      "stepbrobd": 81826728,
+      "stephank": 89950,
+      "stephenstubbs": 18033664,
+      "t-monaghan": 62273348,
+      "thefloweringash": 42933,
+      "tricktron": 16036882,
+      "uncenter": 47499684,
+      "uri-canva": 33242106,
+      "usertam": 22500027,
+      "veprbl": 245573,
+      "viraptor": 188063,
+      "wegank": 9713184,
+      "willcohen": 5185341,
+      "willjr": 5904828,
+      "wldhx": 15619766,
+      "yeongsheng-tan": 809030,
+      "youhaveme9": 58213083,
+      "yzx9": 41458459,
+      "zachcoyle": 908716
+    },
+    "name": "darwin-maintainers"
+  },
+  "documentation-team": {
+    "description": "https://nixos.org/community/teams/documentation",
+    "id": 6590023,
+    "maintainers": {
+      "alejandrosame": 1078000,
+      "fricklerhandwerk": 6599296
+    },
+    "members": {
+      "hsjobeki": 50398876,
+      "wamirez": 24505474
+    },
+    "name": "Documentation Team"
+  },
+  "dotnet": {
+    "description": "Maintain the .NET ecosystem in nixpkgs",
+    "id": 8173604,
+    "maintainers": {
+      "corngood": 3077118,
+      "mdarocha": 11572618
+    },
+    "members": {
+      "GGG-KILLER": 5892127,
+      "IvarWithoutBones": 41924494,
+      "JamieMagee": 1358764,
+      "anpin": 6060545,
+      "meenzen": 22305878,
+      "raphaelr": 121178
+    },
+    "name": "Dotnet"
+  },
+  "emacs": {
+    "description": "",
+    "id": 2516946,
+    "maintainers": {
+      "jian-lin": 75130626,
+      "matthewbauer": 19036
+    },
+    "members": {
+      "AndersonTorres": 5954806,
+      "adisbladis": 63286,
+      "panchoh": 471059,
+      "ttuegel": 563054
+    },
+    "name": "emacs"
+  },
+  "enlightenment": {
+    "description": "Maintainers of the Enlightenment Desktop Environment",
+    "id": 5937665,
+    "maintainers": {
+      "romildo": 1217934
+    },
+    "members": {},
+    "name": "Enlightenment"
+  },
+  "exotic-platform-maintainers": {
+    "description": "",
+    "id": 3727378,
+    "maintainers": {
+      "Ericson2314": 1055245,
+      "matthewbauer": 19036
+    },
+    "members": {
+      "aaronjanse": 16829510,
+      "alyssais": 2768870,
+      "emilytrau": 13267947,
+      "minijackson": 1200507,
+      "r-burns": 52847440,
+      "siraben": 8219659,
+      "sternenseemann": 3154475
+    },
+    "name": "exotic-platform-maintainers"
+  },
+  "flutter": {
+    "description": "",
+    "id": 7718198,
+    "maintainers": {
+      "RossComputerGuy": 19699320
+    },
+    "members": {
+      "FlafyDev": 44374434,
+      "hacker1024": 20849728,
+      "mkg20001": 7735145
+    },
+    "name": "Flutter"
+  },
+  "freedesktop": {
+    "description": "Maintain Freedesktop.org packages for graphical desktop.",
+    "id": 3806136,
+    "maintainers": {},
+    "members": {
+      "jtojnar": 705123
+    },
+    "name": "Freedesktop"
+  },
+  "geospatial": {
+    "description": "Maintain geospatial packages",
+    "id": 7084621,
+    "maintainers": {
+      "imincik": 476346
+    },
+    "members": {
+      "das-g": 97746,
+      "nh2": 399535,
+      "nialov": 47318483,
+      "sikmir": 688044,
+      "willcohen": 5185341
+    },
+    "name": "Geospatial"
+  },
+  "gitlab": {
+    "description": "Maintain GitLab-related packages and modules",
+    "id": 8157777,
+    "maintainers": {
+      "leona-ya": 11006031,
+      "xanderio": 6298052,
+      "yayayayaka": 73759599
+    },
+    "members": {
+      "talyz": 63433
+    },
+    "name": "GitLab"
+  },
+  "gnome": {
+    "description": "Maintain GNOME desktop environment and platform.",
+    "id": 3806133,
+    "maintainers": {},
+    "members": {
+      "hedning": 71978,
+      "jtojnar": 705123
+    },
+    "name": "GNOME"
+  },
+  "golang": {
+    "description": "",
+    "id": 4020424,
+    "maintainers": {
+      "Mic92": 96200,
+      "kalbasit": 87115,
+      "zowoq": 59103226
+    },
+    "members": {
+      "katexochen": 49727155,
+      "mfrw": 4929861,
+      "qbit": 68368
+    },
+    "name": "golang"
+  },
+  "haskell": {
+    "description": "The nixpkgs Haskell team",
+    "id": 4769723,
+    "maintainers": {
+      "cdepillabout": 64804,
+      "maralorn": 1651325,
+      "peti": 28323,
+      "sternenseemann": 3154475
+    },
+    "members": {
+      "expipiplus1": 857308,
+      "wolfgangwalther": 9132420
+    },
+    "name": "Haskell"
+  },
+  "hyprland": {
+    "description": "Maintain Hyprland compositor and ecosystem.",
+    "id": 12048885,
+    "maintainers": {
+      "khaneliman": 1778670
+    },
+    "members": {
+      "JohnRTitor": 50095635,
+      "NotAShelf": 62766066,
+      "donovanglover": 2374245,
+      "fufexan": 36706276
+    },
+    "name": "hyprland"
+  },
+  "java": {
+    "description": "Maintainers of the Nixpkgs Java ecosystem (JDK, JVM, Java, Gradle, Maven, Ant, and adjacent projects); frequently lingering in #jvm:nixos.org on Matrix",
+    "id": 11412419,
+    "maintainers": {
+      "FliegendeWurst": 12560461,
+      "Infinidoge": 22727114,
+      "chayleaf": 9590981,
+      "tomodachi94": 68489118
+    },
+    "members": {
+      "msgilligan": 61612
+    },
+    "name": "Java"
+  },
+  "k3s": {
+    "description": "Lightweight Kubernetes maintainer team (k3s)",
+    "id": 7725877,
+    "maintainers": {
+      "Mic92": 96200,
+      "euank": 2147649,
+      "marcusramberg": 5526,
+      "wrmilling": 6162814,
+      "yajo": 973709
+    },
+    "members": {
+      "frederictobiasc": 26125115,
+      "superherointj": 5861043
+    },
+    "name": "k3s"
+  },
+  "kodi": {
+    "description": "Maintain Kodi related packages.",
+    "id": 4642467,
+    "maintainers": {
+      "aanderse": 7755101
+    },
+    "members": {
+      "cpages": 411324,
+      "edwtjo": 54799,
+      "minijackson": 1200507,
+      "peterhoeg": 722550,
+      "sephalon": 893474
+    },
+    "name": "kodi"
+  },
+  "kubernetes": {
+    "description": "",
+    "id": 5536808,
+    "maintainers": {
+      "johanot": 998763,
+      "offlinehacker": 585547,
+      "saschagrunert": 695473,
+      "srhb": 219362
+    },
+    "members": {},
+    "name": "kubernetes"
+  },
+  "linux-kernel": {
+    "description": "",
+    "id": 13371617,
+    "maintainers": {
+      "alyssais": 2768870
+    },
+    "members": {
+      "K900": 386765,
+      "Ma27": 6025220,
+      "NeQuissimus": 628342,
+      "TredwellGit": 61860346
+    },
+    "name": "Linux kernel"
+  },
+  "lisp": {
+    "description": "The nixpkgs Lisp team",
+    "id": 7678368,
+    "maintainers": {
+      "7c6f434c": 1891350,
+      "Uthar": 15697697,
+      "hraban": 137852,
+      "lukego": 13791,
+      "nagy": 692274
+    },
+    "members": {},
+    "name": "lisp"
+  },
+  "lix-maintainers": {
+    "description": "Lix maintainers in nixpkgs/NixOS",
+    "id": 13838744,
+    "maintainers": {
+      "lf-": 6652840
+    },
+    "members": {
+      "9999years": 15312184,
+      "Qyriad": 1542224,
+      "RaitoBezarius": 314564,
+      "alois31": 36605164
+    },
+    "name": "Lix maintainers"
+  },
+  "llvm": {
+    "description": "Maintain LLVM package sets and related packages",
+    "id": 9955829,
+    "maintainers": {
+      "RossComputerGuy": 19699320,
+      "alyssais": 2768870
+    },
+    "members": {
+      "Ericson2314": 1055245,
+      "dtzWill": 817330,
+      "emilazy": 18535642,
+      "lovek323": 265084,
+      "rrbutani": 7833358,
+      "sternenseemann": 3154475
+    },
+    "name": "LLVM"
+  },
+  "loongarch64": {
+    "description": "Maintain LoongArch64 related packages and code",
+    "id": 13371619,
+    "maintainers": {
+      "Aleksanaa": 42209822
+    },
+    "members": {
+      "Cryolitia": 23723294,
+      "darkyzhou": 7220778,
+      "dramforever": 2818072,
+      "wegank": 9713184
+    },
+    "name": "loongarch64"
+  },
+  "lua": {
+    "description": "Deals with lua ecosystem",
+    "id": 5255750,
+    "maintainers": {
+      "teto": 886074
+    },
+    "members": {
+      "7c6f434c": 1891350,
+      "Shados": 338268,
+      "khaneliman": 1778670,
+      "spencerpogo": 34356756
+    },
+    "name": "lua"
+  },
+  "lumina": {
+    "description": "Maintainers of the Lumina Desktop Environment",
+    "id": 5937661,
+    "maintainers": {
+      "romildo": 1217934
+    },
+    "members": {},
+    "name": "Lumina"
+  },
+  "lxc": {
+    "description": "LXC, LXD, Incus",
+    "id": 9223525,
+    "maintainers": {
+      "adamcstephens": 2071575
+    },
+    "members": {
+      "aanderse": 7755101,
+      "jnsgruk": 668505,
+      "megheaiulian": 1788114,
+      "mkg20001": 7735145
+    },
+    "name": "LXC"
+  },
+  "lxqt": {
+    "description": "Maintainers of the LXQt Desktop Environment",
+    "id": 5937679,
+    "maintainers": {
+      "romildo": 1217934
+    },
+    "members": {},
+    "name": "LXQt"
+  },
+  "mate": {
+    "description": "Maintainers of the MATE Desktop Environment",
+    "id": 5937667,
+    "maintainers": {
+      "romildo": 1217934
+    },
+    "members": {
+      "bobby285271": 20080233
+    },
+    "name": "MATE"
+  },
+  "neovim": {
+    "description": "Maintains neovim ecosystem",
+    "id": 6748534,
+    "maintainers": {
+      "GaetanLepage": 33058747
+    },
+    "members": {
+      "PerchunPak": 68118654,
+      "khaneliman": 1778670,
+      "mrcjkb": 12857160
+    },
+    "name": "neovim"
+  },
+  "nix-formatting": {
+    "description": "Team to maintain the official Nix formatter and apply it to Nixpkgs",
+    "id": 9676823,
+    "maintainers": {
+      "infinisil": 20525370,
+      "jfly": 277474
+    },
+    "members": {
+      "0x4A6F": 9675338,
+      "MattSturgeon": 5046562,
+      "Sereja313": 112060595,
+      "dasJ": 4971975,
+      "piegamesde": 14054505
+    },
+    "name": "nix-formatting"
+  },
+  "nix-team": {
+    "description": "",
+    "id": 174820,
+    "maintainers": {
+      "tomberek": 178444
+    },
+    "members": {
+      "Ericson2314": 1055245,
+      "Mic92": 96200,
+      "edolstra": 1148549,
+      "xokdvium": 145775305
+    },
+    "name": "Nix team"
+  },
+  "nixos-release-managers": {
+    "description": "Team of Release Managers.",
+    "id": 3620128,
+    "maintainers": {
+      "jopejoe1": 34899572,
+      "leona-ya": 11006031
+    },
+    "members": {},
+    "name": "nixos-release-managers"
+  },
+  "nixpkgs-ci": {
+    "description": "Maintaining Nixpkgs CI",
+    "id": 13362067,
+    "maintainers": {
+      "philiptaron": 43863,
+      "wolfgangwalther": 9132420
+    },
+    "members": {
+      "MattSturgeon": 5046562,
+      "Mic92": 96200,
+      "zowoq": 59103226
+    },
+    "name": "Nixpkgs CI"
+  },
+  "nixpkgs-core": {
+    "description": "Provides leadership for and has authority over Nixpkgs.",
+    "id": 14317027,
+    "maintainers": {
+      "K900": 386765,
+      "alyssais": 2768870,
+      "emilazy": 18535642,
+      "wolfgangwalther": 9132420
+    },
+    "members": {},
+    "name": "Nixpkgs core"
+  },
+  "nixpkgs-merge-bot": {
+    "description": "This team exists as a target for triggering the nixpkgs merge bot.",
+    "id": 13926892,
+    "maintainers": {},
+    "members": {},
+    "name": "nixpkgs-merge-bot"
+  },
+  "node": {
+    "description": "Maintains Node.js runtimes and build tooling.\r\n\r\n\"JS is hecked, thanks for coming to my TED Talk\" - @lilyinstarlight",
+    "id": 7309872,
+    "maintainers": {
+      "lilyinstarlight": 298109,
+      "winterqt": 78392041
+    },
+    "members": {},
+    "name": "Node"
+  },
+  "ocaml": {
+    "description": "Maintain the ecosystem around OCaml in Nixpkgs",
+    "id": 7553013,
+    "maintainers": {
+      "Alizter": 8614547,
+      "romildo": 1217934,
+      "superherointj": 5861043,
+      "ulrikstrid": 1607770
+    },
+    "members": {
+      "redianthus": 16472988
+    },
+    "name": "OCaml"
+  },
+  "pantheon": {
+    "description": "Maintainers of the Pantheon desktop",
+    "id": 4786995,
+    "maintainers": {
+      "davidak": 91113
+    },
+    "members": {
+      "bobby285271": 20080233
+    },
+    "name": "Pantheon"
+  },
+  "php": {
+    "description": "Maintain PHP related packages and extensions.",
+    "id": 3806182,
+    "maintainers": {},
+    "members": {
+      "Ma27": 6025220,
+      "aanderse": 7755101,
+      "drupol": 252042,
+      "globin": 1447245,
+      "talyz": 63433
+    },
+    "name": "php"
+  },
+  "podman": {
+    "description": "Maintain Podman and CRI-O related packages and modules.",
+    "id": 3806184,
+    "maintainers": {},
+    "members": {
+      "saschagrunert": 695473,
+      "vdemeester": 6508
+    },
+    "name": "podman"
+  },
+  "postgres": {
+    "description": "Maintain the PostgreSQL package and plugins along with the NixOS module.",
+    "id": 11455958,
+    "maintainers": {
+      "Ma27": 6025220,
+      "thoughtpolice": 3416,
+      "wolfgangwalther": 9132420
+    },
+    "members": {},
+    "name": "postgres"
+  },
+  "qt-kde": {
+    "description": "Maintain the Qt framework, KDE Frameworks and Applications, and Plasma desktop",
+    "id": 4341481,
+    "maintainers": {
+      "ttuegel": 563054
+    },
+    "members": {
+      "FRidh": 2129135,
+      "SCOTT-HAMILTON": 24496705,
+      "bkchr": 5718007,
+      "nyanloutre": 7677321,
+      "peterhoeg": 722550
+    },
+    "name": "Qt-KDE"
+  },
+  "reproducible": {
+    "description": "Team that is interested in reproducible builds",
+    "id": 7625643,
+    "maintainers": {
+      "raboof": 131856,
+      "zimbatm": 3248
+    },
+    "members": {
+      "Artturin": 56650223,
+      "Atemu": 18599032,
+      "RaitoBezarius": 314564,
+      "davidak": 91113,
+      "mschwaig": 3856390
+    },
+    "name": "reproducible"
+  },
+  "risc-v": {
+    "description": "RISC-V team",
+    "id": 13425811,
+    "maintainers": {
+      "0x4A6F": 9675338
+    },
+    "members": {
+      "DarkKirb": 23011243,
+      "dramforever": 2818072,
+      "fgaz": 8182846,
+      "jonhermansen": 660911
+    },
+    "name": "RISC-V"
+  },
+  "rocm": {
+    "description": "AMD ROCm stack and related",
+    "id": 6921873,
+    "maintainers": {
+      "mschwaig": 3856390
+    },
+    "members": {
+      "Flakebi": 6499211,
+      "GZGavinZhao": 74938940,
+      "LunNova": 782440
+    },
+    "name": "rocm"
+  },
+  "rust": {
+    "description": "",
+    "id": 7304571,
+    "maintainers": {
+      "Mic92": 96200,
+      "figsoda": 40620903,
+      "winterqt": 78392041,
+      "zowoq": 59103226
+    },
+    "members": {
+      "tjni": 3806110
+    },
+    "name": "rust"
+  },
+  "scala": {
+    "description": "Maintain Scala-related packages and modules.",
+    "id": 11193149,
+    "maintainers": {
+      "dottybot": 12519979,
+      "hamzaremmal": 56235032
+    },
+    "members": {
+      "natsukagami": 9061737
+    },
+    "name": "Scala"
+  },
+  "sdl": {
+    "description": "Maintain core SDL libraries",
+    "id": 13033942,
+    "maintainers": {
+      "pbsds": 140964
+    },
+    "members": {
+      "LordGrimmauld": 49513131,
+      "evysgarden": 92547295,
+      "jansol": 2588851,
+      "marcin-serwin": 12128106
+    },
+    "name": "SDL"
+  },
+  "security": {
+    "description": "Private reports: security@nixos.org",
+    "id": 2197543,
+    "maintainers": {
+      "LeSuisse": 737767,
+      "mweinelt": 131599,
+      "risicle": 807447
+    },
+    "members": {},
+    "name": "Security"
+  },
+  "static": {
+    "description": "People interested in static builds (creation of `.a` files, fully static executables, etc.) and keeping them working",
+    "id": 5906550,
+    "maintainers": {
+      "nh2": 399535
+    },
+    "members": {
+      "Ericson2314": 1055245,
+      "aherrmann": 732652,
+      "alyssais": 2768870,
+      "basvandijk": 576355,
+      "cdepillabout": 64804,
+      "dtzWill": 817330,
+      "lorenzleutgeb": 542154,
+      "matthewbauer": 19036,
+      "r-burns": 52847440,
+      "rnhmjoj": 2817565,
+      "sternenseemann": 3154475
+    },
+    "name": "static"
+  },
+  "stdenv": {
+    "description": "Maintain the standard environment and its surrounding logic.",
+    "id": 11265412,
+    "maintainers": {
+      "RossComputerGuy": 19699320
+    },
+    "members": {
+      "Artturin": 56650223,
+      "Ericson2314": 1055245,
+      "emilazy": 18535642,
+      "philiptaron": 43863,
+      "reckenrode": 7413633
+    },
+    "name": "stdenv"
+  },
+  "systemd": {
+    "description": "systemd on NixOS.",
+    "id": 3894007,
+    "maintainers": {
+      "flokli": 183879
+    },
+    "members": {
+      "ElvishJerricco": 1365692,
+      "LordGrimmauld": 49513131,
+      "aanderse": 7755101,
+      "arianvp": 628387
+    },
+    "name": "systemd"
+  },
+  "xen-project": {
+    "description": "Maintains the Xen Project ecosystem on Nixpkgs. Members listed as \"Maintainers\" are recipients of Xen Security Advisories sent to xsa@nixos.org.",
+    "id": 11127725,
+    "maintainers": {
+      "CertainLach": 6235312,
+      "SigmaSquadron": 174749595,
+      "hehongbo": 665472
+    },
+    "members": {
+      "digitalrane": 1829286
+    },
+    "name": "Xen Project"
+  },
+  "xfce": {
+    "description": "Maintainers of the Xfce Desktop Environment",
+    "id": 5421745,
+    "maintainers": {
+      "romildo": 1217934
+    },
+    "members": {
+      "bobby285271": 20080233
+    },
+    "name": "Xfce"
+  }
+}

--- a/maintainers/scripts/feature-freeze-teams.pl
+++ b/maintainers/scripts/feature-freeze-teams.pl
@@ -75,3 +75,5 @@ while (my ($team_nix_key, $team_config) = each %{$data}) {
 
     print {*STDOUT} "\n";
 }
+
+print {*STDOUT} "Everyone else: \@NixOS/nixpkgs-committers\n";

--- a/maintainers/scripts/feature-freeze-teams.pl
+++ b/maintainers/scripts/feature-freeze-teams.pl
@@ -1,11 +1,11 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i perl -p perl -p perlPackages.JSON perlPackages.LWPUserAgent perlPackages.LWPProtocolHttps perlPackages.TermReadKey
+#!nix-shell -i perl -p perl -p perlPackages.JSON github-cli
 
 # This script generates a list of teams to ping for the Feature Freeze announcement on Discourse.
 # It's intended to be used by Release Managers before creating such posts.
 #
-# The script interactively reads a GitHub username and a corresponding GitHub Personal Access token.
-# This is required to access the GitHub Teams API so the token needs at least the read:org privilege.
+# The script uses the credentials from the GitHub CLI (gh)
+# This is required to access the GitHub Teams API so it needs at least the read:org privilege.
 
 ## no critic (InputOutput::RequireCheckedSyscalls, InputOutput::ProhibitBacktickOperators)
 use strict;
@@ -14,39 +14,21 @@ use Carp;
 use Cwd 'abs_path';
 use File::Basename;
 use JSON qw(decode_json);
-use LWP::UserAgent;
-use Term::ReadKey qw(ReadLine ReadMode);
 
 sub github_team_members {
-    my ($team_name, $username, $token) = @_;
+    my ($team_name) = @_;
     my @ret;
 
-    my $req = HTTP::Request->new('GET', "https://api.github.com/orgs/NixOS/teams/$team_name/members", [ 'Accept' => 'application/vnd.github.v3+json' ]);
-    $req->authorization_basic($username, $token);
-    my $response = LWP::UserAgent->new->request($req);
-
-    if ($response->is_success) {
-        my $content = decode_json($response->decoded_content);
-        foreach (@{$content}) {
-            push @ret, $_->{'login'};
-        }
-    } else {
-        print {*STDERR} "!! Requesting members of GitHub Team '$team_name' failed: " . $response->status_line;
+    my $content = decode_json(`gh api orgs/NixOS/teams/$team_name/members`);
+    foreach (@{$content}) {
+        push @ret, $_->{'login'};
     }
 
     return \@ret;
 }
 
-# Read GitHub credentials
-print {*STDERR} 'GitHub username: ';
-my $github_user = ReadLine(0);
-ReadMode('noecho');
-print {*STDERR} 'GitHub personal access token (no echo): ';
-my $github_token = ReadLine(0);
-ReadMode('restore');
-print {*STDERR} "\n";
-chomp $github_user;
-chomp $github_token;
+`gh auth status` or die "`gh` comes from `pkgs.github-cli`, or in one command:
+nix-shell -p github-cli --run 'gh auth login'\n";
 
 # Read nix output
 my $nix_version = `nix --version`;
@@ -60,7 +42,6 @@ if ($nix_version =~ m/2[.]3[.]/msx) {
 my $data = decode_json($out);
 
 # Process teams
-print {*STDERR} "\n";
 while (my ($team_nix_key, $team_config) = each %{$data}) {
     # Ignore teams that don't want to be or can't be pinged
     if (not defined $team_config->{enableFeatureFreezePing} or not $team_config->{enableFeatureFreezePing}) {
@@ -76,7 +57,7 @@ while (my ($team_nix_key, $team_config) = each %{$data}) {
     my @github_members;
     if (defined $team_config->{github}) {
         print {*STDERR} " \@NixOS/$team_config->{github}";
-        push @github_members, @{github_team_members($team_config->{github}, $github_user, $github_token)};
+        push @github_members, @{github_team_members($team_config->{github})};
     }
     my %github_members = map { $_ => 1 } @github_members;
     # Members

--- a/maintainers/scripts/feature-freeze-teams.pl
+++ b/maintainers/scripts/feature-freeze-teams.pl
@@ -52,11 +52,11 @@ while (my ($team_nix_key, $team_config) = each %{$data}) {
         next;
     }
     #  Team name
-    print {*STDERR} "$team_config->{shortName}:";
+    print {*STDOUT} "$team_config->{shortName}:";
     # GitHub Teams
     my @github_members;
     if (defined $team_config->{github}) {
-        print {*STDERR} " \@NixOS/$team_config->{github}";
+        print {*STDOUT} " \@NixOS/$team_config->{github}";
         push @github_members, @{github_team_members($team_config->{github})};
     }
     my %github_members = map { $_ => 1 } @github_members;
@@ -69,9 +69,9 @@ while (my ($team_nix_key, $team_config) = each %{$data}) {
             if (defined $github_members{$github_handle}) {
                 next;
             }
-            print {*STDERR} " \@$github_handle";
+            print {*STDOUT} " \@$github_handle";
         }
     }
 
-    print {*STDERR} "\n";
+    print {*STDOUT} "\n";
 }

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -237,7 +237,6 @@ with lib.maintainers;
     members = [ floriansanderscc ];
     scope = "Maintain Clever Cloud related packages.";
     shortName = "CleverCloud";
-    github = "CleverCloud";
   };
 
   cloudposse = {
@@ -367,7 +366,11 @@ with lib.maintainers;
   };
 
   docs = {
-    members = [ ];
+    members = [
+      alejandrosame
+      wamirez
+      hsjobeki
+    ];
     github = "documentation-team";
     scope = "Maintain nixpkgs/NixOS documentation and tools for building it.";
     shortName = "Docs";
@@ -634,6 +637,7 @@ with lib.maintainers;
       fliegendewurst
       infinidoge
       tomodachi94
+      msgilligan
     ];
     shortName = "Java";
     scope = "Maintainers of the Nixpkgs Java ecosystem (JDK, JVM, Java, Gradle, Maven, Ant, and adjacent projects)";
@@ -802,6 +806,13 @@ with lib.maintainers;
   };
 
   lua = {
+    members = [
+      raskin
+      khaneliman
+      teto
+      arobyn
+      scoder12
+    ];
     github = "lua";
     scope = "Maintain the lua ecosystem.";
     shortName = "lua";
@@ -987,6 +998,8 @@ with lib.maintainers;
     members = [
       alizter
       redianthus
+      romildo
+      ulrikstrid
     ];
     github = "ocaml";
     scope = "Maintain the OCaml compiler and package set.";
@@ -1096,6 +1109,11 @@ with lib.maintainers;
       nickcao
       SuperSandro2000
       ttuegel
+      fridh
+      shamilton
+      bkchr
+      peterhoeg
+      nyanloutre
     ];
     github = "qt-kde";
     scope = "Maintain the Qt framework, KDE application suite, Plasma desktop environment and related projects.";
@@ -1169,7 +1187,7 @@ with lib.maintainers;
       marcin-serwin
       pbsds
     ];
-    github = "SDL";
+    github = "sdl";
     scope = "Maintain core SDL libraries.";
     shortName = "SDL";
     enableFeatureFreezePing = true;

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -17,6 +17,7 @@
     - There is limited mention capacity in a single post, so this should be reserved for critical components
       or larger ecosystems within nixpkgs.
   - `github` will ping the specified GitHub team and sync the `members`, `scope` and `shortName` fields from it
+  - `githubId` will be set automatically based on `github`
 
   If `github` is specified and you'd like to be added to the team, contact one of the `githubMaintainers` of the team:
 

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1134,13 +1134,6 @@ with lib.maintainers;
     shortName = "Red Code Labs";
   };
 
-  release = {
-    members = [ ];
-    github = "nixos-release-managers";
-    scope = "Manage the current nixpkgs/NixOS release.";
-    shortName = "Release";
-  };
-
   rocm = {
     members = [
       Flakebi
@@ -1151,13 +1144,6 @@ with lib.maintainers;
     github = "rocm";
     scope = "Maintain ROCm and related packages.";
     shortName = "ROCm";
-  };
-
-  ruby = {
-    members = [ ];
-    scope = "Maintain the Ruby interpreter and related packages.";
-    shortName = "Ruby";
-    enableFeatureFreezePing = true;
   };
 
   rust = {

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -418,15 +418,6 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
-  # Dummy group for the "everyone else" section
-  feature-freeze-everyone-else = {
-    members = [ ];
-    github = "nixpkgs-committers";
-    scope = "Dummy team for the #everyone else' section during feture freezes, not to be used as package maintainers!";
-    shortName = "Everyone else";
-    enableFeatureFreezePing = true;
-  };
-
   flutter = {
     members = [
       mkg20001

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -18,6 +18,10 @@
       or larger ecosystems within nixpkgs.
   - `github` will ping the specified GitHub team and sync the `members`, `scope` and `shortName` fields from it
 
+  If `github` is specified and you'd like to be added to the team, contact one of the `githubMaintainers` of the team:
+
+      nix eval -f lib teams.someTeam.githubMaintainers --json | jq
+
   More fields may be added in the future.
 
   When editing this file:

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1,11 +1,9 @@
 /*
   List of maintainer teams.
     name = {
-      # Required
       members = [ maintainer1 maintainer2 ];
       scope = "Maintain foo packages.";
       shortName = "foo";
-      # Optional
       enableFeatureFreezePing = true;
       github = "my-subsystem";
     };
@@ -18,7 +16,7 @@
   - `enableFeatureFreezePing` will ping this team during the Feature Freeze announcements on releases
     - There is limited mention capacity in a single post, so this should be reserved for critical components
       or larger ecosystems within nixpkgs.
-  - `github` will ping the specified GitHub team as well
+  - `github` will ping the specified GitHub team and sync the `members`, `scope` and `shortName` fields from it
 
   More fields may be added in the future.
 
@@ -56,16 +54,7 @@ with lib.maintainers;
   };
 
   android = {
-    members = [
-      adrian-gierakowski
-      hadilq
-      johnrtitor
-      numinit
-      RossComputerGuy
-    ];
-    scope = "Maintain Android-related tooling in nixpkgs.";
     github = "android";
-    shortName = "Android";
     enableFeatureFreezePing = true;
   };
 
@@ -106,20 +95,7 @@ with lib.maintainers;
   };
 
   beam = {
-    members = [
-      adamcstephens
-      ankhers
-      Br1ght0ne
-      DianaOlympos
-      gleber
-      happysalada
-      minijackson
-      yurrriq
-      savtrip
-    ];
     github = "beam";
-    scope = "Maintain BEAM-related packages and modules.";
-    shortName = "BEAM";
     enableFeatureFreezePing = true;
   };
 
@@ -193,34 +169,11 @@ with lib.maintainers;
   };
 
   categorization = {
-    members = [
-      aleksana
-      fgaz
-      getpsyched
-      lyndeno
-      natsukium
-      philiptaron
-      pyrotelekinetic
-      raskin
-      sigmasquadron
-      tomodachi94
-    ];
     github = "categorization";
-    scope = "Maintain the categorization system in Nixpkgs, per RFC 146. This team has authority over all categorization issues in Nixpkgs.";
-    shortName = "Categorization";
   };
 
   ci = {
-    members = [
-      MattSturgeon
-      mic92
-      philiptaron
-      wolfgangwalther
-      zowoq
-    ];
     github = "nixpkgs-ci";
-    scope = "Maintain Nixpkgs' in-tree Continuous Integration, including GitHub Actions.";
-    shortName = "CI";
   };
 
   cinnamon = {
@@ -262,21 +215,7 @@ with lib.maintainers;
   };
 
   cosmic = {
-    members = [
-      a-kenji
-      ahoneybun
-      drakon64
-      griffi-gh
-      HeitorAugustoLN
-      nyabinary
-      pandapip1
-      qyliss
-      thefossguy
-      michaelBelsanti
-    ];
     github = "cosmic";
-    shortName = "cosmic";
-    scope = "Maintain the COSMIC DE and related packages.";
     enableFeatureFreezePing = true;
   };
 
@@ -290,15 +229,6 @@ with lib.maintainers;
   };
 
   cuda = {
-    members = [
-      connorbaker
-      GaetanLepage
-      prusnak
-      samuela
-      SomeoneSerge
-    ];
-    scope = "Maintain CUDA-enabled packages";
-    shortName = "Cuda";
     github = "cuda-maintainers";
   };
 
@@ -315,14 +245,7 @@ with lib.maintainers;
   };
 
   darwin = {
-    members = [
-      emily
-      reckenrode
-      toonn
-    ];
     github = "darwin-core";
-    scope = "Maintain core platform support and packages for macOS and other Apple platforms.";
-    shortName = "Darwin";
     enableFeatureFreezePing = true;
   };
 
@@ -366,14 +289,7 @@ with lib.maintainers;
   };
 
   docs = {
-    members = [
-      alejandrosame
-      wamirez
-      hsjobeki
-    ];
     github = "documentation-team";
-    scope = "Maintain nixpkgs/NixOS documentation and tools for building it.";
-    shortName = "Docs";
     enableFeatureFreezePing = true;
   };
 
@@ -414,22 +330,11 @@ with lib.maintainers;
   };
 
   enlightenment = {
-    members = [ romildo ];
     github = "enlightenment";
-    scope = "Maintain Enlightenment desktop environment and related packages.";
-    shortName = "Enlightenment";
     enableFeatureFreezePing = true;
   };
 
   flutter = {
-    members = [
-      mkg20001
-      RossComputerGuy
-      FlafyDev
-      hacker1024
-    ];
-    scope = "Maintain Flutter and Dart-related packages and build tools";
-    shortName = "flutter";
     enableFeatureFreezePing = false;
     github = "flutter";
   };
@@ -490,18 +395,7 @@ with lib.maintainers;
   };
 
   geospatial = {
-    members = [
-      autra
-      imincik
-      l0b0
-      nh2
-      nialov
-      sikmir
-      willcohen
-    ];
     github = "geospatial";
-    scope = "Maintain geospatial, remote sensing and OpenStreetMap software.";
-    shortName = "Geospatial";
     enableFeatureFreezePing = true;
   };
 
@@ -518,15 +412,7 @@ with lib.maintainers;
   };
 
   gnome = {
-    members = [
-      bobby285271
-      hedning
-      jtojnar
-      dasj19
-    ];
     github = "gnome";
-    scope = "Maintain GNOME desktop environment and platform.";
-    shortName = "GNOME";
     enableFeatureFreezePing = true;
   };
 
@@ -541,17 +427,7 @@ with lib.maintainers;
   };
 
   golang = {
-    members = [
-      kalbasit
-      katexochen
-      mic92
-      zowoq
-      qbit
-      mfrw
-    ];
     github = "golang";
-    scope = "Maintain Golang compilers.";
-    shortName = "Go";
     enableFeatureFreezePing = true;
   };
 
@@ -567,15 +443,7 @@ with lib.maintainers;
   };
 
   haskell = {
-    members = [
-      cdepillabout
-      maralorn
-      sternenseemann
-      wolfgangwalther
-    ];
     github = "haskell";
-    scope = "Maintain Haskell packages and infrastructure.";
-    shortName = "Haskell";
     enableFeatureFreezePing = true;
   };
 
@@ -601,16 +469,7 @@ with lib.maintainers;
   };
 
   hyprland = {
-    members = [
-      donovanglover
-      fufexan
-      johnrtitor
-      khaneliman
-      NotAShelf
-    ];
     github = "hyprland";
-    scope = "Maintain Hyprland compositor and ecosystem";
-    shortName = "Hyprland";
     enableFeatureFreezePing = true;
   };
 
@@ -632,15 +491,6 @@ with lib.maintainers;
 
   java = {
     github = "java";
-    members = [
-      chayleaf
-      fliegendewurst
-      infinidoge
-      tomodachi94
-      msgilligan
-    ];
-    shortName = "Java";
-    scope = "Maintainers of the Nixpkgs Java ecosystem (JDK, JVM, Java, Gradle, Maven, Ant, and adjacent projects)";
     enableFeatureFreezePing = true;
   };
 
@@ -679,17 +529,6 @@ with lib.maintainers;
 
   k3s = {
     github = "k3s";
-    members = [
-      euank
-      frederictobiasc
-      heywoodlh
-      marcusramberg
-      mic92
-      rorosen
-      wrmilling
-    ];
-    scope = "Maintain K3s package, NixOS module, NixOS tests, update script";
-    shortName = "K3s";
   };
 
   kodi = {
@@ -741,16 +580,7 @@ with lib.maintainers;
   };
 
   lisp = {
-    members = [
-      raskin
-      lukego
-      nagy
-      uthar
-      hraban
-    ];
     github = "lisp";
-    scope = "Maintain the Lisp ecosystem.";
-    shortName = "lisp";
     enableFeatureFreezePing = true;
   };
 
@@ -768,19 +598,7 @@ with lib.maintainers;
   };
 
   llvm = {
-    members = [
-      dtzWill
-      emily
-      ericson2314
-      lovek323
-      qyliss
-      RossComputerGuy
-      rrbutani
-      sternenseemann
-    ];
     github = "llvm";
-    scope = "Maintain LLVM package sets and related packages";
-    shortName = "LLVM";
     enableFeatureFreezePing = true;
   };
 
@@ -792,30 +610,12 @@ with lib.maintainers;
   };
 
   loongarch64 = {
-    members = [
-      aleksana
-      Cryolitia
-      darkyzhou
-      dramforever
-      wegank
-    ];
     github = "loongarch64";
-    scope = "Maintain LoongArch64 related packages and code";
-    shortName = "LoongArch64";
     enableFeatureFreezePing = true;
   };
 
   lua = {
-    members = [
-      raskin
-      khaneliman
-      teto
-      arobyn
-      scoder12
-    ];
     github = "lua";
-    scope = "Maintain the lua ecosystem.";
-    shortName = "lua";
     enableFeatureFreezePing = true;
   };
 
@@ -830,10 +630,7 @@ with lib.maintainers;
   };
 
   lumina = {
-    members = [ romildo ];
     github = "lumina";
-    scope = "Maintain lumina desktop environment and related packages.";
-    shortName = "Lumina";
     enableFeatureFreezePing = true;
   };
 
@@ -849,23 +646,12 @@ with lib.maintainers;
   };
 
   lxqt = {
-    members = [ romildo ];
     github = "lxqt";
-    scope = "Maintain LXQt desktop environment and related packages.";
-    shortName = "LXQt";
     enableFeatureFreezePing = true;
   };
 
   marketing = {
-    members = [
-      djacu
-      flyfloh
-      thilobillerbeck
-      tomberek
-    ];
     github = "marketing-team";
-    scope = "Marketing of Nix/NixOS/nixpkgs.";
-    shortName = "Marketing";
     enableFeatureFreezePing = true;
   };
 
@@ -929,15 +715,7 @@ with lib.maintainers;
   };
 
   neovim = {
-    members = [
-      GaetanLepage
-      khaneliman
-      mrcjkb
-      perchun
-    ];
     github = "neovim";
-    scope = "Maintain the vim and neovim text editors and related packages.";
-    shortName = "Vim/Neovim";
   };
 
   nextcloud = {
@@ -995,15 +773,7 @@ with lib.maintainers;
   };
 
   ocaml = {
-    members = [
-      alizter
-      redianthus
-      romildo
-      ulrikstrid
-    ];
     github = "ocaml";
-    scope = "Maintain the OCaml compiler and package set.";
-    shortName = "OCaml";
     enableFeatureFreezePing = true;
   };
 
@@ -1035,13 +805,7 @@ with lib.maintainers;
   };
 
   pantheon = {
-    members = [
-      davidak
-      bobby285271
-    ];
     github = "pantheon";
-    scope = "Maintain Pantheon desktop environment and platform.";
-    shortName = "Pantheon";
     enableFeatureFreezePing = true;
   };
 
@@ -1057,26 +821,12 @@ with lib.maintainers;
   };
 
   php = {
-    members = [
-      aanderse
-      ma27
-      piotrkwiecinski
-      talyz
-    ];
     github = "php";
-    scope = "Maintain PHP related packages and extensions.";
-    shortName = "PHP";
     enableFeatureFreezePing = true;
   };
 
   podman = {
-    members = [
-      saschagrunert
-      vdemeester
-    ];
     github = "podman";
-    scope = "Maintain Podman and CRI-O related packages and modules.";
-    shortName = "Podman";
   };
 
   postgres = {
@@ -1101,23 +851,7 @@ with lib.maintainers;
   };
 
   qt-kde = {
-    members = [
-      ilya-fedin
-      k900
-      LunNova
-      mjm
-      nickcao
-      SuperSandro2000
-      ttuegel
-      fridh
-      shamilton
-      bkchr
-      peterhoeg
-      nyanloutre
-    ];
     github = "qt-kde";
-    scope = "Maintain the Qt framework, KDE application suite, Plasma desktop environment and related projects.";
-    shortName = "Qt / KDE";
     enableFeatureFreezePing = true;
   };
 
@@ -1144,28 +878,11 @@ with lib.maintainers;
   };
 
   rocm = {
-    members = [
-      Flakebi
-      GZGavinZhao
-      LunNova
-      mschwaig
-    ];
     github = "rocm";
-    scope = "Maintain ROCm and related packages.";
-    shortName = "ROCm";
   };
 
   rust = {
-    members = [
-      figsoda
-      mic92
-      tjni
-      winter
-      zowoq
-    ];
     github = "rust";
-    scope = "Maintain the Rust compiler toolchain and nixpkgs integration.";
-    shortName = "Rust";
     enableFeatureFreezePing = true;
   };
 
@@ -1180,16 +897,7 @@ with lib.maintainers;
   };
 
   sdl = {
-    members = [
-      evythedemon
-      grimmauld
-      jansol
-      marcin-serwin
-      pbsds
-    ];
     github = "sdl";
-    scope = "Maintain core SDL libraries.";
-    shortName = "SDL";
     enableFeatureFreezePing = true;
   };
 
@@ -1216,16 +924,6 @@ with lib.maintainers;
   };
 
   stdenv = {
-    members = [
-      artturin
-      emily
-      ericson2314
-      philiptaron
-      reckenrode
-      RossComputerGuy
-    ];
-    scope = "Maintain the standard environment and its surrounding logic.";
-    shortName = "stdenv";
     enableFeatureFreezePing = true;
     github = "stdenv";
   };
@@ -1262,16 +960,7 @@ with lib.maintainers;
   };
 
   systemd = {
-    members = [
-      flokli
-      arianvp
-      elvishjerricco
-      aanderse
-      grimmauld
-    ];
     github = "systemd";
-    scope = "Maintain systemd for NixOS.";
-    shortName = "systemd";
     enableFeatureFreezePing = true;
   };
 
@@ -1321,14 +1010,6 @@ with lib.maintainers;
   };
 
   xen = {
-    members = [
-      hehongbo
-      lach
-      sigmasquadron
-      rane
-    ];
-    scope = "Maintain the Xen Project Hypervisor and the related tooling ecosystem.";
-    shortName = "Xen Project Hypervisor";
     enableFeatureFreezePing = true;
     github = "xen-project";
   };


### PR DESCRIPTION
This implements the basis of https://github.com/NixOS/nixpkgs/issues/447514#issuecomment-3366610483 by:
- Adding a workflow that runs weekly to synchronise all teams with Nixpkgs access to the `maintainers/github-teams.json` file
- Populating the `.members`, `.shortName` and `.description` of `lib.teams` that have `.github` set based on `github-teams.json`
- Adding an automatically populated `.githubMaintainer` field containing contact information of the GitHub team maintainers, making it easier to know who to ask to join such a team

In order to bring the state of `lib.teams` in sync with GitHub, I compared the outputs of the two and made two commits to update either `lib.teams` or `github-teams.json`, see commit messages for details.

## TODO

- [x] Test the workflow: https://github.com/infinisil-test-org/nixpkgs/pull/47
- [x] Make all the changes listed in the "maintainers/github-teams.json: Manual adjustment of necessary changes" commit subject
- [x] Make sure `lib/tests/teams.nix` works
- [x] Code owners (especially for `maintainers/github-teams.json`, somebody needs to merge the updates)
- [x] Docs
- [x] Check performance
- [x] Test that CI fails when a GitHub user part of a team doesn't have a maintainers entry 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
