### PR TITLE
openssh: split out dev and man outputs

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -51,6 +51,12 @@ assert withFIDO -> withSecurityKey;
 stdenv.mkDerivation (finalAttrs: {
   inherit pname version src;
 
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
   patches = [
     # Making openssh pass the LOCALE_ARCHIVE variable to the forked session processes,
     # so the session 'bash' will receive the proper locale archive, and thus process
@@ -221,7 +227,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Install ssh-copy-id, it's very useful.
     cp contrib/ssh-copy-id $out/bin/
     chmod +x $out/bin/ssh-copy-id
-    cp contrib/ssh-copy-id.1 $out/share/man/man1/
+    cp contrib/ssh-copy-id.1 $man/share/man/man1/
   '';
 
   installTargets = [ "install-nokeys" ];

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     # On Hydra this makes installation fail (sometimes?),
     # and nix store doesn't allow such fancy permission bits anyway.
     ''
-      substituteInPlace Makefile.in --replace '$(INSTALL) -m 4711' '$(INSTALL) -m 0711'
+      substituteInPlace Makefile.in --replace-fail '$(INSTALL) -m 4711' '$(INSTALL) -m 0711'
     '';
 
   strictDeps = true;
@@ -186,13 +186,13 @@ stdenv.mkDerivation (finalAttrs: {
 
       # explicitly enable the PermitUserEnvironment feature
       substituteInPlace regress/test-exec.sh \
-        --replace \
+        --replace-fail \
           'cat << EOF > $OBJ/sshd_config' \
           $'cat << EOF > $OBJ/sshd_config\n\tPermitUserEnvironment yes'
 
       # some tests want to use files under /bin as example files
       for f in regress/sftp-cmds.sh regress/forwarding.sh; do
-        substituteInPlace $f --replace '/bin' "$(dirname $(type -p ls))"
+        substituteInPlace $f --replace-fail '/bin' "$(dirname $(type -p ls))"
       done
 
       # set up NIX_REDIRECTS for direct invocations
@@ -205,7 +205,7 @@ stdenv.mkDerivation (finalAttrs: {
         ''
           # The extra tests check PKCS#11 interactions, which softhsm emulates with software only
           substituteInPlace regress/test-exec.sh \
-            --replace /usr/local/lib/softhsm/libsofthsm2.so ${lib.getLib softhsm}/lib/softhsm/libsofthsm2.so
+            --replace-fail /usr/local/lib/softhsm/libsofthsm2.so ${lib.getLib softhsm}/lib/softhsm/libsofthsm2.so
         ''
   );
   # integration tests hard to get working on darwin with its shaky

--- a/pkgs/tools/networking/openssh/copyid.nix
+++ b/pkgs/tools/networking/openssh/copyid.nix
@@ -6,6 +6,10 @@
 
 runCommand "ssh-copy-id-${openssh.version}"
   {
+    outputs = [
+      "out"
+      "man"
+    ];
     meta = openssh.meta // {
       description = "Tool to copy SSH public keys to a remote machine";
       priority = (openssh.meta.priority or lib.meta.defaultPriority) - 1;
@@ -13,5 +17,5 @@ runCommand "ssh-copy-id-${openssh.version}"
   }
   ''
     install -Dm 755 {${openssh},$out}/bin/ssh-copy-id
-    install -Dm 644 {${openssh},$out}/share/man/man1/ssh-copy-id.1.gz
+    install -Dm 644 {${openssh.man},$man}/share/man/man1/ssh-copy-id.1.gz
   ''


### PR DESCRIPTION
Splitting `dev` allows to reduce the closure size for static build from
150MB to 75MB.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
