### PR TITLE
jetbrains: 2025.2.1.1 -> 2025.2.4

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,18 +11,18 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "47b84f1c853a63586743b28834dfd6b949672f3b0a7a67435907a7ef51730606",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.2.tar.gz",
-      "build_number": "252.26199.153"
+      "version": "2025.2.3",
+      "sha256": "364502648a5f1480bd06a00ee410968d224f96b263c78f5148614063f7bc3961",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3.tar.gz",
+      "build_number": "252.26830.83"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "7cac5ce1fc16ee3e7500a675ebf235e3285d6e87c0d61e8370e847f3a48528a7",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3.tar.gz",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "37d0af4ec30b94c71d3507fe35b3b0bdd389903db7e2f1a8ed73353b22718476",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4.tar.gz",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -35,34 +35,34 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "d1e8c8c61da42adcc9300a2a005830db386698912071eace9813a5c170a9fff8",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.2.tar.gz",
-      "build_number": "252.26199.160"
+      "version": "2025.2.3",
+      "sha256": "2f698af2112fe1e7172c0602916d401dd9d3a34942fc80dc151d587924325684",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.3.tar.gz",
+      "build_number": "252.26830.122"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "e5816136312a419b67cdfab203bd30e305cb2f8952eea76445e908c01f3113c0",
-      "url": "https://download.jetbrains.com/go/goland-2025.2.2.tar.gz",
-      "build_number": "252.26199.158"
+      "version": "2025.2.3",
+      "sha256": "06d9e18cc840e5bc68db6802ed90cfd5c8629d8c434e51aee6e4a93dad56b3e1",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.3.tar.gz",
+      "build_number": "252.26830.102"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "3f1adc095bf78f0949e3f62f6cf02be0c5c9e6528271f16caa3baa041e637664",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.2.tar.gz",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "6b7c671e97b1419ca22ff4c4a32e7ca51577e4177589bfd321bd9a26df16c9ba",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.3.tar.gz",
+      "build_number": "252.26830.84"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "7150ece389a4bc8649f68b103018edeeb09205559671549410ded11de523da62",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.2.tar.gz",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "4a54ae8a17d6427f07d2450324132f59391279c6b1094de02f73e408deb5a23c",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.3.tar.gz",
+      "build_number": "252.26830.84"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -75,59 +75,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "1010c4cfed0d74a0088c80e966c0ea75ed1238dc5b8ae25111e8be3e06bde741",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.2.tar.gz",
-      "build_number": "252.26199.163",
+      "version": "2025.2.3",
+      "sha256": "b34ddb64cc84b9ca29b7d171c71296aab8bd87d7a6d7eb11c410e0e59a81a51d",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.3.tar.gz",
+      "build_number": "252.26830.95",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "3397ebebc3531eca4c6b866e8223a5d53c04794dd847f2bbd7218c2b5d1b9a24",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "c56b987c2ddec9fadfb77db7a920a86bf933cec0ed3acd72b0f34ead53f7b5a0",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.3.tar.gz",
+      "build_number": "252.26830.99"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "280da5efe11f17d86e5173fe0cf05af4704b9c858f1c9c2fea6de6b2071ada83",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "58f6165ea8ace65e708c607bec49d20d46b8d5908045ae31703353a184e59a05",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.3.tar.gz",
+      "build_number": "252.26830.99"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "1ebffac91d70f8ce64567955de35738bb52d5e81b45d8c67dd494ff3fa0301df",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.tar.gz",
-      "build_number": "252.26199.154"
+      "version": "2025.2.3",
+      "sha256": "1cfc4e756007c5a8b749c0848e4c050303aeeaabc0917f19732d908201b69446",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3.tar.gz",
+      "build_number": "252.26830.109"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "f103c2c5ab074aace1ce4678d32fa80d8521a25bb6497130d1185662244cf46d",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.2.tar.gz",
-      "build_number": "252.26199.157"
+      "version": "2025.2.3",
+      "sha256": "cf989d2e3851eb19db747eae0ee5cf4898645209397f955ac28870454a2a390e",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.3.tar.gz",
+      "build_number": "252.26830.94"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "cc2cfd0af3967a5ce65af5064ccac03bfb2ee2a1ed7e18e8a2c1a009a6d3721c",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.2.tar.gz",
-      "build_number": "252.26199.159"
+      "version": "2025.2.3",
+      "sha256": "b96846e7257d14ef38154017cdbe9c63c66d19b59e94ad096db2c9ae2380103b",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3.tar.gz",
+      "build_number": "252.26830.136"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "8bb3bed5c670514ced8614b29848c5d3b7ff4f4e86056cf5cdc5930951c87ff6",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.2.tar.gz",
-      "build_number": "252.26199.162"
+      "version": "2025.2.3",
+      "sha256": "00c82eded289fbd6fdb170314b4402d508175dffcbe1d7ffcc8370da6b400e71",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.3.tar.gz",
+      "build_number": "252.26830.93"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -150,18 +150,18 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "b8749bbec247544767023a25b9e955a9cd462c573e1d08a24ef68c864d5d6859",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.153"
+      "version": "2025.2.3",
+      "sha256": "e4cc668cb1e0cf5b976ab8eb3997388f1e7cc673e51af3f3c6afa3666a9c47b6",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.83"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "33caa8e0fb4c76e2704bc2457d0b87209f53861517bb43a1c675811b0703a773",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3-aarch64.tar.gz",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "7df40778500a599d565ba985d1583f3334903fbb731f53add526b19557208d97",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4-aarch64.tar.gz",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -174,34 +174,34 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "331407afc012f97b5a80fcfced59e256222549038bfe028c7d00b0b4793ebc4a",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.160"
+      "version": "2025.2.3",
+      "sha256": "c8a585a24709231223c7c2cc0a44978bf6c0973e7f8a8a40a4a3b0f66481959b",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.122"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "5873b53e586c1f376ec6e159c962be3400f0be964f8f0d542b55b4a99ff6c870",
-      "url": "https://download.jetbrains.com/go/goland-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.158"
+      "version": "2025.2.3",
+      "sha256": "09d897264b991a0f63e07b3b34f0878e2967ffbf504748881c43c2b21d638976",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.102"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "3ea855820772e36be4b37dd9e503e4fee9b1877dcb614b5baa36819370fa0208",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "f51d2e9428a7d9c3999cc9dfab5fbcccba73d894098724cc5e35865a21932090",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.84"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "d40c5fa210a28a23b9e1d736057a711b41c785e32841f5a27969074feee5df4d",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "42d0e7c9dbb7c0701883e4801bb77c56415817a41556388373bf71c96b3ab94e",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.84"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -214,59 +214,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "edc147816c4fed704206d3ca03e7fcdefde23208599d7732eb0a22af2af6f2ff",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.163",
+      "version": "2025.2.3",
+      "sha256": "96840878a9f648642265899459f867bcdd943ff3f420d4c2df4d49ef3381c05a",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.95",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "f501a424c1554fb529bc3de3ce7ce49587ef419ebfd85d8ec12ddb5eaf291022",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1-aarch64.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "c22683d0e88bfe0b377055197398d62a56e99269de600b28c0100e79400562a5",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.99"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2025.2.1.1",
-      "sha256": "97a359d900e4010a1d1ca57a9ae9f496f16bb377798d8fe0ffbfb071bbbc191c",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1-aarch64.tar.gz",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "41bcc2549f3f60d35d1d3bd0e16edd5b3614f23df499b30cd649bb4ba6148314",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.99"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "36523ab3b94d1ee1b92794476870727faa1ca29fbd365b7c3239f199399f6dbe",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.154"
+      "version": "2025.2.3",
+      "sha256": "bd03e42b3a04cc1e1b234333285873746bd4d04bf3746fb62b171334a168e976",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.109"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "f75616b41eff86d75f51dadb49f1033ff9af021f1d9ca354fc8f99eca251c4ac",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.157"
+      "version": "2025.2.3",
+      "sha256": "ed784cb51ab7272fbf6728f896321c039cb07c4979abbda2ea4a1962783c8da8",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.94"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "d76cb3f3d7affbd9cab937e813f44bafdd2675160b909f27baa7fac042de0765",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.159"
+      "version": "2025.2.3",
+      "sha256": "5ffdff2a6617fcc75b68a145bc9dce14a71d0d9dc31a1adde5c8630d954a370d",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.136"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2025.2.2",
-      "sha256": "aa8eaa8bb200a6fce42582cb37235f3abf77ca7bcad2c9b98c318686c45772e1",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.2-aarch64.tar.gz",
-      "build_number": "252.26199.162"
+      "version": "2025.2.3",
+      "sha256": "57c58ac9164ff4450371709063fca141d79bc104d2454442fcc146ccefc0771b",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.3-aarch64.tar.gz",
+      "build_number": "252.26830.93"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -289,18 +289,18 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "f9c42a3417db66bc88fc039829840662a650fdf79fc02619c5d6fd8a633f6606",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.2.dmg",
-      "build_number": "252.26199.153"
+      "version": "2025.2.3",
+      "sha256": "4763233873139a0adf8c5cb285ace830eb0be363bb132de2f7ac4b4c1a58b2f2",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3.dmg",
+      "build_number": "252.26830.83"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2025.2.3",
-      "sha256": "3b14fce3bef29338a4d369e0236f0972cec18cfa1e32563d37cb10bafa782226",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3.dmg",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "9267cd82c2589f6f2f52f71960a8ba201bd9f02b8c10dede99323b845360de7b",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4.dmg",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -313,34 +313,34 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "1be3476dc9065e9b95f399cb24ff2e5793e09a390bf541695bc932a9f46a2321",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.2.dmg",
-      "build_number": "252.26199.160"
+      "version": "2025.2.3",
+      "sha256": "71b066de7abd66e3c8934f16a4a0a59c5608e739918c985161874434bcb7decd",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.3.dmg",
+      "build_number": "252.26830.122"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "d23f16afaa67f120ce987b59280805f01025e5b971d85544f33f0960035f3a1c",
-      "url": "https://download.jetbrains.com/go/goland-2025.2.2.dmg",
-      "build_number": "252.26199.158"
+      "version": "2025.2.3",
+      "sha256": "cd99bab6debfbeebfddeba1a431f1b45287b5d78023cca5d09a054c8ffab1012",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.3.dmg",
+      "build_number": "252.26830.102"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "112bfa1e1c065ec641f1a242e95b63d4fed1b7dfa1d7b57b6591d8230531adae",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.2.dmg",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "aa7552de772595734f54c0d9fe69dbcba3243d2ae9b05385cad7d488cdc6d9fe",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.3.dmg",
+      "build_number": "252.26830.84"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "7e7b672525e29554e503eecc656de025a96b680d1ee223dfbfd762a1ca6430dd",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.2.dmg",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "deff8866b958542d6f91797ae26415aba50f4e15a889eba41557c3c0bca2482b",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.3.dmg",
+      "build_number": "252.26830.84"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -353,59 +353,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "60413cba4c4492a51af0dd3a439a615a08ec5fbc31c28ee7bb1af8638708eb05",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.2.dmg",
-      "build_number": "252.26199.163",
+      "version": "2025.2.3",
+      "sha256": "d221d5cd46ba1297925ac8437108339c9153edbb06d406fa2d512c17ec0b62ca",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.3.dmg",
+      "build_number": "252.26830.95",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "651d1c0a264e9a4fc8c7e134d42ece4a15fd444cd74424a9ed054659e5346db7",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "793438a14147ccabf961ca062f8b62d0c4de652f36c46f6ddcce12214d9d6775",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.3.dmg",
+      "build_number": "252.26830.99"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "6d90ba78686a32fdd38a1cc13e06462f6be3490b6611d8c05e6092483161a74b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "1c4ebaf6880dee7af500acb3f05362b70a921894566c9f4c6ab61e6229b10fc6",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.3.dmg",
+      "build_number": "252.26830.99"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "ccc7b35691ceb87e3b3103909617e1616c36dcc69cb73c1f7668591c6256ba35",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2.dmg",
-      "build_number": "252.26199.154"
+      "version": "2025.2.3",
+      "sha256": "09717e33d640052143492fe7e4485c93218c04c9efc1615e8f0d5dbdb4fe5526",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3.dmg",
+      "build_number": "252.26830.109"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "9ced0e4a5ebb0e47821d25a7b8d9a2c4a9a8ad821ffefa9b429821379da8486e",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.2.dmg",
-      "build_number": "252.26199.157"
+      "version": "2025.2.3",
+      "sha256": "4e8c66fb8914ad107072923ff7d7e71771a5a4a24331e405e9b9a93c1751b7ea",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.3.dmg",
+      "build_number": "252.26830.94"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "bcb442e4d22a71cd312cae2821187da82f9c58cdd03e5343a070b12af6a11f85",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.2.dmg",
-      "build_number": "252.26199.159"
+      "version": "2025.2.3",
+      "sha256": "7c9e08ded178f233cabc8b0bebdda8504ef10a6afaf1856b33da582d69ca378d",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3.dmg",
+      "build_number": "252.26830.136"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2025.2.2",
-      "sha256": "74af775f515e7cc847ee572cf7720498e6afec3387af285a6685337272c61611",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.2.dmg",
-      "build_number": "252.26199.162"
+      "version": "2025.2.3",
+      "sha256": "69670d0be318ffa64ad00a1d0a4964a171a2557f128cab859f7e6546143957f3",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.3.dmg",
+      "build_number": "252.26830.93"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -428,18 +428,18 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "4dceb6ba2ae1d2fcaaa7f76090bbb18664da30d371d2e950afdffb0f9589ce7e",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.153"
+      "version": "2025.2.3",
+      "sha256": "87d1b9d0188ee540ce26572d648a4a7ef1b2b2d90c18227932a28d9d263b58df",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.83"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2025.2.3",
-      "sha256": "cfe4b7f9e9ede9fa15c0e0ce16e98ba3595051b5da1510c0085f89ff7bcbdf50",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.3-aarch64.dmg",
-      "build_number": "252.26199.73"
+      "version": "2025.2.4",
+      "sha256": "13d41b91c0194078afed78974f5023a793822c46609e6273dfacd831bebecc83",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4-aarch64.dmg",
+      "build_number": "252.26830.46"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
@@ -452,34 +452,34 @@
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "1d9be57de8075eeefcc81ef249b15a60762f82909ca4002846dce13acedba56d",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.160"
+      "version": "2025.2.3",
+      "sha256": "b5577a050a14880c0e9fd8f7e7d7ef51a56d9f3f66770815601aac992d377609",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.122"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "38dd5a302eba4ee5f92c5c5aa810b449b72301c89d209139e75c0efb6bdff919",
-      "url": "https://download.jetbrains.com/go/goland-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.158"
+      "version": "2025.2.3",
+      "sha256": "bb89e8761b5988bf6230cb7e5b79520db4fc5e2a1e9fe31847991e4a108b2071",
+      "url": "https://download.jetbrains.com/go/goland-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.102"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "cc83bbb9531522085d2892499ddb5cb87909291d58ee3e34c06b131aeb2413fe",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "bfee440c818c1ae59f35da858387a7d8fea7b677df157d2c2b29d061328979e2",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.84"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "c93ef0205c18f8b9fd127df2d5f3486e3ad190a0408c374e1795aeaa7899dc8a",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.169"
+      "version": "2025.2.3",
+      "sha256": "c45c1e686793a1b5b8fe61bab25c11164833d312c8431f0038c2576453919f85",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.84"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -492,59 +492,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "08c30cee02829ebca2956a5dc84221322cbd0ce02f33fb023d3d340cdcc2dac3",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.163",
+      "version": "2025.2.3",
+      "sha256": "632306f73bff15b893b0b8b11b3103632d7439a5fe3598f8eb4f0bd74d63a3a0",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.95",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "1afba23b5cc19e42b56bcd35ddb173a9e47c643cb27d9f70aa7dccd3675a9082",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.1.1-aarch64.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "3a78b1bae9ff20383686fec267070edacb96640736ce942d915b99a665bf3844",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.99"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2025.2.1.1",
-      "sha256": "cf54ed7c544f5e21bd563da68725431235ea7b91bebad0ce3c5eecabfd6be0bc",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.1.1-aarch64.dmg",
-      "build_number": "252.25557.178"
+      "version": "2025.2.3",
+      "sha256": "7ace5fcfad27a3fd3274059fbbead5cf1b6890a44a025d81c77c45251b66f939",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.99"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "f6d1a148123519c33d2ec8822e7d83856af68cbb518ac822c638bbd4b1127ad2",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.154"
+      "version": "2025.2.3",
+      "sha256": "67c9c8f73844d9705c8e64f03afc659ef3146caccc079f183a758b0d7666a468",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.109"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "4fa2260b6ca45a3e21bd3aa64517cb5216113a4177ec2b7808f9883cf4a071b5",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.157"
+      "version": "2025.2.3",
+      "sha256": "01b07add7a9cca6a09d4ab7f001b03fe1827ba117a3e8d25faed5c787f4f775a",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.94"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "a673c45f2183d28ac6ac37df9a8cd7084af432793f505589164096a425fa7801",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.159"
+      "version": "2025.2.3",
+      "sha256": "3ebf05feabd5858df21b0215dec39142427b4df50d929c0d94751425478d295d",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.136"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2025.2.2",
-      "sha256": "68fbdbb3abd2ef5ae69d8371f72fd61e39f4331e7b9aacb792a7b6b7b6d05e8f",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.2-aarch64.dmg",
-      "build_number": "252.26199.162"
+      "version": "2025.2.3",
+      "sha256": "370a43bb2461722eb4e2444ceca083d015991d5a53439cab1863ca9053524f67",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.2.3-aarch64.dmg",
+      "build_number": "252.26830.93"
     },
     "writerside": {
       "update-channel": "Writerside EAP",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -18,16 +18,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +36,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "252.26199.169": "https://plugins.jetbrains.com/files/631/861064/python-252.26199.169.zip"
+        "252.26830.84": "https://plugins.jetbrains.com/files/631/870935/python-252.26830.84.zip"
       },
       "name": "python"
     },
