### PR TITLE
pgit: init at 1.1.0

### DIFF
--- a/pkgs/by-name/pg/pgit/package.nix
+++ b/pkgs/by-name/pg/pgit/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  runCommand,
+  git, # for passthru tests
+  pgit, # for passthru tests
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pgit";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "picosh";
+    repo = "pgit";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-81ZiaY973+mGnYbDX+6fhe9NTYjQhWsvdpW0v42pasw=";
+  };
+
+  vendorHash = "sha256-in8GVcOlGsvmcbegJmYwvE0AVJhVJ83x1v3ymV0uTpg=";
+
+  passthru.tests.smoke =
+    runCommand "pgit-smoke-test"
+      {
+        buildInputs = [ git ];
+      }
+      ''
+        ${lib.getExe git} init -b smoke
+        ${lib.getExe git} config --local user.name "Nick Spackages"
+        ${lib.getExe git} config --local user.email "nixbld@localhost"
+        echo "Read me please" > README
+        ${lib.getExe git} add README
+        ${lib.getExe git} commit -m "First commit"
+        ${lib.getExe pgit} -desc "The description" -revs smoke -repo . -out ./public
+        grep "The description" ./public/index.html
+        grep "First commit" ./public/logs/smoke/index.html
+        grep "Read me please" ./public/tree/smoke/item/README.html
+        touch $out
+      '';
+
+  meta = with lib; {
+    description = "static site generator for git";
+    homepage = "https://pgit.pico.sh/";
+    license = licenses.mit;
+    mainProgram = "pgit";
+    maintainers = with maintainers; [ jaculabilis ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[`pgit`](https://pgit.pico.sh/) is a static site generator for git repositories, similar to `stagit`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
