### PR TITLE
Substitute `_IMPORT_PREFIX` in WiresharkTargets-release.cmake

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -200,6 +200,8 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    substituteInPlace $dev/lib/cmake/wireshark/WiresharkTargets-release.cmake \
+      --replace-fail "\''${_IMPORT_PREFIX}" "$out"
   '';
 
   # This is done to remove some binary wrappers that wrapQtApps adds in *.app directories.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I updated the `preFixup` phase in the wireshark derivation to patch the `/nix/store/<hash>-wireshark-qt-4.4.9-dev/WiresharkTargets-release.cmake` file, which in mainline nixpkgs looks like the following:
```cmake
# Import target "epan" for configuration "Release"
set_property(TARGET epan APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
set_target_properties(epan PROPERTIES
  IMPORTED_LINK_DEPENDENT_LIBRARIES_RELEASE "wiretap"
  IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libwireshark.18.0.9.dylib"
  IMPORTED_SONAME_RELEASE "/nix/store/s9rq3pgyakgxd9p7vwhp1ba0nc1wg6rw-wireshark-qt-4.4.9/lib/libwireshark.18.dylib"
  )
...
```
Thus artifacts such as `libwireshark.18.0.9.dylib` are resolved to the "dev" output instead of the "out" output. I confirmed that a CMake project is now able to build against nixpkgs's wireshark with `-DCMAKE_PREFIX_PATH='/nix/store/<hash>-wireshark-qt-4.4.9-dev'`, which wasn't the case before:
```console
CMake Error at /nix/store/br7zs90hbd7d3fhkfgjjf7ln0w2zq210-wireshark-qt-4.4.9-dev/lib/cmake/wireshark/WiresharkTargets.cmake:101 (message):
  The imported target "epan" references the file

     "/nix/store/br7zs90hbd7d3fhkfgjjf7ln0w2zq210-wireshark-qt-4.4.9-dev/lib/libwireshark.18.0.9.dylib"

  but this file does not exist.
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
