### PR TITLE
opencode: 0.14.7 -> 0.15.0

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -22,12 +22,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.14.7";
+  version = "0.15.0";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7Sf74H2ptZoKkOyqy3JU71B2r2DBdosChiWA0dNpiV0=";
+    hash = "sha256-WTWLh50atZ0P+S0BIgInRoaQV94wIO7NJXrpnsiXTAU=";
   };
 
   tui = buildGoModule {
@@ -105,7 +105,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     outputHash =
       {
-        x86_64-linux = "sha256-j6p52NXqKsOiySJO83r3qUvxLs1yt8dPG8q5ClOPLA8=";
+        x86_64-linux = "sha256-WOiJ7bxE/e4zIvjlbw+Hr9TbMoOjmweShAZaeOgp82s=";
         aarch64-linux = "sha256-gxAwc34PIN1ErVchyoX7Fv/VhPHzxVOC/F6P8hSeO/w=";
         x86_64-darwin = "sha256-0I6nTjc7gChk2Djv4hFfKMp0wM3ZX57/pCsPVHSDPqk=";
         aarch64-darwin = "sha256-a/WWhsOP4pZfj5+Vlsyt/adaTTgMt2SlH3UOA+sXNgA=";


### PR DESCRIPTION
## Description
Fixes non-deterministic node_modules build failure reported in #451228.

## Problem
Version 0.14.7 produces different hashes on each build attempt, causing build failures in nixpkgs. This was confirmed through multiple nix-build tests showing different outputHash values:
- Build 1: `sha256-5EZ6ZnBk0xxH8+xVTU6Fc8EutG8gHmorsU3g3HpzeL4=`
- Build 2: `sha256-WjcTMwCyF7oOESjQ36OPlUUgjd1Cr8cno4NiGd2N5as=`
- Build 3: `sha256-BmlZ8e9XTz21ECZn3RIOxhFOblHCu5CrLgpo+MgfUqU=`

## Solution
Version 0.15.0 builds deterministically. Multiple test builds all produce the same hash: `/nix/store/9kkqsrsd9plcnfcizvi0s50bcg80r40r-opencode-node_modules-0.15.0`

The fix appears to be related to the regenerated lockfile in 0.15.0, likely due to improvements in bun's package resolution between the versions used to generate each lockfile.

## Testing
- [x] Built opencode 0.15.0 multiple times - all builds produce identical hashes
- [x] Verified version 0.14.7 produces non-deterministic hashes
- [x] Package builds successfully with the new version

Fixes #451228