### PR TITLE
nixos/systemd/shutdown: make bashless

### DIFF
--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -32,8 +32,6 @@
   boot.kexec.enable = lib.mkDefault false;
   # Relies on bash scripts
   powerManagement.enable = lib.mkDefault false;
-  # Has some bash inside
-  systemd.shutdownRamfs.enable = lib.mkDefault false;
   # Relies on the gzip command which depends on bash
   services.logrotate.enable = lib.mkDefault false;
 

--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -36,8 +36,6 @@
   systemd.shutdownRamfs.enable = lib.mkDefault false;
   # Relies on the gzip command which depends on bash
   services.logrotate.enable = lib.mkDefault false;
-  # Service relies on bash scripts
-  services.timesyncd.enable = lib.mkDefault false;
 
   # Check that the system does not contain a Nix store path that contains the
   # string "bash".

--- a/nixos/modules/system/boot/systemd/shutdown.nix
+++ b/nixos/modules/system/boot/systemd/shutdown.nix
@@ -71,9 +71,21 @@ in
 
       serviceConfig = {
         Type = "oneshot";
+        ExecStart = "${pkgs.makeInitrdNGTool}/bin/make-initrd-ng ${ramfsContents} /run/initramfs";
+
+        # Sandboxing
         ProtectSystem = "strict";
         ReadWritePaths = "/run/initramfs";
-        ExecStart = "${pkgs.makeInitrdNGTool}/bin/make-initrd-ng ${ramfsContents} /run/initramfs";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        PrivateNetwork = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
       };
     };
   };

--- a/nixos/modules/system/boot/systemd/shutdown.nix
+++ b/nixos/modules/system/boot/systemd/shutdown.nix
@@ -17,6 +17,7 @@ in
     enable = lib.mkEnableOption "pivoting back to an initramfs for shutdown" // {
       default = true;
     };
+
     contents = lib.mkOption {
       description = "Set of files that have to be linked into the shutdown ramfs";
       example = lib.literalExpression ''
@@ -34,6 +35,22 @@ in
       type = utils.systemdUtils.types.initrdStorePath;
       default = [ ];
     };
+
+    shell.enable = lib.mkEnableOption "" // {
+      default = config.environment.shell.enable;
+      internal = true;
+      description = ''
+        Whether to enable a shell in the shutdown ramfs.
+
+        In contrast to `environment.shell.enable`, this option actually
+        strictly disables all shells in the shutdown ramfs because they're not
+        copied into it anymore. Paths that use a shell (e.g. via the `script`
+        option), will break if this option is set.
+
+        Only set this option if you're sure that you can recover from potential
+        issues.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -43,8 +60,10 @@ in
       "/etc/os-release".source = config.environment.etc.os-release.source;
     };
     systemd.shutdownRamfs.storePaths = [
-      pkgs.runtimeShell
       "${pkgs.coreutils}/bin"
+    ]
+    ++ lib.optionals cfg.shell.enable [
+      pkgs.runtimeShell
     ]
     ++ map (c: builtins.removeAttrs c [ "text" ]) (builtins.attrValues cfg.contents);
 


### PR DESCRIPTION
- Re-enable systemd-timesyncd in the bashless profile since [it's bashless now](https://github.com/NixOS/nixpkgs/pull/449937) 
- Add more sandboxing options to generate-shutdown-ramfs
- Make shutdown ramfs bashless and re-enable it in the bashless profile

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
