### PR TITLE
clidle: init at 0.1.0

### DIFF
--- a/pkgs/by-name/cl/clidle/package.nix
+++ b/pkgs/by-name/cl/clidle/package.nix
@@ -1,0 +1,32 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+
+let
+  name = "clidle";
+  url = "https://github.com/ajeetdsouza/${name}";
+in
+buildGoModule (finalAttrs: {
+  pname = name;
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ajeetdsouza";
+    repo = name;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WplqB0IvVI/Dyg36xsazhYRpkQxxf+nQo1ye+ewuAiI=";
+  };
+  vendorHash = "sha256-vevil9MxPr3YcB7m1Jzvypioq6aOkWrQeFCC1fPeQKw=";
+
+  meta = {
+    changelog = "${url}/releases/tag/v${finalAttrs.version}";
+    homepage = url;
+    description = "Play Wordle in your terminal";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.nicknb ];
+    mainProgram = "clidle";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds clidle, a Wordle clone for the terminal.

https://github.com/ajeetdsouza/clidle

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
