### PR TITLE
specify-cli: init at 0.0.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4708,6 +4708,12 @@
     githubId = 31200881;
     keys = [ { fingerprint = "5D03 A5E6 0754 A3E3 CA57 5037 E838 CED8 1CFF D3F9"; } ];
   };
+  chuckorde = {
+    name = "Chuck Orde";
+    email = "chuckorde@gmail.com";
+    github = "chuckorde";
+    githubId = 2244935;
+  };
   chvp = {
     email = "nixpkgs@cvpetegem.be";
     matrix = "@charlotte:vanpetegem.me";

--- a/pkgs/by-name/sp/specify/package.nix
+++ b/pkgs/by-name/sp/specify/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+
+  pname = "specify";
+  version = "0.0.62";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "github";
+    repo = "spec-kit";
+    tag = "v${version}";
+    hash = "sha256-WT1M6M/i9UHsFkbNEFp572tqGxEiFvl+EDDoCF6achU=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = with python3Packages; [
+    typer
+    rich
+    httpx
+    platformdirs
+    readchar
+    truststore
+  ];
+
+  meta = {
+    description = "CLI tool to bootstraps projects for SDD and works with AI coding agents";
+    homepage = "https://github.com/github/spec-kit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chuckorde ];
+  };
+}


### PR DESCRIPTION
This package introduces `specify-cli`, the command-line interface tool that is part of the GitHub Spec Kit for Spec-Driven Development (SDD).

The tool is used to bootstrap new projects, generate specifications, and create technical plans for workflows involving AI coding agents (such as GitHub Copilot and Gemini).

The package is built as a Python application and includes necessary dependencies like `typer` and `httpx`.

Maintainer: @chuckorde

## Things done

- Built on platform:
  - [x] x86_64-linux  <-- Check this if you built it on a standard Linux machine
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. <-- **Check this.** You ran `./result/bin/specify --help`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. <-- **Check this.** By following the `by-name` structure, using `meta.json`, and having a clean commit, you meet the conventions.

### Additional Testing Information

* The derivation includes `pythonImportsCheck = [ "specify_cli" ];` which passed successfully.
* I manually confirmed the binary runs by executing `./result/bin/specify --help`.