### PR TITLE
workflows/bot: allow maintainer merges after committer approval

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -45,8 +45,9 @@ To ensure security and a focused utility, the bot adheres to specific limitation
 - The PR targets one of the [development branches](#branch-classification).
 - The PR only touches packages located under `pkgs/by-name/*`.
 - The PR is either:
-  - authored by a [committer][@NixOS/nixpkgs-committers],
-  - backported via label, or
+  - approved by a [committer][@NixOS/nixpkgs-committers].
+  - authored by a [committer][@NixOS/nixpkgs-committers].
+  - backported via label.
   - created by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).
 - The user attempting to merge is a member of [@NixOS/nixpkgs-maintainers].
 - The user attempting to merge is a maintainer of all packages touched by the PR.


### PR DESCRIPTION
*(only the last commit belongs to this PR, everything else is part of #457652)*

This allows committers to approve PRs with additional, optional nits that the author-maintainer can either address or merge immediately without these changes.

It also allows committers to approve a PR for merge, while still waiting for other maintainers to give their feedback - they can then merge the PR directly instead of passing it back to the committer.

Resolves https://github.com/NixOS/nixpkgs-merge-bot/issues/232

## Things done

- [x] [Approvals from nixpkgs-core](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#nixpkgs-merge-bot), because this increases the scope of the merge-bot.
- [x] Very basic testing locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
