### PR TITLE
python313Packages.kiss-headers: fix build

### DIFF
--- a/pkgs/development/python-modules/kiss-headers/default.nix
+++ b/pkgs/development/python-modules/kiss-headers/default.nix
@@ -29,9 +29,12 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
+  preCheck = ''
+    rm -rf src # cause pycache conflict
+  '';
+
   disabledTestPaths = [
     # Tests require internet access
-    "kiss_headers/__init__.py"
     "tests/test_serializer.py"
     "tests/test_with_http_request.py"
   ];


### PR DESCRIPTION
Addresses the following hydra build failures:

- https://hydra.nixos.org/build/309137551
- https://hydra.nixos.org/build/309137549
- https://hydra.nixos.org/build/309137546
- https://hydra.nixos.org/build/309137547
- https://hydra.nixos.org/build/309099439
- https://hydra.nixos.org/build/309099435
- https://hydra.nixos.org/build/309099437
- https://hydra.nixos.org/build/309099434

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
