### PR TITLE
workflows/bot: allow maintainers to merge backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -57,8 +57,9 @@ jobs:
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 
-            * [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
-              * Even as a non-committer, if you find that it is not acceptable, leave a comment.
+            **Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).**
+
+            Even as a non-committer, if you find that it is not acceptable, leave a comment.
 
       - name: Log current API rate limits
         env:

--- a/ci/README.md
+++ b/ci/README.md
@@ -42,10 +42,11 @@ These issues effectively list PRs the merge bot has interacted with.
 
 To ensure security and a focused utility, the bot adheres to specific limitations:
 
-- The PR targets `master`, `staging`, or `staging-next`.
+- The PR targets one of the [development branches](#branch-classification).
 - The PR only touches packages located under `pkgs/by-name/*`.
 - The PR is either:
-  - authored by a [committer][@NixOS/nixpkgs-committers], or
+  - authored by a [committer][@NixOS/nixpkgs-committers],
+  - backported via label, or
   - created by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).
 - The user attempting to merge is a member of [@NixOS/nixpkgs-maintainers].
 - The user attempting to merge is a maintainer of all packages touched by the PR.

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -1,3 +1,5 @@
+const { classify } = require('../supportedBranches.js')
+
 function runChecklist({
   committers,
   files,
@@ -22,14 +24,14 @@ function runChecklist({
         .reduce((acc, cur) => acc?.intersection(cur) ?? cur)
 
   const checklist = {
-    'PR targets one of the allowed branches: master, staging, staging-next.': [
-      'master',
-      'staging',
-      'staging-next',
-    ].includes(pull_request.base.ref),
+    'PR targets a [development branch](https://github.com/NixOS/nixpkgs/blob/-/ci/README.md#branch-classification).':
+      classify(pull_request.base.ref).type.includes('development'),
     'PR touches only packages in `pkgs/by-name/`.': allByName,
     'PR is at least one of:': {
       'Authored by a committer.': committers.has(pull_request.user.id),
+      'Backported via label.':
+        pull_request.user.login === 'nixpkgs-ci[bot]' &&
+        pull_request.head.ref.startsWith('backport-'),
       'Created by r-ryantm.': pull_request.user.login === 'r-ryantm',
     },
   }


### PR DESCRIPTION
*(only the last commit belongs to this PR, everything else is part of #457652)*

All other conditions equal, there is no reason to prevent maintainers from backporting changes to their packages. Maintainers are probably in the *best* position to tell whether a certain change is backportable or not - because they know the package well.

Resolves https://github.com/NixOS/nixpkgs-merge-bot/issues/196, Supersedes https://github.com/NixOS/nixpkgs-merge-bot/pull/204.

## Things done

- [x] [Approvals from nixpkgs-core](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#nixpkgs-merge-bot), because this increases the scope of the merge-bot.
- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
