### PR TITLE
agdaPackages.agdarsec: 0.4.1 -> 0.5.0-unstable-2025-08-05

### DIFF
--- a/pkgs/development/libraries/agda/agdarsec/default.nix
+++ b/pkgs/development/libraries/agda/agdarsec/default.nix
@@ -5,16 +5,20 @@
   standard-library,
 }:
 
-mkDerivation rec {
+mkDerivation {
   pname = "agdarsec";
-  version = "0.4.1";
+  version = "0.5.0-unstable-2025-08-05";
 
   src = fetchFromGitHub {
     owner = "gallais";
     repo = "agdarsec";
-    rev = "v${version}";
-    sha256 = "02fqkycvicw6m2xsz8p01aq8n3gj2d2gyx8sgj15l46f8434fy0x";
+    rev = "28c5233e905474f3b02cb97fe410beb60364ba80";
+    sha256 = "sha256-IMxRqZQ7XtPT2cDkoP5mBAj2ovMf5cHcN4U4V5FMEaQ=";
   };
+
+  postPatch = ''
+    sed -Ei 's/standard-library-[0-9.]+/standard-library/' agdarsec.agda-lib
+  '';
 
   buildInputs = [ standard-library ];
 
@@ -24,6 +28,5 @@ mkDerivation rec {
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ turion ];
-    broken = true;
   };
 }


### PR DESCRIPTION
Unbreak agdarsec by updating to an unstable revision compatible with stdlib ≥ 2.0.

Closes https://github.com/NixOS/nixpkgs/pull/451015

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
