### PR TITLE
nixos/etesync-dav: Declarative options

### DIFF
--- a/nixos/modules/services/misc/etesync-dav.nix
+++ b/nixos/modules/services/misc/etesync-dav.nix
@@ -11,6 +11,8 @@ in
   options.services.etesync-dav = {
     enable = lib.mkEnableOption "etesync-dav, end-to-end encrypted sync for contacts, calendars and tasks";
 
+    package = lib.mkPackageOption pkgs "etesync-dav" { };
+
     host = lib.mkOption {
       type = lib.types.str;
       default = "localhost";
@@ -64,7 +66,7 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.etesync-dav ];
+      path = [ cfg.package ];
       environment = {
         ETESYNC_LISTEN_ADDRESS = cfg.host;
         ETESYNC_LISTEN_PORT = toString cfg.port;
@@ -76,7 +78,7 @@ in
         Type = "simple";
         DynamicUser = true;
         StateDirectory = "etesync-dav";
-        ExecStart = "${pkgs.etesync-dav}/bin/etesync-dav";
+        ExecStart = "${cfg.package}/bin/etesync-dav";
         ExecStartPre = lib.mkIf (cfg.sslCertificate != null || cfg.sslCertificateKey != null) (
           pkgs.writers.writeBash "etesync-dav-copy-keys" ''
             ${lib.optionalString (cfg.sslCertificate != null) ''


### PR DESCRIPTION
## Problem Statement
The etesync-dav service module has several hard-coded elements:
1. The `etesync-dav` package is pinned to use `pkgs.etesync-dav` by default.
2. The name of the data directory that the service module uses is hard-coded to be `/var/lib/etesync-dav`.

## Resolution
This PR extends this service module by adding user options to make it more declarative:
1. A `services.etesync-dav.package` option that defaults to `pkgs.etesync-dav` allows the user to choose a different version/patch of `etesync-dav`.
2. A `services.etesync-dav.dataDir` option that defaults to `/var/lib/etesync-dav` allows the user to choose the name of the data directory, whilst also exposing it as a configuration variable that can be accessed in other modules.

## Other Information
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
