### PR TITLE
rode-central: init at 2.0.101-212

### DIFF
--- a/pkgs/by-name/ro/rode-central/package.nix
+++ b/pkgs/by-name/ro/rode-central/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  cpio,
+  gzip,
+  xar,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rode-central";
+  version = "2.0.101-212";
+
+  # archive.org link used because the url is not stable and is updated frequently with new versions
+  src = fetchzip {
+    url = "https://web.archive.org/web/20250730140348/https://update.rode.com/central/RODE_Central_MACOS.zip";
+    hash = "sha256-qgOosVOETeIbKBUhRvp2WGaO0mWEceOjtahF0fYrZ1E=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cpio
+    gzip
+    xar
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    xar -xf $src/RØDE\ Central\ \(${finalAttrs.version}\).pkg
+    zcat RodeCentral.pkg/Payload | cpio -i
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    mv Applications/RODE\ Central.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Companion app for configuring compatible RØDE devices, unlocking advanced features, enabling or disabling functions and updating firmware";
+    homepage = "https://rode.com/en-us/apps/rode-central";
+    changelog = "https://rode.com/en-us/release-notes/rode-central";
+    license = [ lib.licenses.unfree ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    platforms = lib.platforms.darwin;
+    hydraPlatforms = [ ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Homepage: https://rode.com/en-us/apps/rode-central

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
