### PR TITLE
switchfin: init at 0.7.5

### DIFF
--- a/pkgs/by-name/sw/switchfin/package.nix
+++ b/pkgs/by-name/sw/switchfin/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  curl,
+  dbus,
+  ffmpeg,
+  fmt,
+  libwebp,
+  mpv,
+  SDL2,
+  tinyxml-2,
+  tweeny,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "switchfin";
+  version = "0.7.5";
+
+  src = fetchFromGitHub {
+    owner = "dragonflylee";
+    repo = "switchfin";
+    rev = version;
+    hash = "sha256-vmf7urq3lnfvmdZUJ+G5zn4ZpNA2N4jlLo8D5ZG3tUQ=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    dbus
+    ffmpeg
+    fmt
+    libwebp
+    mpv
+    SDL2
+    tinyxml-2
+    tweeny
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL=ON"
+
+    "-DPLATFORM_DESKTOP=ON"
+    "-DUSE_EGL=ON"
+    "-DUSE_SDL2=ON"
+
+    "-DUSE_SYSTEM_CURL=ON"
+    "-DUSE_SYSTEM_FMT=ON"
+    "-DUSE_SYSTEM_SDL2=ON"
+    "-DUSE_SYSTEM_TINYXML2=ON"
+    "-DUSE_SYSTEM_TWEENY=ON"
+  ];
+
+  meta = {
+    description = "Third-party native Jellyfin client for PC/PS4/PSVita/Nintendo Switch";
+    homepage = "https://github.com/dragonflylee/switchfin";
+    changelog = "https://github.com/dragonflylee/switchfin/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.k900 ];
+    mainProgram = "switchfin";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ti/tinyxml-2/package.nix
+++ b/pkgs/by-name/ti/tinyxml-2/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
     # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR
     # correctly (setting it to an absolute path causes include files to go to
     # $out/$out/include, because the absolute path is interpreted with root at


### PR DESCRIPTION
https://github.com/dragonflylee/switchfin

Draft to make sure the tinyxml-2 changes don't break anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
