### PR TITLE
nixos/containers: add copyResolvConf option

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -111,7 +111,9 @@ let
       "/nix/var/nix/profiles/per-container/$INSTANCE" \
       "/nix/var/nix/gcroots/per-container/$INSTANCE"
 
-    cp --remove-destination /etc/resolv.conf "$root/etc/resolv.conf"
+    if [ "$COPY_RESOLV_CONF" = 1 ]; then
+      cp --remove-destination /etc/resolv.conf "$root/etc/resolv.conf"
+    fi
 
     if [ -n "''${FLAKE-}" ] && [ ! -e "/nix/var/nix/profiles/per-container/$INSTANCE/system" ]; then
       # we create the etc/nixos-container config file, then if we utilize the update function, we can then build all the necessary system files for the container
@@ -690,6 +692,14 @@ in
                 '';
               };
 
+              copyResolvConf = mkOption {
+                type = types.bool;
+                default = true;
+                description = ''
+                  Whether to copy host /etc/resolv.conf into the container.
+                '';
+              };
+
               privateNetwork = mkOption {
                 type = types.bool;
                 default = false;
@@ -1088,6 +1098,7 @@ in
                 ${optionalString (cfg.flake != null) ''
                   FLAKE=${cfg.flake}
                 ''}
+                COPY_RESOLV_CONF=${if cfg.copyResolvConf then "1" else "0"}
                 ${optionalString cfg.privateNetwork ''
                   PRIVATE_NETWORK=1
                   ${optionalString (cfg.hostBridge != null) ''


### PR DESCRIPTION
NixOS containers currently copy the /etc/resolv.conf from the host to the guest indiscriminantly. When using features like `extraFlags = ["--network-namespace-path=/run/netns/..."]` this can cause the container to have completely broken DNS, as it can copy a resolv.conf that specifies a resolver running on localhost when that resolver is inaccessible.

Add an option `copyResolvConf` to NixOS containers that defaults to true (the existing behaviour) and decides whether to copy the resolv.conf from the host. This allows running containers using a network namespace that contains only a wireguard interface, for example.

I've been using this feature for close to a year now and it works well. Please let me know if it would be appropriate to add tests for this - I think it will end up being quite a niche feature but is extremely useful.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
