### PR TITLE
[Backport release-25.05] victorialogs: init package and update module to revive victorialogs in 25.05

### DIFF
--- a/nixos/modules/services/databases/victorialogs.nix
+++ b/nixos/modules/services/databases/victorialogs.nix
@@ -29,7 +29,7 @@ in
 {
   options.services.victorialogs = {
     enable = mkEnableOption "VictoriaLogs is an open source user-friendly database for logs from VictoriaMetrics";
-    package = mkPackageOption pkgs "victoriametrics" { };
+    package = mkPackageOption pkgs "victorialogs" { };
     listenAddress = mkOption {
       default = ":9428";
       type = types.str;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1458,6 +1458,7 @@ in
   vector = handleTest ./vector { };
   velocity = runTest ./velocity.nix;
   vengi-tools = handleTest ./vengi-tools.nix { };
+  victorialogs = runTest ./victorialogs.nix;
   victoriametrics = handleTest ./victoriametrics { };
   vikunja = handleTest ./vikunja.nix { };
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };

--- a/nixos/tests/victorialogs.nix
+++ b/nixos/tests/victorialogs.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+{
+  name = "victorialogs";
+  meta.maintainers = with lib.maintainers; [ marie ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.victorialogs.enable = true;
+
+      services.journald.upload = {
+        enable = true;
+        settings = {
+          Upload.URL = "http://localhost:9428/insert/journald";
+        };
+      };
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("victorialogs.service")
+
+    machine.succeed("echo 'meow' | systemd-cat -p info")
+    machine.wait_until_succeeds("curl --fail http://localhost:9428/select/logsql/query -d 'query=\"meow\"' | grep meow")
+  '';
+}

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -56,6 +56,11 @@ buildGoModule (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   passthru = {
+    tests = {
+      inherit (nixosTests)
+        victorialogs
+        ;
+    };
     updateScript = nix-update-script {
       extraArgs = [ "--version-regex=(.*)-victorialogs" ];
     };

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.25.0";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KhXB+37uK08dDYXtnaPDS7gP/gBGZ0gqyR0u572QOx8=";
+    hash = "sha256-PnXpu2Dna5grozKOGRHi/Gic7djszYh7wJ96EiEYP8U=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.24.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
-    repo = "VictoriaMetrics";
-    tag = "v${finalAttrs.version}-victorialogs";
-    hash = "sha256-E52hvxazzbz9FcPFZFcRHs2vVg6fJJQ8HsieQovQSi4=";
+    repo = "VictoriaLogs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KhXB+37uK08dDYXtnaPDS7gP/gBGZ0gqyR0u572QOx8=";
   };
 
   vendorHash = null;
@@ -28,30 +28,11 @@ buildGoModule (finalAttrs: {
     "app/vlogscli"
   ];
 
-  postPatch = ''
-    # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package
-    # github.com/VictoriaMetrics/VictoriaMetrics/app/vmui/packages/vmui/web
-    #
-    # This appears to be some kind of test server for development purposes only.
-    # rm -f app/vmui/packages/vmui/web/{go.mod,main.go}
-
-    # Increase timeouts in tests to prevent failure on heavily loaded builders
-    substituteInPlace lib/storage/storage_test.go \
-      --replace-fail "time.After(10 " "time.After(120 " \
-      --replace-fail "time.NewTimer(30 " "time.NewTimer(120 " \
-      --replace-fail "time.NewTimer(time.Second * 10)" "time.NewTimer(time.Second * 120)" \
-  '';
-
   ldflags = [
     "-s"
     "-w"
     "-X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${finalAttrs.version}"
   ];
-
-  preCheck = ''
-    # `lib/querytracer/tracer_test.go` expects `buildinfo.Version` to be unset
-    export ldflags=''${ldflags//=${finalAttrs.version}/=}
-  '';
 
   __darwinAllowLocalNetworking = true;
 
@@ -61,9 +42,7 @@ buildGoModule (finalAttrs: {
         victorialogs
         ;
     };
-    updateScript = nix-update-script {
-      extraArgs = [ "--version-regex=(.*)-victorialogs" ];
-    };
+    updateScript = nix-update-script { };
   };
 
   meta = {
@@ -71,7 +50,7 @@ buildGoModule (finalAttrs: {
     description = "User friendly log database from VictoriaMetrics";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ marie ];
-    changelog = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "victoria-logs";
   };
 })

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.30.0";
+  version = "1.32.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Jc7crSUV1p1PE3QAeDeBvNV9BUhQLq62ksdnW5Plm88=";
+    hash = "sha256-VcFgPxsxPjvo92/TiVec6sSPprRQ4sbQwe4teGC60/o=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.32.0";
+  version = "1.33.1";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VcFgPxsxPjvo92/TiVec6sSPprRQ4sbQwe4teGC60/o=";
+    hash = "sha256-CLrXkyLHPA4t0srIME2Td9/6QQ5fsJyq+kuKfzawwFs=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   nix-update-script,
   nixosTests,
+  withServer ? true,
+  withVlAgent ? false,
 }:
 
 buildGoModule (finalAttrs: {
@@ -19,14 +21,16 @@ buildGoModule (finalAttrs: {
 
   vendorHash = null;
 
-  subPackages = [
-    "app/victoria-logs"
-    "app/vlinsert"
-    "app/vlselect"
-    "app/vlstorage"
-    "app/vlogsgenerator"
-    "app/vlogscli"
-  ];
+  subPackages =
+    lib.optionals withServer [
+      "app/victoria-logs"
+      "app/vlinsert"
+      "app/vlselect"
+      "app/vlstorage"
+      "app/vlogsgenerator"
+      "app/vlogscli"
+    ]
+    ++ lib.optionals withVlAgent [ "app/vlagent" ];
 
   ldflags = [
     "-s"
@@ -49,7 +53,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://docs.victoriametrics.com/victorialogs/";
     description = "User friendly log database from VictoriaMetrics";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ marie ];
+    maintainers = with lib.maintainers; [
+      marie
+      shawn8901
+    ];
     changelog = "https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "victoria-logs";
   };

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.35.0";
+  version = "1.36.1";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9g23rtLi/tHIXpfZSHgaIHIGHwQ0eYW5kLtMHqrIlMk=";
+    hash = "sha256-TZhgZ8x1ESXrNMU6Sa4cQMurTZ+obD/JqqIJFJ18KOA=";
   };
 
   vendorHash = null;
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
   postPatch = ''
     # Allow older go versions
     substituteInPlace go.mod \
-      --replace-fail "go 1.25.1" "go ${finalAttrs.passthru.go.version}"
+      --replace-fail "go 1.25.2" "go ${finalAttrs.passthru.go.version}"
 
     substituteInPlace vendor/modules.txt \
       --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "VictoriaLogs";
+  version = "1.24.0";
+
+  src = fetchFromGitHub {
+    owner = "VictoriaMetrics";
+    repo = "VictoriaMetrics";
+    tag = "v${finalAttrs.version}-victorialogs";
+    hash = "sha256-E52hvxazzbz9FcPFZFcRHs2vVg6fJJQ8HsieQovQSi4=";
+  };
+
+  vendorHash = null;
+
+  subPackages = [
+    "app/victoria-logs"
+    "app/vlinsert"
+    "app/vlselect"
+    "app/vlstorage"
+    "app/vlogsgenerator"
+    "app/vlogscli"
+  ];
+
+  postPatch = ''
+    # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package
+    # github.com/VictoriaMetrics/VictoriaMetrics/app/vmui/packages/vmui/web
+    #
+    # This appears to be some kind of test server for development purposes only.
+    # rm -f app/vmui/packages/vmui/web/{go.mod,main.go}
+
+    # Increase timeouts in tests to prevent failure on heavily loaded builders
+    substituteInPlace lib/storage/storage_test.go \
+      --replace-fail "time.After(10 " "time.After(120 " \
+      --replace-fail "time.NewTimer(30 " "time.NewTimer(120 " \
+      --replace-fail "time.NewTimer(time.Second * 10)" "time.NewTimer(time.Second * 120)" \
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${finalAttrs.version}"
+  ];
+
+  preCheck = ''
+    # `lib/querytracer/tracer_test.go` expects `buildinfo.Version` to be unset
+    export ldflags=''${ldflags//=${finalAttrs.version}/=}
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=(.*)-victorialogs" ];
+    };
+  };
+
+  meta = {
+    homepage = "https://docs.victoriametrics.com/victorialogs/";
+    description = "User friendly log database from VictoriaMetrics";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marie ];
+    changelog = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "victoria-logs";
+  };
+})

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.34.0";
+  version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NUfFXssgNtlb8p9B32aMVSzRJxafMrsuxsR38oHAm2M=";
+    hash = "sha256-9g23rtLi/tHIXpfZSHgaIHIGHwQ0eYW5kLtMHqrIlMk=";
   };
 
   vendorHash = null;
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
   postPatch = ''
     # Allow older go versions
     substituteInPlace go.mod \
