### PR TITLE
haskellPackages: fix executables built for ghcjs

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -239,6 +239,10 @@
           hash = "sha256-sb+AHdkGkCu8MW0xoQIpD5kEc0zYX8udAMDoC+TWc0Q=";
         })
       ]
+      ++ lib.optionals stdenv.targetPlatform.isGhcjs [
+        # https://gitlab.haskell.org/ghc/ghc/-/issues/26290
+        ./export-heap-methods.patch
+      ]
       # Prevents passing --hyperlinked-source to haddock. Note that this can
       # be configured via a user defined flavour now. Unfortunately, it is
       # impossible to import an existing flavour in UserSettings, so patching

--- a/pkgs/development/compilers/ghc/export-heap-methods.patch
+++ b/pkgs/development/compilers/ghc/export-heap-methods.patch
@@ -1,0 +1,11 @@
+diff --git a/rts/js/mem.js b/rts/js/mem.js
+index 44c5c37ac4..1f150c5d55 100644
+--- a/rts/js/mem.js
++++ b/rts/js/mem.js
+@@ -1,5 +1,5 @@
+ //#OPTIONS:CPP
+-//#OPTIONS:EMCC:EXPORTED_RUNTIME_METHODS=addFunction,removeFunction,getEmptyTableSlot
++//#OPTIONS:EMCC:EXPORTED_RUNTIME_METHODS=addFunction,removeFunction,getEmptyTableSlot,HEAP8,HEAPU8
+ 
+ // #define GHCJS_TRACE_META 1
+ 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Tested with `$(nix-build -A pkgsCross.ghcjs.haskell.packages.ghc912.aeson-gadt-th)/bin/readme`

Before 
```
Aborted('HEAP8' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ))
/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:107023
  var e = new WebAssembly.RuntimeError(what);
          ^

RuntimeError: Aborted('HEAP8' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the Emscripten FAQ))
    at abort (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:107023:11)
    at Object.get (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:106824:9)
    at h$initEmscriptenHeap (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:13532:35)
    at Module.onRuntimeInitialized (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:108062:1)
    at doRun (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:107996:37)
    at run (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:108012:5)
    at removeRunDependency (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:106993:7)
    at receiveInstance (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:107135:5)
    at receiveInstantiationResult (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:107153:12)
    at createWasm (/nix/store/br2hbl66m2d47219wbzs5ifa9dl824j8-aeson-gadt-th-0.2.5.4/bin/readme:107179:17)

Node.js v22.19.0
```

After
```
Encoding of A_a:
"[\"A_a\",[]]"
Decoding of encoded A_a:
Just (Some A_a)

Encoding of (A_b 1):
"[\"A_b\",1]"
Decoding of encoded (A_b 1):
Just (Some (A_b 1))

Encoding of (B_a 'a' (A_b 1)):
"[\"B_a\",[\"a\",[\"A_b\",1]]]"
Decoding of encoded (B_a 'a' (A_b 1)):
Succeeded
```



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
