### PR TITLE
Revert "python3Packages.pytest: don't wrap binaries"

### DIFF
--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -76,9 +76,6 @@ buildPythonPackage rec {
   '';
 
   doCheck = false;
-  # FIXME(jade): perhaps this should be the default?
-  # https://github.com/NixOS/nixpkgs/issues/435069
-  dontWrapPythonPrograms = true;
   passthru.tests.pytest = callPackage ./tests.nix { };
 
   # Remove .pytest_cache when using py.test in a Nix build


### PR DESCRIPTION
Reverts NixOS/nixpkgs#435749

This patch broke pkgsStatic.pytest (and all its children).