### PR TITLE
deadbeef: remove gtk2, cleanup

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -144,6 +144,8 @@
     and backwards incompatible database migrations. Ensure backups are valid and run a Full Scan after
     starting the new version.
 
+- `deabbeef` no longer support `gtk2`.
+
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.
 
 - `fetchFromBitBucket` has gained a `fetchgit` backend when passing in git-related arguments similar to `fetchFromGitHub`.

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -10,10 +10,6 @@
   pkg-config,
   jansson,
   swift-corelibs-libdispatch,
-  # deadbeef can use either gtk2 or gtk3
-  gtk2Support ? false,
-  gtk2,
-  gtk3Support ? true,
   gtk3,
   gsettings-desktop-schemas,
   wrapGAppsHook3,
@@ -65,8 +61,6 @@
   curl,
 }:
 
-assert gtk2Support || gtk3Support;
-
 let
   inherit (lib) optionals;
 
@@ -87,11 +81,6 @@ clangStdenv.mkDerivation {
   buildInputs = [
     jansson
     swift-corelibs-libdispatch
-  ]
-  ++ optionals gtk2Support [
-    gtk2
-  ]
-  ++ optionals gtk3Support [
     gtk3
     gsettings-desktop-schemas
   ]
@@ -163,8 +152,6 @@ clangStdenv.mkDerivation {
     intltool
     libtool
     pkg-config
-  ]
-  ++ optionals gtk3Support [
     wrapGAppsHook3
   ];
 

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -3,8 +3,7 @@
   config,
   clangStdenv,
   fetchFromGitHub,
-  autoconf,
-  automake,
+  autoreconfHook,
   libtool,
   intltool,
   pkg-config,
@@ -147,8 +146,7 @@ clangStdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     intltool
     libtool
     pkg-config
@@ -156,17 +154,6 @@ clangStdenv.mkDerivation {
   ];
 
   enableParallelBuilding = true;
-
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
-  postPatch = ''
-    # Fix the build on c++17 compiler:
-    #   https://github.com/DeaDBeeF-Player/deadbeef/issues/3012
-    # TODO: remove after 1.9.5 release.
-    substituteInPlace plugins/adplug/Makefile.am --replace 'adplug_la_CXXFLAGS = ' 'adplug_la_CXXFLAGS = -std=c++11 '
-  '';
 
   meta = with lib; {
     description = "Ultimate Music Player for GNU/Linux";


### PR DESCRIPTION
- part of #410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