@@ -47,7 +47,7 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/1347/861692/scala-intellij-bin-2025.2.30.zip"
+        "252.26830.84": "https://plugins.jetbrains.com/files/1347/861692/scala-intellij-bin-2025.2.30.zip"
       },
       "name": "scala"
     },
@@ -69,16 +69,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
       },
       "name": "stringmanipulation"
     },
@@ -100,16 +100,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -131,16 +131,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/6954/841446/Kotlin-252.25557.131-IJ.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip"
       },
       "name": "kotlin"
     },
@@ -162,16 +162,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": "https://plugins.jetbrains.com/files/6981/846966/ini-252.25557.135.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip"
       },
       "name": "ini"
     },
@@ -193,16 +193,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -224,16 +224,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -255,16 +255,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
       },
       "name": "file-watchers"
     },
@@ -275,7 +275,7 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
+        "252.26830.84": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
       },
       "name": "maven-helper"
     },
@@ -297,16 +297,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -316,8 +316,8 @@
         "phpstorm"
       ],
       "builds": {
-        "252.26199.163": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
+        "252.26830.84": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
       },
       "name": "symfony-plugin"
     },
@@ -327,8 +327,8 @@
         "phpstorm"
       ],
       "builds": {
-        "252.26199.163": "https://plugins.jetbrains.com/files/7320/855846/PHP_Annotations-12.0.1.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7320/855846/PHP_Annotations-12.0.1.zip"
+        "252.26830.84": "https://plugins.jetbrains.com/files/7320/855846/PHP_Annotations-12.0.1.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7320/855846/PHP_Annotations-12.0.1.zip"
       },
       "name": "php-annotations"
     },
