### PR TITLE
php: add new test to check if `vendorHash` is stable with Composer updates

### DIFF
--- a/pkgs/test/php/default.nix
+++ b/pkgs/test/php/default.nix
@@ -125,4 +125,18 @@ in
       checking "if second override is there"
       ${check (builtins.match ".*oAs-second.*" customPhp.unwrapped.postInstall != null)}
     '';
+
+  builder-check-stable-fods =
+    let
+      testPackage = php.buildComposerProject2 {
+        pname = "nix-stable-fods";
+        version = "1.0.0";
+        src = ./tests/stable-fods;
+        vendorHash = "sha256-EiBM9UZZ4yDleoMwfRqYCiGo791arF1AqAjEadPfhig=";
+      };
+    in
+    runTest "php-test-builder-check-stable-fods" ''
+      checking "if vendorHash stays the same for package: ${testPackage}"
+      ${check (testPackage.vendorHash == "sha256-EiBM9UZZ4yDleoMwfRqYCiGo791arF1AqAjEadPfhig=")}
+    '';
 }

--- a/pkgs/test/php/tests/stable-fods/composer.json
+++ b/pkgs/test/php/tests/stable-fods/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "nix/stable-fods",
+  "description": "A trivial test package",
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Nix\\StableFods\\": "src/"
+    }
+  },
+  "require": {
+    "php": "^8"
+  }
+}

--- a/pkgs/test/php/tests/stable-fods/composer.lock
+++ b/pkgs/test/php/tests/stable-fods/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "31d8a19005597a9125930a1d3d888115",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
