### PR TITLE
haskellPackages.gi-gtk-hs: Fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3363,6 +3363,25 @@ with haskellLib;
   stripe-signature = doJailbreak super.stripe-signature;
   stripe-wreq = doJailbreak super.stripe-wreq;
 
+  # 2025-10-12: gi-gtk was renamed to gi-gtk3
+  # https://github.com/haskell-gi/haskell-gi/issues/478
+  gi-gtk-hs =
+    appendPatches
+      [
+        (pkgs.fetchpatch {
+          name = "gi-gtk-hs-use-gtk3.patch";
+          url = "https://github.com/haskell-gi/haskell-gi/commit/e2ed85835499f70e119f050a2f37f22481f93886.patch";
+          sha256 = "sha256-MzxXtBNBbJJaNwTOrq/CYqK4yGfS4Yk5fQ38ihFcclA=";
+          relative = "gi-gtk-hs";
+        })
+      ]
+      (
+        super.gi-gtk-hs.override {
+          gi-gdk = self.gi-gdk3;
+          gi-gtk = self.gi-gtk3;
+        }
+      );
+
   # 2025-08-04: Disable failing testcases. It would feel bad to disable all the
   # checks in a cryptography related package.
   botan-low = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2169,7 +2169,6 @@ broken-packages:
   - gi-gstapp # failure in job https://hydra.nixos.org/build/253686159 at 2024-03-31
   - gi-gsttag # failure in job https://hydra.nixos.org/build/233197576 at 2023-09-02
   - gi-gtk-declarative # failure in job https://hydra.nixos.org/build/307610571 at 2025-09-19
-  - gi-gtk-hs # failure in job https://hydra.nixos.org/build/307610574 at 2025-09-19
   - gi-gtk4-layer-shell # failure in job https://hydra.nixos.org/build/302803068 at 2025-07-27
   - gi-gtksheet # failure in job https://hydra.nixos.org/build/233211386 at 2023-09-02
   - gi-ibus # failure in job https://hydra.nixos.org/build/233220272 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -679,7 +679,6 @@ dont-distribute-packages:
  - datadog-tracing
  - datafix
  - dataflow
- - dataframe_0_3_0_4
  - datasets
  - date-conversions
  - dbjava


### PR DESCRIPTION
This PR is for merging into PR #445213.

An override is added `gi-gtk-hs` to patch the Cabal file build-depends.

The upstream issue is haskell-gi/haskell-gi#478.