@@ -346,14 +346,14 @@
       ],
       "builds": {
         "251.25410.129": null,
-        "252.25557.178": "https://plugins.jetbrains.com/files/7322/841474/python-ce-252.25557.131.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip"
       },
       "name": "python-community-edition"
     },
@@ -373,18 +373,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip"
       },
       "name": "asciidoc"
     },
@@ -406,16 +406,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -435,18 +435,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -468,16 +468,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": "https://plugins.jetbrains.com/files/7724/841415/clouds-docker-impl-252.25557.130.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip"
       },
       "name": "docker"
     },
@@ -499,16 +499,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip"
       },
       "name": "graphql"
     },
@@ -529,15 +529,15 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": null,
-        "252.26199.153": null,
-        "252.26199.154": null,
-        "252.26199.157": null,
-        "252.26199.158": null,
-        "252.26199.162": null,
-        "252.26199.163": null,
-        "252.26199.169": null,
-        "252.26199.73": null
+        "252.26830.102": null,
+        "252.26830.109": null,
+        "252.26830.46": null,
+        "252.26830.83": null,
+        "252.26830.84": null,
+        "252.26830.93": null,
+        "252.26830.94": null,
+        "252.26830.95": null,
+        "252.26830.99": null
       },
       "name": "-deprecated-rust"
     },
