### PR TITLE
git-gone: 1.2.5 -> 1.3.1

### DIFF
--- a/pkgs/by-name/gi/git-gone/package.nix
+++ b/pkgs/by-name/gi/git-gone/package.nix
@@ -2,41 +2,20 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  installShellFiles,
-  asciidoctor,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "git-gone";
-  version = "1.2.5";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "swsnr";
     repo = "git-gone";
     tag = "v${version}";
-    hash = "sha256-4BhFombZCmv/GNG2OcNlWNKTk2h65yKn1ku734gCBCQ=";
+    hash = "sha256-/8ujbZ7FQTZzTG4HnHg6v3rWhxt2PuSGwIJpBVTxhfM=";
   };
 
-  # remove if updating to rust 1.85
-  postPatch = ''
-    substituteInPlace Cargo.toml \
-      --replace-fail "[package]" ''$'cargo-features = ["edition2024"]\n[package]'
-  '';
-
-  cargoHash = "sha256-VjnnrVN+uST99paImI1uNj34CNozid7ZiPslJqvmKCs=";
-
-  # remove if updating to rust 1.85
-  env.RUSTC_BOOTSTRAP = 1;
-
-  nativeBuildInputs = [
-    installShellFiles
-    asciidoctor
-  ];
-
-  postInstall = ''
-    asciidoctor --backend=manpage git-gone.1.adoc -o git-gone.1
-    installManPage git-gone.1
-  '';
+  cargoHash = "sha256-93nZhZOtti28FetuOYtvh6LOtQJV+cEHbOkrJ+3m1m4=";
 
   meta = {
     description = "Cleanup stale Git branches of merge requests";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
