### PR TITLE
tt-smi: move to by-name

### DIFF
--- a/nixos/modules/hardware/tenstorrent.nix
+++ b/nixos/modules/hardware/tenstorrent.nix
@@ -24,7 +24,7 @@ in
     ];
 
     environment.systemPackages = with pkgs; [
-      python3Packages.tt-smi
+      tt-smi
       tt-system-tools
     ];
   };

--- a/pkgs/by-name/tt/tt-smi/package.nix
+++ b/pkgs/by-name/tt/tt-smi/package.nix
@@ -1,21 +1,11 @@
 {
   lib,
-  buildPythonPackage,
+  python3Packages,
   fetchFromGitHub,
-  pythonOlder,
-  setuptools,
-  distro,
-  elasticsearch,
-  pydantic,
-  pyluwen,
-  rich,
-  textual,
   pre-commit,
-  importlib-resources,
-  tt-tools-common,
-  tomli,
+  versionCheckHook,
 }:
-buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "tt-smi";
   version = "3.0.30";
   pyproject = true;
@@ -27,13 +17,11 @@ buildPythonPackage rec {
     hash = "sha256-C6CfcS0H3rFew/Y1uhmzICdFp1UYU7H9h3YPeAKlcbE=";
   };
 
-  disabled = pythonOlder "3.13";
-
-  build-system = [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = [
+  dependencies = with python3Packages; [
     distro
     elasticsearch
     pydantic
@@ -47,10 +35,17 @@ buildPythonPackage rec {
     tomli
   ];
 
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
   # Fails due to having no tests
   dontUsePytestCheck = true;
 
+  versionCheckProgramArg = "--version";
+
   meta = {
+    mainProgram = "tt-smi";
     description = "Tenstorrent console based hardware information program";
     homepage = "https://github.com/tenstorrent/tt-smi";
     maintainers = with lib.maintainers; [ RossComputerGuy ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18851,8 +18851,6 @@ self: super: with self; {
 
   tt-flash = callPackage ../development/python-modules/tt-flash { };
 
-  tt-smi = callPackage ../development/python-modules/tt-smi { };
-
   tt-tools-common = callPackage ../development/python-modules/tt-tools-common { };
 
   ttach = callPackage ../development/python-modules/ttach { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