@@ -558,15 +558,15 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": null,
-        "252.25557.178": null,
-        "252.26199.153": null,
-        "252.26199.154": null,
-        "252.26199.157": null,
-        "252.26199.158": null,
-        "252.26199.162": null,
-        "252.26199.163": null,
-        "252.26199.169": null,
-        "252.26199.73": null
+        "252.26830.102": null,
+        "252.26830.109": null,
+        "252.26830.46": null,
+        "252.26830.83": null,
+        "252.26830.84": null,
+        "252.26830.93": null,
+        "252.26830.94": null,
+        "252.26830.95": null,
+        "252.26830.99": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -587,17 +587,17 @@
       ],
       "builds": {
         "251.25410.129": null,
-        "252.23892.529": "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8195/846963/toml-252.25557.135.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip"
+        "252.23892.529": null,
+        "252.26830.102": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip"
       },
       "name": "toml"
     },
@@ -608,7 +608,7 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip"
+        "252.26830.84": "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip"
       },
       "name": "minecraft-development"
     },
@@ -630,16 +630,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8554/834301/featuresTrainer-252.25557.79.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -661,16 +661,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
       },
       "name": "nixidea"
     },
@@ -692,16 +692,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip"
       },
       "name": "gherkin"
     },
@@ -723,16 +723,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
       },
       "name": "-env-files"
     },
