### PR TITLE
bcachefs: Disable in-tree module.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -317,7 +317,7 @@
 
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
-- `bcachefs` file systems will now use the out-of-tree module for supported kernels. The in-tree module is unmaintained and users are strongly recommended to switch to kernels that support the out-of-tree module.
+- `bcachefs` file systems will now use the out-of-tree module for supported kernels. The in-tree module has been removed, and users will need to switch to kernels that support the out-of-tree module.
 
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 

--- a/nixos/modules/installer/cd-dvd/latest-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/latest-kernel.nix
@@ -2,6 +2,7 @@
 {
   boot.kernelPackages = pkgs.linuxPackages_latest;
   boot.supportedFilesystems.zfs = false;
+  boot.supportedFilesystems.bcachefs = true;
   environment.etc."nixos-generate-config.conf".text = ''
     [Defaults]
     Kernel=latest

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -242,14 +242,6 @@ in
           }
         ];
 
-        warnings = lib.mkIf cfg.modulePackage.meta.broken [
-          ''
-            Using unmaintained in-tree bcachefs kernel module. This
-            will be removed in 26.05. Please use a kernel supported
-            by the out-of-tree module package.
-          ''
-        ];
-
         # Bcachefs upstream recommends using the latest kernel
         boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
@@ -257,9 +249,7 @@ in
         system.fsPackages = [ cfg.package ];
         services.udev.packages = [ cfg.package ];
 
-        boot.extraModulePackages = lib.optionals (!cfg.modulePackage.meta.broken) [
-          cfg.modulePackage
-        ];
+        boot.extraModulePackages = [ cfg.modulePackage ];
 
         systemd = {
           packages = [ cfg.package ];

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -709,8 +709,8 @@ let
 
       BTRFS_FS_POSIX_ACL = yes;
 
-      BCACHEFS_QUOTA = whenBetween "6.7" "6.18" (option yes);
-      BCACHEFS_POSIX_ACL = whenBetween "6.7" "6.18" (option yes);
+      # Provided by external module
+      BCACHEFS_FS = whenBetween "6.7" "6.18" no;
 
       UBIFS_FS_ADVANCED_COMPR = option yes;
 


### PR DESCRIPTION
The external module is preferred to the in-tree module. It's probably best to simply remove the in-tree one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
