### PR TITLE
elephant: init at 2.1.1

### DIFF
--- a/pkgs/by-name/el/elephant/package.nix
+++ b/pkgs/by-name/el/elephant/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGo125Module,
+  fetchFromGitHub,
+  fd,
+  makeWrapper,
+  protoc-gen-go,
+  protobuf,
+}:
+buildGo125Module (finalAttrs: {
+  pname = "elephant";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "abenz1267";
+    repo = "elephant";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-KsftBsOJ22B4TU24mmIUyVRMBnjR7Eh5QJsT9aiZ58k=";
+  };
+
+  vendorHash = "sha256-shdrMMCdAntH/V1wWHG6kBYWf3Kn4DNimHyCtLrWIWE=";
+
+  buildInputs = [
+    protobuf
+  ];
+
+  nativeBuildInputs = [
+    protoc-gen-go
+    makeWrapper
+  ];
+
+  # Build from cmd/elephant/elephant.go
+  subPackages = [
+    "cmd/elephant"
+  ];
+
+  postFixup = ''
+     wrapProgram $out/bin/elephant \
+       --prefix PATH : ${lib.makeBinPath [ fd ]}
+  '';
+
+  meta = {
+    description = "Data provider service and backend for building custom application launchers";
+    homepage = "https://github.com/abenz1267/elephant";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Link: https://github.com/abenz1267/elephant

NOT Tested. CC @aanderse for testing.

PS: I don't use the service so might be better if you take over maintainership.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
