### PR TITLE
Add python apify-fingerprint-datapoints package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17303,6 +17303,11 @@
     githubId = 20619776;
     name = "moni";
   };
+  monk3yd = {
+    name = "monk3yd";
+    github = "monk3yd";
+    githubId = 59047243;
+  };
   monkieeboi = {
     name = "MonkieeBoi";
     github = "MonkieeBoi";

--- a/pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
+++ b/pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
@@ -1,0 +1,44 @@
+# pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
+
+{
+  lib,
+  buildPythonPackage,
+  # fetchPypi,
+  hatchling,
+  setuptools,
+  fetchurl,
+}:
+
+buildPythonPackage {
+  pname = "apify-fingerprint-datapoints";
+  version = "0.1.0";
+  format = "pyproject";
+
+  # src = fetchPypi {
+  #   inherit pname version;
+  #   hash = "sha256-sF7N7RiSli4yGWzH0cS66GRtNS3k/te8u8OOnGvNQTY=";
+  # };
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/63/7d/355f0d8ac50d03e0877a071deacecb3297d59a52fd2ecf1fab6c9d9474e9/apify_fingerprint_datapoints-0.1.0.tar.gz";
+    hash = "sha256-sF7N7RiSli4yGWzH0cS66GRtNS3k/te8u8OOnGvNQTY=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+    setuptools
+  ];
+
+  # It's good practice to run tests if they are available and work offline.
+  # Since you set doCheck = false, we'll keep it that way for now.
+  doCheck = false;
+
+  pythonImportsCheck = [ "apify_fingerprint_datapoints" ];
+
+  meta = with lib; {
+    description = "Fingerprint datapoints files collected by Apify and originally stored at https://github.com/apify/fingerprint-suite. This package contains datafiles and helper functions for getting the path to the datafiles.";
+    homepage = "https://docs.apify.com/academy/anti-scraping/techniques/fingerprinting";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ monk3yd ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -779,6 +779,10 @@ self: super: with self; {
 
   apeye-core = callPackage ../development/python-modules/apeye-core { };
 
+  apify-fingerprint-datapoints =
+    callPackage ../development/python-modules/apify-fingerprint-datapoints
+      { };
+
   apipkg = callPackage ../development/python-modules/apipkg { };
 
   apischema = callPackage ../development/python-modules/apischema { };


### PR DESCRIPTION

This package is a core dependency of [crawlee-python](https://github.com/apify/crawlee-python).

Fingerprint datapoints files collected by Apify and originally stored at https://github.com/apify/fingerprint-suite. This package contains datafiles and helper functions for getting the path to the datafiles.

https://docs.apify.com/academy/anti-scraping/techniques/fingerprinting

- Built on platform:
  - [ x] x86_64-linux

- NixOS Release Notes
  - [ x] Module addition: when adding a new NixOS module.