### PR TITLE
lib.systems.parse: Default glibc ppc64 to ELFv1 ABI

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -919,9 +919,9 @@ rec {
           else if isLinux parsed || isWindows parsed then
             if isAarch32 parsed then
               if versionAtLeast (parsed.cpu.version or "0") "6" then abis.gnueabihf else abis.gnueabi
-            # Default ppc64 BE to ELFv2
+            # Default ppc64 BE to ELFv1
             else if isPower64 parsed && isBigEndian parsed then
-              abis.gnuabielfv2
+              abis.gnuabielfv1
             else
               abis.gnu
           else


### PR DESCRIPTION
Unlike glibc w/ ELFv2, glibc w/ ELFv1 is actually *mostly* in a state where one can build a bootable installer image.

https://tech.lgbt/@Puna/115323957077318335
<img width="3264" height="2448" alt="image" src="https://github.com/user-attachments/assets/65d049d2-eedd-4687-8fc1-283798440e7e" />

glibc w/ ELFv1 is the path of lesser resistance. Let's make ~~my life~~ *our lives* a little easier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
