### PR TITLE
lib.systems: Simplify ABI on POWER for rust.rustcTarget

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -491,6 +491,13 @@ let
                 }
                 .${cpu.name} or cpu.name;
               vendor_ = final.rust.platform.vendor;
+              abi_ =
+                # We're very explicit about the POWER ELF ABI w/ glibc in our parsing, while Rust is not.
+                # TODO: Somehow ensure that Rust actually *uses* the correct ABI, and not just a libc-based default.
+                if (lib.strings.hasPrefix "powerpc" cpu.name) && (lib.strings.hasPrefix "gnuabielfv" abi.name) then
+                  "gnu"
+                else
+                  abi.name;
             in
             # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
             args.rust.rustcTarget or args.rustc.config or (
@@ -501,7 +508,7 @@ let
               if final.isWasi then
                 "${cpu_}-wasip1"
               else
-                "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi.name}"}"
+                "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi_}"}"
             );
 
           # The name of the rust target if it is standard, or the json file

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -23,7 +23,6 @@ rec {
 
   ppc64-elfv1 = {
     config = "powerpc64-unknown-linux-gnuabielfv1";
-    rust.rustcTarget = "powerpc64-unknown-linux-gnu";
   };
   ppc64-elfv2 = {
     config = "powerpc64-unknown-linux-gnuabielfv2";


### PR DESCRIPTION
Move the fix from just `lib.systems.examples.ppc64-elfv1` into generic code, so it gets automatically applied for both ABI targets and any manually specified `*System` settings.

(If someone from the Rust team has any advice for how I could actually tell Rust what ABI it should use, or whether they even have such an option, please let me know! From browsing upstream issues & PRs, it's possible to *query* the ABI in use in Rust code, but I don't really see anything about telling the compiler which one it should actually use… Not urgent though, glibc ELFv2 is really low on my list of priorities.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