@@ -742,8 +742,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "252.26199.158": "https://plugins.jetbrains.com/files/9568/861058/go-plugin-252.26199.169.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/9568/861058/go-plugin-252.26199.169.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/9568/866545/go-plugin-252.26830.24.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/9568/866545/go-plugin-252.26830.24.zip"
       },
       "name": "go"
     },
@@ -765,16 +765,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
+        "252.26830.102": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.109": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.136": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.83": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.84": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.93": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.94": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.95": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.26830.99": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -796,16 +796,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -827,16 +827,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
       },
       "name": "randomness"
     },
@@ -858,16 +858,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip"
       },
       "name": "csv-editor"
     },
@@ -887,18 +887,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -920,16 +920,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -951,16 +951,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
     },
@@ -981,15 +981,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
+        "252.26830.109": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
       },
       "name": "go-template"
     },
@@ -1009,18 +1009,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip"
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/11349/861955/aws-toolkit-jetbrains-standalone-3.94.251.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/871361/aws-toolkit-jetbrains-standalone-3.96.251.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1060,7 +1060,7 @@
         "rider"
       ],
       "builds": {
-        "252.26199.154": "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip"
+        "252.26830.109": "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1082,16 +1082,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1113,16 +1113,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1144,16 +1144,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1175,16 +1175,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1206,16 +1206,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1237,16 +1237,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1268,16 +1268,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "252.26830.102": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.109": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.136": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.83": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.84": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.93": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.94": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.95": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.26830.99": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1299,16 +1299,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "252.26830.102": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.109": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.136": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.83": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.84": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.93": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.94": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.95": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.26830.99": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1330,16 +1330,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.23892.529": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
+        "252.26830.102": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.109": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.136": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.83": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.84": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.93": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.94": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.95": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.26830.99": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
       },
       "name": "which-key"
     },
@@ -1361,16 +1361,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1392,16 +1392,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1423,16 +1423,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1452,18 +1452,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1483,18 +1483,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.23892.529": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.25557.178": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.153": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.154": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.157": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.158": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.159": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.162": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.163": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.169": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar",
-        "252.26199.73": "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.23892.529": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.102": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.109": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.136": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.46": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.83": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.84": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.93": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.94": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.95": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar",
+        "252.26830.99": "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1547,16 +1547,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1578,16 +1578,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
       },
       "name": "mermaid"
     },
@@ -1609,16 +1609,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1640,16 +1640,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
       },
       "name": "code-complexity"
     },
@@ -1671,16 +1671,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1696,14 +1696,14 @@
         "webstorm"
       ],
       "builds": {
-        "252.26199.153": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip"
       },
       "name": "dev-containers"
     },
@@ -1714,9 +1714,9 @@
         "rust-rover"
       ],
       "builds": {
-        "252.26199.153": "https://plugins.jetbrains.com/files/22407/860027/intellij-rust-252.26199.159.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/22407/860027/intellij-rust-252.26199.159.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/22407/860027/intellij-rust-252.26199.159.zip"
+        "252.26830.136": "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip"
       },
       "name": "rust"
     },
@@ -1736,18 +1736,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip"
       },
       "name": "continue"
     },
@@ -1769,16 +1769,16 @@
       "builds": {
         "251.25410.129": null,
         "252.23892.529": "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/22857/829212/vcs-gitlab-IU-252.25557.35-IU.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1798,18 +1798,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1831,16 +1831,16 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.23892.529": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "252.26830.102": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1860,18 +1860,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
-        "252.23892.529": null,
-        "252.25557.178": null,
-        "252.26199.153": null,
-        "252.26199.154": null,
-        "252.26199.157": null,
-        "252.26199.158": null,
-        "252.26199.159": null,
-        "252.26199.162": null,
-        "252.26199.163": null,
-        "252.26199.169": null,
-        "252.26199.73": null
+        "251.25410.129": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip"
       },
       "name": "oxocarbon"
     },
@@ -1891,18 +1891,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1922,18 +1922,18 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.23892.529": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.25557.178": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.153": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.154": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.157": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.158": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.159": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.162": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.163": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.169": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip",
-        "252.26199.73": "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.23892.529": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.102": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.109": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.136": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.46": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.83": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.84": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.93": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.94": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.95": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip",
+        "252.26830.99": "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1950,15 +1950,15 @@
         "webstorm"
       ],
       "builds": {
-        "252.26199.153": null,
-        "252.26199.154": null,
-        "252.26199.157": null,
-        "252.26199.158": null,
-        "252.26199.159": null,
-        "252.26199.162": null,
-        "252.26199.163": null,
-        "252.26199.169": null,
-        "252.26199.73": null
+        "252.26830.102": null,
+        "252.26830.109": null,
+        "252.26830.136": null,
+        "252.26830.46": null,
+        "252.26830.83": null,
+        "252.26830.84": null,
+        "252.26830.93": null,
+        "252.26830.94": null,
+        "252.26830.95": null
       },
       "name": "nix-lsp"
     },
