### PR TITLE
natscli: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/by-name/na/natscli/package.nix
+++ b/pkgs/by-name/na/natscli/package.nix
@@ -7,16 +7,19 @@
 
 buildGoModule rec {
   pname = "natscli";
-  version = "0.2.2";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "nats-io";
     repo = "natscli";
     tag = "v${version}";
-    hash = "sha256-5iGU23HsaMuRDcy3qeCJZE3p2ikaIlLnuWyGfCAlMYQ=";
+    hash = "sha256-GaP1qC90agVJa7t8aAyB+t++URxbQzkrCJ+KAVFqoBA=";
   };
 
-  vendorHash = "sha256-8JtMcEI3UMMuTa9jmkTspjKtseIb2XUcbNuWlrkAVfg=";
+  proxyVendor = true;
+  vendorHash = "sha256-8Kva9aMWzGctpq51jVOz6umVTNB9NaGHIGoKmw7gl3I=";
+
+  subPackages = [ "nats" ];
 
   ldflags = [
     "-s"
@@ -33,7 +36,6 @@ buildGoModule rec {
   '';
 
   doInstallCheck = true;
-
   versionCheckProgram = "${placeholder "out"}/bin/nats";
 
   meta = {

--- a/pkgs/by-name/na/natscli/package.nix
+++ b/pkgs/by-name/na/natscli/package.nix
@@ -41,7 +41,7 @@ buildGoModule rec {
   meta = {
     description = "NATS Command Line Interface";
     homepage = "https://github.com/nats-io/natscli";
-    changelog = "https://github.com/nats-io/natscli/releases/tag/v${version}";
+    changelog = "https://github.com/nats-io/natscli/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "nats";


### PR DESCRIPTION
This PR updates natscli from version 0.2.2 to 0.3.0.

Changelog: https://github.com/nats-io/natscli/releases/tag/v0.3.0

Note: This PR replaces a previous one (https://github.com/NixOS/nixpkgs/pull/449585) which was closed due to git issues on my end, I'm sorry for that. I addressed all the feedback i got from the previous PR.

Closes #449226

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.