### PR TITLE
{spandsp,spandsp3}: Enable tests, adopt

### DIFF
--- a/pkgs/development/libraries/spandsp/3.nix
+++ b/pkgs/development/libraries/spandsp/3.nix
@@ -4,16 +4,19 @@
   libjpeg,
 }:
 
-(callPackage ./common.nix { }).overrideAttrs (previousAttrs: {
+((callPackage ./common.nix { }) {
   version = "3.0.0";
   src = fetchFromGitHub {
     owner = "freeswitch";
-    repo = previousAttrs.pname;
+    repo = "spandsp";
     rev = "6ec23e5a7e411a22d59e5678d12c4d2942c4a4b6"; # upstream does not seem to believe in tags
     sha256 = "03w0s99y3zibi5fnvn8lk92dggfgrr0mz5255745jfbz28b2d5y7";
   };
-
-  propagatedBuildInputs = previousAttrs.propagatedBuildInputs or [ ] ++ [
-    libjpeg
-  ];
-})
+}).overrideAttrs
+  (
+    finalAttrs: previousAttrs: {
+      propagatedBuildInputs = previousAttrs.propagatedBuildInputs or [ ] ++ [
+        libjpeg
+      ];
+    }
+  )

--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -5,11 +5,27 @@
   libtiff,
   buildPackages,
   fetchpatch,
