### PR TITLE
unixODBCDrivers.mysql: drop

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   fetchurl,
   stdenv,
   unixODBC,
@@ -98,39 +99,6 @@
       homepage = "https://downloads.mariadb.org/connector-odbc/";
       license = licenses.gpl2;
       platforms = platforms.linux ++ platforms.darwin;
-    };
-  };
-
-  mysql = stdenv.mkDerivation rec {
-    pname = "mysql-connector-odbc";
-    majorVersion = "5.3";
-    version = "${majorVersion}.6";
-
-    src = fetchurl {
-      url = "https://dev.mysql.com/get/Downloads/Connector-ODBC/${majorVersion}/${pname}-${version}-src.tar.gz";
-      sha256 = "1smi4z49i4zm7cmykjkwlxxzqvn7myngsw5bc35z6gqxmi8c55xr";
-    };
-
-    nativeBuildInputs = [ cmake ];
-    buildInputs = [
-      unixODBC
-      mariadb
-    ];
-
-    cmakeFlags = [ "-DWITH_UNIXODBC=1" ];
-
-    # see the top of the file for an explanation
-    passthru = {
-      fancyName = "MySQL";
-      driver = "lib/libmyodbc3-3.51.12.so";
-    };
-
-    meta = with lib; {
-      description = "MySQL ODBC database driver";
-      homepage = "https://dev.mysql.com/downloads/connector/odbc/";
-      license = licenses.gpl2;
-      platforms = platforms.linux;
-      broken = true;
     };
   };
 
@@ -379,4 +347,7 @@
       maintainers = with maintainers; [ sir4ur0n ];
     };
   };
+}
+// lib.optionalAttrs config.allowAliases {
+  mysql = throw "unixODBCDrivers.mysql has been removed because it has been marked as broken since 2016."; # Added 2025-10-11
 }


### PR DESCRIPTION
Has been broken since 2016(!) (1a3f7d553d4b5fe78f5f186a08ded841a85c45a1).

Dropping per [RFC 180](https://github.com/NixOS/rfcs/blob/master/rfcs/0180-broken-package-removal.md). There have been updates since 2016, but clearly no one uses this, so it's not worth the effort, I think.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Package drops:
  * [X] `pkgs/top-level/aliases.nix` (or language-specific alias) entry added.
* [x] 0 rebuilds verified
* [X] `rg unixODBCDrivers` run and verified to not contain references to this package (outside of aliases.nix, rename.nix, and release notes).
* [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
