### PR TITLE
cvc5: 1.3.0 → 1.3.1

### DIFF
--- a/pkgs/by-name/ca/cadical/package.nix
+++ b/pkgs/by-name/ca/cadical/package.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation rec {
     install -Dm0755 build/mobical "$out/bin/mobical"
     install -Dm0644 src/ccadical.h "$dev/include/ccadical.h"
     install -Dm0644 src/cadical.hpp "$dev/include/cadical.hpp"
+    install -Dm0644 src/cadical.hpp "$dev/include/cadical/cadical.hpp"
+    install -Dm0644 src/tracer.hpp "$dev/include/cadical/tracer.hpp"
     install -Dm0644 build/libcadical.a "$lib/lib/libcadical.a"
     mkdir -p "$out/share/doc/${pname}/"
     install -Dm0755 {LICEN?E,README*,VERSION} "$out/share/doc/${pname}/"

--- a/pkgs/by-name/cv/cvc5/package.nix
+++ b/pkgs/by-name/cv/cvc5/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cvc5";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "cvc5";
     repo = "cvc5";
-    rev = "cvc5-${version}";
-    hash = "sha256-w8rIGPG9BTEPV9HG2U40A4DYYnC6HaWbzqDKCRhaT00=";
+    tag = "cvc5-${version}";
+    hash = "sha256-nxJjrpWZfYPuuKN4CWxOHEuou4r+MdK0AjdEPZHZbHI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
