### PR TITLE
gimpPlugins.exposureBlend: drop

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -362,16 +362,6 @@ lib.makeScope pkgs.newScope (
 
     # =============== simple script files ====================
 
-    # also have a look at enblend-enfuse in all-packages.nix
-    exposureBlend = scriptDerivation {
-      name = "exposure-blend";
-      src = fetchurl {
-        url = "http://tir.astro.utoledo.edu/jdsmith/code/eb/exposure-blend.scm";
-        sha256 = "1b6c9wzpklqras4wwsyw3y3jp6fjmhnnskqiwm5sabs8djknfxla";
-      };
-      meta.broken = true;
-    };
-
     lightning = scriptDerivation {
       name = "Lightning";
       src = fetchurl {


### PR DESCRIPTION
Has been marked broken since 2019, dropping per [RFC 180](https://github.com/NixOS/rfcs/blob/master/rfcs/0180-broken-package-removal.md).

* Package drops:
  * [ ] <s>`pkgs/top-level/aliases.nix` (or language-specific alias) entry added.</s>
        Not done: it's been broken (effectively throwing) for 6 years, far longer than an alias would (or at least should) last. See https://github.com/NixOS/nixpkgs/pull/451103#issuecomment-3393689048.
* [x] 0 rebuilds verified
* [X] `rg ${pname}` run and verified to not contain references to this package (outside of aliases.nix, rename.nix, and release notes).
* [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