@@ -1978,30 +1978,30 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
-        "252.25557.178": null,
-        "252.26199.153": null,
-        "252.26199.154": null,
-        "252.26199.157": null,
-        "252.26199.158": null,
-        "252.26199.159": null,
-        "252.26199.162": null,
-        "252.26199.163": null,
-        "252.26199.169": null,
-        "252.26199.73": null
+        "252.26830.102": null,
+        "252.26830.109": null,
+        "252.26830.136": null,
+        "252.26830.46": null,
+        "252.26830.83": null,
+        "252.26830.84": null,
+        "252.26830.93": null,
+        "252.26830.94": null,
+        "252.26830.95": null,
+        "252.26830.99": null
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip": "sha256-jk5JisClylJCL6PdQIUC5pyKb9ccEYJl7T7AyAkAkEE=",
-    "https://plugins.jetbrains.com/files/10080/834534/intellij-rainbow-brackets-2025.3.4.zip": "sha256-hB6m8uJ+QpLhYLiBzzcw6TB0yla4enKEJLN6aRLDcGU=",
+    "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip": "sha256-50IFDt9PC6IpjFLL8ggbybhf8dCi4U3ceKDfbDjEK6Q=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
     "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip": "sha256-XKv4jEKOk2O++VdHycGoLgICsusULbWRlQ0J5p+KgAE=",
-    "https://plugins.jetbrains.com/files/11058/857270/Extra_Icons-2025.1.14.zip": "sha256-iHyO6ZnEaP4rZMywGXZo6+PPMv+2KOjeWRLpdM8qAsU=",
-    "https://plugins.jetbrains.com/files/11349/861953/aws-toolkit-jetbrains-standalone-3.94.252.zip": "sha256-RABuHyvvbw1rGzvQpOk4tEpilVghQE75VzLIvRmFNfw=",
-    "https://plugins.jetbrains.com/files/11349/861955/aws-toolkit-jetbrains-standalone-3.94.251.zip": "sha256-y+AdD8SPKUpB1FU5bWknSkW+q1rhQR5j56pHP5s4NXE=",
+    "https://plugins.jetbrains.com/files/11058/873994/Extra_Icons-2025.1.15.zip": "sha256-uLDveZZrKi0RD+KeXgH3e4kDn70L/PxUrEyS3h5FV4g=",
+    "https://plugins.jetbrains.com/files/11349/871355/aws-toolkit-jetbrains-standalone-3.96.252.zip": "sha256-sZhyIm1s9FRGaL4Tw5lkKHKvhFqbx1KnUHbB28fZqmg=",
+    "https://plugins.jetbrains.com/files/11349/871361/aws-toolkit-jetbrains-standalone-3.96.251.zip": "sha256-v0soM5OJPpfowXES5lXh443qAcrVw8TxFY7vgSuc82g=",
     "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip": "sha256-XDBmYpBpLhuLGTB8aP0csK1NBEncmMUPKWoPJx2AVao=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
     "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip": "sha256-V3Vk6UYLUSiSmypD+g0DCX1sPw3/wZqvLxFhbkTqY34=",
@@ -2022,9 +2022,9 @@
     "https://plugins.jetbrains.com/files/16604/857267/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.14.zip": "sha256-g07e6dfHkNbdiG54cqGBChxNsEHQ/5kMBhLlGkK6di4=",
     "https://plugins.jetbrains.com/files/17718/859668/github-copilot-intellij-1.5.57-243.zip": "sha256-UN+4+QhGHloiSuaSf5KwTCaSorYBLb0h2OusmOjd64k=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
-    "https://plugins.jetbrains.com/files/18682/852457/Catppuccin_Theme-3.5.1.zip": "sha256-dxZAIsXfdwsdTx+bp/1aaahw+D4HXOSEpyY7JWAhLys=",
-    "https://plugins.jetbrains.com/files/18824/859305/CodeGlancePro-1.9.9-signed.zip": "sha256-uAHkTDvFUEzdasYgyB0yn8yVMEHvB8dn+Z5jSoB5PQo=",
-    "https://plugins.jetbrains.com/files/18922/856642/GerryThemes.jar": "sha256-0QVCCkrgDWEX8tAkfPfiYRpaROd3ELGZn5TBGa3lJXQ=",
+    "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip": "sha256-F37RoWSV96ofEw7ckvhSS4nHaXUJOBuWecEhzaH2Zk4=",
+    "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip": "sha256-v/BwU04VevdH7I40yiU7wOMn6CsFmSc63TKAVAcMiJI=",
+    "https://plugins.jetbrains.com/files/18922/875516/GerryThemes.jar": "sha256-G7LFG73y4i3ZtduZjKQKmNA+Kv1N+5WUZwxoo9vV0Eo=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip": "sha256-QTh77pyi4lh7V0DGPFx9kERjFCop219d76wTDwD0SYY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
@@ -2032,25 +2032,22 @@
     "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip": "sha256-8agNBVenqaV9DlvRmFP7ul3IZfj9Dij8v/h8QMUb72E=",
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip": "sha256-uwonawWIgXi9OXZlQaZl/GDt/iHqsyAKV7ifCgcMqWU=",
-    "https://plugins.jetbrains.com/files/22407/860027/intellij-rust-252.26199.159.zip": "sha256-/7/PFoHjJpuuqvtW9P8L/cKtiA1o5gRCCROmkGW+dl4=",
-    "https://plugins.jetbrains.com/files/22707/857674/continue-intellij-extension-1.0.44.zip": "sha256-EvCNPNYeEtQRmNEbLizH6MEIqPNvTwsk2qJm873s8oo=",
+    "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip": "sha256-6UI1p3SzOgdQg7NjWQJv7r6qAVcTOktwTkuvO7/b5ls=",
+    "https://plugins.jetbrains.com/files/22707/865828/continue-intellij-extension-1.0.46.zip": "sha256-RyE9IPYalQptgZP206bq03pkK34N/bQPc13fQniLOCc=",
     "https://plugins.jetbrains.com/files/22857/826717/vcs-gitlab-IU-252.23892.515-IU.zip": "sha256-1fkImbCktws9WcnJSwnMiZ7ULc3hKj9TiFXuNDf+L/U=",
