### PR TITLE
kexec-tools: fix build with LLVM linker

### DIFF
--- a/pkgs/by-name/ke/kexec-tools/package.nix
+++ b/pkgs/by-name/ke/kexec-tools/package.nix
@@ -28,6 +28,11 @@ stdenv.mkDerivation rec {
       url = "https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/patch/?id=daa29443819d3045338792b5ba950ed90e79d7a5";
       hash = "sha256-Nq5HIcLY6KSvvrs2sbfE/vovMbleJYElHW9AVRU5rSA=";
     })
+    # Fix kexec_test linking with LLVM linker (will be in 2.0.32)
+    (fetchpatch {
+      url = "https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/patch/?id=efb97b509b1a43fce8fe150135cf8167aa0db440";
+      hash = "sha256-NiiiJM6+knsfrMqzcfqbedIBK+apBjDCZwIb4tSj0ho=";
+    })
   ]
   ++ lib.optionals (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isAbiElfv2) [
     # Use ELFv2 ABI on ppc64be


### PR DESCRIPTION
## Description

Backports upstream fix for kexec-tools failing to build with newer LLVM linkers.

## Problem

The kexec_test target was failing to link with ld.lld:
```
x86_64-unknown-linux-gnu-ld.lld: error: section '.text' address (0x10000) is smaller than image base (0x400000); specify --image-base
```

Newer versions of ld.lld use a default image base of 0x400000, but kexec_test needs sections placed at 0x10000.

## Solution

Backports upstream commit [efb97b509b1a](https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/commit/?id=efb97b509b1a43fce8fe150135cf8167aa0db440) by Khem Raj, which provides a linker script that:
- Sets the image base to 0x10000
- Explicitly orders sections to avoid overlaps with .note.gnu.property
- Works with both ld.bfd and LLD 21+

This fix will be included in the upcoming kexec-tools 2.0.32 release.

Fixes #450670

## Testing

Built successfully on x86_64-linux with LLVM toolchain.