### PR TITLE
libultrahdr: init at 1.4.0

### DIFF
--- a/pkgs/by-name/li/libultrahdr/gtest.patch
+++ b/pkgs/by-name/li/libultrahdr/gtest.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5128335..bacf495 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -536,16 +536,6 @@ if(UHDR_BUILD_TESTS)
+     set(GTEST_LIB_PREFIX ${GTEST_BINARY_DIR}/lib/)
+   endif()
+   set(GTEST_BOTH_LIBRARIES ${GTEST_LIB_PREFIX}${GTEST_LIB} ${GTEST_LIB_PREFIX}${GTEST_LIB_MAIN})
+-  ExternalProject_Add(${GTEST_TARGET_NAME}
+-      GIT_REPOSITORY https://github.com/google/googletest
+-      GIT_TAG v1.14.0
+-      PREFIX ${GTEST_PREFIX_DIR}
+-      SOURCE_DIR ${GTEST_SOURCE_DIR}
+-      BINARY_DIR ${GTEST_BINARY_DIR}
+-      CMAKE_ARGS ${UHDR_CMAKE_ARGS}
+-      BUILD_BYPRODUCTS ${GTEST_BOTH_LIBRARIES}
+-      INSTALL_COMMAND ""
+-  )
+ endif()
+ 
+ if(UHDR_BUILD_BENCHMARK)
+@@ -675,16 +665,15 @@ endif()
+ 
+ if(UHDR_BUILD_TESTS)
+   add_executable(ultrahdr_unit_test ${UHDR_TEST_SRCS_LIST})
+-  add_dependencies(ultrahdr_unit_test ${GTEST_TARGET_NAME} ${UHDR_CORE_LIB_NAME})
+   target_compile_options(ultrahdr_unit_test PRIVATE ${UHDR_WERROR_FLAGS})
+   target_include_directories(ultrahdr_unit_test PRIVATE
+     ${PRIVATE_INCLUDE_DIR}
+-    ${GTEST_INCLUDE_DIRS}
++    @GTEST_INCLUDE_DIRS@
+   )
+   if(UHDR_BUILD_FUZZERS)
+     target_link_options(ultrahdr_unit_test PRIVATE -fsanitize=fuzzer-no-link)
+   endif()
+-  target_link_libraries(ultrahdr_unit_test ${UHDR_CORE_LIB_NAME} ${GTEST_BOTH_LIBRARIES})
++  target_link_libraries(ultrahdr_unit_test ${UHDR_CORE_LIB_NAME} -lgtest -lgtest_main)
+   add_test(NAME UHDRUnitTests, COMMAND ultrahdr_unit_test)
+ endif()

--- a/pkgs/by-name/li/libultrahdr/package.nix
+++ b/pkgs/by-name/li/libultrahdr/package.nix
@@ -1,0 +1,97 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  replaceVars,
+  cmake,
+  ninja,
+  pkg-config,
+  libjpeg,
+  gtest,
+  ctestCheckHook,
+  versionCheckHook,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "1.4.0";
+  pname = "libultrahdr";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "libultrahdr";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SLhHiwuyHzVx/Kv+eBy8LzHTnShKXlJoszxZNPATbhs=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    (replaceVars ./gtest.patch {
+      GTEST_INCLUDE_DIRS = "${lib.getDev gtest}/include";
+    })
+  ];
+
+  # CMake incorrect absolute include/lib paths: https://github.com/NixOS/nixpkgs/issues/144170
+  postPatch = ''
+    substituteInPlace cmake/libuhdr.pc.in \
+      --replace-fail \
+        'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' \
+        'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail \
+        'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
+        'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "UHDR_BUILD_TESTS" true)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    libjpeg
+    gtest
+  ];
+
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
+  doCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Reference codec for the Ultra HDR format";
+    longDescription = ''
+      Ultra HDR is a true HDR image format, and is backcompatible. libultrahdr
+      is the reference codec for the Ultra HDR format. The codecs that support
+      the format can render the HDR intent of the image on HDR displays; other
+      codecs can still decode and display the SDR intent of the image.
+    '';
+    homepage = "https://developer.android.com/media/platform/hdr-image-format";
+    changelog = "https://github.com/google/libultrahdr/releases/tag/v${finalAttrs.version}";
+    pkgConfigModules = [ "libuhdr" ];
+    maintainers = with lib.maintainers; [
+      yzx9
+    ];
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [
+      asl20
+    ];
+    mainProgram = "ultrahdr_app";
+  };
+})

--- a/pkgs/by-name/op/openimageio/package.nix
+++ b/pkgs/by-name/op/openimageio/package.nix
@@ -11,6 +11,7 @@
   libwebp,
   libjxl,
   libheif,
+  libultrahdr,
   opencolorio,
   openexr,
   openjph,
@@ -53,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libtiff
     libwebp
+    libultrahdr
     opencolorio
     openexr
     openjph


### PR DESCRIPTION
Ultra HDR is a true HDR image format, and is backcompatible. libultrahdr is the reference codec for the Ultra HDR format. The codecs that support the format can render the HDR intent of the image on HDR displays; other codecs can still decode and display the SDR intent of the image. 
- Homepage: https://github.com/google/libultrahdr

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
