### PR TITLE
monophony: 3.4.2 -> 4.1.1

### DIFF
--- a/pkgs/by-name/mo/monophony/package.nix
+++ b/pkgs/by-name/mo/monophony/package.nix
@@ -3,37 +3,36 @@
   fetchFromGitLab,
   python3Packages,
   wrapGAppsHook4,
-  gst_all_1,
   gobject-introspection,
   yt-dlp,
+  gst_all_1,
   libadwaita,
   glib-networking,
   nix-update-script,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "monophony";
-  version = "3.4.2";
+  version = "4.1.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "zehkira";
     repo = "monophony";
-    rev = "v${version}";
-    hash = "sha256-D/3yJ1KIXF1rv8iH4+HvfD6N94LzkZGRippZj8nk1nQ=";
+    tag = "v${version}";
+    hash = "sha256-0/yzOoO9WeArTm9qlL3++rn0EUCJAjmUX2zxClu3LRE=";
   };
 
   sourceRoot = "${src.name}/source";
 
   dependencies = with python3Packages; [
-    mpris-server
-    pygobject3
+    mprisify
+    requests
     ytmusicapi
   ];
 
   build-system = with python3Packages; [
-    pip
     setuptools
-    wheel
+    pip
   ];
 
   nativeBuildInputs = [
@@ -52,14 +51,7 @@ python3Packages.buildPythonApplication rec {
     gstreamer
   ]);
 
-  pythonRelaxDeps = [
-    "mpris_server"
-    "ytmusicapi"
-  ];
-
-  postInstall = ''
-    make install prefix=$out
-  '';
+  postInstall = "make install prefix=$out";
 
   dontWrapGApps = true;
 
@@ -74,9 +66,9 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "Linux app for streaming music from YouTube";
-    longDescription = "Monophony is a free and open source Linux app for streaming music from YouTube. It has no ads and does not require an account.";
+    longDescription = "Monophony allows you to stream and download music from YouTube Music without ads, as well as create and import playlists without signing in.";
     homepage = "https://gitlab.com/zehkira/monophony";
-    license = lib.licenses.agpl3Plus;
+    license = lib.licenses.bsd0;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ quadradical ];
     mainProgram = "monophony";

--- a/pkgs/development/python-modules/mprisify/default.nix
+++ b/pkgs/development/python-modules/mprisify/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  pydbus,
+  pygobject3,
+  setuptools,
+  strenum,
+}:
+buildPythonPackage rec {
+  pname = "mprisify";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "zehkira";
+    repo = "mprisify";
+    tag = "v${version}";
+    hash = "sha256-05i3N61cqRgGaBjYOEhxeCSV2wDh9yMaXTvEZ/JGrZo=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pydbus
+    pygobject3
+    strenum
+  ];
+
+  pythonImportsCheck = [ "mprisify" ];
+
+  meta = {
+    description = "Python MPRIS server library for Linux media player apps";
+    homepage = "https://gitlab.com/zehkira/mprisify";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ quadradical ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9786,6 +9786,8 @@ self: super: with self; {
 
   mpris-server = callPackage ../development/python-modules/mpris-server { };
 
+  mprisify = callPackage ../development/python-modules/mprisify { };
+
   mpv = callPackage ../development/python-modules/mpv { inherit (pkgs) mpv; };
 
   mpyq = callPackage ../development/python-modules/mpyq { };


### PR DESCRIPTION
Monophony was completely rewritten, and required quite extensive package changes. They also no longer use mpris-server, so I dropped it (it's not used elsewhere), and packaged their fork, mprisify.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