-    "https://plugins.jetbrains.com/files/22857/829212/vcs-gitlab-IU-252.25557.35-IU.zip": "sha256-7fLyaf7JNH3FwKSH+HsQcGNszzzVMUy2qsFmcWgW0/g=",
-    "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip": "sha256-dJM8j5aLWD6elv46HtXUhPvYWTdAE77m/jwRqztIwDk=",
-    "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
+    "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip": "sha256-bTqJlTkoOyBm370Ks6kFpvxzRJJ7CSucT298YBQtl/M=",
+    "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip": "sha256-fE0M8jYTYVIC0bbBDY9fWB+mgGcVIFkeee0VTAMXt2E=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
-    "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip": "sha256-+cLKIu8abGXZqJ3GutQsoQQg3s0wkmk5qKosW0O8RII=",
-    "https://plugins.jetbrains.com/files/23927/839297/Extra_IDE_Tweaks_Subscription-2025.1.12.zip": "sha256-EtPWFr7stHfRSVowuH3BN3r2oBx8mut2T+6Ij8LEgmE=",
-    "https://plugins.jetbrains.com/files/24559/857271/Extra_Tools_Pack-2025.1.16.zip": "sha256-l/PChea8RmVLlD3COrikZ3xTq2iwztbCsJkzKIvUcaQ=",
+    "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip": "sha256-952sONSgui6bSVFYfRhx1PbHWHas24y0SdHl5QhNIdQ=",
+    "https://plugins.jetbrains.com/files/23927/873992/Extra_IDE_Tweaks_Subscription-2025.1.13.zip": "sha256-hcJAYJPMQVrGJZwuaz/5xuKtJOIlwYpVsqPqCclAZL8=",
+    "https://plugins.jetbrains.com/files/24559/873995/Extra_Tools_Pack-2025.1.17.zip": "sha256-CfIlfFC659GPN4DJFTctleSF0RvGMjvcxP35Hj8QMLM=",
     "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip": "sha256-2Vrm9k4ZqqpWl/EgDrAFNTpUeBhDSYt48JhAWlSWY1A=",
-    "https://plugins.jetbrains.com/files/631/861064/python-252.26199.169.zip": "sha256-SEX/CnP3d3itW9gzGx3QA3WyGRn2pRSDBjSbzBGOGM8=",
+    "https://plugins.jetbrains.com/files/631/870935/python-252.26830.84.zip": "sha256-euot7m1AZOBRvyijKldXCVomgXFw2OGlhg9Zro8snEU=",
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
     "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip": "sha256-iWKLgk+eWhUmv/lH9+B2HI97d++EYvLwGgtRsJf4aSE=",
     "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip": "sha256-pQGVguF7zzzasLm2tlmtvqiPtdFN4Q5NKRwYx1r62fM=",
-    "https://plugins.jetbrains.com/files/6954/841446/Kotlin-252.25557.131-IJ.zip": "sha256-ogFUJ+BMATp7fM2vDjWkoGhLCRw9TN+ifopFlpP+q4Q=",
-    "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip": "sha256-Fk/Df5MthwTWnhxv/u8/n2ITMLzZXKogj0tRRyPi5Zw=",
-    "https://plugins.jetbrains.com/files/6981/846966/ini-252.25557.135.zip": "sha256-9rrbHi+3fe/dlTkGGSnZ/fKh44vsLDOEbFCx5rPokfQ=",
-    "https://plugins.jetbrains.com/files/6981/861757/ini-252.26199.163.zip": "sha256-l+ETZNsDuQf+Cjh2vYi6/xi3th2QZeR+UflOtRRcKWI=",
+    "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip": "sha256-C1JXMUNESJ29psA661Z8/R5Jj1155YjVXdgDFcBY01k=",
+    "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip": "sha256-hETXYiz7bXDOWXjK9tUWST/VzaKdfU4hluuDWF3FTGY=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip": "sha256-KcRoHqvCcC6qRz58DHkQ6AFqnpyqPhETekuMWBQYYw8=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
@@ -2060,31 +2057,26 @@
     "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip": "sha256-ypJOPmcl4881TpMboomVvmspJ3I1sfm5a26l54cfFpo=",
     "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/855846/PHP_Annotations-12.0.1.zip": "sha256-FQmHb4oo9TgXiJ4b7EEEELagOx31C9iQtsTRoqxCnO4=",
