### PR TITLE
libui-ng: only build native arch on darwin

### DIFF
--- a/pkgs/by-name/li/libui-ng/darwin-no-universal.patch
+++ b/pkgs/by-name/li/libui-ng/darwin-no-universal.patch
@@ -1,0 +1,13 @@
+--- a/meson.build
++++ b/meson.build
+@@ -72,10 +72,6 @@
+ 	libui_macosx_version_min = '-mmacosx-version-min=10.8'
+ 	add_global_arguments(libui_macosx_version_min, language: libui_darwin_langs)
+ 	add_global_link_arguments(libui_macosx_version_min, language: libui_darwin_langs)
+-
+-	libui_arch = ['-arch', 'x86_64', '-arch', 'arm64']
+-	add_global_arguments(libui_arch, language: libui_darwin_langs)
+-	add_global_link_arguments(libui_arch, language: libui_darwin_langs)
+ endif
+ 
+ if libui_MSVC

--- a/pkgs/by-name/li/libui-ng/package.nix
+++ b/pkgs/by-name/li/libui-ng/package.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation {
     hash = "sha256-pnfrSPDIvG0tFYQoeMBONATkNRNjY/tJGp9n2I4cN/U=";
   };
 
-  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
-    substituteInPlace meson.build --replace "'-arch', 'arm64'" ""
-  '';
+  patches = [
+    ./darwin-no-universal.patch
+  ];
 
   nativeBuildInputs = [
     cmocka


### PR DESCRIPTION
Hydra failure: https://hydra.nixos.org/build/309030064

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
