### PR TITLE
maintainers: drop AdsonCicilioti

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -685,12 +685,6 @@
     githubId = 260983;
     name = "Adrien Lemaire";
   };
-  AdsonCicilioti = {
-    name = "Adson Cicilioti";
-    email = "adson.cicilioti@live.com";
-    github = "AdsonCicilioti";
-    githubId = 6278398;
-  };
   adsr = {
     email = "as@php.net";
     github = "adsr";

--- a/pkgs/by-name/bi/bibata-cursors/package.nix
+++ b/pkgs/by-name/bi/bibata-cursors/package.nix
@@ -64,7 +64,6 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       rawkode
-      AdsonCicilioti
     ];
   };
 }

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -25,6 +25,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/Silicasandwhich/Bibata_Cursor_Translucent";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ AdsonCicilioti ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/clickgen/default.nix
+++ b/pkgs/development/python-modules/clickgen/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
       .png files. clickgen is using anicursorgen and xcursorgen under the hood.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AdsonCicilioti ];
+    maintainers = [ ];
     # fails with:
     # ld: unknown option: -zdefs
     broken = stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
Hasn't been active in Nixpkgs since 2021 ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3AAdsonCicilioti), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3AAdsonCicilioti)), which is much longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs. His package such as `clickgen` where maintained through r-ryantm automatic bumps merged by committers (eg. https://github.com/NixOS/nixpkgs/pull/314750, https://github.com/NixOS/nixpkgs/pull/319208, https://github.com/NixOS/nixpkgs/pull/317523)

@AdsonCicilioti, you have 1 (one) week (Oct 19 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