-    "https://plugins.jetbrains.com/files/7322/841474/python-ce-252.25557.131.zip": "sha256-OA3GRyoEzIqsIqKCwIHcMss8SSb5u/YqNUo9kEjszsA=",
-    "https://plugins.jetbrains.com/files/7322/861072/python-ce-252.26199.169.zip": "sha256-fzoj+iBfEEE6gjlGNtqfqpYXqwaEr2LFECNOglMyz5Y=",
-    "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip": "sha256-6VpRIidsf8iWJeR3OarwwgS1NDXj9j6bLnxU/YBskeY=",
+    "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip": "sha256-7Tkcnl2km29lxQtBIX0ahKXShy16Lk1EBiwmKZBjpIc=",
+    "https://plugins.jetbrains.com/files/7391/875464/asciidoctor-intellij-plugin-0.44.9.zip": "sha256-3QMCwQ+rBIC+dgws5LbyilccnXCYPyDA37GypJEE36s=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
-    "https://plugins.jetbrains.com/files/7499/840762/gittoolbox-600.1.10_243-signed.zip": "sha256-AEkeSl3yUelw5jOEBXCPPeWZU/Q2cE9ekUSXN409iCw=",
-    "https://plugins.jetbrains.com/files/7724/841415/clouds-docker-impl-252.25557.130.zip": "sha256-u5BDqZlqkx9cEmDuri5+DN6E40YyF9G0f0gLehhtZ2s=",
-    "https://plugins.jetbrains.com/files/7724/861752/clouds-docker-impl-252.26199.163.zip": "sha256-izEzIQxn23ZV2ZClMmd6g9H0sd+jy+OoaISvX94H7hQ=",
+    "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip": "sha256-o6HEc0RuM/GRZL0ke+Zrr8uSZGMLL0dDlubuwHdnGJc=",
+    "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip": "sha256-abY9ZqQ0z80B2l6HNUJxF3ZyLdLjCYo0K6Y5mlDOZvc=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
     "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip": "sha256-eLh0p5vDNG7fUV7pqbIbkL30dpPj19NE9JbwcDwxZXs=",
     "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip": "sha256-wN3+7++f6i0MvEmOTiWZgAW1QzM5HiD7jSAMS8jWC5s=",
-    "https://plugins.jetbrains.com/files/8195/819801/toml-252.23892.464.zip": "sha256-CXbS+/k9a4YqYPRxd5OWGxtal2+5ECshavcOSrYqca0=",
-    "https://plugins.jetbrains.com/files/8195/846963/toml-252.25557.135.zip": "sha256-vICiXs86VP1gyMy594bCOcb5jZ+Ptw1Ui7r6dQwIveQ=",
-    "https://plugins.jetbrains.com/files/8195/861057/toml-252.26199.169.zip": "sha256-8miuDbuQkeB4Nc9DsI+NiGbZ9PdEFrFMfEG9sB4FJEM=",
+    "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip": "sha256-trwXodrcUo1SHloOm6hQa3IUBS9F+VxK5jYvOxtSOI8=",
     "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip": "sha256-mePVZa+63bheH85ylkbX9oOX1Nq/IYLAGHHseOJx520=",
     "https://plugins.jetbrains.com/files/8327/809294/Minecraft_Development-2025.2-1.8.6.zip": "sha256-NOuzQ+CL+Z8n5gwMBaberLyMvS5KNmXKwZ+j88+SFqU=",
     "https://plugins.jetbrains.com/files/8554/826552/featuresTrainer-252.23892.514.zip": "sha256-AQLuTcRERFq2ZfzOqUGMte/pLe7/3g6G+9UqNMuUYiY=",
-    "https://plugins.jetbrains.com/files/8554/834301/featuresTrainer-252.25557.79.zip": "sha256-b+Xv06OhVZirdqR8qOsNv+6gXfBo6VOb27iuipmoEJY=",
-    "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip": "sha256-euvA9ZNcFcQ6iZ5AC6tpyeJKTkAGzIq4jJ2sdLF0Fno=",
+    "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip": "sha256-evHs8vwjnUSjN20ewZaMCpKHQbbjOmN+TspNqOMhihM=",
     "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip": "sha256-JShheBoOBiWM9HubMUJvBn4H3DnWykvqPyrmetaCZiM=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
     "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip": "sha256-KrC3EK4wYLSxWywF8I8nVx6tkclr1wAMya1Z1XF0QY8=",
     "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip": "sha256-y66kYTYD+R9Sert2JHWGwFFIgc5UJTssZrjgvzOjljk=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
     "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip": "sha256-N0DNEtF3FDcRirfjfSCCVUbDIA4SB35F/9XY1tPXXmg=",
-    "https://plugins.jetbrains.com/files/9568/861058/go-plugin-252.26199.169.zip": "sha256-tt/vvW8EVNP9n9aTGtn+9pmxwz450p3a0Rclkg65aKw=",
+    "https://plugins.jetbrains.com/files/9568/866545/go-plugin-252.26830.24.zip": "sha256-6cm6rsco5560iq9FKQzShq3j0j/Ol3x1ubRbAMbEy9k=",
     "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar": "sha256-XYCD4kOHDeIKhti0T175xhBHR8uscaFN4c9CNlUaCDs=",
     "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar": "sha256-mp1k2BdksxbGH4zUp/7DnjcGi5OXJ7UekCfX6dWZOtU=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",


### PR DESCRIPTION
jetbrains.clion: 2025.2.2 -> 2025.2.3
jetbrains.datagrip: 2025.2.3 -> 2025.2.4
jetbrains.gateway: 2025.2.2 -> 2025.2.3
jetbrains.goland: 2025.2.2 -> 2025.2.3
jetbrains.idea-community: 2025.2.2 -> 2025.2.3
jetbrains.idea-ultimate: 2025.2.2 -> 2025.2.3
jetbrains.phpstorm: 2025.2.2 -> 2025.2.3
jetbrains.pycharm-community: 2025.2.1.1 -> 2025.2.3
jetbrains.pycharm-professional: 2025.2.1.1 -> 2025.2.3
jetbrains.rider: 2025.2.2 -> 2025.2.3
jetbrains.ruby-mine: 2025.2.2 -> 2025.2.3
jetbrains.rust-rover: 2025.2.2 -> 2025.2.3
jetbrains.webstorm: 2025.2.2 -> 2025.2.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
