### PR TITLE
ruby_{3_3,3_4}: backport patches for GCC 15 and LLVM 21

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -183,13 +183,35 @@ let
           # make: *** [uncommon.mk:373: do-install-all] Error 1
           enableParallelInstalling = false;
 
-          patches = op useBaseRuby ./do-not-update-gems-baseruby-3.2.patch ++ [
-            # When using a baseruby, ruby always sets "libdir" to the build
-            # directory, which nix rejects due to a reference in to /build/ in
-            # the final product. Removing this reference doesn't seem to break
-            # anything and fixes cross compilation.
-            ./dont-refer-to-build-dir.patch
-          ];
+          patches =
+            op useBaseRuby ./do-not-update-gems-baseruby-3.2.patch
+            ++ [
+              # When using a baseruby, ruby always sets "libdir" to the build
+              # directory, which nix rejects due to a reference in to /build/ in
+              # the final product. Removing this reference doesn't seem to break
+              # anything and fixes cross compilation.
+              ./dont-refer-to-build-dir.patch
+            ]
+            ++ ops (lib.versionOlder ver.majMin "3.4") [
+              (fetchpatch {
+                name = "ruby-3.3-fix-llvm-21.patch";
+                url = "https://github.com/ruby/ruby/commit/5a8d7642168f4ea0d9331fded3033c225bbc36c5.patch";
+                excludes = [ "version.h" ];
+                hash = "sha256-dV98gXXTSKM2ZezTvhVXNaKaXJxiWKEeUbqqL360cWw=";
+              })
+            ]
+            ++ ops (lib.versionAtLeast ver.majMin "3.4" && lib.versionOlder ver.majMin "3.5") [
+              (fetchpatch {
+                name = "ruby-3.4-fix-gcc-15-llvm-21-1.patch";
+                url = "https://github.com/ruby/ruby/commit/846bb760756a3bf1ab12d56d8909e104f16e6940.patch";
+                hash = "sha256-+f0mzHsGAe9FT9NWE345BxzaB6vmWzMTvEfWF84uFOs=";
+              })
+              (fetchpatch {
+                name = "ruby-3.4-fix-gcc-15-llvm-21-2.patch";
+                url = "https://github.com/ruby/ruby/commit/18e176659e8afe402cab7d39972f2d56f2cf378f.patch";
+                hash = "sha256-TKPG1hcC1G2WmUkvNV6QSnvUpTEDqrYKrIk/4fAS8QE=";
+              })
+            ];
 
           cargoRoot = opString yjitSupport "yjit";
 

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -192,7 +192,8 @@ let
               # anything and fixes cross compilation.
               ./dont-refer-to-build-dir.patch
             ]
-            ++ ops (lib.versionOlder ver.majMin "3.4") [
+            # TODO: drop the isClang condition
+            ++ ops (lib.versionOlder ver.majMin "3.4" && stdenv.cc.isClang) [
               (fetchpatch {
                 name = "ruby-3.3-fix-llvm-21.patch";
                 url = "https://github.com/ruby/ruby/commit/5a8d7642168f4ea0d9331fded3033c225bbc36c5.patch";


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/451385; only the last commit is relevant. Will retarget to `staging-next` after that is merged.

Closes: #449970
Closes: #450512
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
