### PR TITLE
python3Packages.cassandra-driver: unbreak for Python >= 3.13

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -6,6 +6,7 @@
   cython,
   eventlet,
   fetchFromGitHub,
+  fetchpatch,
   geomet,
   gevent,
   gremlinpython,
@@ -21,7 +22,6 @@
   twisted,
   setuptools,
   distutils,
-  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
@@ -35,6 +35,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-RX9GLk2admzRasmP7LCwIfsJIt8TC/9rWhIcoTqS0qc=";
   };
+
+  patches = [
+    # https://github.com/datastax/python-driver/pull/1242
+    (fetchpatch {
+      name = "Maintain-compatibility-with-CPython-3.13.patch";
+      url = "https://github.com/datastax/python-driver/commit/b144a84a1f97002c4545b335efaac719519cd9fa.patch";
+      hash = "sha256-60ki6i1SiGxK+J4x/8voS7Hh2x249ykpjU9EMYKD8kc=";
+    })
+  ];
 
   pythonRelaxDeps = [ "geomet" ];
 
@@ -120,8 +129,6 @@ buildPythonPackage rec {
   };
 
   meta = {
-    # cassandra/io/libevwrapper.c:668:10: error: implicit declaration of function ‘PyEval_ThreadsInitialized’ []
-    broken = pythonAtLeast "3.13";
     description = "Python client driver for Apache Cassandra";
     homepage = "http://datastax.github.io/python-driver";
     changelog = "https://github.com/datastax/python-driver/blob/${version}/CHANGELOG.rst";

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -62,6 +62,10 @@ buildPythonPackage rec {
   # This is used to determine the version of cython that can be used
   CASS_DRIVER_ALLOWED_CYTHON_VERSION = cython.version;
 
+  preBuild = ''
+    export CASS_DRIVER_BUILD_CONCURRENCY=$NIX_BUILD_CORES
+  '';
+
   # Make /etc/protocols accessible to allow socket.getprotobyname('tcp') in sandbox,
   # also /etc/resolv.conf is referenced by some tests
   preCheck =


### PR DESCRIPTION
also enables parallel building for the package

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `f0d35152bd7e1999e9a375cf832e6043965eb5cf`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 22 packages built:</summary>
  <ul>
    <li>cassandra</li>
    <li>python312Packages.cassandra-driver</li>
    <li>python312Packages.cassandra-driver.dist</li>
    <li>python312Packages.swh-export</li>
    <li>python312Packages.swh-export.dist</li>
    <li>python312Packages.swh-objstorage</li>
    <li>python312Packages.swh-objstorage.dist</li>
    <li>python312Packages.swh-scheduler</li>
    <li>python312Packages.swh-scheduler.dist</li>
    <li>python312Packages.swh-storage</li>
    <li>python312Packages.swh-storage.dist</li>
    <li>python313Packages.cassandra-driver</li>
    <li>python313Packages.cassandra-driver.dist</li>
    <li>python313Packages.swh-export</li>
    <li>python313Packages.swh-export.dist</li>
    <li>python313Packages.swh-objstorage</li>
    <li>python313Packages.swh-objstorage.dist</li>
    <li>python313Packages.swh-scheduler</li>
    <li>python313Packages.swh-scheduler.dist</li>
    <li>python313Packages.swh-storage</li>
    <li>python313Packages.swh-storage.dist</li>
    <li>swh</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc