### PR TITLE
kodiPackages.osmc-skin: 20.1.0 -> 21.1.1; unbreak

### DIFF
--- a/pkgs/applications/video/kodi/addons/osmc-skin/default.nix
+++ b/pkgs/applications/video/kodi/addons/osmc-skin/default.nix
@@ -6,13 +6,13 @@
 buildKodiAddon rec {
   pname = "osmc-skin";
   namespace = "skin.osmc";
-  version = "20.1.0";
+  version = "21.1.1";
 
   src = fetchFromGitHub {
     owner = "osmc";
     repo = namespace;
-    rev = "v20.1.0-August-update";
-    sha256 = "E/+gC7NlVRMaymeYMBO39/+rs0blDjr2zIROr24ekzQ=";
+    tag = "v${version}-August-update";
+    hash = "sha256-3BR6HfKefuyybDv9c/ZkkZMRDyWNZWpftulXyUAD9nY=";
   };
 
   meta = with lib; {
@@ -21,7 +21,5 @@ buildKodiAddon rec {
     platforms = platforms.all;
     maintainers = [ ];
     license = licenses.cc-by-nc-sa-30;
-
-    broken = true; # no release for kodi 21
   };
 }


### PR DESCRIPTION
Diff: https://github.com/osmc/skin.osmc/compare/v20.1.0-August-update...v21.1.1-August-update

Changelog: https://github.com/osmc/skin.osmc/blob/v21.1.1-August-update/Changelog.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
