### PR TITLE
vrcx: 2025.09.10 -> 2025.10.11

### DIFF
--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -11,35 +11,38 @@
   stdenv,
 }:
 let
-  dotnet = dotnetCorePackages.dotnet_9;
   electron = electron_37;
+  dotnet = dotnetCorePackages.dotnet_9;
 in
 buildNpmPackage (finalAttrs: {
   pname = "vrcx";
-  version = "2025.09.10";
+  version = "2025.10.11";
 
   src = fetchFromGitHub {
-    owner = "vrcx-team";
     repo = "VRCX";
-    rev = "b233bbc299fca9a956db387b83d90a4dbba61175";
-    hash = "sha256-7axYnsImG+VllQE1rhr8NmuMCm5t3bgNYGIIn9j2wMk=";
+    owner = "vrcx-team";
+    rev = "cb6bc979d9371b89b289b6cb0bb8b6f60b350bc7";
+    hash = "sha256-0LnFXSLyby5b2gSIse7Qld4cQlwNAFHSuGGqk6B9TZY=";
   };
 
-  npmDepsHash = "sha256-VFYWXPhZrg3q2PW4kWfVr5/DY8W6Uf1mvnwfB4mVBrs=";
-  npmFlags = [ "--ignore-scripts" ];
   makeCacheWritable = true;
+  npmFlags = [ "--ignore-scripts" ];
+  npmDepsHash = "sha256-giWeXrsiFaZOh5zs7L4L0w3wcnD/F3TyrMM/POfOTvE=";
 
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
   ];
 
+  preBuild = ''
+    # Build fails at executing dart from sass-embedded
+    rm -r node_modules/sass-embedded*
+  '';
+
   buildPhase = ''
     runHook preBuild
 
-    # need to run vue-demi postinstall for pinia
-    node ./node_modules/vue-demi/scripts/postinstall.js
-    env PLATFORM=linux npm exec webpack -- --config webpack.config.js --mode production
+    env PLATFORM=linux npm exec vite build src
     node ./src-electron/patch-package-version.js
     npm exec electron-builder -- --dir \
       -c.electronDist=${electron.dist} \
@@ -64,7 +67,7 @@ buildNpmPackage (finalAttrs: {
       --set DOTNET_ROOT ${dotnet.runtime}/share/dotnet      \
       --prefix PATH : ${lib.makeBinPath [ dotnet.runtime ]}
 
-    install -Dm644 VRCX.png "$out/share/icons/hicolor/256x256/apps/vrcx.png"
+    install -Dm644 images/VRCX.png "$out/share/icons/hicolor/256x256/apps/vrcx.png"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vrcx-team/VRCX/releases/tag/v2025.10.11
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
