### PR TITLE
onesixtyone: 0-unstable-2019-12-26 -> 0.3.4-unstable-2025-08-30

### DIFF
--- a/pkgs/by-name/on/onesixtyone/package.nix
+++ b/pkgs/by-name/on/onesixtyone/package.nix
@@ -2,17 +2,18 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
   pname = "onesixtyone";
-  version = "unstable-2019-12-26";
+  version = "0.3.4-unstable-2025-08-30";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "onesixtyone";
-    rev = "9ce1dcdad73d45c8694086a4f90d7713be1cbdd7";
-    sha256 = "111nxn4pcbx6p9j8cjjxv1j1s7dgf7f4dix8acsmahwbpzinzkg3";
+    rev = "3bedd7cab7fe1bcfc2def208f87fbf10a013efc7";
+    hash = "sha256-9gvulDEaEFZdGl/x5oNHTuMNbBK56dgOydQRyzGO29Q=";
   };
 
   buildPhase = ''
@@ -22,6 +23,12 @@ stdenv.mkDerivation {
   installPhase = ''
     install -D onesixtyone $out/bin/onesixtyone
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://github.com/trailofbits/onesixtyone";
+    tagPrefix = "v";
+    branch = "master"; # optional, defaults to default branch
+  };
 
   meta = with lib; {
     description = "Fast SNMP Scanner";


### PR DESCRIPTION
  - add and test unstableGitUpdater to track latest release

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
