### PR TITLE
python3Packages.snitun: 0.45.0 -> 0.45.1

### DIFF
--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   aiohttp,
-  async-timeout,
-  attrs,
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
@@ -11,22 +9,19 @@
   pytest-codspeed,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "snitun";
-  version = "0.45.0";
+  version = "0.45.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "NabuCasa";
     repo = "snitun";
     tag = version;
-    hash = "sha256-LAl6En7qMiGeKciY6UIOgtfaCdHqx/T/ohv9vQvk9gE=";
+    hash = "sha256-luXv5J0PUvW+AGTecwkEq+qkG1N5Ja5NbBKJ3M6HC0I=";
   };
 
   postPatch = ''
@@ -38,8 +33,6 @@ buildPythonPackage rec {
 
   dependencies = [
     aiohttp
-    async-timeout
-    attrs
     cryptography
   ];
 
@@ -49,35 +42,13 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # AssertionError: Expected 'fileno' to not have been called. Called 1 times.
-    "test_client_stop_no_wait"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     "test_multiplexer_data_channel_abort_full" # https://github.com/NabuCasa/snitun/issues/61
     # port binding conflicts
     "test_snitun_single_runner_timeout"
     "test_snitun_single_runner_throttling"
     # ConnectionResetError: [Errno 54] Connection reset by peer
     "test_peer_listener_timeout"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.12") [
-    # blocking
-    "test_flow_client_peer"
-    "test_close_client_peer"
-    "test_init_connector"
-    "test_flow_connector"
-    "test_close_connector_remote"
-    "test_init_connector_whitelist"
-    "test_init_multiplexer_server"
-    "test_init_multiplexer_client"
-    "test_init_multiplexer_server_throttling"
-    "test_init_multiplexer_client_throttling"
-    "test_multiplexer_ping"
-    "test_multiplexer_ping_error"
-    "test_multiplexer_init_channel_full"
-    "test_multiplexer_close_channel_full"
-    "test_init_dual_peer_with_multiplexer"
   ];
 
   pythonImportsCheck = [ "snitun" ];


### PR DESCRIPTION
Diff: https://github.com/NabuCasa/snitun/compare/0.45.0...0.45.1

Changelog: https://github.com/NabuCasa/snitun/releases/tag/0.45.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
