### PR TITLE
gcovr: 8.3 -> 8.4, build from source, enable tests;  yaxmldiff: init at 0.2.0 

### DIFF
--- a/pkgs/by-name/gc/gcovr/package.nix
+++ b/pkgs/by-name/gc/gcovr/package.nix
@@ -6,22 +6,26 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "gcovr";
-  version = "8.3";
+  version = "8.4";
   pyproject = true;
 
   disabled = python3Packages.pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-+qNx+cSn94yYANplUQfU+Z8EtxjRwNn0jK/cvvAEkHk=";
+    hash = "sha256-jqDPIxdrECnyjbZ51xLKZHezgHCXw3VcE1vcU7Uc+nI=";
   };
 
-  build-system = [ python3Packages.hatchling ];
+  build-system = with python3Packages; [
+    hatchling
+    hatch-fancy-pypi-readme
+    hatch-vcs
+  ];
 
   # pythonRelaxDeps do not work on pyproject.toml
   preBuild = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "hatchling==1.26.1" "hatchling"
+      --replace-fail "hatchling==1.26.3" "hatchling"
     substituteInPlace pyproject.toml \
       --replace-fail "hatch-fancy-pypi-readme==24.1.0" "hatch-fancy-pypi-readme>=24.1.0"
     substituteInPlace pyproject.toml \
@@ -36,8 +40,6 @@ python3Packages.buildPythonPackage rec {
         jinja2
         lxml
         pygments
-        hatch-fancy-pypi-readme
-        hatch-vcs
       ]
       ++ lib.optionals (pythonOlder "3.11") [ tomli ]
     );

--- a/pkgs/development/python-modules/yaxmldiff/default.nix
+++ b/pkgs/development/python-modules/yaxmldiff/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  hatchling,
+  hatch-fancy-pypi-readme,
+  # dependencies
+  lxml,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "yaxmldiff";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "latk";
+    repo = "yaxmldiff.py";
+    tag = "v${version}";
+    hash = "sha256-AOXnK1d+b/ae50ofBfgxiDS6Dj6TIeHMrE9ME95Yj1Q=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-fancy-pypi-readme
+  ];
+
+  dependencies = [ lxml ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Yet Another XML Differ";
+    homepage = "https://github.com/latk/yaxmldiff.py";
+    changelog = "https://https://github.com/latk/yaxmldiff.py/blob/v${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sigmanificient ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20442,6 +20442,8 @@ self: super: with self; {
 
   yattag = callPackage ../development/python-modules/yattag { };
 
+  yaxmldiff = callPackage ../development/python-modules/yaxmldiff { };
+
   ydata-profiling = callPackage ../development/python-modules/ydata-profiling { };
 
   ydiff = callPackage ../development/python-modules/ydiff { };


### PR DESCRIPTION
Out of the 600 tests, i have re-enabled 137 of them. This is far from being perfect, but it will serve as a good smoke test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
