### PR TITLE
rPackages.ulex: use pname and version

### DIFF
--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -27,14 +27,14 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
   "ulex is not available for OCaml ${ocaml.version}"
 
   stdenv.mkDerivation
-  rec {
-    name = "ocaml${ocaml.version}-${pname}-${version}";
+  {
+    pname = "ocaml${ocaml.version}-${pname}";
     inherit (param) version;
 
     src = fetchFromGitHub {
-      owner = "whitequark";
+      owner = "ocaml-community";
       repo = pname;
-      rev = "v${version}";
+      rev = "v${param.version}";
       inherit (param) sha256;
     };
 
@@ -56,7 +56,7 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
     ];
 
     meta = {
-      inherit (src.meta) homepage;
+      homepage = "https://opam.ocaml.org/packages/ulex/";
       description = "Lexer generator for Unicode and OCaml";
       license = lib.licenses.mit;
       inherit (ocaml.meta) platforms;


### PR DESCRIPTION
part of #103997

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