-  autoreconfHook,
+  autoconf,
+  automake,
+  fftw,
+  libpcap,
+  libsndfile,
+  libtool,
+  libxml2,
+  netpbm,
+  sox,
+  util-linux,
+  which,
+}:
+
+{
+  version,
+  src,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spandsp";
+  inherit version src;
 
   patches = [
     # submitted upstream: https://github.com/freeswitch/spandsp/pull/47
@@ -19,33 +35,169 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  postPatch = ''
+    patchShebangs autogen.sh
+
+    # pkg-config? What's that?
+    # Actually *check* the value given for --{en,dis}able-tests, not just whether the option was passed
+    substituteInPlace configure.ac \
+      --replace-fail '$xml2_include_dir /usr/include /usr/local/include /usr/include/libxml2 /usr/local/include/libxml2' '$xml2_include_dir ${lib.getDev libxml2}/include ${lib.getDev libxml2}/include/libxml2 /usr/local/include/libxml2' \
+      --replace-fail 'if test -n "$enable_tests" ; then' 'if test "$enable_tests" = "yes" ; then'
+  '';
+
   outputs = [
     "out"
     "dev"
   ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    util-linux
+    which
+  ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   propagatedBuildInputs = [
     audiofile
     libtiff
   ];
 
+  nativeCheckInputs = [
+    libtiff
+    netpbm
+    sox
+  ];
+
+  checkInputs = [
+    fftw
+    libpcap
+    libsndfile
+    libxml2
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
   configureFlags = [
+    (lib.strings.enableFeature finalAttrs.finalPackage.doCheck "tests")
+
     # This flag is required to prevent linking error in the cross-compilation case.
     # I think it's fair to assume that realloc(NULL, size) will return a valid memory
     # block for most libc implementation, so let's just assume that and hope for the best.
     "ac_cv_func_malloc_0_nonnull=yes"
   ];
 
-  enableParallelBuilding = true;
+  # Issues with test asset generation under heavy parallelism
+  enableParallelBuilding = false;
 
   makeFlags = [
     "CC=${stdenv.cc.targetPrefix}cc"
     "CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/cc"
   ];
 
-  strictDeps = true;
+  env.NIX_CFLAGS_COMPILE = toString [
+    # Missing const conversion on some calls
+    "-Wno-error=incompatible-pointer-types"
+  ];
+
+  hardeningDisable = lib.optionals (lib.strings.versionOlder finalAttrs.version "3.0.0") [
+    "format"
+  ];
+
+  doCheck =
+    stdenv.buildPlatform.canExecute stdenv.hostPlatform
+    # Compat with i.e. Clang improved by 0446f4e0c72553f3ea9b50c5333ece6ac980e58d, too big to apply
+    && stdenv.cc.isGNU;
+
+  disabledTests = [
+    # Need proprietary recordings that aren't included
+    "ademco_contactid_tests"
+    "dtmf_rx_tests"
+    "g722_tests"
+    "g726_tests"
+    "gsm0610_tests"
+    "modem_connect_tones_tests"
+    "sig_tone_tests"
+    "t42_tests"
+    "t43_tests"
+    "v42bis_tests"
+
+    # Fails to initialise modem.
+    "data_modems_tests"
+
+    # ERROR PTY Fatal error: failed to create /dev/spandsp/0 symbolic link
+    "dummy_modems_tests" # needs extra setup, but eventually runs into the above error
+    "pseudo_terminal_tests"
+
+    # Hangs. Maybe needs setup / some interaction
+    "fax_tests"
+
+    # Needs an input file, unsure what's suitable
+    "playout_tests"
+
+    # Borked in the packaged versions due to missing audio file - copy-pasting mistake
+    # Maybe fixed after 5394b2cae6c482ccb835335b769469977e6802ae, but too big to apply
+    "super_tone_rx_tests"
+
+    # Stuck
+    "t31_pseudo_terminal_tests"
+
+    # Generated signal has more than the expected maximum samples - 441 vs 422
+    "time_scale_tests"
+
+    # Test failed - -16dBm0 of noise, signal is 9056.993164 (11440.279297)
+    "tone_detect_tests"
+
+    # Fails due to result different from reference
+    "v18_tests"
+
+    # Seemingly runs forever, with tons of output
+    "v22bis_tests"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    pushd tests
+
+    for test in *_tests; do
+      testArgs=()
+      case "$test" in
+        # Skipped tests
+        ${lib.strings.concatStringsSep "|" finalAttrs.disabledTests})
+          echo "Skipping $test"
+          continue
+          ;;
+
+        # Needs list of subtests to run
+        echo_tests)
+          testArgs+=(
+            sanity 2a 2b 2ca 3a 3ba 3bb 3c 4 5 6 7 8 9 10a 10b 10c 11 12 13 14 15
+          )
+          # Fallthough for running the test
+          ;;&
+
+        *)
+          echo "Running $test"
+          if ! ./"$test" "''${testArgs[@]}" >"$test".log 2>&1; then
+            echo "$test failed! Output:"
+            cat "$test".log
+            exit 1
+          fi
+          ;;
+      esac
+    done
+
+    popd
+
+    runHook postCheck
+  '';
 
   meta = {
     description = "Portable and modular SIP User-Agent with audio and video support";

--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -204,6 +204,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/freeswitch/spandsp";
     platforms = with lib.platforms; unix;
     maintainers = with lib.maintainers; [ misuzu ];
+    teams = [ lib.teams.ngi ];
     license = lib.licenses.gpl2;
     downloadPage = "http://www.soft-switch.org/downloads/spandsp/";
   };

--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -3,10 +3,10 @@
   callPackage,
 }:
 
-(callPackage ./common.nix { }).overrideAttrs (_: rec {
+(callPackage ./common.nix { }) rec {
   version = "0.0.6";
   src = fetchurl {
     url = "https://www.soft-switch.org/downloads/spandsp/spandsp-${version}.tar.gz";
     sha256 = "0rclrkyspzk575v8fslzjpgp4y2s4x7xk3r55ycvpi4agv33l1fc";
   };
-})
+}


### PR DESCRIPTION
Upstreaming from NGIpkgs (kinda). We will depend on this for BigBlueButton, so adopting it.

Really not a fan of the test running stuff, but it seems like there's no nice way to actually run & control the tests… There seems to be no Makefile target for running them. There is `/tests/regression_tests.sh`, but there's no *nice* way to disable tests in there… Hence, the here-submitted `disabledTests` array & `checkPhase` code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
