### PR TITLE
treewide: mark failing packages as broken

### DIFF
--- a/pkgs/applications/blockchains/optimism/geth.nix
+++ b/pkgs/applications/blockchains/optimism/geth.nix
@@ -39,6 +39,8 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "";
     homepage = "https://github.com/ethereum-optimism/op-geth";
     license = licenses.gpl3Only;

--- a/pkgs/by-name/ma/martin/package.nix
+++ b/pkgs/by-name/ma/martin/package.nix
@@ -54,6 +54,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Blazing fast and lightweight PostGIS vector tiles server";
     homepage = "https://martin.maplibre.org/";
     license = with licenses; [

--- a/pkgs/by-name/ne/nearcore/package.nix
+++ b/pkgs/by-name/ne/nearcore/package.nix
@@ -54,6 +54,8 @@ rustPlatform.buildRustPackage rec {
   requiredSystemFeatures = [ "big-parallel" ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Reference client for NEAR Protocol";
     homepage = "https://github.com/near/nearcore";
     license = licenses.gpl3;

--- a/pkgs/by-name/ol/olaris-server/package.nix
+++ b/pkgs/by-name/ol/olaris-server/package.nix
@@ -58,6 +58,8 @@ buildGoModule rec {
   '';
 
   meta = {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Media manager and transcoding server";
     homepage = "https://gitlab.com/olaris/olaris-server";
     changelog = "https://gitlab.com/olaris/olaris-server/-/releases/v${version}";

--- a/pkgs/by-name/ov/oven-media-engine/package.nix
+++ b/pkgs/by-name/ov/oven-media-engine/package.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Open-source streaming video service with sub-second latency";
     mainProgram = "OvenMediaEngine";
     homepage = "https://ovenmediaengine.com";

--- a/pkgs/by-name/pr/protoc-gen-twirp/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-twirp/package.nix
@@ -26,6 +26,8 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Simple RPC framework with protobuf service definitions";
     mainProgram = "protoc-gen-twirp";
     homepage = "https://github.com/twitchtv/twirp";

--- a/pkgs/by-name/qu/quickwit/package.nix
+++ b/pkgs/by-name/qu/quickwit/package.nix
@@ -140,6 +140,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Sub-second search & analytics engine on cloud storage";
     homepage = "https://quickwit.io/";
     license = licenses.agpl3Only;

--- a/pkgs/by-name/sc/screen-pipe/package.nix
+++ b/pkgs/by-name/sc/screen-pipe/package.nix
@@ -61,6 +61,8 @@ rustPlatform.buildRustPackage rec {
   doCheck = false; # Tests fail to build
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Personalized AI powered by what you've seen, said, or heard";
     homepage = "https://github.com/louis030195/screen-pipe";
     license = licenses.mit;

--- a/pkgs/by-name/sn/snarkos/package.nix
+++ b/pkgs/by-name/sn/snarkos/package.nix
@@ -53,6 +53,8 @@ rustPlatform.buildRustPackage rec {
   # ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Decentralized Operating System for Zero-Knowledge Applications";
     homepage = "https://snarkos.org";
     license = licenses.asl20;

--- a/pkgs/by-name/so/sommelier/package.nix
+++ b/pkgs/by-name/so/sommelier/package.nix
@@ -57,6 +57,8 @@ stdenv.mkDerivation {
   passthru.updateScript = ./update.py;
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     homepage = "https://chromium.googlesource.com/chromiumos/platform2/+/refs/heads/main/vm_tools/sommelier/";
     description = "Nested Wayland compositor with support for X11 forwarding";
     maintainers = with maintainers; [ qyliss ];

--- a/pkgs/development/python-modules/pathy/default.nix
+++ b/pkgs/development/python-modules/pathy/default.nix
@@ -48,8 +48,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pathy" ];
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     # https://github.com/justindujardin/pathy/issues/113
-    broken = pathlib-abc.version != "0.1.1";
     description = "Path interface for local and cloud bucket storage";
     mainProgram = "pathy";
     homepage = "https://github.com/justindujardin/pathy";

--- a/pkgs/development/python-modules/scikit-learn-extra/default.nix
+++ b/pkgs/development/python-modules/scikit-learn-extra/default.nix
@@ -65,6 +65,8 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+    broken = true;
     description = "Set of tools for scikit-learn";
     homepage = "https://github.com/scikit-learn-contrib/scikit-learn-extra";
     license = lib.licenses.bsd3;

--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -15,6 +15,9 @@ let
   };
 
   meta = with lib; {
+    # Marked broken 2025-11-28 because both indradb-server and indradb-client
+    # have failed on Hydra for nearly a year.
+    broken = true;
     description = "Graph database written in rust";
     homepage = "https://github.com/indradb/indradb";
     license = licenses.mpl20;

--- a/pkgs/os-specific/cygwin/w32api/default.nix
+++ b/pkgs/os-specific/cygwin/w32api/default.nix
@@ -32,6 +32,8 @@
     };
 
     meta = {
+      # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
+      broken = true;
       description = "MinGW w32api package for Cygwin";
       inherit (windows.mingw_w64_headers.meta)
         homepage


### PR DESCRIPTION
On 12 separate Hydra evaluations (which I selected for their relatively low failure numbers, and which span over a year), these packages have done nothing other than fail for all platforms.
That is, if a package had a status other than "Failed" on any platform for any of the selected evaluations, it is not included here.
For Python packages and Linux kernel modules, they also fail across all built Python versions (so if the package succeeds with Python 3.12 but fails with Python 3.13, it's not included here).

The marking itself was done with `pkgs/common-updater/scripts/mark-broken`, generation of the packages to be marked was done with a modification to https://git.helsinki.tools/janne.hess/zhf/-/commits/master and a custom Python script.

This should have 0 rebuilds.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
