### PR TITLE
ghc: use available bootstrap binaries on aarch64-musl

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -123,7 +123,9 @@ in
       ghc98 = compiler.ghc984;
       ghc9101 = callPackage ../development/compilers/ghc/9.10.1.nix {
         bootPkgs =
-          if stdenv.buildPlatform.isDarwin then
+          if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isMusl then
+            bb.packages.ghc984Binary
+          else if stdenv.buildPlatform.isDarwin then
             # it seems like the GHC 9.6.* bindists are built with a different
             # toolchain than we are using (which I'm guessing from the fact
             # that 9.6.4 bindists pass linker flags our ld doesn't support).
@@ -141,7 +143,9 @@ in
       };
       ghc9102 = callPackage ../development/compilers/ghc/9.10.2.nix {
         bootPkgs =
-          if stdenv.buildPlatform.isDarwin then
+          if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isMusl then
+            bb.packages.ghc984Binary
+          else if stdenv.buildPlatform.isDarwin then
             # it seems like the GHC 9.6.* bindists are built with a different
             # toolchain than we are using (which I'm guessing from the fact
             # that 9.6.4 bindists pass linker flags our ld doesn't support).
@@ -159,7 +163,9 @@ in
       };
       ghc9103 = callPackage ../development/compilers/ghc/9.10.3.nix {
         bootPkgs =
-          if stdenv.buildPlatform.isDarwin then
+          if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isMusl then
+            bb.packages.ghc984Binary
+          else if stdenv.buildPlatform.isDarwin then
             # it seems like the GHC 9.6.* bindists are built with a different
             # toolchain than we are using (which I'm guessing from the fact
             # that 9.6.4 bindists pass linker flags our ld doesn't support).


### PR DESCRIPTION
Prior work: #395724

This is the same fallback to ghc-bin 9.8.x instead of ghc-bin 9.6.x (which isn't available for aarch64-musl) as bootPkgs, but when building 9.10.x.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
