### PR TITLE
maintainers: drop raroh73

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21482,12 +21482,6 @@
     githubId = 11351304;
     name = "Ricardo Ardissone";
   };
-  raroh73 = {
-    email = "me@raroh73.com";
-    github = "Raroh73";
-    githubId = 96078496;
-    name = "Raroh73";
-  };
   rasendubi = {
     email = "rasen.dubi@gmail.com";
     github = "rasendubi";

--- a/nixos/modules/services/web-apps/commafeed.nix
+++ b/nixos/modules/services/web-apps/commafeed.nix
@@ -111,5 +111,5 @@ in
     };
   };
 
-  meta.maintainers = [ lib.maintainers.raroh73 ];
+  meta.maintainers = [ ];
 }

--- a/nixos/tests/commafeed.nix
+++ b/nixos/tests/commafeed.nix
@@ -15,5 +15,5 @@
     server.succeed("curl --fail --silent http://localhost:8082")
   '';
 
-  meta.maintainers = [ lib.maintainers.raroh73 ];
+  meta.maintainers = [ ];
 }

--- a/pkgs/applications/editors/vscode/extensions/continue.continue/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/continue.continue/default.nix
@@ -41,10 +41,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=Continue.continue";
     homepage = "https://github.com/continuedev/continue";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      raroh73
-      flacks
-    ];
+    maintainers = with lib.maintainers; [ flacks ];
     platforms = [
       "x86_64-linux"
       "x86_64-darwin"

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3871,7 +3871,7 @@ let
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml";
           homepage = "https://github.com/redhat-developer/vscode-yaml";
           license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.raroh73 ];
+          maintainers = [ ];
         };
       };
 
@@ -5386,7 +5386,7 @@ let
           downloadPage = "https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one";
           homepage = "https://github.com/yzhang-gh/vscode-markdown";
           license = lib.licenses.mit;
-          maintainers = [ lib.maintainers.raroh73 ];
+          maintainers = [ ];
         };
       };
 

--- a/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
@@ -26,6 +26,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck";
     homepage = "https://github.com/vscode-shellcheck/vscode-shellcheck";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.raroh73 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/commafeed/package.nix
+++ b/pkgs/by-name/co/commafeed/package.nix
@@ -101,6 +101,6 @@ maven.buildMavenPackage {
     homepage = "https://github.com/Athou/commafeed";
     license = lib.licenses.asl20;
     mainProgram = "commafeed";
-    maintainers = [ lib.maintainers.raroh73 ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
