### PR TITLE
Add python puccinialin package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17303,6 +17303,11 @@
     githubId = 20619776;
     name = "moni";
   };
+  monk3yd = {
+    name = "monk3yd";
+    github = "monk3yd";
+    githubId = 59047243;
+  };
   monkieeboi = {
     name = "MonkieeBoi";
     github = "MonkieeBoi";

--- a/pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
+++ b/pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
@@ -1,0 +1,44 @@
+# pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
+
+{
+  lib,
+  buildPythonPackage,
+  # fetchPypi,
+  hatchling,
+  setuptools,
+  fetchurl,
+}:
+
+buildPythonPackage {
+  pname = "apify-fingerprint-datapoints";
+  version = "0.1.0";
+  format = "pyproject";
+
+  # src = fetchPypi {
+  #   inherit pname version;
+  #   hash = "sha256-sF7N7RiSli4yGWzH0cS66GRtNS3k/te8u8OOnGvNQTY=";
+  # };
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/63/7d/355f0d8ac50d03e0877a071deacecb3297d59a52fd2ecf1fab6c9d9474e9/apify_fingerprint_datapoints-0.1.0.tar.gz";
+    hash = "sha256-sF7N7RiSli4yGWzH0cS66GRtNS3k/te8u8OOnGvNQTY=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+    setuptools
+  ];
+
+  # It's good practice to run tests if they are available and work offline.
+  # Since you set doCheck = false, we'll keep it that way for now.
+  doCheck = false;
+
+  pythonImportsCheck = [ "apify_fingerprint_datapoints" ];
+
+  meta = with lib; {
+    description = "Fingerprint datapoints files collected by Apify and originally stored at https://github.com/apify/fingerprint-suite. This package contains datafiles and helper functions for getting the path to the datafiles.";
+    homepage = "https://docs.apify.com/academy/anti-scraping/techniques/fingerprinting";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ monk3yd ];
+  };
+}

--- a/pkgs/development/python-modules/puccinialin/default.nix
+++ b/pkgs/development/python-modules/puccinialin/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+  setuptools-rust,
+  hatchling,
+  cargo,
+  rustc,
+  httpx,
+  platformdirs,
+  tqdm,
+}:
+
+buildPythonPackage {
+  pname = "puccinialin";
+  version = "0.1.5";
+  format = "pyproject";
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/a5/1a/27a2a9ee534555c3bdccd04cdc63db17066e0bd6817e8540283d1c0a87a5/puccinialin-0.1.5.tar.gz";
+    hash = "sha256-u7ZkGmNX9wYWvSb8Ajeov23+GbKO/Qdn/yBYvzfD1gI=";
+  };
+  nativeBuildInputs = [
+    setuptools-rust
+    cargo
+    rustc
+    hatchling
+  ];
+  propagatedBuildInputs = [
+    httpx
+    platformdirs
+    tqdm
+  ];
+  pythonImportsCheck = [ "puccinialin" ];
+  meta = with lib; {
+    description = "Install rust into a temporary directory for boostrapping a rust-based build backend";
+    homepage = "https://github.com/messense/puccinialin-py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ monk3yd ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -779,6 +779,10 @@ self: super: with self; {
 
   apeye-core = callPackage ../development/python-modules/apeye-core { };
 
+  apify-fingerprint-datapoints =
+    callPackage ../development/python-modules/apify-fingerprint-datapoints
+      { };
+
   apipkg = callPackage ../development/python-modules/apipkg { };
 
   apischema = callPackage ../development/python-modules/apischema { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12361,6 +12361,8 @@ self: super: with self; {
 
   pubnubsub-handler = callPackage ../development/python-modules/pubnubsub-handler { };
 
+  puccinialin = callPackage ../development/python-modules/puccinialin { };
+
   pudb = callPackage ../development/python-modules/pudb { };
 
   pueblo = callPackage ../development/python-modules/pueblo { };


### PR DESCRIPTION
Impit dependency, impit is a rust client used by crawlee.

This package installs rust into a temporary directory for boostrapping a rust-based build backend.

https://pypi.org/project/puccinialin/

- Built on platform:
  - [ x] x86_64-linux

- NixOS Release Notes
  - [x ] Module addition: when adding a new NixOS module.

