### PR TITLE
python3Packages.pytest-asyncio: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-asyncio/default.nix
+++ b/pkgs/development/python-modules/pytest-asyncio/default.nix
@@ -7,18 +7,19 @@
   pytest,
   setuptools-scm,
   backports-asyncio-runner,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "pytest-asyncio";
-  version = "1.1.0"; # N.B.: when updating, tests bleak and aioesphomeapi tests
+  version = "1.2.0"; # N.B.: when updating, tests bleak and aioesphomeapi tests
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytest-dev";
     repo = "pytest-asyncio";
     tag = "v${version}";
-    hash = "sha256-+dLOzMPKI3nawfyZVZZ6hg6OkaEGZBp8oC5VIr7y0es=";
+    hash = "sha256-27FCV7zgFGe/Q0fkYyh5Z05foVGhbKBRPTH4UK/tW5A=";
   };
 
   outputs = [
@@ -29,8 +30,12 @@ buildPythonPackage rec {
   build-system = [ setuptools-scm ];
 
   buildInputs = [ pytest ];
-  dependencies = lib.optionals (pythonOlder "3.11") [
+
+  dependencies = [
     backports-asyncio-runner
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
+    typing-extensions
   ];
 
   postInstall = ''


### PR DESCRIPTION
Diff: https://github.com/pytest-dev/pytest-asyncio/compare/v1.1.0...v1.2.0

Changelog: https://github.com/pytest-dev/pytest-asyncio/blob/v1.2.0/docs/reference/changelog.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
