### PR TITLE
armagetronad, armagetronad-dedicated: move to by-name, modernize

### DIFF
--- a/pkgs/by-name/ar/armagetronad-dedicated/package.nix
+++ b/pkgs/by-name/ar/armagetronad-dedicated/package.nix
@@ -1,0 +1,7 @@
+{
+  armagetronad,
+}:
+
+armagetronad.override {
+  dedicatedServer = true;
+}

--- a/pkgs/by-name/ar/armagetronad/package.nix
+++ b/pkgs/by-name/ar/armagetronad/package.nix
@@ -248,13 +248,13 @@ let
             tests.armagetronad = nixosTests.armagetronad;
           };
 
-      meta = with lib; {
+      meta = {
         inherit mainProgram;
         homepage = "https://www.armagetronad.org";
         description = "Multiplayer networked arcade racing game in 3D similar to Tron";
-        maintainers = with maintainers; [ numinit ];
-        license = licenses.gpl2Plus;
-        platforms = platforms.linux;
+        maintainers = with lib.maintainers; [ numinit ];
+        license = lib.licenses.gpl2Plus;
+        platforms = lib.platforms.linux;
       };
     };
 in

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13288,10 +13288,6 @@ with pkgs;
   anki-bin = callPackage ../games/anki/bin.nix { };
   anki-sync-server = callPackage ../games/anki/sync-server.nix { };
 
-  armagetronad = callPackage ../games/armagetronad { };
-
-  armagetronad-dedicated = callPackage ../games/armagetronad { dedicatedServer = true; };
-
   art = callPackage ../by-name/ar/art/package.nix {
     fftw = fftwSinglePrec;
   };


### PR DESCRIPTION
Moved `armagetronad` and `armagetronad-dedicated` to pkgs/by-name, modernized meta.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
