### PR TITLE
maintainers: drop BarinovMaxim

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2876,12 +2876,6 @@
     githubId = 127523;
     name = "Herman Fries";
   };
-  BarinovMaxim = {
-    name = "Barinov Maxim";
-    email = "barinov274@gmail.com";
-    github = "barinov274";
-    githubId = 54442153;
-  };
   BarrOff = {
     name = "BarrOff";
     github = "BarrOff";

--- a/pkgs/applications/graphics/unigine-sanctuary/default.nix
+++ b/pkgs/applications/graphics/unigine-sanctuary/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     homepage = "https://benchmark.unigine.com/sanctuary";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/applications/graphics/unigine-superposition/default.nix
+++ b/pkgs/applications/graphics/unigine-superposition/default.nix
@@ -143,7 +143,7 @@ buildFHSEnv {
     homepage = "https://benchmark.unigine.com/superposition";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "unigine-superposition";
   };

--- a/pkgs/applications/graphics/unigine-tropics/default.nix
+++ b/pkgs/applications/graphics/unigine-tropics/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation {
     homepage = "https://benchmark.unigine.com/tropics";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/by-name/un/unigine-heaven/package.nix
+++ b/pkgs/by-name/un/unigine-heaven/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation {
     homepage = "https://benchmark.unigine.com/heaven";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/development/python-modules/fontmake/default.nix
+++ b/pkgs/development/python-modules/fontmake/default.nix
@@ -59,6 +59,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/googlefonts/fontmake";
     changelog = "https://github.com/googlefonts/fontmake/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/glyphslib/default.nix
+++ b/pkgs/development/python-modules/glyphslib/default.nix
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     description = "Bridge from Glyphs source files (.glyphs) to UFOs and Designspace files via defcon and designspaceLib";
     homepage = "https://github.com/googlefonts/glyphsLib";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/openstep-plist/default.nix
+++ b/pkgs/development/python-modules/openstep-plist/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     description = "Parser for the 'old style' OpenStep property list format also known as ASCII plist";
     homepage = "https://github.com/fonttools/openstep-plist";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     description = "Python access to operations on paths using the Skia library";
     homepage = "https://github.com/fonttools/skia-pathops";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.BarinovMaxim ];
+    maintainers = [ ];
     # "The Skia team is not endian-savvy enough to support big-endian CPUs."
     badPlatforms = lib.platforms.bigEndian;
     # ERROR at //gn/BUILDCONFIG.gn:87:14: Script returned non-zero exit code.


### PR DESCRIPTION
Hasn't been active in Nixpkgs since 2021 ([authorship](https://github.com/NixOS/nixpkgs/issues?q=author%3Abarinov274), [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Abarinov274)), which is much longer than what's described in [maintainers/README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), making them eligible to removal from Nixpkgs. They haven't been responding to pings (eg: https://github.com/NixOS/nixpkgs/pull/436335, https://github.com/NixOS/nixpkgs/pull/378356)

@barinov274, you have 1 (one) week (Oct 19 to be loose) to object this, or you can approve this PR and make it merge earlier. Even if you don't make it, you're still welcome back.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
