### PR TITLE
nixos/nextcloud-notify_push: automatically install notify_push nextcloud app

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -172,6 +172,11 @@ in
           '';
       };
       nextcloud = {
+        extraApps = {
+          inherit (config.services.nextcloud.package.packages.apps)
+            notify_push
+            ;
+        };
         settings.trusted_proxies = lib.mkIf cfg.bendDomainToLocalhost [
           "127.0.0.1"
           "::1"

--- a/nixos/modules/services/web-apps/nextcloud-notify_push.nix
+++ b/nixos/modules/services/web-apps/nextcloud-notify_push.nix
@@ -159,27 +159,24 @@ in
       "::1" = [ cfgN.hostName ];
     };
 
-    services = lib.mkMerge [
-      {
-        nginx.virtualHosts.${cfgN.hostName}.locations."^~ /push/" = {
-          proxyPass = "http://unix:${cfg.socketPath}";
-          proxyWebsockets = true;
-          recommendedProxySettings = lib.mkDefault true;
-          extraConfig = # nginx
-            ''
-              # disable in case it was configured on a higher level
-              keepalive_timeout 0;
-              proxy_buffering off;
-            '';
-        };
-      }
-
-      (lib.mkIf cfg.bendDomainToLocalhost {
-        nextcloud.settings.trusted_proxies = [
+    services = {
+      nginx.virtualHosts.${cfgN.hostName}.locations."^~ /push/" = {
+        proxyPass = "http://unix:${cfg.socketPath}";
+        proxyWebsockets = true;
+        recommendedProxySettings = lib.mkDefault true;
+        extraConfig = # nginx
+          ''
+            # disable in case it was configured on a higher level
+            keepalive_timeout 0;
+            proxy_buffering off;
+          '';
+      };
+      nextcloud = {
+        settings.trusted_proxies = lib.mkIf cfg.bendDomainToLocalhost [
           "127.0.0.1"
           "::1"
         ];
-      })
-    ];
+      };
+    };
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