-      --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"
+      --replace-fail "go 1.25.1" "go ${finalAttrs.passthru.go.version}"
 
     substituteInPlace vendor/modules.txt \
       --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.26.0";
+  version = "1.29.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PnXpu2Dna5grozKOGRHi/Gic7djszYh7wJ96EiEYP8U=";
+    hash = "sha256-IKKVCVsHFijSnLawy9oq1qCji2O4+QkSWUvQ4S6tAN8=";
   };
 
   vendorHash = null;
@@ -31,6 +31,15 @@ buildGoModule (finalAttrs: {
       "app/vlogscli"
     ]
     ++ lib.optionals withVlAgent [ "app/vlagent" ];
+
+  postPatch = ''
+    # Allow older go versions
+    substituteInPlace go.mod \
+      --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"
+
+    substituteInPlace vendor/modules.txt \
+      --replace-fail "go 1.25.0" "go ${finalAttrs.passthru.go.version}"
+  '';
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.29.0";
+  version = "1.30.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IKKVCVsHFijSnLawy9oq1qCji2O4+QkSWUvQ4S6tAN8=";
+    hash = "sha256-Jc7crSUV1p1PE3QAeDeBvNV9BUhQLq62ksdnW5Plm88=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.33.1";
+  version = "1.34.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CLrXkyLHPA4t0srIME2Td9/6QQ5fsJyq+kuKfzawwFs=";
+    hash = "sha256-NUfFXssgNtlb8p9B32aMVSzRJxafMrsuxsR38oHAm2M=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/vl/vlagent/package.nix
+++ b/pkgs/by-name/vl/vlagent/package.nix
@@ -1,0 +1,11 @@
+{ lib, victorialogs }:
+
+# This package is build out of the victorialogs package.
+# so no separate update prs are needed for vlagent
+# nixpkgs-update: no auto update
+lib.addMetaAttrs { mainProgram = "vlagent"; } (
+  victorialogs.override {
+    withServer = false;
+    withVlAgent = true;
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In https://github.com/NixOS/nixpkgs/pull/450723 we backported victoriametrics to a recent version.
We oversaw that there is a breaking change hidden, that victorialogs (and vlagent), had been removed from the victoriametrics repository in version 1.222.0 (https://github.com/NixOS/nixpkgs/pull/427162 https://github.com/VictoriaMetrics/VictoriaMetrics/commit/624497a954f2fd612696d8c50b9103e7c19e4d4d , which is included in that version https://github.com/VictoriaMetrics/VictoriaMetrics/compare/v1.121.0...v1.122.0 but not mentioned explicitly in the release notes, thus we overlooked it in the backport).

This Backport does fix the situation on default settings to bring back a victorialogs and companion package (vlagent) and updates the module in default to use the new package.
I included all version bumps.

IMHO that is the cleanest fix for the situation without reverting the version bump of victoriametrics.

see https://github.com/NixOS/nixpkgs/pull/450723#issuecomment-3393564788 as ref.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
