### PR TITLE
nixos/mautrix-whatsapp: fix config format from JSON to YAML

### DIFF
--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -10,7 +10,7 @@ let
   registrationFile = "${dataDir}/whatsapp-registration.yaml";
   settingsFile = "${dataDir}/config.yaml";
   settingsFileUnsubstituted = settingsFormat.generate "mautrix-whatsapp-config-unsubstituted.json" cfg.settings;
-  settingsFormat = pkgs.formats.json { };
+  settingsFormat = pkgs.formats.yaml { };
   appservicePort = 29318;
 
   # to be used with a list of lib.mkIf values


### PR DESCRIPTION
## Description

The mautrix-whatsapp bridge expects YAML configuration format, but the NixOS module was generating JSON format, causing the bridge to fail with "Legacy bridge config detected" errors.

## Changes

- Changed `settingsFormat` from `pkgs.formats.json` to `pkgs.formats.yaml` on line 13

## Testing

Tested with mautrix-whatsapp v0.12.5 on nixos-unstable. The bridge now starts successfully and generates the registration file without errors.

## Motivation

The bridge binary validates the config format on startup and rejects JSON as "legacy". The module was updated 3 months ago to support the new config structure but the format type wasn't changed from JSON to YAML.

## Checklist

- [x] Tested using sandboxing
- [x] Built on platform(s): x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md )
