### PR TITLE
python3Packages.pymbolic: 2024.2.2 -> 2025.1

### DIFF
--- a/pkgs/development/python-modules/firedrake/default.nix
+++ b/pkgs/development/python-modules/firedrake/default.nix
@@ -36,6 +36,7 @@
   sympy,
   islpy,
   matplotlib,
+  immutabledict,
 
   # tests
   pytest,
@@ -129,6 +130,8 @@ buildPythonPackage rec {
     sympy
     # required by script spydump
     matplotlib
+    # required by pyop2
+    immutabledict
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     islpy

--- a/pkgs/development/python-modules/pymbolic/default.nix
+++ b/pkgs/development/python-modules/pymbolic/default.nix
@@ -7,8 +7,9 @@
   hatchling,
 
   # dependencies
-  immutabledict,
+  constantdict,
   pytools,
+  typing-extensions,
 
   # optional-dependencies
   matchpy,
@@ -20,21 +21,22 @@
 
 buildPythonPackage rec {
   pname = "pymbolic";
-  version = "2024.2.2";
+  version = "2025.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "inducer";
     repo = "pymbolic";
     tag = "v${version}";
-    hash = "sha256-07RWdEPhO+n9/FOvIWe4nm9fGekut9X6Tz4HlIkBSpo=";
+    hash = "sha256-cn2EdhMn5qjK854AF5AY4Hv4M5Ib6gPRJk+kQvsFWRk=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
-    immutabledict
+    constantdict
     pytools
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -51,6 +53,6 @@ buildPythonPackage rec {
     homepage = "https://documen.tician.de/pymbolic/";
     changelog = "https://github.com/inducer/pymbolic/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ qbisi ];
   };
 }


### PR DESCRIPTION
changelog: https://github.com/inducer/pymbolic/releases/tag/v2025.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
