### PR TITLE
xcodegen: 2.42.0 -> 2.44.1

### DIFF
--- a/pkgs/by-name/xc/xcodegen/nix/default.nix
+++ b/pkgs/by-name/xc/xcodegen/nix/default.nix
@@ -2,7 +2,7 @@
 {
   workspaceStateFile = ./workspace-state.json;
   hashes = {
-    "AEXML" = "sha256-bQcXq1aS76sOjW8yYCOlGVZ2tStDvzRQSyj9VrAj6nI=";
+    "AEXML" = "sha256-6KvO8zT667Td+4qOeYzHbd51hDzFJFrxcVyYr2h5igc=";
     "ArtifactBundleGen" = "sha256-mSXJiRGFIm2RtzBG8l6s4RJ2BzSbPZKUZIqWM4vDIhc=";
     "JSONUtilities" = "sha256-jl8XfgoB5IX0qwwDtzcWgK0u3SNG2HfrPoEb2a6/mlA=";
     "PathKit" = "sha256-ewxTC1kpu6PXhwamCxYfI50ooYO1SIU0+IXH2tc/uv4=";
@@ -10,7 +10,7 @@
     "Spectre" = "sha256-fipGRIgw+jV7Wrxa+xivRk7YMyxDhGFB6SHIHscrmV8=";
     "SwiftCLI" = "sha256-PmjzLss0D12iy6YKsudFa8i63NQAssyCBqqq8VjRiH4=";
     "Version" = "sha256-4IwQlexWtIH9M0sSai1a+ITTAKkD2zJtbYoV4Cg+Snw=";
-    "XcodeProj" = "sha256-ycHDzay37YtT/3QqUpG6XPjRh32P5iU/I5GpfjrXs/I=";
+    "XcodeProj" = "sha256-UMnSV/kdRlUxp23Rd70xCHzJeP6Vh1viyHNERo3haRE=";
     "Yams" = "sha256-5qxuCkmopm3uFcoYJKQA8ofW98f53H1gZaPiOh2DS4U=";
   };
 }

--- a/pkgs/by-name/xc/xcodegen/nix/workspace-state.json
+++ b/pkgs/by-name/xc/xcodegen/nix/workspace-state.json
@@ -12,8 +12,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-            "version": "4.6.1"
+            "revision": "db806756c989760b35108146381535aec231092b",
+            "version": "4.7.0"
           },
           "name": "sourceControlCheckout"
         },
@@ -148,8 +148,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "447c159b0c5fb047a024fd8d942d4a76cf47dde0",
-            "version": "8.16.0"
+            "revision": "b1caa062d4aaab3e3d2bed5fe0ac5f8ce9bf84f4",
+            "version": "8.27.7"
           },
           "name": "sourceControlCheckout"
         },

--- a/pkgs/by-name/xc/xcodegen/package.nix
+++ b/pkgs/by-name/xc/xcodegen/package.nix
@@ -16,13 +16,13 @@ in
 
 swiftPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "xcodegen";
-  version = "2.42.0";
+  version = "2.44.1";
 
   src = fetchFromGitHub {
     owner = "yonaskolb";
     repo = "XcodeGen";
     tag = finalAttrs.version;
-    hash = "sha256-wcjmADG+XnS2kR8BHe6ijApomucS9Tx7ZRjWZmTCUiI=";
+    hash = "sha256-RQlmQfmrLZRrgIA09fE84JuqmYkkrz4KSw2dvYXw0Rs=";
   };
 
   # Including SwiftPM as a nativeBuildInput provides a buildPhase for you.


### PR DESCRIPTION
Updates XcodeGen to 2.44.1. Closes #437854.

Note that this depends on the (just merged!) #447292, which is (as of the time of writing) uncached, so `nixpkgs-review` will do a *lot* more building than you might expect.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
