### PR TITLE
tarball: generate packages.json in nix

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -24,7 +24,6 @@ let
   # We're using Debian's binary package, and patching it into a usable-in-Nixpkgs state.
   ghcDebs = {
     powerpc64-linux = {
-      variantSuffix = "";
       src = {
         url = "http://ftp.ports.debian.org/debian-ports/pool-ppc64/main/g/ghc/ghc_9.6.6-4_ppc64.deb";
         sha256 = "722cc301b6ba70b342e5e3d9d0671440bcd749cd2f13dcccbd23c3f6a6060171";
@@ -76,7 +75,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   inherit version;
-  pname = "ghc-debian-binary${debUsed.variantSuffix}";
+  pname = "ghc-debian-binary";
 
   src = fetchurl debUsed.src;
 

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -44,11 +44,7 @@ pkgs.releaseTools.sourceTarball {
   checkPhase = ''
     echo "generating packages.json"
 
-    (
-      echo -n '{"version":2,"packages":'
-      NIX_STATE_DIR=$TMPDIR NIX_PATH= nix-env -f $src -qa --meta --json --show-trace --arg config 'import ${./packages-config.nix}'
-      echo -n '}'
-    ) | sed "s|$src/||g" | jq -c > packages.json
+    NIX_STATE_DIR=$TMPDIR NIX_PATH= nix-instantiate --eval --raw --expr "import $src/pkgs/top-level/packages-info.nix {}" | sed "s|$src/||g" | jq -c > packages.json
 
     # Arbitrary number. The index has ~115k packages as of April 2024.
     if [ $(jq -r '.packages | length' < packages.json) -lt 100000 ]; then

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -2,6 +2,7 @@
 {
   # Ensures no aliases are in the results.
   allowAliases = false;
+  allowVariants = false;
 
   # Enable recursion into attribute sets that nix-env normally doesn't look into
   # so that we can get a more complete picture of the available packages for the

--- a/pkgs/top-level/packages-info.nix
+++ b/pkgs/top-level/packages-info.nix
@@ -1,0 +1,52 @@
+{
+  trace ? false,
+}:
+
+let
+  pkgs = import ../.. { config = import ./packages-config.nix; };
+  inherit (pkgs) lib;
+  generateInfo =
+    path: value:
+    let
+      result =
+        if path == [ "AAAAAASomeThingsFailToEvaluate" ] || !(lib.isAttrs value) then
+          [ ]
+        else if lib.isDerivation value then
+          [
+            {
+              name = lib.showAttrPath path;
+              value = {
+                ${if value ? "meta" then "meta" else null} = value.meta;
+                ${if value ? "name" then "name" else null} = value.name;
+                ${if value ? "outputName" then "outputName" else null} = value.outputName;
+                ${if value ? "outputs" then "outputs" else null} = lib.listToAttrs (
+                  lib.map (x: {
+                    name = x;
+                    value = null;
+                  }) value.outputs
+                );
+                ${if value ? "pname" then "pname" else null} = value.pname;
+                ${if value ? "system" then "system" else null} = value.system;
+                ${if value ? "version" then "version" else null} = value.version;
+              };
+            }
+          ]
+        else if value.recurseForDerivations or false then
+          lib.pipe value [
+            (lib.mapAttrsToList (
+              name: value:
+              lib.addErrorContext "while evaluating package set attribute path '${
+                lib.showAttrPath (path ++ [ name ])
+              }'" (generateInfo (path ++ [ name ]) value)
+            ))
+            lib.concatLists
+          ]
+        else
+          [ ];
+    in
+    lib.traceIf trace "** ${lib.showAttrPath path}" (lib.deepSeq result result);
+in
+lib.strings.toJSON {
+  version = "2";
+  packages = lib.listToAttrs (generateInfo [ ] (lib.recurseIntoAttrs pkgs));
+}


### PR DESCRIPTION
Instead of using nix-env, let's generate directly in Nix. This fixes the issue that version and pname contain the wrong information, as nix-env generates those by splitting name into version and pname instead of directly using those to attrs.

This would work towards fixing the following issues:
NixOS/nixos-search#770
repology/repology-updater#854

Note this depends on and includes changes from the following PRs, and only the last commit is for the changes in this PR:
~#451244~
~#451417~
~#406555~
~#455366~
~#456539~
~#478128~

~Also currently depends on either #453291 or #453322 to fix the evaling broken in #421125~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
