### PR TITLE
workflows/bot: set "merge-bot eligible" label

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -112,7 +112,7 @@ module.exports = async ({ github, context, core, dry }) => {
 
     const maintainers = await getMaintainerMap(pull_request.base.ref)
 
-    await handleMerge({
+    const merge_bot_eligible = await handleMerge({
       github,
       context,
       core,
@@ -199,6 +199,7 @@ module.exports = async ({ github, context, core, dry }) => {
       // The second pass will then read the result from the first pass and set the label.
       '2.status: merge conflict':
         merge_commit_sha_valid && !pull_request.merge_commit_sha,
+      '2.status: merge-bot eligible': merge_bot_eligible,
       '12.approvals: 1': approvals.size === 1,
       '12.approvals: 2': approvals.size === 2,
       '12.approvals: 3+': approvals.size >= 3,

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -251,6 +251,10 @@ async function handleMerge({
 
     if (canMerge) break
   }
+
+  // Returns a boolean, which indicates whether the PR is merge-bot eligible in principle.
+  // This is used to set the respective label in bot.js.
+  return result
 }
 
 module.exports = {


### PR DESCRIPTION
This makes it more visible which PRs are merge-bot eligible, by setting a label respectively.

~The label will be unset 90 days after the last CI run, because the artifacts will expire at this stage and we can't determine whether there are any eligible maintainers for merge. Every maintainer can re-trigger CI by closing and re-opening the PR.~

Simple solution to resolve #378214.

## Things done

- [x] Created new label.
- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
