### PR TITLE
tuxedo-drivers: 4.15.4 -> 4.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27747,6 +27747,12 @@
     githubId = 43357387;
     keys = [ { fingerprint = "F844 80B2 0CA9 D6CC C7F5  2479 A776 D2AD 099E 8BC0"; } ];
   };
+  wetisobe = {
+    name = "Martin Woods";
+    github = "wetisobe";
+    email = "weti.sobe@pen-net.de";
+    githubId = 172606048;
+  };
   wetrustinprize = {
     email = "git@wetrustinprize.com";
     github = "wetrustinprize";

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -71,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
       keksgesicht
       xaverdh
       XBagon
+      wetisobe
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -13,17 +13,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuxedo-drivers-${kernel.version}";
-  version = "4.15.4";
+  version = "4.16.0";
 
   src = fetchFromGitLab {
     group = "tuxedocomputers";
     owner = "development/packages";
     repo = "tuxedo-drivers";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-WJeju+czbCw03ALW7yzGAFENCEAvDdKqHvedchd7NVY=";
+    hash = "sha256-NjKhr8wsnoKSFx5kEXVaQ2SQzAX8XG8ENpYKOSMB2yc=";
   };
 
-  patches = [ ./no-cp-etc-usr.patch ];
+  patches = [ ./no-cp-usr.patch ];
 
   postInstall = ''
     echo "Running postInstallhook"

--- a/pkgs/os-specific/linux/tuxedo-drivers/no-cp-usr.patch
+++ b/pkgs/os-specific/linux/tuxedo-drivers/no-cp-usr.patch
@@ -6,7 +6,7 @@ index 75a6bc1..6021d42 100644
  
  install: all
  	make -C $(KDIR) M=$(PWD) $(MAKEFLAGS) modules_install
--	cp -r etc usr /
+-	cp -r usr /
  
  clean:
  	make -C $(KDIR) M=$(PWD) $(MAKEFLAGS) clean


### PR DESCRIPTION
Updates the [tuxedo-drivers](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers) from [v4.15.4](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/tags/v4.15.4) to [v4.16.0](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/tags/v4.16.0).

The [changelog](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/blob/a3c07b271783d9b498b3ab9d9c61479990eefa04/debian/changelog) does not contain any breaking changes, it seems to build nicely on my machine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
