### PR TITLE
carla: remove gtk2

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -136,6 +136,8 @@
 
 - Greetd and its original greeters (`tuigreet`, `gtkgreet`, `qtgreet`, `regreet`, `wlgreet`) were moved from `greetd` namespace to top level (`greetd.tuigreet` -> `tuigreet`, `greetd.greetd` -> `greetd`, etc). The original attrs are available for compatibility as passthrus of `greetd`, but will emit a warning. They will be removed in future releases.
 
+- `carla` no longer support `gtk2` override.
+
 - The `archipelago-minecraft` package was removed, as upstream no longer provides support for the Minecraft APWorld.
 
 - `pcp` has been removed because the upstream repo was archived and it hasn't been updated since 2021.

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   alsa-lib,
   file,
   fluidsynth,
@@ -13,11 +12,9 @@
   pkg-config,
   python3Packages,
   which,
-  gtk2 ? null,
   gtk3 ? null,
   qtbase ? null,
   withFrontend ? true,
-  withGtk2 ? true,
   withGtk3 ? true,
   withQt ? true,
   wrapQtAppsHook ? null,
@@ -62,7 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
   ]
   ++ lib.optional withQt qtbase
-  ++ lib.optional withGtk2 gtk2
   ++ lib.optional withGtk3 gtk3;
 
   propagatedBuildInputs = finalAttrs.pythonPath;
@@ -77,11 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
         filename="$(basename -- "$file")"
         substituteInPlace "$file" --replace-fail '--with-appname="$0"' "--with-appname=\"$filename\""
     done
-  ''
-  + lib.optionalString withGtk2 ''
-    # Will try to dlopen() libgtk-x11-2.0 at runtime when using the bridge.
-    substituteInPlace source/bridges-ui/Makefile \
-        --replace-fail '$(CXX) $(OBJS_GTK2)' '$(CXX) $(OBJS_GTK2) -lgtk-x11-2.0'
   '';
 
   dontWrapQtApps = true;


### PR DESCRIPTION
- Part of #410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
