### PR TITLE
cxxopts: Unpin icu, fix build

### DIFF
--- a/pkgs/by-name/cx/cxxopts/package.nix
+++ b/pkgs/by-name/cx/cxxopts/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchpatch2,
   cmake,
-  icu74,
+  icu,
   pkg-config,
   testers,
   validatePkgConfig,
@@ -22,9 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-baM6EX9D0yfrKxuPXyUUV9RqdrVLyygeG6x57xN8lc4=";
   };
 
-  propagatedBuildInputs = lib.optionals enableUnicodeHelp [ icu74.dev ];
+  propagatedBuildInputs = lib.optionals enableUnicodeHelp [ icu.dev ];
   cmakeFlags = [
     "-DCXXOPTS_BUILD_EXAMPLES=OFF"
+    "-DCXXOPTS_CXX_STANDARD=17"
   ]
   ++ lib.optional enableUnicodeHelp "-DCXXOPTS_USE_UNICODE_HELP=TRUE";
   nativeBuildInputs = [


### PR DESCRIPTION
Set -DCXXOPTS_CXX_STANDARD=17 while building to avoid icu-related error.

This is supported by cxxopts and included in their testing [1]. The build just *defaults* to C++11, which icu >= 75 no longer supports.

\[1]: https://github.com/jarro2783/cxxopts/commit/76bd60dc17ca514f2febb49382b38d526d5502a5

cc @fpletz from #383900
cc @Scrumplex from https://github.com/NixOS/nixpkgs/pull/449312#issuecomment-3376227700
cc @somasis for testing, this should fix tremotesf

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
