### PR TITLE
quick-lint-js: cleanup, fix CMake 4 compatibility

### DIFF
--- a/pkgs/by-name/qu/quick-lint-js/package.nix
+++ b/pkgs/by-name/qu/quick-lint-js/package.nix
@@ -15,9 +15,16 @@ let
   src = fetchFromGitHub {
     owner = "quick-lint";
     repo = "quick-lint-js";
-    rev = version;
+    tag = version;
     hash = "sha256-L2LCRm1Fsg+xRdPc8YmgxDnuXJo92nxs862ewzObZ3I=";
   };
+
+  cmakeFlags = [
+    (lib.cmakeBool "QUICK_LINT_JS_ENABLE_BUILD_TOOLS" true)
+
+    # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
+    (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+  ];
 
   quick-lint-js-build-tools = buildPackages.stdenv.mkDerivation {
     pname = "quick-lint-js-build-tools";
@@ -27,13 +34,7 @@ let
       cmake
       ninja
     ];
-    doCheck = false;
-
-    cmakeFlags = [
-      "-DQUICK_LINT_JS_ENABLE_BUILD_TOOLS=ON"
-      # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
-      "-DCMAKE_SKIP_BUILD_RPATH=ON"
-    ];
+    inherit cmakeFlags;
     ninjaFlags = "quick-lint-js-build-tools";
 
     installPhase = ''
@@ -41,9 +42,11 @@ let
       cmake --install . --component build-tools
       runHook postInstall
     '';
+
+    doCheck = false;
   };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "quick-lint-js";
   inherit version src;
 
@@ -51,27 +54,28 @@ stdenv.mkDerivation {
     cmake
     ninja
   ];
+
+  inherit cmakeFlags;
+
   doCheck = true;
 
-  cmakeFlags = [
-    "-DQUICK_LINT_JS_USE_BUILD_TOOLS=${quick-lint-js-build-tools}/bin"
-    # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
-    "-DCMAKE_SKIP_BUILD_RPATH=ON"
-  ];
+  passthru = {
+    # Expose quick-lint-js-build-tools to nix repl as quick-lint-js.build-tools.
+    build-tools = quick-lint-js-build-tools;
 
-  passthru.tests = {
-    version = testers.testVersion { package = quick-lint-js; };
+    tests = {
+      version = testers.testVersion { package = quick-lint-js; };
+    };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Find bugs in Javascript programs";
     mainProgram = "quick-lint-js";
     homepage = "https://quick-lint-js.com";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ratsclub ];
-    platforms = platforms.all;
+    downloadPage = "https://github.com/quick-lint/quick-lint-js";
+    changelog = "https://github.com/quick-lint/quick-lint-js/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ratsclub ];
+    platforms = lib.platforms.all;
   };
-
-  # Expose quick-lint-js-build-tools to nix repl as quick-lint-js.build-tools.
-  passthru.build-tools = quick-lint-js-build-tools;
-}
+})

--- a/pkgs/by-name/qu/quick-lint-js/package.nix
+++ b/pkgs/by-name/qu/quick-lint-js/package.nix
@@ -24,6 +24,10 @@ let
 
     # Temporary workaround for https://github.com/NixOS/nixpkgs/pull/108496#issuecomment-1192083379
     (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+
+    # CMake 4 dropped support of versions lower than 3.5,
+    # versions lower than 3.10 are deprecated.
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.10")
   ];
 
   quick-lint-js-build-tools = buildPackages.stdenv.mkDerivation {

--- a/pkgs/by-name/qu/quick-lint-js/package.nix
+++ b/pkgs/by-name/qu/quick-lint-js/package.nix
@@ -5,8 +5,7 @@
   lib,
   ninja,
   stdenv,
-  testers,
-  quick-lint-js,
+  versionCheckHook,
 }:
 
 let
@@ -63,13 +62,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
   passthru = {
     # Expose quick-lint-js-build-tools to nix repl as quick-lint-js.build-tools.
     build-tools = quick-lint-js-build-tools;
-
-    tests = {
-      version = testers.testVersion { package = quick-lint-js; };
-    };
   };
 
   meta = {


### PR DESCRIPTION
## Things done

- **quick-lint-js: cleanup**
- **quick-lint-js: fix CMake 4 compatibility**
    Tracking: https://github.com/NixOS/nixpkgs/issues/445447
- **quick-lint-js: use versionCheckHook instead of testers.testVersion**

cc @ratsclub

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
