### PR TITLE
jstest-gtk: 2018-07-10 -> 0.1.1-unstable-2025-04-03, fix CMake4 build

### DIFF
--- a/pkgs/by-name/js/jstest-gtk/package.nix
+++ b/pkgs/by-name/js/jstest-gtk/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitLab,
+  fetchFromGitHub,
   cmake,
   pkg-config,
   gtkmm3,
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation {
   pname = "jstest-gtk";
-  version = "2018-07-10";
+  version = "0.1.1-unstable-2025-04-03";
 
-  src = fetchFromGitLab {
-    owner = "jstest-gtk";
+  src = fetchFromGitHub {
+    owner = "Grumbel";
     repo = "jstest-gtk";
-    rev = "62f6e2d7d44620e503149510c428df9e004c9f3b";
-    sha256 = "0icbbhrj5aqljhiavdy3hic60vp0zzfzyg0d6vpjaqkbzd5pv9d8";
+    rev = "92bdf8e945a6d14fdd0aa6fa961f6da34f5ac810";
+    sha256 = "sha256-ypGMxN0k+Y72Hjk5OKJMdc4mci38xg3DJYkboOpa/fs=";
   };
 
   nativeBuildInputs = [
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
       buttons and axis are pressed, a way to remap axis and buttons and a way
       to calibrate your joystick.
     '';
-    homepage = "https://jstest-gtk.gitlab.io/";
+    homepage = "https://github.com/Grumbel/jstest-gtk";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ wucke13 ];
     platforms = platforms.linux;


### PR DESCRIPTION
Updates jstest-gtk to the latest commit which fixes the build with CMake4. Tracking: #445447

The project also appears to have moved to GitHub since the last package update.

Full Changelog: https://github.com/Grumbel/jstest-gtk/compare/62f6e2d7d44620e503149510c428df9e004c9f3b...92bdf8e945a6d14fdd0aa6fa961f6da34f5ac810

CC: @wucke13

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
