### PR TITLE
caido: support for linux-aarch64 and Darwin platforms

### DIFF
--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -5,10 +5,11 @@
   appimageTools,
   makeWrapper,
   autoPatchelfHook,
+  _7zz,
+  unzip,
   libgcc,
   appVariants ? [ ],
 }:
-
 let
   pname = "caido";
   appVariantList = [
@@ -16,52 +17,161 @@ let
     "desktop"
   ];
   version = "0.52.0";
+
+  system = stdenv.hostPlatform.system;
+  isLinux = stdenv.isLinux;
+  isDarwin = stdenv.isDarwin;
+
+  # CLI sources
+  cliSources = {
+    x86_64-linux = {
+      url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
+      hash = "sha256-gxB5GeJXTrPDGRXxKV3kdYQ0VgmmIeO8rggRPQlTDqw=";
+    };
+    aarch64-linux = {
+      url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-aarch64.tar.gz";
+      hash = "sha256-VaYy3OkAeuxZ0+UFENOvFYowa9jExQd3WO7VFJ6kPMg=";
+    };
+    x86_64-darwin = {
+      url = "https://caido.download/releases/v${version}/caido-cli-v${version}-mac-x86_64.zip";
+      hash = "sha256-GhPKxkCJjhwafmXOgaCePCn3g1Mls+ZFu4xWBzVXaQo=";
+    };
+    aarch64-darwin = {
+      url = "https://caido.download/releases/v${version}/caido-cli-v${version}-mac-aarch64.zip";
+      hash = "sha256-R394RFaYHm8zi4gKuaP0Ljhybq/80MGYlTlld3tACdQ=";
+    };
+  };
+
+  # Desktop sources
+  desktopSources = {
+    x86_64-linux = {
+      url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
+      hash = "sha256-ANCMHJTeH0UyJvCpslbxc0I3BbfPfR7kr4UISWeo2ec=";
+    };
+    aarch64-linux = {
+      url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-aarch64.AppImage";
+      hash = "sha256-tlNcxc+eh/Y0HrkMXWJ2SP+Lr5xfXJUAhZAgk7s/WRE=";
+    };
+    x86_64-darwin = {
+      url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-x86_64.dmg";
+      hash = "sha256-c2Hc6KCwgebAa3rHAvV9FgVeiexSuwqYbe85PwNxV08=";
+    };
+    aarch64-darwin = {
+      url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-aarch64.dmg";
+      hash = "sha256-fbhQ4Q0TyRySd3k9h7CutnreVJj29+XvX/RM1cDTRSg=";
+    };
+  };
+
+  cliSource = cliSources.${system} or (throw "Unsupported system for caido-cli: ${system}");
+  desktopSource =
+    desktopSources.${system} or (throw "Unsupported system for caido-desktop: ${system}");
+
   cli = fetchurl {
-    url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
-    hash = "sha256-gxB5GeJXTrPDGRXxKV3kdYQ0VgmmIeO8rggRPQlTDqw=";
+    url = cliSource.url;
+    hash = cliSource.hash;
   };
+
   desktop = fetchurl {
-    url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-    hash = "sha256-ANCMHJTeH0UyJvCpslbxc0I3BbfPfR7kr4UISWeo2ec=";
+    url = desktopSource.url;
+    hash = desktopSource.hash;
   };
+
   appimageContents = appimageTools.extractType2 {
     inherit pname version;
     src = desktop;
   };
 
-  wrappedDesktop = appimageTools.wrapType2 {
-    src = desktop;
-    inherit pname version;
+  wrappedDesktop =
+    if isLinux then
+      appimageTools.wrapType2 {
+        src = desktop;
+        inherit pname version;
 
-    nativeBuildInputs = [ makeWrapper ];
+        nativeBuildInputs = [ makeWrapper ];
 
-    extraPkgs = pkgs: [ pkgs.libthai ];
+        extraPkgs = pkgs: [ pkgs.libthai ];
 
-    extraInstallCommands = ''
-      install -m 444 -D ${appimageContents}/caido.desktop -t $out/share/applications
-      install -m 444 -D ${appimageContents}/caido.png \
-        $out/share/icons/hicolor/512x512/apps/caido.png
-      wrapProgram $out/bin/caido \
-        --set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
-    '';
-  };
+        extraInstallCommands = ''
+          install -m 444 -D ${appimageContents}/caido.desktop -t $out/share/applications
+          install -m 444 -D ${appimageContents}/caido.png \
+            $out/share/icons/hicolor/512x512/apps/caido.png
+          wrapProgram $out/bin/caido \
+            --set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
+            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+        '';
+      }
+    else if isDarwin then
+      stdenv.mkDerivation {
+        src = desktop;
+        inherit pname version;
 
-  wrappedCli = stdenv.mkDerivation {
-    src = cli;
-    inherit pname version;
+        nativeBuildInputs = [ _7zz ];
+        sourceRoot = ".";
 
-    nativeBuildInputs = [ autoPatchelfHook ];
+        unpackPhase = ''
+          runHook preUnpack
+          ${_7zz}/bin/7zz x $src
+          runHook postUnpack
+        '';
 
-    buildInputs = [ libgcc ];
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/Applications
+          cp -r Caido.app $out/Applications/
+          mkdir -p $out/bin
+          ln -s $out/Applications/Caido.app/Contents/MacOS/Caido $out/bin/caido
+          runHook postInstall
+        '';
 
-    sourceRoot = ".";
+        meta = {
+          platforms = [
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      }
+    else
+      throw "Desktop variant is not supported on ${stdenv.hostPlatform.system}";
 
-    installPhase = ''
-      runHook preInstall
-      install -m755 -D caido-cli $out/bin/caido-cli
-    '';
-  };
+  wrappedCli =
+    if isLinux then
+      stdenv.mkDerivation {
+        src = cli;
+        inherit pname version;
+
+        nativeBuildInputs = [ autoPatchelfHook ];
+        buildInputs = [ libgcc ];
+        sourceRoot = ".";
+
+        installPhase = ''
+          runHook preInstall
+          install -m755 -D caido-cli $out/bin/caido-cli
+          runHook postInstall
+        '';
+      }
+    else if isDarwin then
+      stdenv.mkDerivation {
+        src = cli;
+        inherit pname version;
+
+        nativeBuildInputs = [ unzip ];
+        sourceRoot = ".";
+
+        installPhase = ''
+          runHook preInstall
+          install -m755 -D caido-cli $out/bin/caido-cli
+          runHook postInstall
+        '';
+
+        meta = {
+          platforms = [
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ];
+        };
+      }
+    else
+      throw "CLI variant is not supported on ${stdenv.hostPlatform.system}";
 
   meta = {
     description = "Lightweight web security auditing toolkit";
@@ -73,9 +183,13 @@ let
       d3vil0p3r
       blackzeshi
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
-
 in
 lib.checkListOfEnum "${pname}: appVariants" appVariantList appVariants (
   if appVariants == [ "desktop" ] then


### PR DESCRIPTION
This PR adds multi-platform support to the caido package, extending it beyond just Linux x86_64.

Since I don't have access to a Mac to test the Darwin implementation, I would like someone to test it for me, please.
CC @NixOS/darwin-maintainers

Caido does officially support all of these different architectures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
