### PR TITLE
legendary-gl: move to by-name, modernize

### DIFF
--- a/pkgs/by-name/le/legendary-gl/package.nix
+++ b/pkgs/by-name/le/legendary-gl/package.nix
@@ -2,43 +2,44 @@
   lib,
   gitUpdater,
   fetchFromGitHub,
-  buildPythonApplication,
-  pythonOlder,
-  requests,
-  filelock,
+  python3Packages,
 }:
 
-buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "legendary-gl"; # Name in pypi
   version = "0.20.34";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "derrod";
     repo = "legendary";
     rev = "56d439ed2d3d9f34e2b08fa23e627c23a487b8d6";
-    sha256 = "sha256-yCHeeEGw+9gtRMGyIhbStxJhmSM/1Fqly7HSRDkZILQ=";
+    hash = "sha256-yCHeeEGw+9gtRMGyIhbStxJhmSM/1Fqly7HSRDkZILQ=";
   };
 
-  propagatedBuildInputs = [
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
     requests
     filelock
   ];
 
-  disabled = pythonOlder "3.8";
+  disabled = python3Packages.pythonOlder "3.8";
 
   # no tests
   doCheck = false;
 
   pythonImportsCheck = [ "legendary" ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
     description = "Free and open-source Epic Games Launcher alternative";
     homepage = "https://github.com/derrod/legendary";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ equirosa ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ equirosa ];
     mainProgram = "legendary";
   };
-
-  passthru.updateScript = gitUpdater { };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13485,8 +13485,6 @@ with pkgs;
 
   leela-zero = libsForQt5.callPackage ../games/leela-zero { };
 
-  legendary-gl = python3Packages.callPackage ../games/legendary-gl { };
-
   liquidwar = callPackage ../games/liquidwar {
     guile = guile_2_0;
   };


### PR DESCRIPTION
Moved `legendary-gl` to pkgs/by-name and modernized a few things.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
