### PR TITLE
Cmake patch cubocore libcprime

### DIFF
--- a/pkgs/applications/misc/cubocore-packages/libcprime/0002-Edit-CMakeLists.txt.patch
+++ b/pkgs/applications/misc/cubocore-packages/libcprime/0002-Edit-CMakeLists.txt.patch
@@ -1,0 +1,23 @@
+From 505931e9634d1b55ea97bdaa0f68dcd51faaea39 Mon Sep 17 00:00:00 2001
+From: rahmanshaber <rahmanshaber@yahoo.com>
+Date: Mon, 31 Mar 2025 18:04:16 +0000
+Subject: [PATCH] Edit CMakeLists.txt
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b2a4381..02c94c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ project( cprime )
+-cmake_minimum_required( VERSION 3.3 )
++cmake_minimum_required( VERSION 3.16 )
+ 
+ set( PROJECT_VERSION 5.0.0 )
+ set( PROJECT_VERSION_MAJOR 5 )
+-- 
+GitLab
+

--- a/pkgs/applications/misc/cubocore-packages/libcprime/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/libcprime/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./0001-fix-application-dirs.patch
+    ./0002-Edit-CMakeLists.txt.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update CuboCore.libcprime with upstream CMake fix for CMake 4.

- tracking issue: https://github.com/NixOS/nixpkgs/issues/445447
- upstream commit here: https://gitlab.com/cubocore/libcprime/-/commit/505931e9634d1b55ea97bdaa0f68dcd51faaea39

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
