### PR TITLE
vscode-extensions.prince781.vala: fix vala language server path

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/prince781.vala/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prince781.vala/default.nix
@@ -2,6 +2,8 @@
   lib,
   vala-language-server,
   vscode-utils,
+  jq,
+  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -13,8 +15,14 @@ vscode-utils.buildVscodeMarketplaceExtension {
   };
 
   nativeBuildInputs = [
-    vala-language-server
+    jq
+    moreutils
   ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration.properties."vala.languageServerPath".default = "${lib.getExe vala-language-server}"' package.json | sponge package.json
+  '';
 
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/prince781.vala/changelog";


### PR DESCRIPTION
Missed this in the PR I approved (https://github.com/NixOS/nixpkgs/pull/451273) and also experienced a false positive given that VLS is on my PATH.

To test this:

```bash
nix-build --expr '
let
  src  = builtins.fetchTarball
    "https://github.com/matteo-pacini/nixpkgs/archive/vala-vscode-ext-fix.tar.gz";
  pkgs = import src { config.allowUnfree = true; };
in
pkgs.vscode-with-extensions.override {
  vscode = pkgs.vscode; 
  vscodeExtensions = with pkgs.vscode-extensions; [
    prince781.vala
  ];
}'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
