### PR TITLE
nixos/etebase-server: Refactor hardcoded host address

### DIFF
--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -224,7 +224,7 @@ in
             if cfg.unixSocket != null then
               "--uds ${cfg.unixSocket}"
             else
-              "--host 0.0.0.0 --port ${toString cfg.port}";
+              "--host ${cfg.settings.allowed_hosts.allowed_host1} --port ${toString cfg.port}";
         in
         ''
           ${python.pkgs.uvicorn}/bin/uvicorn ${networking} \


### PR DESCRIPTION
## The Problem Statement

The status quo does not respect the user's declared host to run uvicorn on, i.e., `services.etebase-server.settings.allowed_hosts.allowed_host1`. This user option is the "main host" address that the app should be accessible from. However, the fact that uvicorn is started on 0.0.0.0 means that the app will still remain accessible from all the other host addresses that the main host may have; this may lead to an unexpected security issue.

One such example is the intention to host the app only on the local machine, i.e., to set the user option to `localhost`, and not have it accessible via the machine's IP address, e.g., 192.168.1.10:8001. However, the app would still be accessible at 192.168.1.10:8001, which goes against what the user intended in the first place.

## Things Done

This commit refactors the hardcoded uvicorn host from 0.0.0.0 to the already present user option, which defaults to 0.0.0.0.

## Other Information

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
