### PR TITLE
nixos/lxd-image-server: set `reloadTriggers` in systemd unit, split `script`

### DIFF
--- a/nixos/modules/services/networking/lxd-image-server.nix
+++ b/nixos/modules/services/networking/lxd-image-server.nix
@@ -78,6 +78,8 @@ in
           ${pkgs.lxd-image-server}/bin/lxd-image-server watch
         '';
 
+        reloadTriggers = [ config.environment.etc."lxd-image-server/config.toml".source ];
+
         serviceConfig = {
           User = "lxd-image-server";
           Group = cfg.group;

--- a/nixos/modules/services/networking/lxd-image-server.nix
+++ b/nixos/modules/services/networking/lxd-image-server.nix
@@ -73,11 +73,6 @@ in
 
         description = "LXD Image Server";
 
-        script = ''
-          ${pkgs.lxd-image-server}/bin/lxd-image-server init
-          ${pkgs.lxd-image-server}/bin/lxd-image-server watch
-        '';
-
         reloadTriggers = [ config.environment.etc."lxd-image-server/config.toml".source ];
 
         serviceConfig = {
@@ -86,6 +81,8 @@ in
           DynamicUser = true;
           LogsDirectory = "lxd-image-server";
           RuntimeDirectory = "lxd-image-server";
+          ExecStartPre = "${pkgs.lxd-image-server}/bin/lxd-image-server init";
+          ExecStart = "${pkgs.lxd-image-server}/bin/lxd-image-server watch";
           ExecReload = "${pkgs.lxd-image-server}/bin/lxd-image-server reload";
           ReadWritePaths = [ location ];
         };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Small cleanup for the systemd unit. It sets a reload trigger to ensure that the unit is reloaded when rebuilt with config changes, as well as splitting the `script`, removing the need for a bash wrapper.

Built `nixosTests.lxd-image-server`, seems to still be working as intended.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
