### PR TITLE
freecad: dependencies cleanup

### DIFF
--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "coin";
-  version = "4.0.5";
+  version = "4.0.6";
 
   src = fetchFromGitHub {
     owner = "coin3d";
     repo = "coin";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2lfy33Qx0AjKDfwwRn7hjaz7mPQsr7MRB9v75qshGjM=";
+    hash = "sha256-XBkb8CbfAXBwOO9JkExpsy8HxtbZo3/fnU6cReuSETI=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -28,8 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     libGLU
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libX11;
-
-  cmakeFlags = [ "-DCOIN_USE_CPACK=OFF" ];
 
   meta = with lib; {
     homepage = "https://github.com/coin3d/coin";

--- a/pkgs/by-name/fr/freecad/README.md
+++ b/pkgs/by-name/fr/freecad/README.md
@@ -1,7 +1,0 @@
-This package supports the following parameters:
-
-- withWayland (default: true): when false, set QT_QPA_PLATFORM to xcb
-- spaceNavSupport (enabled by default on Linux): whether to enable
-  [spacenavd support](https://spacenav.sourceforge.net/)
-- ifcSupport (default: false): whether to enable ifc support through
-  ifcopenshell

--- a/pkgs/by-name/fr/freecad/freecad-utils.nix
+++ b/pkgs/by-name/fr/freecad/freecad-utils.nix
@@ -3,7 +3,7 @@
   buildEnv,
   makeWrapper,
   lib,
-  python311,
+  python,
   writeShellScript,
 }:
 let
@@ -36,7 +36,7 @@ let
     if builtins.isString pyt then
       pyt
     else if builtins.isFunction pyt then
-      "${(python311.withPackages pyt)}/lib/python3.11/site-packages"
+      "${(python.withPackages pyt)}/${python.sitePackages}"
     else
       throw "Expected string or function as python paths for freecad"
   );

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -52,7 +52,7 @@ let
     shiboken6
   ];
 
-  freecad-utils = callPackage ./freecad-utils.nix { };
+  freecad-utils = callPackage ./freecad-utils.nix { inherit (python3Packages) python; };
 in
 freecad-utils.makeCustomizable (
   stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -133,15 +133,6 @@ freecad-utils.makeCustomizable (
       "-DFREECAD_USE_PYBIND11=ON"
       "-DBUILD_QT5=OFF"
       "-DBUILD_QT6=ON"
-      "-DSHIBOKEN_INCLUDE_DIR=${python3Packages.shiboken6}/include"
-      "-DSHIBOKEN_LIBRARY=Shiboken6::libshiboken"
-      (
-        "-DPYSIDE_INCLUDE_DIR=${python3Packages.pyside6}/include"
-        + ";${python3Packages.pyside6}/include/PySide6/QtCore"
-        + ";${python3Packages.pyside6}/include/PySide6/QtWidgets"
-        + ";${python3Packages.pyside6}/include/PySide6/QtGui"
-      )
-      "-DPYSIDE_LIBRARY=PySide6::pyside6"
     ];
 
     # This should work on both x86_64, and i686 linux

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -8,7 +8,6 @@
   fetchFromGitHub,
   fetchpatch,
   fmt,
-  gfortran,
   gts,
   hdf5,
   libGLU,
@@ -19,13 +18,11 @@
   ninja,
   ode,
   opencascade-occt,
+  microsoft-gsl,
   pkg-config,
   python3Packages,
-  spaceNavSupport ? stdenv.hostPlatform.isLinux,
   stdenv,
   swig,
-  vtk,
-  wrapGAppsHook3,
   xercesc,
   yaml-cpp,
   zlib,
@@ -50,6 +47,7 @@ let
     pyyaml # (at least for) PyrateWorkbench
     scipy
     shiboken6
+    vtk
   ];
 
   freecad-utils = callPackage ./freecad-utils.nix { inherit (python3Packages) python; };
@@ -71,10 +69,8 @@ freecad-utils.makeCustomizable (
       cmake
       ninja
       pkg-config
-      gfortran
       swig
       doxygen
-      wrapGAppsHook3
       qt6.wrapQtAppsHook
     ];
 
@@ -86,21 +82,21 @@ freecad-utils.makeCustomizable (
       hdf5
       libGLU
       libXmu
+      libspnav
       medfile
       ode
-      vtk
       xercesc
       yaml-cpp
       zlib
       opencascade-occt
+      microsoft-gsl
       qt6.qtbase
       qt6.qtsvg
       qt6.qttools
       qt6.qtwayland
       qt6.qtwebengine
     ]
-    ++ pythonDeps
-    ++ lib.optionals spaceNavSupport [ libspnav ];
+    ++ pythonDeps;
 
     patches = [
       ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -135,13 +131,6 @@ freecad-utils.makeCustomizable (
       "-DBUILD_QT6=ON"
     ];
 
-    # This should work on both x86_64, and i686 linux
-    preBuild = ''
-      export NIX_LDFLAGS="-L${gfortran.cc.lib}/lib64 -L${gfortran.cc.lib}/lib $NIX_LDFLAGS";
-    '';
-
-    dontWrapGApps = true;
-
     qtWrapperArgs =
       let
         binPath = lib.makeBinPath [
@@ -153,7 +142,6 @@ freecad-utils.makeCustomizable (
         "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
         "--prefix PATH : ${binPath}"
         "--prefix PYTHONPATH : ${python3Packages.makePythonPath pythonDeps}"
-        "\${gappsWrapperArgs[@]}"
       ];
 
     postFixup = ''


### PR DESCRIPTION
nativeBuildInputs:
gfortran: dropped as no longer needed
wrapGappHook3: dropped as gappsWrapperArgs is empty string

buildInputs:
libspnav: always enable libspnavSupport on linux platform
vtk -> python3Packages.vtk : some python code in freecad require optional vtk python binding
microsoft-gsl: prefer system microsoft-gsl than vendored microsoft-gsl
python3Packages.netgen-mesher: added, we can use the new python interface for netgen in freecad by uncheck 'Legacy Netgen' in fem setting. see https://github.com/FreeCAD/FreeCAD/pull/23387

cc @LordGrimmauld 
what will happen if 
```
  substituteInPlace src/Mod/Fem/femmesh/gmshtools.py \
    --replace-fail 'self.gmsh_bin = "gmsh"' 'self.gmsh_bin = "${lib.getExe gmsh}"'
```
in postPatch is removed. I can still see gmsh info without this postPatch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
