### PR TITLE
szurubooru: Host option and fixes for backwards compatibility

### DIFF
--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -72,6 +72,13 @@ in
           '';
         };
 
+        host = lib.mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          example = "0.0.0.0";
+          description = "The host address for Szurubooru to bind to.";
+        };
+
         threads = mkOption {
           type = types.int;
           default = 4;
@@ -265,9 +272,6 @@ in
             (lib.filterAttrsRecursive (_: x: x != null))
           ]
         );
-        pyenv = python.buildEnv.override {
-          extraLibs = [ (python.pkgs.toPythonModule cfg.server.package) ];
-        };
       in
       {
         description = "Server of Szurubooru, an image board engine dedicated for small and medium communities";
@@ -283,20 +287,9 @@ in
         ];
         wants = [ "network-online.target" ];
 
-        environment = {
-          PYTHONPATH = "${pyenv}/${pyenv.sitePackages}/";
-        };
-
-        path =
-          with pkgs;
-          [
-            envsubst
-            ffmpeg_4-full
-          ]
-          ++ (with python.pkgs; [
-            alembic
-            waitress
-          ]);
+        path = with pkgs; [
+          ffmpeg_4-full
+        ];
 
         script = ''
           export SZURUBOORU_SECRET="$(<$CREDENTIALS_DIRECTORY/secret)"
@@ -307,10 +300,10 @@ in
           install -m0640 ${cfg.server.package.src}/config.yaml.dist ${cfg.dataDir}/config.yaml.dist
           touch ${cfg.dataDir}/config.yaml
           chmod 0640 ${cfg.dataDir}/config.yaml
-          envsubst -i ${configFile} -o ${cfg.dataDir}/config.yaml
+          ${lib.getExe pkgs.envsubst} -i ${configFile} -o ${cfg.dataDir}/config.yaml
           sed 's|script_location = |script_location = ${cfg.server.package.src}/|' ${cfg.server.package.src}/alembic.ini > ${cfg.dataDir}/alembic.ini
-          alembic upgrade head
-          waitress-serve --port ${toString cfg.server.port} --threads ${toString cfg.server.threads} szurubooru.facade:app
+          ${lib.getExe cfg.server.package.alembic} upgrade head
+          ${lib.getExe cfg.server.package.waitress} --host ${cfg.server.host} --port ${toString cfg.server.port} --threads ${toString cfg.server.threads} szurubooru.facade:app
         '';
 
         serviceConfig = {

--- a/nixos/tests/szurubooru.nix
+++ b/nixos/tests/szurubooru.nix
@@ -26,6 +26,7 @@ import ./make-test-python.nix (
 
           server = {
             port = 6666;
+            host = "127.0.0.1";
             settings = {
               domain = "http://127.0.0.1";
               secretFile = pkgs.writeText "secret" "secret";

--- a/pkgs/servers/web-apps/szurubooru/default.nix
+++ b/pkgs/servers/web-apps/szurubooru/default.nix
@@ -14,7 +14,8 @@ let
   };
 in
 
-lib.recurseIntoAttrs {
+lib.recurseIntoAttrs rec {
   client = callPackage ./client.nix { inherit src version; };
   server = callPackage ./server.nix { inherit src version; };
+  inherit (server) tests;
 }

--- a/pkgs/servers/web-apps/szurubooru/server.nix
+++ b/pkgs/servers/web-apps/szurubooru/server.nix
@@ -6,6 +6,7 @@
   fetchPypi,
   python3,
   ffmpeg_4-full,
+  szurubooru,
 }:
 
 let
@@ -53,7 +54,6 @@ python.pkgs.buildPythonApplication {
 
   nativeBuildInputs = with python.pkgs; [ setuptools ];
   propagatedBuildInputs = with python.pkgs; [
-    alembic
     certifi
     coloredlogs
     legacy-cgi
@@ -79,6 +79,20 @@ python.pkgs.buildPythonApplication {
   '';
 
   passthru.tests.szurubooru = nixosTests.szurubooru;
+
+  # Database migration. Needs the szurubooru server in its environment for the
+  # migration to complete successfully.
+  passthru.alembic = python.pkgs.alembic.overrideAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [
+      szurubooru.server
+    ];
+  });
+  # Waitress is used to run the serer.
+  passthru.waitress = python.pkgs.waitress.overrideAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [
+      szurubooru.server
+    ];
+  });
 
   meta = {
     description = "Server of szurubooru, an image board engine for small and medium communities";


### PR DESCRIPTION
Pass through alembic and waitress so that it uses the versions from the package definition and not from the evaluation of the module. This allows the module to be imported and used even if it is ported to NixOS versions that use a different default python3 version. This should be more robust against divergence in version numbers between the system and package.

Also add a `host` config option to set the bind address. Waitress would otherwise bind to 0.0.0.0, which isn't preferable since it's usually the case the szurubooru is being run behind a reverse proxy.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
