### PR TITLE
chez: Fix on Darwin

### DIFF
--- a/pkgs/by-name/ch/chez/package.nix
+++ b/pkgs/by-name/ch/chez/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
   depsBuildBuild = [
     zuo # Used as the build driver
-    buildPackages.stdenv.cc # Needed for cross
   ];
   nativeBuildInputs =
     lib.optionals stdenv.hostPlatform.isDarwin [
@@ -86,8 +85,9 @@ stdenv.mkDerivation (finalAttrs: {
     "--threads"
     "--installprefix=${placeholder "out"}"
     "--installman=${placeholder "out"}/share/man"
+    "--installabsolute"
     "--enable-libffi"
-    "CC_FOR_BUILD=cc"
+    "CC_FOR_BUILD=${lib.getExe buildPackages.stdenv.cc}"
     # Use Nixpkgs dependencies
     "ZUO=zuo"
     "ZLIB=${zlib}/lib/libz${extensions.sharedLibrary}"
@@ -111,6 +111,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   setupHook = ./setup-hook.sh;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    echo "(exit)" | "$out/bin/scheme"
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = finalAttrs.finalPackage;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes #451203 and its associated build failures on Darwin

Basically some weird things with `CC_FOR_BUILD=cc` on Darwin. Also add a sanity check, and set absolute paths just cause it makes sense with Nix.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
