### PR TITLE
 lidarr: 2.13.3.4711 -> 2.14.5.4836

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21429,6 +21429,12 @@
     githubId = 14829269;
     name = "Ram Kromberg";
   };
+  ramonacat = {
+    email = "ramona@luczkiewi.cz";
+    github = "ramonacat";
+    githubId = 303398;
+    name = "ramona";
+  };
   rampoina = {
     email = "rampoina@protonmail.com";
     matrix = "@rampoina:matrix.org";

--- a/pkgs/by-name/li/lidarr/package.nix
+++ b/pkgs/by-name/li/lidarr/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     description = "Usenet/BitTorrent music downloader";
     homepage = "https://lidarr.audio/";
     license = licenses.gpl3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ramonacat ];
     mainProgram = "Lidarr";
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/li/lidarr/package.nix
+++ b/pkgs/by-name/li/lidarr/package.nix
@@ -2,11 +2,9 @@
   lib,
   stdenv,
   fetchurl,
-  mono,
   libmediainfo,
   sqlite,
   curl,
-  chromaprint,
   makeWrapper,
   icu,
   dotnet-runtime,
@@ -34,13 +32,14 @@ let
     }
     ."${arch}-${os}_hash";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lidarr";
   version = "2.14.5.4836";
 
   src = fetchurl {
-    url = "https://github.com/lidarr/Lidarr/releases/download/v${version}/Lidarr.master.${version}.${os}-core-${arch}.tar.gz";
-    sha256 = hash;
+    inherit hash;
+
+    url = "https://github.com/lidarr/Lidarr/releases/download/v${finalAttrs.version}/Lidarr.master.${finalAttrs.version}.${os}-core-${arch}.tar.gz";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -48,10 +47,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share/${pname}-${version}}
-    cp -r * $out/share/${pname}-${version}/.
+    mkdir -p $out/{bin,share/${finalAttrs.pname}-${finalAttrs.version}}
+    cp -r * $out/share/${finalAttrs.pname}-${finalAttrs.version}/.
     makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Lidarr \
-      --add-flags "$out/share/${pname}-${version}/Lidarr.dll" \
+      --add-flags "$out/share/${finalAttrs.pname}-${finalAttrs.version}/Lidarr.dll" \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
           curl
@@ -71,10 +70,10 @@ stdenv.mkDerivation rec {
     tests.smoke-test = nixosTests.lidarr;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Usenet/BitTorrent music downloader";
     homepage = "https://lidarr.audio/";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ramonacat ];
     mainProgram = "Lidarr";
     platforms = [
@@ -84,4 +83,4 @@ stdenv.mkDerivation rec {
       "aarch64-darwin"
     ];
   };
-}
+})

--- a/pkgs/by-name/li/lidarr/package.nix
+++ b/pkgs/by-name/li/lidarr/package.nix
@@ -27,16 +27,16 @@ let
     ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   hash =
     {
-      x64-linux_hash = "sha256-24bNK4iHgaobxYpy+OJAocGugV0CwF3q1ND6maEaYSY=";
-      arm64-linux_hash = "sha256-ck2AspRkKm8hdzO70acTGUUd8WTOevIJF50YwQf/R20=";
-      x64-osx_hash = "sha256-ut/4154i/yKlm2JacgW9jvevDniedzLudfeuUXV9XzM=";
-      arm64-osx_hash = "sha256-/aIusVUmsqLCNNhosCAVbR5oN6oLROEuJKnH22cRXfo=";
+      x64-linux_hash = "sha256-LeJBed6Zo2+r6ZdgBTkcg+3ORoohvDpx37gOOorg9wY=";
+      arm64-linux_hash = "sha256-eS4MccKhISJBc68lhrYwbESV0FcqtAI/b4ojfQO/9m8=";
+      x64-osx_hash = "sha256-l3hi+X91DQNmGZKNJ4Y/DkB7ohu0/HTTnhSInIBiPlo=";
+      arm64-osx_hash = "sha256-ehZJZKxEiupLyBZCgz2subtD7BICXjAqIdnOnh+OMe4=";
     }
     ."${arch}-${os}_hash";
 in
 stdenv.mkDerivation rec {
   pname = "lidarr";
-  version = "2.13.3.4711";
+  version = "2.14.5.4836";
 
   src = fetchurl {
     url = "https://github.com/lidarr/Lidarr/releases/download/v${version}/Lidarr.master.${version}.${os}-core-${arch}.tar.gz";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
