### PR TITLE
kaminpar: 3.5.1 -> 3.7.0

### DIFF
--- a/pkgs/by-name/ka/kaminpar/package.nix
+++ b/pkgs/by-name/ka/kaminpar/package.nix
@@ -2,69 +2,43 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   cmake,
   numactl,
   mpi,
   sparsehash,
   onetbb,
+  kagen,
+  kassert,
   gtest,
   mpiCheckPhaseHook,
 }:
-let
-  kassert-src = fetchFromGitHub {
-    owner = "kamping-site";
-    repo = "kassert";
-    rev = "988b7d54b79ae6634f2fcc53a0314fb1cf2c6a23";
-
-    fetchSubmodules = true;
-    hash = "sha256-CBglUfVl9lgEa1t95G0mG4CCj0OWnIBwk7ep62rwIAA=";
-  };
-
-  kagen-src = fetchFromGitHub {
-    owner = "KarlsruheGraphGeneration";
-    repo = "KaGen";
-    rev = "70386f48e513051656f020360c482ce6bff9a24f";
-
-    fetchSubmodules = true;
-    hash = "sha256-5EvRPpjUZpmAIEgybXjNU/mO0+gsAyhlwbT+syDUr48=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "kaminpar";
-  version = "3.5.1";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "KaHIP";
     repo = "KaMinPar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1azBj1DSEb7b8u+S51Sncn6EVMgu+SuFJcK4QVVhRk4=";
+    hash = "sha256-CkGVRJncQBrwDV7eoJ02jcpPDRWNukwibbWXVrx4P8g=";
   };
-
-  patches = [
-    # require gtest to be preinstalled by default if building tests
-    (fetchpatch2 {
-      url = "https://github.com/KaHip/KaMinPar/commit/9cb9883eea076d11cffcf4b0d14bf1f4f95a00e4.patch?full_index=1";
-      hash = "sha256-aUO5E0HTZqjfu5BUzyRdSZgyQYcE4PGqZaJvLD40sn8=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = lib.optional stdenv.hostPlatform.isLinux numactl;
 
   propagatedBuildInputs = [
+    kagen
+    kassert
     mpi
-    sparsehash
     onetbb
+    sparsehash
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "KAMINPAR_BUILD_DISTRIBUTED" true)
     (lib.cmakeBool "KAMINPAR_BUILD_WITH_MTUNE_NATIVE" false)
-    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_KASSERT" "${kassert-src}")
-    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_KAGEN" "${kagen-src}")
   ];
 
   doCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/KaHIP/KaMinPar/compare/v3.5.1...v3.7.0

Updates KaMinPar to the latest release. Additionally, it switches the Nix package to use the system-provided versions of KaGen and kassert instead of fetching them from GitHub

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
