### PR TITLE
ovn: fix build failure due to make install race condition

### DIFF
--- a/pkgs/by-name/ov/ovn/0001-build-Fix-race-condition-when-installing-ovn-detrace.patch
+++ b/pkgs/by-name/ov/ovn/0001-build-Fix-race-condition-when-installing-ovn-detrace.patch
@@ -1,0 +1,64 @@
+From a94104a0c419a5049712f7372690dab10f54ab2f Mon Sep 17 00:00:00 2001
+From: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+Date: Sun, 12 Oct 2025 18:46:14 -0400
+Subject: [PATCH ovn] build: Fix race condition when installing ovn-detrace.
+
+When running parallel make install (-j), ovn-detrace-install could
+trigger before ovn_detrace.py is installed. In this case, `ln` will
+fail.
+
+When it happens, make fails with:
+
+```
+ln: failed to create symbolic link '[...]/bin/ovn-detrace': No such file or directory
+make[2]: *** [Makefile:3852: ovn-detrace-install] Error 1
+```
+
+Automake install-*-local targets are not guaranteed any order. In
+contrast, install-*-hook does [1]. This patch switches the make target
+to use the latter.
+
+[1] https://www.gnu.org/software/automake/manual/html_node/Extending-Installation.html
+
+Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+---
+ Makefile.am           | 2 ++
+ utilities/automake.mk | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 6119ef510..060d3189d 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -128,6 +128,7 @@ dist_scripts_SCRIPTS =
+ dist_scripts_DATA =
+ EXTRA_PROGRAMS =
+ INSTALL_DATA_LOCAL =
++INSTALL_DATA_HOOK =
+ UNINSTALL_LOCAL =
+ man_MANS =
+ MAN_FRAGMENTS =
+@@ -487,6 +488,7 @@ dist-hook: $(DIST_HOOKS)
+ all-local: $(ALL_LOCAL)
+ clean-local: $(CLEAN_LOCAL)
+ install-data-local: $(INSTALL_DATA_LOCAL)
++install-data-hook: $(INSTALL_DATA_HOOK)
+ uninstall-local: $(UNINSTALL_LOCAL)
+ .PHONY: $(DIST_HOOKS) $(CLEAN_LOCAL) $(INSTALL_DATA_LOCAL) $(UNINSTALL_LOCAL)
+ 
+diff --git a/utilities/automake.mk b/utilities/automake.mk
+index 1de33614f..ec955f6bf 100644
+--- a/utilities/automake.mk
++++ b/utilities/automake.mk
+@@ -106,7 +106,7 @@ utilities_ovn_appctl_SOURCES = utilities/ovn-appctl.c
+ utilities_ovn_appctl_LDADD = lib/libovn.la $(OVSDB_LIBDIR)/libovsdb.la $(OVS_LIBDIR)/libopenvswitch.la
+ 
+ # ovn-detrace
+-INSTALL_DATA_LOCAL += ovn-detrace-install
++INSTALL_DATA_HOOK += ovn-detrace-install
+ ovn-detrace-install:
+ 	ln -sf ovn_detrace.py $(DESTDIR)$(bindir)/ovn-detrace
+ 
+-- 
+2.51.0
+

--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ovn-org/ovn/commit/b396babaa54ea0c8d943bbfef751dbdbf288c7af.patch";
       hash = "sha256-RjWxT3EYKjGhtvCq3bAhKN9PrPTkSR72xPkQQ4SPWWU=";
     })
+    # Fix build failure due to make install race condition.
+    # Posted at: https://patchwork.ozlabs.org/project/ovn/patch/20251012225908.37855-1-ihar.hrachyshka@gmail.com/
+    ./0001-build-Fix-race-condition-when-installing-ovn-detrace.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Periodically happens in Hydra: https://hydra.nixos.org/build/309529541


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
