### PR TITLE
treewide: replace `sha256 = <SRI>` with `hash` in fetchpatch calls

### DIFF
--- a/nixos/modules/services/x11/window-managers/dwm.nix
+++ b/nixos/modules/services/x11/window-managers/dwm.nix
@@ -32,7 +32,7 @@ in
             patches = [
               (super.fetchpatch {
                 url = "https://dwm.suckless.org/patches/steam/dwm-steam-6.2.diff";
-                sha256 = "sha256-f3lffBjz7+0Khyn9c9orzReoLTqBb/9gVGshYARGdVc=";
+                hash = "sha256-f3lffBjz7+0Khyn9c9orzReoLTqBb/9gVGshYARGdVc=";
               })
             ];
           })

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -66,7 +66,7 @@ mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/archlinux/svntogit-community/cf64acc45e3264c6923885867e2dbf8b7586a36b/trunk/lmms-carla-export.patch";
-      sha256 = "sha256-wlSewo93DYBN2PvrcV58dC9kpoo9Y587eCeya5OX+j4=";
+      hash = "sha256-wlSewo93DYBN2PvrcV58dC9kpoo9Y587eCeya5OX+j4=";
     })
   ];
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -947,12 +947,12 @@ assertNoAdditions {
       (fetchpatch {
         name = "drop_python2_pt1.patch";
         url = "https://github.com/JazzCore/ctrlp-cmatcher/commit/3abad6ea155a7f6e138e1de3ac5428177bfb0254.patch";
-        sha256 = "sha256-fn2puqYeJdPTdlTT4JjwVz7b3A+Xcuj/xtP6TETlB1U=";
+        hash = "sha256-fn2puqYeJdPTdlTT4JjwVz7b3A+Xcuj/xtP6TETlB1U=";
       })
       (fetchpatch {
         name = "drop_python2_pt2.patch";
         url = "https://github.com/JazzCore/ctrlp-cmatcher/commit/385c8d02398dbb328b1a943a94e7109fe6473a08.patch";
-        sha256 = "sha256-yXKCq8sqO0Db/sZREuSeqKwKO71cmTsAvWftoOQehZo=";
+        hash = "sha256-yXKCq8sqO0Db/sZREuSeqKwKO71cmTsAvWftoOQehZo=";
       })
     ];
     buildInputs = with python3.pkgs; [

--- a/pkgs/applications/graphics/apngasm/default.nix
+++ b/pkgs/applications/graphics/apngasm/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     # Fix parallel build and avoid static linking of binary.
     (fetchpatch {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/apngasm/files/apngasm-3.1.10-static.patch?id=45fd0cde71ca2ae0e7e38ab67400d84b86b593d7";
-      sha256 = "sha256-eKthgInWxXEqN5PupvVf9wVQDElxsPYRFXT7pMc6vIU=";
+      hash = "sha256-eKthgInWxXEqN5PupvVf9wVQDElxsPYRFXT7pMc6vIU=";
     })
   ];
 

--- a/pkgs/applications/networking/cluster/kubeval/default.nix
+++ b/pkgs/applications/networking/cluster/kubeval/default.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     (fetchpatch {
       name = "bump-golang.org/x/sys.patch";
       url = "https://github.com/instrumenta/kubeval/commit/d64502b04d9e1b85fd3d5509049adb50f3e39954.patch";
-      sha256 = "sha256-S/lgwdykFLU2QZRW927fgCPxaIAMK3vSqmH08pXBQxM=";
+      hash = "sha256-S/lgwdykFLU2QZRW927fgCPxaIAMK3vSqmH08pXBQxM=";
     })
   ];
 

--- a/pkgs/applications/networking/instant-messengers/linphone/bc-soci/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/bc-soci/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     (fetchpatch {
       name = "fix-backend-search-path.patch";
       url = "https://github.com/SOCI/soci/commit/56c93afc467bdba8ffbe68739eea76059ea62f7a.patch";
-      sha256 = "sha256-nC/39pn3Cv5e65GgIfF3l64/AbCsfZHPUPIWETZFZAY=";
+      hash = "sha256-nC/39pn3Cv5e65GgIfF3l64/AbCsfZHPUPIWETZFZAY=";
     })
   ];
 

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/tdlib-purple/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     # Update to tdlib 1.8.0
     (fetchpatch {
       url = "https://github.com/ars3niy/tdlib-purple/commit/8c87b899ddbec32ec6ab4a34ddf0dc770f97d396.patch";
-      sha256 = "sha256-sysPYPno+wS8mZwQAXtX5eVnhwKAZrtr5gXuddN3mko=";
+      hash = "sha256-sysPYPno+wS8mZwQAXtX5eVnhwKAZrtr5gXuddN3mko=";
     })
   ];
 

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -159,7 +159,7 @@ let
         # fix version display in MacOS Finder
         (fetchpatch {
           url = "https://github.com/mumble-voip/mumble/commit/fbd21bd422367bed19f801bf278562f567cbb8b7.patch";
-          sha256 = "sha256-qFhC2j/cOWzAhs+KTccDIdcgFqfr4y4VLjHiK458Ucs=";
+          hash = "sha256-qFhC2j/cOWzAhs+KTccDIdcgFqfr4y4VLjHiK458Ucs=";
         })
       ];
 

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -87,17 +87,17 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/shogun-toolbox/shogun/pull/4811
     (fetchpatch {
       url = "https://github.com/shogun-toolbox/shogun/commit/c8b670be4790e0f06804b048a6f3d77c17c3ee95.patch";
-      sha256 = "sha256-MxsR3Y2noFQevfqWK3nmX5iK4OVWeKBl5tfeDNgjcXk=";
+      hash = "sha256-MxsR3Y2noFQevfqWK3nmX5iK4OVWeKBl5tfeDNgjcXk=";
     })
     (fetchpatch {
       url = "https://github.com/shogun-toolbox/shogun/commit/5aceefd9fb0e2132c354b9a0c0ceb9160cc9b2f7.patch";
-      sha256 = "sha256-AgJJKQA8vc5oKaTQDqMdwBR4hT4sn9+uW0jLe7GteJw=";
+      hash = "sha256-AgJJKQA8vc5oKaTQDqMdwBR4hT4sn9+uW0jLe7GteJw=";
     })
 
     # Fix virtual destruction
     (fetchpatch {
       url = "https://github.com/shogun-toolbox/shogun/commit/ef0e4dc1cc4a33c9e6b17a108fa38a436de2d7ee.patch";
-      sha256 = "sha256-a9Rm0ytqkSAgC3dguv8m3SwOSipb+VByBHHdmV0d63w=";
+      hash = "sha256-a9Rm0ytqkSAgC3dguv8m3SwOSipb+VByBHHdmV0d63w=";
     })
     ./fix-virtual-destruction.patch
 
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/shogun-toolbox/shogun/pull/4104
     (fetchpatch {
       url = "https://github.com/shogun-toolbox/shogun/commit/365ce4c4c700736d2eec8ba6c975327a5ac2cd9b.patch";
-      sha256 = "sha256-OhEWwrHtD/sOcjHmPY/C9zJ8ruww8yXrRcTw38nGEJU=";
+      hash = "sha256-OhEWwrHtD/sOcjHmPY/C9zJ8ruww8yXrRcTw38nGEJU=";
     })
 
     # Fix compile errors with Eigen 3.4

--- a/pkgs/applications/science/math/yacas/default.nix
+++ b/pkgs/applications/science/math/yacas/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     # PR: https://github.com/grzegorzmazur/yacas/pull/343
     (fetchpatch {
       url = "https://github.com/grzegorzmazur/yacas/commit/8bc22d517ecfdde3ac94800dc8506f5405564d48.patch";
-      sha256 = "sha256-aPO5T8iYNkGtF8j12YxNJyUPJJPKrXje1DmfCPt317A=";
+      hash = "sha256-aPO5T8iYNkGtF8j12YxNJyUPJJPKrXje1DmfCPt317A=";
     })
   ];
   preCheck = ''

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -277,7 +277,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Workaround for upstream issue with nested virtualisation: https://gitlab.com/qemu-project/qemu/-/issues/1008
     (fetchpatch {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/3e4546d5bd38a1e98d4bd2de48631abf0398a3a2.diff";
-      sha256 = "sha256-oC+bRjEHixv1QEFO9XAm4HHOwoiT+NkhknKGPydnZ5E=";
+      hash = "sha256-oC+bRjEHixv1QEFO9XAm4HHOwoiT+NkhknKGPydnZ5E=";
       revert = true;
     })
   ]

--- a/pkgs/applications/window-managers/i3/lock-blur.nix
+++ b/pkgs/applications/window-managers/i3/lock-blur.nix
@@ -24,7 +24,7 @@ i3lock-color.overrideAttrs (oldAttrs: rec {
     (fetchpatch {
       name = "fno-common.patch";
       url = "https://github.com/karulont/i3lock-blur/commit/ec8fe0e7f7d78bf445602ed517efd5c324bb32f7.patch";
-      sha256 = "sha256-0hXUr+ZEB1tpI3xw80/hGzKyeGuna4CQmEvK6t0VBqU=";
+      hash = "sha256-0hXUr+ZEB1tpI3xw80/hGzKyeGuna4CQmEvK6t0VBqU=";
     })
   ];
 

--- a/pkgs/by-name/ae/aewan/package.nix
+++ b/pkgs/by-name/ae/aewan/package.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation rec {
     # https://sourceforge.net/p/aewan/bugs/14/
     (fetchpatch {
       url = "https://sourceforge.net/p/aewan/bugs/14/attachment/aewan-1.0.01-fix-incompatible-function-pointer-types.patch";
-      sha256 = "sha256-NlnsOe/OCMXCrehBq20e0KOMcWt5rUv9fIvu9eoOMqw=";
+      hash = "sha256-NlnsOe/OCMXCrehBq20e0KOMcWt5rUv9fIvu9eoOMqw=";
     })
     # https://sourceforge.net/p/aewan/bugs/16/
     (fetchpatch {
       url = "https://sourceforge.net/p/aewan/bugs/16/attachment/implicit-function-declaration.patch";
-      sha256 = "sha256-RWFJRDaYoiQySkB2L09JHSX90zgIJ9q16IrPhg03Ruc=";
+      hash = "sha256-RWFJRDaYoiQySkB2L09JHSX90zgIJ9q16IrPhg03Ruc=";
       # patch is in CVS diff format, add 'a/' prefix
       extraPrefix = "";
     })

--- a/pkgs/by-name/an/ananicy/package.nix
+++ b/pkgs/by-name/an/ananicy/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     # fix makefile destinations
     (fetchpatch {
       url = "https://github.com/Nefelim4ag/Ananicy/commit/dbda0f50670de3f249991706ef1cc107c5197a2f.patch";
-      sha256 = "sha256-vMcJxekg2QUbm253CLAv3tmo5kedSlw+/PI/LamNWwc=";
+      hash = "sha256-vMcJxekg2QUbm253CLAv3tmo5kedSlw+/PI/LamNWwc=";
       # only used for debian packaging. lets exclude it so the patch applies even when that file is changed
       excludes = [ "package.sh" ];
     })

--- a/pkgs/by-name/bm/bmon/package.nix
+++ b/pkgs/by-name/bm/bmon/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://github.com/macports/macports-ports/raw/6d1dd5e9c8fae608bd22f3ede21e576f29c6358c/net/bmon/files/patch-fix__unused.diff";
       extraPrefix = "";
-      sha256 = "sha256-UYIiJZzipsx9a0xabrKfyj8TWNW7IM77oXnVnSPkQkc=";
+      hash = "sha256-UYIiJZzipsx9a0xabrKfyj8TWNW7IM77oXnVnSPkQkc=";
     })
   ];
 

--- a/pkgs/by-name/bo/bombono/package.nix
+++ b/pkgs/by-name/bo/bombono/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     (fetchpatch {
       name = "bombono-dvd-1.2.4-scons3.patch";
       url = "https://svnweb.mageia.org/packages/cauldron/bombono-dvd/current/SOURCES/bombono-dvd-1.2.4-scons-python3.patch?revision=1447925&view=co&pathrev=1484457";
-      sha256 = "sha256-5OKBWrRZvHem2MTdAObfdw76ig3Z4ZdDFtq4CJoJISA=";
+      hash = "sha256-5OKBWrRZvHem2MTdAObfdw76ig3Z4ZdDFtq4CJoJISA=";
     })
 
     # Fix compilation errors having ffmpeg 2:5.1

--- a/pkgs/by-name/bo/bootiso/package.nix
+++ b/pkgs/by-name/bo/bootiso/package.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://code.opensuse.org/package/bootiso/raw/3799710e3da40c1b429ea1a2ce3896d18d08a5c5/f/syslinux-lib-root.patch";
-      sha256 = "sha256-x2EJppQsPPymSrjRwEy7mylW+2OKcGzKsKF3y7fzrB8=";
+      hash = "sha256-x2EJppQsPPymSrjRwEy7mylW+2OKcGzKsKF3y7fzrB8=";
     })
   ];
 

--- a/pkgs/by-name/bo/bootspec-lix/package.nix
+++ b/pkgs/by-name/bo/bootspec-lix/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     (fetchpatch {
       name = "aarch64-support.patch";
       url = "https://github.com/DeterminateSystems/bootspec/commit/1d0e925f360f0199f13422fb7541225fd162fd4f.patch";
-      sha256 = "sha256-wU/jWnOqVBrU2swANdXbQfzRpNd/JIS4cxSyCvixZM0=";
+      hash = "sha256-wU/jWnOqVBrU2swANdXbQfzRpNd/JIS4cxSyCvixZM0=";
     })
   ];
 

--- a/pkgs/by-name/bo/bowtie/package.nix
+++ b/pkgs/by-name/bo/bowtie/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fix_compilation_on_arm64";
       url = "https://github.com/BenLangmead/bowtie/commit/091d72f4cb69ca0713704d38bd7f9b37e6c4ff2d.patch";
-      sha256 = "sha256-XBvgICUBnE5HKpJ36IHTDiKjJgLFKETsIaJC46uN+2I=";
+      hash = "sha256-XBvgICUBnE5HKpJ36IHTDiKjJgLFKETsIaJC46uN+2I=";
     })
 
     # Without this patch, compilation adds the current source directory to the
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fix_include_search_path";
       url = "https://github.com/BenLangmead/bowtie/commit/c208b9db936eab0bc3ffdf0182b4f59a9017a1c4.patch";
-      sha256 = "sha256-772EE+oWFWXssSMabPryb0AfIS1tC10mPTRCBm7RrUs=";
+      hash = "sha256-772EE+oWFWXssSMabPryb0AfIS1tC10mPTRCBm7RrUs=";
     })
   ];
 

--- a/pkgs/by-name/br/bridge-utils/package.nix
+++ b/pkgs/by-name/br/bridge-utils/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "musl-includes.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/bridge-utils/fix-PATH_MAX-on-ppc64le.patch?id=12c9046eee3a0a35665dc4e280c1f5ae2af5845d";
-      sha256 = "sha256-uY1tgJhcm1DFctg9scmC8e+mgowgz4f/oF0+k+x+jqw=";
+      hash = "sha256-uY1tgJhcm1DFctg9scmC8e+mgowgz4f/oF0+k+x+jqw=";
     })
   ];
 

--- a/pkgs/by-name/bs/bsdiff/package.nix
+++ b/pkgs/by-name/bs/bsdiff/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://sources.debian.org/data/main/b/bsdiff/4.3-22/debian/patches/20-CVE-2014-9862.patch";
-      sha256 = "sha256-3UuUfNvShQ8fLqxCKUTb/n4BmjL4+Nl7aEqCxYrrERQ=";
+      hash = "sha256-3UuUfNvShQ8fLqxCKUTb/n4BmjL4+Nl7aEqCxYrrERQ=";
     })
     ./CVE-2020-14315.patch
     ./include-systypes.patch
@@ -27,15 +27,15 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     (fetchpatch {
       url = "https://sources.debian.org/data/main/b/bsdiff/4.3-22/debian/patches/30-bug-632585-mmap-src-file-instead-of-malloc-read-it.patch";
-      sha256 = "sha256-esbhz2/efUiuQDuF7LGfSeEn3/f1WbqCxQpTs2A0ulI=";
+      hash = "sha256-esbhz2/efUiuQDuF7LGfSeEn3/f1WbqCxQpTs2A0ulI=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/b/bsdiff/4.3-22/debian/patches/31-bug-632585-mmap-dst-file-instead-of-malloc-read-it.patch";
-      sha256 = "sha256-Of4aOcI0rsgdRzPqyw2VRn2p9wQuo3hdlgDTBdXGzoc=";
+      hash = "sha256-Of4aOcI0rsgdRzPqyw2VRn2p9wQuo3hdlgDTBdXGzoc=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/b/bsdiff/4.3-22/debian/patches/32-bug-632585-use-int32_t-instead-off_t-for-file-size.patch";
-      sha256 = "sha256-SooFnFK4uKNXvXQb/LEcH8GocnRtkryExI4b3BZTsAY=";
+      hash = "sha256-SooFnFK4uKNXvXQb/LEcH8GocnRtkryExI4b3BZTsAY=";
     })
   ];
 

--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0002-cemu-imgui.patch
     (fetchpatch2 {
       url = "https://github.com/cemu-project/Cemu/commit/c1c2962b6633017cd956c6925288e2529c532ee4.diff?full_index=1";
-      sha256 = "sha256-Dz7WnCf5+Vbr/ETX71wIo/x/zPWdrsOtPH7bsL5Bd+A=";
+      hash = "sha256-Dz7WnCf5+Vbr/ETX71wIo/x/zPWdrsOtPH7bsL5Bd+A=";
     })
   ];
 

--- a/pkgs/by-name/cl/clutter-gst/package.nix
+++ b/pkgs/by-name/cl/clutter-gst/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     # https://github.com/archlinux/svntogit-packages/tree/packages/clutter-gst/trunk
     (fetchpatch {
       url = "https://github.com/archlinux/svntogit-packages/raw/c4dd0bbda35aa603ee790676f6e15541f71b6d36/trunk/0001-video-sink-Remove-RGBx-BGRx-support.patch";
-      sha256 = "sha256-k1fCiM/u7q81UrDYgbqhN/C+q9DVQ+qOyq6vmA3hbSQ=";
+      hash = "sha256-k1fCiM/u7q81UrDYgbqhN/C+q9DVQ+qOyq6vmA3hbSQ=";
     })
   ];
 

--- a/pkgs/by-name/co/colmena/package.nix
+++ b/pkgs/by-name/co/colmena/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     # Fixes nix 2.24 compat: https://github.com/zhaofengli/colmena/pull/236
     (fetchpatch {
       url = "https://github.com/zhaofengli/colmena/commit/36382ee2bef95983848435065f7422500c7923a8.patch";
-      sha256 = "sha256-5cQ2u3eTzhzjPN+rc6xWIskHNtheVXXvlSeJ1G/lz+E=";
+      hash = "sha256-5cQ2u3eTzhzjPN+rc6xWIskHNtheVXXvlSeJ1G/lz+E=";
     })
   ];
 

--- a/pkgs/by-name/cu/cubicsdr/package.nix
+++ b/pkgs/by-name/cu/cubicsdr/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     # Fix for liquid-dsp v1.50
     (fetchpatch {
       url = "https://github.com/cjcliffe/CubicSDR/commit/0e3a785bd2af56d18ff06b56579197b3e89b34ab.patch";
-      sha256 = "sha256-mPfNZcV3FnEtGVX4sCMSs+Qc3VeSBIRkpCyx24TKkcU=";
+      hash = "sha256-mPfNZcV3FnEtGVX4sCMSs+Qc3VeSBIRkpCyx24TKkcU=";
     })
   ];
 

--- a/pkgs/by-name/da/dante/package.nix
+++ b/pkgs/by-name/da/dante/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "0002-osdep-m4-Remove-getaddrinfo-too-low-checks.patch";
       url = "https://raw.githubusercontent.com/buildroot/buildroot/master/package/dante/0002-osdep-m4-Remove-getaddrinfo-too-low-checks.patch";
-      sha256 = "sha256-e+qF8lB5tkiA7RlJ+tX5O6KxQrQp33RSPdP1TxU961Y=";
+      hash = "sha256-e+qF8lB5tkiA7RlJ+tX5O6KxQrQp33RSPdP1TxU961Y=";
     })
   ];
 

--- a/pkgs/by-name/de/decoder/package.nix
+++ b/pkgs/by-name/de/decoder/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     (fetchpatch {
       name = "fno-common.patch";
       url = "https://github.com/PeterPawn/decoder/commit/843ac477c31108023d8008581bf91c5a3acc1859.patch";
-      sha256 = "sha256-rRylz8cxgNyPSqL/THdgEBpzcVx1K+xbjUn4PwP9Jn4=";
+      hash = "sha256-rRylz8cxgNyPSqL/THdgEBpzcVx1K+xbjUn4PwP9Jn4=";
     })
   ];
 

--- a/pkgs/by-name/di/directfb/package.nix
+++ b/pkgs/by-name/di/directfb/package.nix
@@ -41,11 +41,11 @@ stdenv.mkDerivation rec {
     # Fixes for build of `pkgsMusl.directfb`; applied everywhere to prevent patchrot
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/community/directfb/0001-directfb-fix-musl-compile.patch?id=f8158258493fc0c3eb5de2302e40f4bc44ecfb09";
-      sha256 = "sha256-hmwzbaXu30ZkAqUn1NmvtlJkM6ctddKcO4hxh+1LSS4=";
+      hash = "sha256-hmwzbaXu30ZkAqUn1NmvtlJkM6ctddKcO4hxh+1LSS4=";
     })
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/community/directfb/0002-Fix-musl-PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP-comp.patch?id=f8158258493fc0c3eb5de2302e40f4bc44ecfb09";
-      sha256 = "sha256-j3+mcP6hV9LKuba1GOdcM1cZfmXuJtRgx4vE484jIns=";
+      hash = "sha256-j3+mcP6hV9LKuba1GOdcM1cZfmXuJtRgx4vE484jIns=";
     })
     # This uses POSIX basename() while directfb expects GNU
     # basename(), but the POSIX behaviour of modifying the input

--- a/pkgs/by-name/di/dirstalk/package.nix
+++ b/pkgs/by-name/di/dirstalk/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
     # update dependencies to fix darwin build - remove in next release
     (fetchpatch {
       url = "https://github.com/stefanoj3/dirstalk/commit/79aef14c5c048f3a3a8374f42c7a0d52fc9f7b50.patch";
-      sha256 = "sha256-2rSrMowfYdKV69Yg2QBzam3WOwGrSHQB+3uVi1Z2oJ8=";
+      hash = "sha256-2rSrMowfYdKV69Yg2QBzam3WOwGrSHQB+3uVi1Z2oJ8=";
     })
   ];
 

--- a/pkgs/by-name/dm/dmenu-wayland/package.nix
+++ b/pkgs/by-name/dm/dmenu-wayland/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
     (fetchpatch {
       name = "support-cross-compilation.patch";
       url = "https://github.com/nyyManni/dmenu-wayland/commit/3434410de5dcb007539495395f7dc5421923dd3a.patch";
-      sha256 = "sha256-im16kU8RWrCY0btYOYjDp8XtfGEivemIPlhwPX0C77o=";
+      hash = "sha256-im16kU8RWrCY0btYOYjDp8XtfGEivemIPlhwPX0C77o=";
     })
   ];
 

--- a/pkgs/by-name/do/dosfstools/package.nix
+++ b/pkgs/by-name/do/dosfstools/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     # TODO: remove on the next release
     (fetchpatch {
       url = "https://github.com/dosfstools/dosfstools/commit/77ffb87e8272760b3bb2dec8f722103b0effb801.patch";
-      sha256 = "sha256-xHxIs3faHK/sK3vAVoG8JcTe4zAV+ZtkozWIIFBvPWI=";
+      hash = "sha256-xHxIs3faHK/sK3vAVoG8JcTe4zAV+ZtkozWIIFBvPWI=";
     })
     (fetchpatch {
       url = "https://github.com/dosfstools/dosfstools/commit/2d3125c4a74895eae1f66b93287031d340324524.patch";
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     # TODO: remove on the next release
     (fetchpatch {
       url = "https://github.com/dosfstools/dosfstools/commit/8da7bc93315cb0c32ad868f17808468b81fa76ec.patch";
-      sha256 = "sha256-Quegj5uYZgACgjSZef6cjrWQ64SToGQxbxyqCdl8C7o=";
+      hash = "sha256-Quegj5uYZgACgjSZef6cjrWQ64SToGQxbxyqCdl8C7o=";
     })
     ./gettext-0.25.patch
   ];

--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "musl-strndupa.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/elfutils/musl-strndupa.patch?id=2e3d4976eeffb4704cf83e2cc3306293b7c7b2e9";
-      sha256 = "sha256-7daehJj1t0wPtQzTv+/Rpuqqs5Ng/EYnZzrcf2o/Lb0=";
+      hash = "sha256-7daehJj1t0wPtQzTv+/Rpuqqs5Ng/EYnZzrcf2o/Lb0=";
     })
   ]
   ++ lib.optionals stdenv.hostPlatform.isMusl [ ./musl-error_h.patch ];

--- a/pkgs/by-name/ep/epgstation/package.nix
+++ b/pkgs/by-name/ep/epgstation/package.nix
@@ -27,11 +27,11 @@ buildNpmPackage rec {
     # upgrade dependencies to make it compatible with node 18
     (fetchpatch {
       url = "https://github.com/midchildan/EPGStation/commit/5d6cad746b7d9b6d246adcdecf9c991b77c9d89e.patch";
-      sha256 = "sha256-9a8VUjczlyQHVO7w9MYorPIZunAuBuif1HNmtp1yMk8=";
+      hash = "sha256-9a8VUjczlyQHVO7w9MYorPIZunAuBuif1HNmtp1yMk8=";
     })
     (fetchpatch {
       url = "https://github.com/midchildan/EPGStation/commit/c948e833e485c2b7cb7fb33b953cca1e20de3a70.patch";
-      sha256 = "sha256-nM6KkVRURuQFZLXZ2etLU1a1+BoaJnfjngo07TFbe58=";
+      hash = "sha256-nM6KkVRURuQFZLXZ2etLU1a1+BoaJnfjngo07TFbe58=";
     })
   ];
 

--- a/pkgs/by-name/er/eresi/package.nix
+++ b/pkgs/by-name/er/eresi/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     #   https://github.com/thorkill/eresi/pull/167
     (fetchpatch {
       url = "https://github.com/thorkill/eresi/commit/f85397c4dce633764fab29b0642f59fc4764658a.patch";
-      sha256 = "sha256-mKmJHjyWwCNh/pueB94Ndhj/3uZLBZNn/m9gXenP5ns=";
+      hash = "sha256-mKmJHjyWwCNh/pueB94Ndhj/3uZLBZNn/m9gXenP5ns=";
     })
   ];
 

--- a/pkgs/by-name/fa/fakechroot/package.nix
+++ b/pkgs/by-name/fa/fakechroot/package.nix
@@ -36,19 +36,19 @@ stdenv.mkDerivation rec {
     # glibc 2.33 compat (https://github.com/dex4er/fakechroot/pull/85/)
     (fetchpatch {
       url = "https://github.com/dex4er/fakechroot/commit/534e6d555736b97211523970d378dfb0db2608e9.patch";
-      sha256 = "sha256-bUlGJZvOSrATPt8bxGqU1UETTUD9V/HhJyA5ZxsOLQU=";
+      hash = "sha256-bUlGJZvOSrATPt8bxGqU1UETTUD9V/HhJyA5ZxsOLQU=";
     })
     (fetchpatch {
       url = "https://github.com/dex4er/fakechroot/commit/75d7e6fa191c11a791faff06a0de86eaa7801d05.patch";
-      sha256 = "sha256-vWN7zFkKlBd/F+h/66z21RiZqkSCn3UIzy9NHV7TYDg=";
+      hash = "sha256-vWN7zFkKlBd/F+h/66z21RiZqkSCn3UIzy9NHV7TYDg=";
     })
     (fetchpatch {
       url = "https://github.com/dex4er/fakechroot/commit/693a3597ea7fccfb62f357503ff177bd3e3d5a89.patch";
-      sha256 = "sha256-bFXsT0hWocJFbtS1cpzo7oIy/x66iUw6QE1/cEoZ+3k=";
+      hash = "sha256-bFXsT0hWocJFbtS1cpzo7oIy/x66iUw6QE1/cEoZ+3k=";
     })
     (fetchpatch {
       url = "https://github.com/dex4er/fakechroot/commit/e7c1f3a446e594a4d0cce5f5d499c9439ce1d5c5.patch";
-      sha256 = "sha256-eX6kB4U1ZlXoRtkSVEIBTRjO/cTS/7z5a9S366DiRMg=";
+      hash = "sha256-eX6kB4U1ZlXoRtkSVEIBTRjO/cTS/7z5a9S366DiRMg=";
     })
     # pass __readlinkat_chk buffer length
     (fetchpatch {

--- a/pkgs/by-name/fa/fakeroot/package.nix
+++ b/pkgs/by-name/fa/fakeroot/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
       (fetchpatch {
         name = "fakeroot-no64.patch";
         url = "https://git.alpinelinux.org/aports/plain/main/fakeroot/fakeroot-no64.patch?id=f68c541324ad07cc5b7f5228501b5f2ce4b36158";
-        sha256 = "sha256-NCDaB4nK71gvz8iQxlfaQTazsG0SBUQ/RAnN+FqwKkY=";
+        hash = "sha256-NCDaB4nK71gvz8iQxlfaQTazsG0SBUQ/RAnN+FqwKkY=";
       })
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/fa/fallout-ce/package.nix
+++ b/pkgs/by-name/fa/fallout-ce/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix case-sensitive filesystems issue when save/load games
     (fetchpatch2 {
       url = "https://github.com/alexbatalov/fallout1-ce/commit/fbd25f00e9ccfb5391e394272d536206bb86678b.patch?full_index=1";
-      sha256 = "sha256-MylI1DZwaANuScyRJ7fXch3aym8n6BDRhccAXAyvU70=";
+      hash = "sha256-MylI1DZwaANuScyRJ7fXch3aym8n6BDRhccAXAyvU70=";
     })
   ];
 

--- a/pkgs/by-name/fa/fallout2-ce/package.nix
+++ b/pkgs/by-name/fa/fallout2-ce/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix case-sensitive filesystems issue when save/load games
     (fetchpatch2 {
       url = "https://github.com/alexbatalov/fallout2-ce/commit/e770e64a48cd4d0a58a07f8db72839e4747e4c1e.patch?full_index=1";
-      sha256 = "sha256-49N6uXwOBL/sE+f+W4nX6Gpwwpmbgvy38B1NjECiia0=";
+      hash = "sha256-49N6uXwOBL/sE+f+W4nX6Gpwwpmbgvy38B1NjECiia0=";
     })
   ];
 

--- a/pkgs/by-name/fi/figlet/package.nix
+++ b/pkgs/by-name/fi/figlet/package.nix
@@ -24,12 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/figlet/musl-fix-cplusplus-decls.patch?h=3.4-stable&id=71776c73a6f04b6f671430f702bcd40b29d48399";
       name = "musl-fix-cplusplus-decls.patch";
-      sha256 = "sha256-8tg/3rBnjFG2Q4W807+Z0NpTO7VZrontn6qm6fL7QJw=";
+      hash = "sha256-8tg/3rBnjFG2Q4W807+Z0NpTO7VZrontn6qm6fL7QJw=";
     })
     (fetchpatch {
       url = "https://github.com/cmatsuoka/figlet/commit/9a50c1795bc32e5a698b855131ee87c8d7762c9e.patch";
       name = "unistd-on-darwin.patch";
-      sha256 = "sha256-hyfY87N+yuAwjsBIjpgvcdJ1IbzlR4A2yUJQSzShCRI=";
+      hash = "sha256-hyfY87N+yuAwjsBIjpgvcdJ1IbzlR4A2yUJQSzShCRI=";
     })
   ];
 

--- a/pkgs/by-name/fl/flamerobin/package.nix
+++ b/pkgs/by-name/fl/flamerobin/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     # rely on compiler command line for __int128 and std::decimal::decimal128
     (fetchpatch {
       url = "https://github.com/mariuz/flamerobin/commit/8e0ea6d42aa28a4baeaa8c8b8b57c56eb9ae3540.patch";
-      sha256 = "sha256-l6LWXA/sRQGQKi798bzl0iIJ2vdvXHOjG7wdFSXv+NM=";
+      hash = "sha256-l6LWXA/sRQGQKi798bzl0iIJ2vdvXHOjG7wdFSXv+NM=";
     })
   ];
 

--- a/pkgs/by-name/fl/flock/package.nix
+++ b/pkgs/by-name/fl/flock/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fix-format-specifier.patch";
       url = "https://github.com/discoteq/flock/commit/408bad42eb8d76cdd0c504c2f97f21c0b424c3b1.patch";
-      sha256 = "sha256-YuFKXWTBu9A2kBNqkg1Oek6vDbVo/y8dB1k9Fuh3QmA";
+      hash = "sha256-YuFKXWTBu9A2kBNqkg1Oek6vDbVo/y8dB1k9Fuh3QmA";
     })
   ];
 

--- a/pkgs/by-name/fl/flopoco/package.nix
+++ b/pkgs/by-name/fl/flopoco/package.nix
@@ -37,12 +37,12 @@ stdenv.mkDerivation {
         substituteInPlace $out \
           --replace 'FixSinCosCORDIC.hpp' 'CordicSinCos.hpp'
       '';
-      sha256 = "sha256-BlamA/MZuuqqvGYto+jPeQPop6gwva0y394Odw8pdwg=";
+      hash = "sha256-BlamA/MZuuqqvGYto+jPeQPop6gwva0y394Odw8pdwg=";
     })
     (fetchpatch {
       name = "fix-clang-error-atan2.patch";
       url = "https://gitlab.com/flopoco/flopoco/-/commit/a3ffe2436c1b59ee0809b3772b74f2d43c6edb99.patch";
-      sha256 = "sha256-dSYcufLHDL0p1V1ghmy6X6xse5f6mjUqckaVqLZnTaA=";
+      hash = "sha256-dSYcufLHDL0p1V1ghmy6X6xse5f6mjUqckaVqLZnTaA=";
     })
   ];
 

--- a/pkgs/by-name/fp/fprintd-tod/package.nix
+++ b/pkgs/by-name/fp/fprintd-tod/package.nix
@@ -41,22 +41,22 @@
       (fetchpatch {
         name = "use-more-idiomatic-correct-embedded-shell-scripting";
         url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/f4256533d1ffdc203c3f8c6ee42e8dcde470a93f.patch";
-        sha256 = "sha256-4uPrYEgJyXU4zx2V3gwKKLaD6ty0wylSriHlvKvOhek=";
+        hash = "sha256-4uPrYEgJyXU4zx2V3gwKKLaD6ty0wylSriHlvKvOhek=";
       })
       (fetchpatch {
         name = "remove-pointless-copying-of-files-into-build-directory";
         url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/2c34cef5ef2004d8479475db5523c572eb409a6b.patch";
-        sha256 = "sha256-2pZBbMF1xjoDKn/jCAIldbeR2JNEVduXB8bqUrj2Ih4=";
+        hash = "sha256-2pZBbMF1xjoDKn/jCAIldbeR2JNEVduXB8bqUrj2Ih4=";
       })
       (fetchpatch {
         name = "build-Do-not-use-positional-arguments-in-i18n.merge_file";
         url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/50943b1bd4f18d103c35233f0446ce7a31d1817e.patch";
-        sha256 = "sha256-ANkAq6fr0VRjkS0ckvf/ddVB2mH4b2uJRTI4H8vPPes=";
+        hash = "sha256-ANkAq6fr0VRjkS0ckvf/ddVB2mH4b2uJRTI4H8vPPes=";
       })
       (fetchpatch {
         name = "tests-Fix-dbusmock-AddDevice-calls-to-include-option";
         url = "https://gitlab.freedesktop.org/libfprint/fprintd/-/commit/ae04fa989720279e5558c3b8ff9ebe1959b1cf36.patch";
-        sha256 = "sha256-jW5vlzrbZQ1gUDLBf7G50GnZfZxhlnL2Eu+9Bghdwdw=";
+        hash = "sha256-jW5vlzrbZQ1gUDLBf7G50GnZfZxhlnL2Eu+9Bghdwdw=";
       })
     ];
 

--- a/pkgs/by-name/gf/gfan/package.nix
+++ b/pkgs/by-name/gf/gfan/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "clang-fix-miscompilation.patch";
       url = "https://raw.githubusercontent.com/sagemath/sage/eea1f59394a5066e9acd8ae39a90302820914ee3/build/pkgs/gfan/patches/nodel.patch";
-      sha256 = "sha256-RrncSgFyrBIk/Bwe3accxiJ2rpOSJKQ84cV/uBvQsDc=";
+      hash = "sha256-RrncSgFyrBIk/Bwe3accxiJ2rpOSJKQ84cV/uBvQsDc=";
     })
   ];
 

--- a/pkgs/by-name/gi/giac/package.nix
+++ b/pkgs/by-name/gi/giac/package.nix
@@ -52,13 +52,13 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "pari_2_15.patch";
       url = "https://raw.githubusercontent.com/sagemath/sage/07a2afd65fb4b0a1c9cbc43ede7d4a18c921a000/build/pkgs/giac/patches/pari_2_15.patch";
-      sha256 = "sha256-Q3xBFED7XEAyNz6AHjzt63XtospmdGAIdS6iPq1C2UE=";
+      hash = "sha256-Q3xBFED7XEAyNz6AHjzt63XtospmdGAIdS6iPq1C2UE=";
     })
 
     (fetchpatch {
       name = "infinity.patch";
       url = "https://github.com/geogebra/giac/commit/851c2cd91e879c79d6652f8a5d5bed03b65c6d39.patch";
-      sha256 = "sha256-WJRT2b8I9kgAkRuIugMiXoF4hT7yR7qyad8A6IspNTM=";
+      hash = "sha256-WJRT2b8I9kgAkRuIugMiXoF4hT7yR7qyad8A6IspNTM=";
       stripLen = 5;
       extraPrefix = "/src/";
       excludes = [ "src/kdisplay.cc" ];
@@ -69,14 +69,14 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fix-string-compiler-error.patch";
       url = "https://salsa.debian.org/science-team/giac/-/raw/9ca8dbf4bb16d9d96948aa4024326d32485d7917/debian/patches/fix-string-compiler-error.patch";
-      sha256 = "sha256-r+M+9MRPRqhHcdhYWI6inxyNvWbXUbBcPCeDY7aulvk=";
+      hash = "sha256-r+M+9MRPRqhHcdhYWI6inxyNvWbXUbBcPCeDY7aulvk=";
     })
 
     # issue with include path precedence
     (fetchpatch {
       name = "fix_implicit_declaration.patch";
       url = "https://salsa.debian.org/science-team/giac/-/raw/c05ae9b9e74d3c6ee6411d391071989426a76201/debian/patches/fix_implicit_declaration.patch";
-      sha256 = "sha256-ompUceYJLiL0ftfjBkIMcYvX1YqG2/XA7e1yDyFY0IY=";
+      hash = "sha256-ompUceYJLiL0ftfjBkIMcYvX1YqG2/XA7e1yDyFY0IY=";
     })
   ]
   ++ lib.optionals (!enableGUI) [
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "nofltk-check.patch";
       url = "https://raw.githubusercontent.com/sagemath/sage/7553a3c8dfa7bcec07241a07e6a4e7dcf5bb4f26/build/pkgs/giac/patches/nofltk-check.patch";
-      sha256 = "sha256-nAl5q3ufLjK3X9s0qMlGNowdRRf3EaC24eVtJABzdXY=";
+      hash = "sha256-nAl5q3ufLjK3X9s0qMlGNowdRRf3EaC24eVtJABzdXY=";
     })
   ];
 

--- a/pkgs/by-name/gi/git-ftp/package.nix
+++ b/pkgs/by-name/gi/git-ftp/package.nix
@@ -35,7 +35,7 @@ resholve.mkDerivation rec {
     (fetchpatch {
       name = "fix-function-invocation-typo.patch";
       url = "https://github.com/git-ftp/git-ftp/commit/cddf7cbba80e710758f6aac0ec0d77552ea8cd75.patch";
-      sha256 = "sha256-2B0QaMJi78Bg3bA1jp41aiyql1/LCryoaDs7+xmS1HY=";
+      hash = "sha256-2B0QaMJi78Bg3bA1jp41aiyql1/LCryoaDs7+xmS1HY=";
     })
   ];
 

--- a/pkgs/by-name/gi/git-trim/package.nix
+++ b/pkgs/by-name/gi/git-trim/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     # Update git2 https://github.com/foriequal0/git-trim/pull/202
     (fetchpatch {
       url = "https://github.com/foriequal0/git-trim/commit/4355cd1d6f605455087c4d7ad16bfb92ffee941f.patch";
-      sha256 = "sha256-C1pX4oe9ZCgvqYTBJeSjMdr0KFyjv2PNVMJDlwCAngY=";
+      hash = "sha256-C1pX4oe9ZCgvqYTBJeSjMdr0KFyjv2PNVMJDlwCAngY=";
     })
   ];
 

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage {
     # TOREMOVE for gitui > 0.27.0
     (fetchpatch {
       url = "https://github.com/gitui-org/gitui/commit/950e703cab1dd37e3d02e7316ec99cc0dc70513c.patch";
-      sha256 = "sha256-KDgOPLKGuJaF0Nc6rw9FPFmcI07I8Gyp/KNX8x6+2xw=";
+      hash = "sha256-KDgOPLKGuJaF0Nc6rw9FPFmcI07I8Gyp/KNX8x6+2xw=";
     })
   ];
 

--- a/pkgs/by-name/gl/globulation2/package.nix
+++ b/pkgs/by-name/gl/globulation2/package.nix
@@ -44,19 +44,19 @@ stdenv.mkDerivation rec {
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/g/glob2/0.9.4.4-6/debian/patches/10_pthread_underlinkage.patch";
-      sha256 = "sha256-L9POADlkgQbUQEUmx4s3dxXG9tS0w2IefpRGuQNRMI0=";
+      hash = "sha256-L9POADlkgQbUQEUmx4s3dxXG9tS0w2IefpRGuQNRMI0=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/g/glob2/0.9.4.4-6/debian/patches/link-boost-system.patch";
-      sha256 = "sha256-ne6F2ZowB+TUmg3ePuUoPNxXI0ZJC6HEol3oQQHJTy4=";
+      hash = "sha256-ne6F2ZowB+TUmg3ePuUoPNxXI0ZJC6HEol3oQQHJTy4=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/g/glob2/0.9.4.4-6/debian/patches/scons.patch";
-      sha256 = "sha256-Gah7SoVcd/Aljs0Nqo3YF0lZImUWtrGM4HbbQ4yrhHU=";
+      hash = "sha256-Gah7SoVcd/Aljs0Nqo3YF0lZImUWtrGM4HbbQ4yrhHU=";
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/g/glob2/0.9.4.4-6/debian/patches/boost-1.69.patch";
-      sha256 = "sha256-D7agFR4uyIHxQz690Q8EHPF+rTEoiGUpgkm7r5cL5SI=";
+      hash = "sha256-D7agFR4uyIHxQz690Q8EHPF+rTEoiGUpgkm7r5cL5SI=";
     })
   ];
 

--- a/pkgs/by-name/gl/glpk/package.nix
+++ b/pkgs/by-name/gl/glpk/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "error_recovery.patch";
       url = "https://raw.githubusercontent.com/sagemath/sage/d3c1f607e32f964bf0cab877a63767c86fd00266/build/pkgs/glpk/patches/error_recovery.patch";
-      sha256 = "sha256-2hNtUEoGTFt3JgUvLH3tPWnz+DZcXNhjXzS+/V89toA=";
+      hash = "sha256-2hNtUEoGTFt3JgUvLH3tPWnz+DZcXNhjXzS+/V89toA=";
     })
   ];
 

--- a/pkgs/by-name/gn/gnome-doc-utils/package.nix
+++ b/pkgs/by-name/gn/gnome-doc-utils/package.nix
@@ -26,12 +26,12 @@ python3Packages.buildPythonApplication rec {
     # https://bugzilla.redhat.com/show_bug.cgi?id=438638
     (fetchpatch {
       url = "https://src.fedoraproject.org/rpms/gnome-doc-utils/raw/6b8908abe5af61a952db7174c5d1843708d61f1b/f/gnome-doc-utils-0.14.0-package.patch";
-      sha256 = "sha256-V2L2/30NoHY/wj3+dsombxveWRSUJb2YByOKtEgVx/0=";
+      hash = "sha256-V2L2/30NoHY/wj3+dsombxveWRSUJb2YByOKtEgVx/0=";
     })
     # python3 support
     (fetchpatch {
       url = "https://src.fedoraproject.org/rpms/gnome-doc-utils/raw/6b8908abe5af61a952db7174c5d1843708d61f1b/f/gnome-doc-utils-0.20.10-python3.patch";
-      sha256 = "sha256-niH/Yx5H44rsRgkCZS8LWLFB9ZvuInt75zugzoVUhH0=";
+      hash = "sha256-niH/Yx5H44rsRgkCZS8LWLFB9ZvuInt75zugzoVUhH0=";
     })
   ];
 

--- a/pkgs/by-name/go/goreplay/package.nix
+++ b/pkgs/by-name/go/goreplay/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
     # Fix build on arm64-linux, see https://github.com/buger/goreplay/pull/1140
     (fetchpatch {
       url = "https://github.com/buger/goreplay/commit/a01afa1e322ef06f36995abc3fda3297bdaf0140.patch";
-      sha256 = "sha256-w3aVe/Fucwd2OuK5Fu2jJTbmMci8ilWaIjYjsWuLRlo=";
+      hash = "sha256-w3aVe/Fucwd2OuK5Fu2jJTbmMci8ilWaIjYjsWuLRlo=";
     })
   ];
 

--- a/pkgs/by-name/ht/html-tidy/package.nix
+++ b/pkgs/by-name/ht/html-tidy/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   patches = (
     fetchpatch {
       url = "https://github.com/htacg/tidy-html5/commit/e9aa038bd06bd8197a0dc049380bc2945ff55b29.diff";
-      sha256 = "sha256-Q2GjinNBWLL+HXUtslzDJ7CJSTflckbjweiSMCnIVwg=";
+      hash = "sha256-Q2GjinNBWLL+HXUtslzDJ7CJSTflckbjweiSMCnIVwg=";
     }
   );
   # https://github.com/htacg/tidy-html5/issues/1139

--- a/pkgs/by-name/ht/http-parser/package.nix
+++ b/pkgs/by-name/ht/http-parser/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     # https://github.com/nodejs/http-parser/pull/510
     (fetchpatch {
       url = "https://github.com/nodejs/http-parser/commit/4f15b7d510dc7c6361a26a7c6d2f7c3a17f8d878.patch";
-      sha256 = "sha256-rZZMJeow3V1fTnjadRaRa+xTq3pdhZn/eJ4xjxEDoU4=";
+      hash = "sha256-rZZMJeow3V1fTnjadRaRa+xTq3pdhZn/eJ4xjxEDoU4=";
     })
   ];
 

--- a/pkgs/by-name/il/illum/package.nix
+++ b/pkgs/by-name/il/illum/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "prevent-unplug-segfault"; # See https://github.com/jmesmon/illum/issues/19
       url = "https://github.com/jmesmon/illum/commit/47b7cd60ee892379e5d854f79db343a54ae5a3cc.patch";
-      sha256 = "sha256-hIBBCIJXAt8wnZuyKye1RiEfOCelP3+4kcGrM43vFOE=";
+      hash = "sha256-hIBBCIJXAt8wnZuyKye1RiEfOCelP3+4kcGrM43vFOE=";
     })
   ];
 

--- a/pkgs/by-name/in/infnoise/package.nix
+++ b/pkgs/by-name/in/infnoise/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Patch providing version info at compile time
     (fetchpatch {
       url = "https://github.com/leetronics/infnoise/commit/04d52a975bf78d2aff2bb4c176c286715e1948ba.patch";
-      sha256 = "sha256-vtPAR6gCyny9UP+U6/7X8CPEUuMDl7RIyICIwiaWyfc=";
+      hash = "sha256-vtPAR6gCyny9UP+U6/7X8CPEUuMDl7RIyICIwiaWyfc=";
     })
   ];
 

--- a/pkgs/by-name/jf/jfsutils/package.nix
+++ b/pkgs/by-name/jf/jfsutils/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "musl-fix-includes.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/jfsutils/musl-fix-includes.patch?id=567823dca7dc1f8ce919efbe99762d2d5c020124";
-      sha256 = "sha256-FjdUOI+y+MdSWxTR+csH41uR0P+PWWTfIMPwQjBfQtQ=";
+      hash = "sha256-FjdUOI+y+MdSWxTR+csH41uR0P+PWWTfIMPwQjBfQtQ=";
     })
   ];
 

--- a/pkgs/by-name/jt/jtc/package.nix
+++ b/pkgs/by-name/jt/jtc/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     # Fix building with Clang. Removing with next release.
     (fetchpatch {
       url = "https://github.com/ldn-softdev/jtc/commit/92a5116e5524c0b6d2f539db7b5cc9fdd7c5b8ab.patch";
-      sha256 = "sha256-AAvDH0XsT8/CAguG611/odg0m1HR+veC0jbAw6KLHLM=";
+      hash = "sha256-AAvDH0XsT8/CAguG611/odg0m1HR+veC0jbAw6KLHLM=";
     })
   ];
 

--- a/pkgs/by-name/ju/jumanpp/package.nix
+++ b/pkgs/by-name/ju/jumanpp/package.nix
@@ -23,17 +23,17 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fix-unused-warning.patch";
       url = "https://github.com/ku-nlp/jumanpp/commit/cc0d555287c8b214e9d6f0279c449a4e035deee4.patch";
-      sha256 = "sha256-yRKwuUJ2UPXJcjxBGhSOmcQI/EOijiJDMmmmSRdNpX8=";
+      hash = "sha256-yRKwuUJ2UPXJcjxBGhSOmcQI/EOijiJDMmmmSRdNpX8=";
     })
     (fetchpatch {
       name = "update-libs.patch";
       url = "https://github.com/ku-nlp/jumanpp/commit/5e9068f56ae310ed7c1df185b14d49654ffe1ab6.patch";
-      sha256 = "sha256-X49/ZoLT0OGePLZYlgacNxA1dHM4WYdQ8I4LW3sW16E=";
+      hash = "sha256-X49/ZoLT0OGePLZYlgacNxA1dHM4WYdQ8I4LW3sW16E=";
     })
     (fetchpatch {
       name = "fix-mmap-on-apple-m1.patch";
       url = "https://github.com/ku-nlp/jumanpp/commit/0c22249f12928d0c962f03f229026661bf0c7921.patch";
-      sha256 = "sha256-g6CuruqyoMJxU/hlNoALx1QnFM8BlTsTd0pwlVrco3I=";
+      hash = "sha256-g6CuruqyoMJxU/hlNoALx1QnFM8BlTsTd0pwlVrco3I=";
     })
   ];
   cmakeFlags = [ "-DJPP_ENABLE_TESTS=OFF" ];

--- a/pkgs/by-name/ke/keyleds/package.nix
+++ b/pkgs/by-name/ke/keyleds/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   patches = [
     (fetchpatch {
       url = "https://github.com/keyleds/keyleds/commit/bffed5eb181127df915002b6ed830f85f15feafd.patch";
-      sha256 = "sha256-i2N3D/K++34JVqJloNK2UcN473NarIjdjAz6PUhXcNY=";
+      hash = "sha256-i2N3D/K++34JVqJloNK2UcN473NarIjdjAz6PUhXcNY=";
     })
   ];
 

--- a/pkgs/by-name/ko/kompute/package.nix
+++ b/pkgs/by-name/ko/kompute/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "vulkan-14-support.patch";
       url = "https://github.com/KomputeProject/kompute/commit/299b11fb4b8a7607c5d2c27e2735f26b06ae8e29.patch";
-      sha256 = "sha256-JuoTQ+VjIdyF+I1IcT1ofbBjRS0Ibm2w6F2jrRJlx40=";
+      hash = "sha256-JuoTQ+VjIdyF+I1IcT1ofbBjRS0Ibm2w6F2jrRJlx40=";
     })
 
     # Fix the build with fmt ≥ 11.

--- a/pkgs/by-name/le/lemonade/package.nix
+++ b/pkgs/by-name/le/lemonade/package.nix
@@ -19,7 +19,7 @@ buildGoModule {
   patches = [
     (fetchpatch {
       url = "https://github.com/lemonade-command/lemonade/commit/2b292b0c9d8dc57f73c30a58b3f0f790a953b212.patch";
-      sha256 = "sha256-jUcOfsKu1IYa7arZuAvhuD0vw7JTmhzA/VLxOtAnbmI=";
+      hash = "sha256-jUcOfsKu1IYa7arZuAvhuD0vw7JTmhzA/VLxOtAnbmI=";
     })
   ];
 

--- a/pkgs/by-name/le/leveldb/package.nix
+++ b/pkgs/by-name/le/leveldb/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     # https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/K4OSAA4AJS2V7FQI6GNCKCK3IRQDBQRS/.
     (fetchpatch {
       url = "https://src.fedoraproject.org/rpms/leveldb/raw/e8178670c664e952fdd00f1fc6e3eb28b2c5b6a8/f/0006-revert-no-rtti.patch";
-      sha256 = "sha256-d2YAV8O+1VKu3WwgNsWw6Cxg5sUUR+xOlJtA7pTcigQ=";
+      hash = "sha256-d2YAV8O+1VKu3WwgNsWw6Cxg5sUUR+xOlJtA7pTcigQ=";
     })
   ];
 

--- a/pkgs/by-name/li/libLAS/package.nix
+++ b/pkgs/by-name/li/libLAS/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "aarch64-darwin.patch";
       url = "https://github.com/libLAS/libLAS/commit/ded463732db1f9baf461be6f3fe5b8bb683c41cd.patch";
-      sha256 = "sha256-aWMpazeefDHE9OzuLR3FJ8+oXeGhEsk1igEm6j2DUnw=";
+      hash = "sha256-aWMpazeefDHE9OzuLR3FJ8+oXeGhEsk1igEm6j2DUnw=";
     })
     (fetchpatch {
       name = "fix-build-with-boost-1.73-1.patch";

--- a/pkgs/by-name/li/libb64/package.nix
+++ b/pkgs/by-name/li/libb64/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) (fetchpatch {
     name = "0001-example-Do-not-run-the-tests.patch";
     url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-support/libb64/libb64/0001-example-Do-not-run-the-tests.patch?id=484e0de1e4ee107f21ae2a5c5f976ed987978baf";
-    sha256 = "sha256-KTsiIWJe66BKlu/A43FWfW0XAu4E7lWX/RY4NITRrm4=";
+    hash = "sha256-KTsiIWJe66BKlu/A43FWfW0XAu4E7lWX/RY4NITRrm4=";
   });
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/li/libcanberra/package.nix
+++ b/pkgs/by-name/li/libcanberra/package.nix
@@ -64,12 +64,12 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (fetchpatch {
       url = "https://github.com/macports/macports-ports/raw/5a7965dfea7727d1ceedee46c7b0ccee9cb23468/audio/libcanberra/files/patch-configure.diff";
-      sha256 = "sha256-pEJy1krciUEg5BFIS8FJ4BubjfS/nt9aqi6BLnS1+4M=";
+      hash = "sha256-pEJy1krciUEg5BFIS8FJ4BubjfS/nt9aqi6BLnS1+4M=";
       extraPrefix = "";
     })
     (fetchpatch {
       url = "https://github.com/macports/macports-ports/raw/5a7965dfea7727d1ceedee46c7b0ccee9cb23468/audio/libcanberra/files/dynamic_lookup-11.patch";
-      sha256 = "sha256-nUjha2pKh5VZl0ZZzcr9NTo1TVuMqF4OcLiztxW+ofQ=";
+      hash = "sha256-nUjha2pKh5VZl0ZZzcr9NTo1TVuMqF4OcLiztxW+ofQ=";
       extraPrefix = "";
     })
   ];

--- a/pkgs/by-name/li/libevent/package.nix
+++ b/pkgs/by-name/li/libevent/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     # Don't define BIO_get_init() for LibreSSL 3.5+
     (fetchpatch {
       url = "https://github.com/libevent/libevent/commit/883630f76cbf512003b81de25cd96cb75c6cf0f9.patch";
-      sha256 = "sha256-VPJqJUAovw6V92jpqIXkIR1xYGbxIWxaHr8cePWI2SU=";
+      hash = "sha256-VPJqJUAovw6V92jpqIXkIR1xYGbxIWxaHr8cePWI2SU=";
     })
   ];
 

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "0001-libfaketime.c-wrap-timespec_get-in-TIME_UTC-macro.patch";
       url = "https://github.com/wolfcw/libfaketime/commit/e0e6b79568d36a8fd2b3c41f7214769221182128.patch";
-      sha256 = "sha256-KwwP76v0DXNW73p/YBvwUOPdKMAcVdbQSKexD/uFOYo=";
+      hash = "sha256-KwwP76v0DXNW73p/YBvwUOPdKMAcVdbQSKexD/uFOYo=";
     })
     (fetchpatch {
       name = "LFS64.patch";

--- a/pkgs/by-name/li/libnfs/package.nix
+++ b/pkgs/by-name/li/libnfs/package.nix
@@ -23,12 +23,12 @@ stdenv.mkDerivation rec {
     # Fixes 100% CPU usage in multi-threaded mode
     (fetchpatch {
       url = "https://github.com/sahlberg/libnfs/commit/34d6fe37e986da5b0ced86cd028a88e482537d5a.patch";
-      sha256 = "sha256-i7mi+TVdkLb4MztT5Ic/Q8XBIWk9lo8v5bNjHOr6LaI=";
+      hash = "sha256-i7mi+TVdkLb4MztT5Ic/Q8XBIWk9lo8v5bNjHOr6LaI=";
     })
     # Fixes deprecation warnings on macOS
     (fetchpatch {
       url = "https://github.com/sahlberg/libnfs/commit/f6631c54a7b0385988f11357bf96728a6d7345b9.patch";
-      sha256 = "sha256-xLRZ9J1vr04n//gNv9ljUBt5LHUGBRRVIXJCMlFbHFI=";
+      hash = "sha256-xLRZ9J1vr04n//gNv9ljUBt5LHUGBRRVIXJCMlFbHFI=";
     })
   ];
 

--- a/pkgs/by-name/li/libtar/package.nix
+++ b/pkgs/by-name/li/libtar/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       (fetchpatch {
         name = "no_static_buffers.patch";
         url = "https://src.fedoraproject.org/rpms/libtar/raw/e25b692fc7ceaa387dafb865b472510754f51bd2/f/libtar-1.2.20-no-static-buffer.patch";
-        sha256 = "sha256-QcWOgdkNlALb+YDVneT1zCNAMf4d8IUm2kUUUy2VvJs=";
+        hash = "sha256-QcWOgdkNlALb+YDVneT1zCNAMf4d8IUm2kUUUy2VvJs=";
       })
       (fp "no_maxpathlen" "11riv231wpbdb1cm4nbdwdsik97wny5sxcwdgknqbp61ibk572b7")
       (fp "CVE-2013-4420" "0d010190bqgr2ggy02qwxvjaymy9a22jmyfwdfh4086v876cbxpq")
@@ -38,12 +38,12 @@ stdenv.mkDerivation rec {
       (fetchpatch {
         name = "CVE-2021-33643_CVE-2021-33644.patch";
         url = "https://src.fedoraproject.org/rpms/libtar/raw/e25b692fc7ceaa387dafb865b472510754f51bd2/f/libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch";
-        sha256 = "sha256-HdjotTvKJNntkdcV+kR08Ht/MyNeB6qUT0qo67BBOVA=";
+        hash = "sha256-HdjotTvKJNntkdcV+kR08Ht/MyNeB6qUT0qo67BBOVA=";
       })
       (fetchpatch {
         name = "CVE-2021-33645_CVE-2021-33646_CVE-2021-33640.patch";
         url = "https://src.fedoraproject.org/rpms/libtar/raw/e25b692fc7ceaa387dafb865b472510754f51bd2/f/libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch";
-        sha256 = "sha256-p9DEFAL5Y+Ldy5c9Wj9h/BSg4TDxIxCjCQJD+wGQ7oI=";
+        hash = "sha256-p9DEFAL5Y+Ldy5c9Wj9h/BSg4TDxIxCjCQJD+wGQ7oI=";
       })
     ];
 

--- a/pkgs/by-name/li/libxklavier/package.nix
+++ b/pkgs/by-name/li/libxklavier/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (fetchpatch {
       url = "https://gitlab.freedesktop.org/archived-projects/libxklavier/-/commit/1387c21a788ec1ea203c8392ea1460fc29d83f70.patch";
-      sha256 = "sha256-fyWu7sVfDv/ozjhLSLCVsv+iNFawWgJqHUsQHHSkQn4=";
+      hash = "sha256-fyWu7sVfDv/ozjhLSLCVsv+iNFawWgJqHUsQHHSkQn4=";
     })
   ];
 

--- a/pkgs/by-name/ma/mac-fdisk/package.nix
+++ b/pkgs/by-name/ma/mac-fdisk/package.nix
@@ -19,57 +19,57 @@ stdenv.mkDerivation {
     # Debian's changeset, extracted into a patch
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1b708c8a90e3548c4954c6367a9376f76f3746bd/user/mac-fdisk/mac-fdisk-0.1-debian.patch";
-      sha256 = "sha256-a9pGF+UsFeZiXgracmT4anqgpmcGcS/W3jGtFzHZtt4=";
+      hash = "sha256-a9pGF+UsFeZiXgracmT4anqgpmcGcS/W3jGtFzHZtt4=";
     })
     # Include a lot more headers and remove a bunch of braindead __linux__ checks
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-0.1-headers.patch";
-      sha256 = "sha256-FIk9K+lP+3e1pgmNfymTdpdSoTpBDv29kmwYgqYwWQw=";
+      hash = "sha256-FIk9K+lP+3e1pgmNfymTdpdSoTpBDv29kmwYgqYwWQw=";
     })
     # Add support for more architectures
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1b708c8a90e3548c4954c6367a9376f76f3746bd/user/mac-fdisk/mac-fdisk-0.1-more-arches.patch";
-      sha256 = "sha256-HNRmzETUmKfZQFrjg6Y/HPwUnLk0vO5DokfU4umdOm0=";
+      hash = "sha256-HNRmzETUmKfZQFrjg6Y/HPwUnLk0vO5DokfU4umdOm0=";
     })
     # From p16 (source?), adjusts some types & fixes PPC64 support
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-0.1_p16-ppc64.patch";
-      sha256 = "sha256-GK0nfga59nOXotkbKI+2ejA9TtyZUwDIxuXWFGGbeFg=";
+      hash = "sha256-GK0nfga59nOXotkbKI+2ejA9TtyZUwDIxuXWFGGbeFg=";
     })
     # From p16 (source?), makes some inlines static
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-0.1_p16-proper-inline.patch";
-      sha256 = "sha256-wr2teKpm0FyqNudKYlTD49pTFDis33Fo+0LULNYIJko=";
+      hash = "sha256-wr2teKpm0FyqNudKYlTD49pTFDis33Fo+0LULNYIJko=";
     })
     # Adds x86_64 support
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1b708c8a90e3548c4954c6367a9376f76f3746bd/user/mac-fdisk/mac-fdisk-amd64.patch";
-      sha256 = "sha256-iO4/sY5sGKQyymMmAOb/TlCc9id2qgEDw7E8pFZpsHI=";
+      hash = "sha256-iO4/sY5sGKQyymMmAOb/TlCc9id2qgEDw7E8pFZpsHI=";
     })
     # Fix missing header in fdisk.c on musl
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-fdisk-header-musl.patch";
-      sha256 = "sha256-mKBVjvLKtxKPADeoPqp17YdJ1QWj2enAYhKKSqTnQ44=";
+      hash = "sha256-mKBVjvLKtxKPADeoPqp17YdJ1QWj2enAYhKKSqTnQ44=";
     })
     # Support disks >550GB
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-large-disk-support.patch";
-      sha256 = "sha256-IXZZdozqZKyZEz87ZzB8Jof22GgvHf4GaXBqSKn8su8=";
+      hash = "sha256-IXZZdozqZKyZEz87ZzB8Jof22GgvHf4GaXBqSKn8su8=";
     })
     # Enable Large File Support (>2GiB)
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-largerthan2gb.patch";
-      sha256 = "sha256-ATK7QYXV7BOk8iIFeXY8g+ZHLuuhww9pcrqOMDn/oLM=";
+      hash = "sha256-ATK7QYXV7BOk8iIFeXY8g+ZHLuuhww9pcrqOMDn/oLM=";
     })
     # Fix compilation on non-glibc
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/1fa4c88ee21866eeb0feae8f6b0bf609a04711cc/user/mac-fdisk/mac-fdisk-non-glibc-support.patch";
-      sha256 = "sha256-CBZUKf7dPvvpuG5L+SI1FQ4W7/fDgeKXHUMFkJNu/MY=";
+      hash = "sha256-CBZUKf7dPvvpuG5L+SI1FQ4W7/fDgeKXHUMFkJNu/MY=";
     })
     # Flush stdout after printing prompt for better UX
     (fetchpatch {
       url = "https://git.adelielinux.org/adelie/packages/-/raw/656ae6bf9f8a64aee95c4797b20bfe713627f1f4/user/mac-fdisk/flush-stdout.patch";
-      sha256 = "sha256-k7+UPiUf/oCQdDhxDcC+FRwkxS89WSsYzFw6fUB/10I=";
+      hash = "sha256-k7+UPiUf/oCQdDhxDcC+FRwkxS89WSsYzFw6fUB/10I=";
     })
   ];
 

--- a/pkgs/by-name/ma/masscan/package.nix
+++ b/pkgs/by-name/ma/masscan/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "resume.patch";
       url = "https://github.com/robertdavidgraham/masscan/commit/90791550bbdfac8905917a109ed74024161f14b3.patch";
-      sha256 = "sha256-A7Fk3MBNxaad69MrUYg7fdMG77wba5iESDTIRigYslw=";
+      hash = "sha256-A7Fk3MBNxaad69MrUYg7fdMG77wba5iESDTIRigYslw=";
     })
   ];
 

--- a/pkgs/by-name/mi/mimetic/package.nix
+++ b/pkgs/by-name/mi/mimetic/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     # Fix build with gcc11
     (fetchpatch {
       url = "https://github.com/tat/mimetic/commit/bf84940f9021950c80846e6b1a5f8b0b55991b00.patch";
-      sha256 = "sha256-1JW9zPg67BgNsdIjK/jp9j7QMg50eRMz5FsDsbbzBlI=";
+      hash = "sha256-1JW9zPg67BgNsdIjK/jp9j7QMg50eRMz5FsDsbbzBlI=";
     })
   ]
   ++ lib.optional stdenv.hostPlatform.isAarch64 ./narrowing.patch;

--- a/pkgs/by-name/mp/mpdscribble/package.nix
+++ b/pkgs/by-name/mp/mpdscribble/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "remove-empty-static-lib.patch";
       url = "https://github.com/MusicPlayerDaemon/mpdscribble/commit/0dbcea25c81f3fdc608f71ef71a9784679fee17f.patch";
-      sha256 = "sha256-3wLfQvbwx+OFrCl5vMV7Zps4e4iEYFhqPiVCo5hDqgw=";
+      hash = "sha256-3wLfQvbwx+OFrCl5vMV7Zps4e4iEYFhqPiVCo5hDqgw=";
     })
   ];
 

--- a/pkgs/by-name/ms/mstflint/package.nix
+++ b/pkgs/by-name/ms/mstflint/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     # fixes build errors due to missing declarations in headers
     (fetchpatch {
       url = "https://patch-diff.githubusercontent.com/raw/Mellanox/mstflint/pull/1131.patch";
-      sha256 = "sha256-tn8EO9HkDrMroV6byUPgjclBIK8tq4xGyi4Kx/rIj+w=";
+      hash = "sha256-tn8EO9HkDrMroV6byUPgjclBIK8tq4xGyi4Kx/rIj+w=";
     })
   ];
 

--- a/pkgs/by-name/my/mygui/package.nix
+++ b/pkgs/by-name/my/mygui/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "darwin-mygui-framework-fix.patch";
       url = "https://gitlab.com/OpenMW/openmw-dep/-/raw/ade30e6e98c051ac2a505f6984518f5f41fa87a5/macos/mygui.patch";
-      sha256 = "sha256-Tk+O4TFgPZOqWAY4c0Q69bZfvIB34wN9e7h0tXhLULU=";
+      hash = "sha256-Tk+O4TFgPZOqWAY4c0Q69bZfvIB34wN9e7h0tXhLULU=";
     })
   ];
 

--- a/pkgs/by-name/ne/neofetch/package.nix
+++ b/pkgs/by-name/ne/neofetch/package.nix
@@ -30,13 +30,13 @@ stdenvNoCC.mkDerivation {
     # https://github.com/dylanaraps/neofetch/pull/2114
     (fetchpatch {
       url = "https://github.com/dylanaraps/neofetch/commit/c4eb4ec7783bb94cca0dbdc96db45a4d965956d2.patch";
-      sha256 = "sha256-F6Q4dUtfmR28VxLbITiLFJ44FjG4T1Cvuz3a0nLisMs=";
+      hash = "sha256-F6Q4dUtfmR28VxLbITiLFJ44FjG4T1Cvuz3a0nLisMs=";
       name = "update_old_nixos_logo.patch";
     })
     # https://github.com/dylanaraps/neofetch/pull/2157
     (fetchpatch {
       url = "https://github.com/dylanaraps/neofetch/commit/de253afcf41bab441dc58d34cae654040cab7451.patch";
-      sha256 = "sha256-3i7WnCWNfsRjbenTULmKHft5o/o176imzforNmuoJwo=";
+      hash = "sha256-3i7WnCWNfsRjbenTULmKHft5o/o176imzforNmuoJwo=";
       name = "improve_detect_nixos_version.patch";
     })
   ];

--- a/pkgs/by-name/ne/newlib/package.nix
+++ b/pkgs/by-name/ne/newlib/package.nix
@@ -32,7 +32,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "newlib-3.3.0-no-nano-cxx.patch";
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/newlib/files/newlib-3.3.0-no-nano-cxx.patch?id=9ee5a1cd6f8da6d084b93b3dbd2e8022a147cfbf";
-      sha256 = "sha256-S3mf7vwrzSMWZIGE+d61UDH+/SK/ao1hTPee1sElgco=";
+      hash = "sha256-S3mf7vwrzSMWZIGE+d61UDH+/SK/ao1hTPee1sElgco=";
     })
   ];
 

--- a/pkgs/by-name/nq/nqc/package.nix
+++ b/pkgs/by-name/nq/nqc/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ./nqc-unistd.patch
     (fetchpatch {
       url = "https://sourceforge.net/p/bricxcc/patches/_discuss/thread/00b427dc/b84b/attachment/nqc-01-Linux_usb_and_tcp.diff";
-      sha256 = "sha256-UZmmhhhfLAUus36TOBhiDQ8KUeEdYhGHVFwqKqDIqII=";
+      hash = "sha256-UZmmhhhfLAUus36TOBhiDQ8KUeEdYhGHVFwqKqDIqII=";
     })
   ];
 

--- a/pkgs/by-name/nt/ntfy/package.nix
+++ b/pkgs/by-name/nt/ntfy/package.nix
@@ -49,7 +49,7 @@ python.pkgs.buildPythonApplication rec {
     (fetchpatch {
       name = "ntfy-Add-compatibility-with-emoji-2.0.patch";
       url = "https://github.com/dschep/ntfy/commit/4128942bb7a706117e7154a50a73b88f531631fe.patch";
-      sha256 = "sha256-V8dIy/K957CPFQQS1trSI3gZOjOcVNQLgdWY7g17bRw=";
+      hash = "sha256-V8dIy/K957CPFQQS1trSI3gZOjOcVNQLgdWY7g17bRw=";
     })
     # Change getargspec to getfullargspec for python 3.11 compatibility
     (fetchpatch {

--- a/pkgs/by-name/nx/nx-libs/package.nix
+++ b/pkgs/by-name/nx/nx-libs/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "binutils-2.36.patch";
       url = "https://github.com/ArcticaProject/nx-libs/commit/605a266911b50ababbb3f8a8b224efb42743379c.patch";
-      sha256 = "sha256-kk5ms3i0PrHL74I4OlsqDrdDcCJ0us03cQcBy4zjAoQ=";
+      hash = "sha256-kk5ms3i0PrHL74I4OlsqDrdDcCJ0us03cQcBy4zjAoQ=";
     })
   ];
 

--- a/pkgs/by-name/od/odyssey/package.nix
+++ b/pkgs/by-name/od/odyssey/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     # Fix compression build. Remove with the next release. https://github.com/yandex/odyssey/pull/441
     (fetchpatch {
       url = "https://github.com/yandex/odyssey/commit/01ca5b345c4483add7425785c9c33dfa2c135d63.patch";
-      sha256 = "sha256-8UPkZkiI08ZZL6GShhug/5/kOVrmdqYlsD1bcqfxg/w=";
+      hash = "sha256-8UPkZkiI08ZZL6GShhug/5/kOVrmdqYlsD1bcqfxg/w=";
     })
     # Fixes kiwi build.
     ./fix-missing-c-header.patch

--- a/pkgs/by-name/op/openbox/package.nix
+++ b/pkgs/by-name/op/openbox/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     # and committed to a work branch in the upstream repo. See https://bugs.archlinux.org/task/77853.
     (fetchpatch {
       url = "https://github.com/Mikachu/openbox/commit/d41128e5a1002af41c976c8860f8299cfcd3cd72.patch";
-      sha256 = "sha256-4/aoI4y98JPybZ1MNI7egOhkroQgh/oeGnYrhNGX4t4=";
+      hash = "sha256-4/aoI4y98JPybZ1MNI7egOhkroQgh/oeGnYrhNGX4t4=";
     })
   ];
 

--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -49,12 +49,12 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2022-0496.patch";
       url = "https://github.com/openscad/openscad/commit/00a4692989c4e2f191525f73f24ad8727bacdf41.patch";
-      sha256 = "sha256-q3SLj2b5aM/IQ8vIDj4iVcwCajgyJ5juNV/KN35uxfI=";
+      hash = "sha256-q3SLj2b5aM/IQ8vIDj4iVcwCajgyJ5juNV/KN35uxfI=";
     })
     (fetchpatch {
       name = "CVE-2022-0497.patch";
       url = "https://github.com/openscad/openscad/commit/84addf3c1efbd51d8ff424b7da276400bbfa1a4b.patch";
-      sha256 = "sha256-KNEVu10E2d4G2x+FJcuHo2tjD8ygMRuhUcW9NbN98bM=";
+      hash = "sha256-KNEVu10E2d4G2x+FJcuHo2tjD8ygMRuhUcW9NbN98bM=";
     })
     (fetchpatch {
       # needed for cgal_5

--- a/pkgs/by-name/op/opusfile/package.nix
+++ b/pkgs/by-name/op/opusfile/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2022-47021.patch";
       url = "https://github.com/xiph/opusfile/commit/0a4cd796df5b030cb866f3f4a5e41a4b92caddf5.patch";
-      sha256 = "sha256-XThI/ys5caB+OncFVfxm5IsvQPy1MbLQKwIlYjPvTJQ=";
+      hash = "sha256-XThI/ys5caB+OncFVfxm5IsvQPy1MbLQKwIlYjPvTJQ=";
     })
   ]
   # fixes problem with openssl 1.1 dependency

--- a/pkgs/by-name/or/orthorobot/package.nix
+++ b/pkgs/by-name/or/orthorobot/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       name = "Stabyourself-orthorobot-pull-3.patch";
       url = "https://github.com/Stabyourself/orthorobot/compare/48f07423950b29a94b04aefe268f2f951f55b62e...05856ba7dbf1bb86d0f16a5f511d8ee9f2176015.patch";
-      sha256 = "sha256-WHHP6QM7R5eEkVF+J2pGNnds/OKRIRXyon85wjd3GXI=";
+      hash = "sha256-WHHP6QM7R5eEkVF+J2pGNnds/OKRIRXyon85wjd3GXI=";
     })
   ];
 

--- a/pkgs/by-name/pa/pasystray/package.nix
+++ b/pkgs/by-name/pa/pasystray/package.nix
@@ -31,13 +31,13 @@ stdenv.mkDerivation rec {
     # https://github.com/christophgysin/pasystray/issues/98
     (fetchpatch {
       url = "https://sources.debian.org/data/main/p/pasystray/0.8.1-1/debian/patches/0001-Build-against-ayatana-appindicator.patch";
-      sha256 = "sha256-/HKPqVARfHr/3Vyls6a1n8ejxqW9Ztu4+8KK4jK8MkI=";
+      hash = "sha256-/HKPqVARfHr/3Vyls6a1n8ejxqW9Ztu4+8KK4jK8MkI=";
     })
     # Require X11 backend
     # https://github.com/christophgysin/pasystray/issues/90#issuecomment-361881076
     (fetchpatch {
       url = "https://sources.debian.org/data/main/p/pasystray/0.8.1-1/debian/patches/0002-Require-X11-backend.patch";
-      sha256 = "sha256-6njC3vqBPWFS1xAsa1katQ4C0KJdVkHAP1MCPiZ6ELM=";
+      hash = "sha256-6njC3vqBPWFS1xAsa1katQ4C0KJdVkHAP1MCPiZ6ELM=";
     })
   ];
 

--- a/pkgs/by-name/pd/pdisk/package.nix
+++ b/pkgs/by-name/pd/pdisk/package.nix
@@ -22,22 +22,22 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix makefile for Unix
     (fetchpatch {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/makefile.patch?h=pdisk&id=39dc371712d2f7dbd38f6e8ddc6ba661faa1a7a9";
-      sha256 = "sha256-mLFclu8IlDN/gxNTI7Kei6ARketlAhJRu8ForFUzFU0=";
+      hash = "sha256-mLFclu8IlDN/gxNTI7Kei6ARketlAhJRu8ForFUzFU0=";
     })
     # Fix lseek usage in file_media.c
     (fetchpatch {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/file_media.c.patch?h=pdisk&id=39dc371712d2f7dbd38f6e8ddc6ba661faa1a7a9";
-      sha256 = "sha256-CCq5fApwx6w1GKDrgP+0nUdQy/5z5ON7/fdp4M63nko=";
+      hash = "sha256-CCq5fApwx6w1GKDrgP+0nUdQy/5z5ON7/fdp4M63nko=";
     })
     # Fix open_partition_map call in cvt_pt.c
     (fetchpatch {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/cvt_pt.c.patch?h=pdisk&id=39dc371712d2f7dbd38f6e8ddc6ba661faa1a7a9";
-      sha256 = "sha256-jScPfzt9/fQHkf2MfHLvYsh/Rw2NZZXkzZiiVo8F5Mc=";
+      hash = "sha256-jScPfzt9/fQHkf2MfHLvYsh/Rw2NZZXkzZiiVo8F5Mc=";
     })
     # Replace removed sys_nerr and sys_errlist with strerror
     (fetchpatch {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/linux_strerror.patch?h=pdisk&id=d0c930ea8bcac008bbd0ade1811133a625caea54";
-      sha256 = "sha256-HGJIS+vTn6456KtaETutIgTPPBm2C9OHf1anG8yaJPo=";
+      hash = "sha256-HGJIS+vTn6456KtaETutIgTPPBm2C9OHf1anG8yaJPo=";
     })
 
     # Fix missing includes on Linux

--- a/pkgs/by-name/pi/pixiecore/package.nix
+++ b/pkgs/by-name/pi/pixiecore/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     # Also backed up in https://github.com/danderson/netboot/compare/main...Mic92:netboot:upgrade-go-mod-117?expand=1
     (fetchpatch {
       url = "https://github.com/danderson/netboot/commit/c999a6ca573c973e760c8df531b4c970c21f3d05.patch";
-      sha256 = "sha256-pRWcBz24cqqajLvJffugB/T6lKGVtvOG4ch3vyzDDQQ=";
+      hash = "sha256-pRWcBz24cqqajLvJffugB/T6lKGVtvOG4ch3vyzDDQQ=";
     })
   ];
 

--- a/pkgs/by-name/pl/plib/package.nix
+++ b/pkgs/by-name/pl/plib/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     })
     (fetchpatch {
       url = "https://sources.debian.org/data/main/p/plib/1.8.5-13/debian/patches/08_CVE-2021-38714.patch";
-      sha256 = "sha256-3f1wZn0QqK/hPWCg1KEzbB95IGoxBjLZoCOFlW98t5w=";
+      hash = "sha256-3f1wZn0QqK/hPWCg1KEzbB95IGoxBjLZoCOFlW98t5w=";
     })
   ];
 

--- a/pkgs/by-name/pr/procdump/package.nix
+++ b/pkgs/by-name/pr/procdump/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "parallel.patch";
       url = "https://github.com/Sysinternals/ProcDump-for-Linux/commit/0d735836f11281cc6134be93eac8acb302f2055e.patch";
-      sha256 = "sha256-zsqllPHF8ZuXAIDSAPvbzdKa43uSSx9ilUKM1vFVW90=";
+      hash = "sha256-zsqllPHF8ZuXAIDSAPvbzdKa43uSSx9ilUKM1vFVW90=";
     })
   ];
 

--- a/pkgs/by-name/re/redfang/package.nix
+++ b/pkgs/by-name/re/redfang/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     # make install rule
     (fetchpatch {
       url = "https://gitlab.com/kalilinux/packages/redfang/-/merge_requests/1.diff";
-      sha256 = "sha256-oxIrUAucxsBL4+u9zNNe2XXoAd088AEAHcRB/AN7B1M=";
+      hash = "sha256-oxIrUAucxsBL4+u9zNNe2XXoAd088AEAHcRB/AN7B1M=";
     })
     # error: implicit declaration of function 'pthread_create' []
     ./include-pthread.patch

--- a/pkgs/by-name/re/reproc/package.nix
+++ b/pkgs/by-name/re/reproc/package.nix
@@ -21,12 +21,12 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "reproc-gcc-13-2.patch";
       url = "https://github.com/DaanDeMeyer/reproc/commit/0b23d88894ccedde04537fa23ea55cb2f8365342.patch";
-      sha256 = "sha256-QyC0UcKAWCKSvSvyZTLI2eF/TuuqbGGH6cOQrS2DiCE=";
+      hash = "sha256-QyC0UcKAWCKSvSvyZTLI2eF/TuuqbGGH6cOQrS2DiCE=";
     })
     (fetchpatch {
       name = "reproc-gcc-13-1.patch";
       url = "https://github.com/DaanDeMeyer/reproc/commit/9f399675b821e175f85ac3ee6e3fd2e6056573eb.patch";
-      sha256 = "sha256-h/gnDFPWPpUFkys10YXjjEPibgRT1atHSVwbO0kId+U=";
+      hash = "sha256-h/gnDFPWPpUFkys10YXjjEPibgRT1atHSVwbO0kId+U=";
     })
   ];
 

--- a/pkgs/by-name/re/retro-gtk/package.nix
+++ b/pkgs/by-name/re/retro-gtk/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     # fix build with meson 0.60 (https://gitlab.gnome.org/GNOME/retro-gtk/-/merge_requests/167)
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/retro-gtk/-/commit/8016c10e7216394bc66281f2d9be740140b6fad6.patch";
-      sha256 = "sha256-HcQnqadK5sJM5mMqi4KERkJM3H+MUl8AJAorpFDsJ68=";
+      hash = "sha256-HcQnqadK5sJM5mMqi4KERkJM3H+MUl8AJAorpFDsJ68=";
     })
   ];
 

--- a/pkgs/by-name/rp/rpcsvc-proto/package.nix
+++ b/pkgs/by-name/rp/rpcsvc-proto/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "follow-RPCGEN_CPP-env-var";
       url = "https://github.com/thkukuk/rpcsvc-proto/commit/e772270774ff45172709e39f744cab875a816667.diff";
-      sha256 = "sha256-KrUD6YwdyxW9S99h4TB21ahnAOgQmQr2tYz++MIbk1Y=";
+      hash = "sha256-KrUD6YwdyxW9S99h4TB21ahnAOgQmQr2tYz++MIbk1Y=";
     })
   ];
 

--- a/pkgs/by-name/rt/rtags/package.nix
+++ b/pkgs/by-name/rt/rtags/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "define-obsolete-function-alias.patch";
       url = "https://github.com/Andersbakken/rtags/commit/63f18acb21e664fd92fbc19465f0b5df085b5e93.patch";
-      sha256 = "sha256-dmEPtnk8Pylmf5479ovHKItRZ+tJuOWuYOQbWB/si/Y=";
+      hash = "sha256-dmEPtnk8Pylmf5479ovHKItRZ+tJuOWuYOQbWB/si/Y=";
     })
   ];
 

--- a/pkgs/by-name/sa/samurai/package.nix
+++ b/pkgs/by-name/sa/samurai/package.nix
@@ -27,14 +27,14 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2021-30218.patch";
       url = "https://github.com/michaelforney/samurai/commit/e84b6d99c85043fa1ba54851ee500540ec206918.patch";
-      sha256 = "sha256-hyndwj6st4rwOJ35Iu0qL12dR5E6CBvsulvR27PYKMw=";
+      hash = "sha256-hyndwj6st4rwOJ35Iu0qL12dR5E6CBvsulvR27PYKMw=";
     })
     # NULL pointer dereference in printstatus() in build.c; remove this at the
     # next release
     (fetchpatch {
       name = "CVE-2021-30219.patch";
       url = "https://github.com/michaelforney/samurai/commit/d2af3bc375e2a77139c3a28d6128c60cd8d08655.patch";
-      sha256 = "sha256-rcdwKjHeq5Oaga9wezdHSg/7ljkynfbnkBc2ciMW5so=";
+      hash = "sha256-rcdwKjHeq5Oaga9wezdHSg/7ljkynfbnkBc2ciMW5so=";
     })
   ];
 

--- a/pkgs/by-name/se/setroot/package.nix
+++ b/pkgs/by-name/se/setroot/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/ttzhou/setroot/commit/d8ff8edd7d7594d276d741186bf9ccf0bce30277.patch";
-      sha256 = "sha256-e0iMSpiOmTOpQnp599fjH2UCPU4Oq1VKXcVypVoR9hw=";
+      hash = "sha256-e0iMSpiOmTOpQnp599fjH2UCPU4Oq1VKXcVypVoR9hw=";
     })
   ];
 

--- a/pkgs/by-name/sp/spotify-tray/package.nix
+++ b/pkgs/by-name/sp/spotify-tray/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fix-building-with-automake-1.16.5.patch";
       url = "https://github.com/tsmetana/spotify-tray/commit/1305f473ba4a406e907b98c8255f23154f349613.patch";
-      sha256 = "sha256-u2IopfMzNCu2F06RZoJw3OAsRxxZYdIMnKnyb7/KBgk=";
+      hash = "sha256-u2IopfMzNCu2F06RZoJw3OAsRxxZYdIMnKnyb7/KBgk=";
     })
   ];
 

--- a/pkgs/by-name/st/stargate-libcds/package.nix
+++ b/pkgs/by-name/st/stargate-libcds/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "malloc-to-stdlib.patch";
       url = "https://github.com/stargateaudio/libcds/commit/65dc08f059deda8ba5707ba6116b616d0ad0bd8d.patch";
-      sha256 = "sha256-FIGlobUVrDYOtnHjsWyE420PoULPHEK/3T9Fv8hfTl4=";
+      hash = "sha256-FIGlobUVrDYOtnHjsWyE420PoULPHEK/3T9Fv8hfTl4=";
     })
   ];
 

--- a/pkgs/by-name/sy/sylpheed/package.nix
+++ b/pkgs/by-name/sy/sylpheed/package.nix
@@ -29,12 +29,12 @@ stdenv.mkDerivation rec {
       name = "patch-libsylph_ssl_c.patch";
       extraPrefix = "";
       url = "https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/mail/sylpheed/patches/patch-libsylph_ssl_c?rev=1.4&content-type=text/plain";
-      sha256 = "sha256-+FetU5vrfvE78nYAjKK/QFZnFw+Zr2PvoUGRWCuZczs=";
+      hash = "sha256-+FetU5vrfvE78nYAjKK/QFZnFw+Zr2PvoUGRWCuZczs=";
     })
     (fetchpatch {
       name = "CVE-2021-37746.patch";
       url = "https://git.claws-mail.org/?p=claws.git;a=patch;h=ac286a71ed78429e16c612161251b9ea90ccd431";
-      sha256 = "sha256-oLmUShtvO6io3jibKT67eO0O58vEDZEeaB51QTd3UkU=";
+      hash = "sha256-oLmUShtvO6io3jibKT67eO0O58vEDZEeaB51QTd3UkU=";
     })
     (fetchurl {
       name = "0013-fix-FTBFS-GCC-14.patch";

--- a/pkgs/by-name/ti/timezonemap/package.nix
+++ b/pkgs/by-name/ti/timezonemap/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     # https://bugs.launchpad.net/ubuntu/+source/libtimezonemap/+bug/2012116
     (fetchpatch {
       url = "https://git.launchpad.net/ubuntu/+source/libtimezonemap/plain/debian/patches/timezone-map-Never-try-to-access-to-free-d-or-null-values.patch?id=88f72f724e63df061204f6818c9a1e7d8c003e29";
-      sha256 = "sha256-M5eR0uaqpJOeW2Ya1Al+3ZciXukzHpnjJTMVvdO0dPE=";
+      hash = "sha256-M5eR0uaqpJOeW2Ya1Al+3ZciXukzHpnjJTMVvdO0dPE=";
     })
 
     # Port to libsoup3

--- a/pkgs/by-name/to/totem-pl-parser/package.nix
+++ b/pkgs/by-name/to/totem-pl-parser/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     # Upstream MR: https://gitlab.gnome.org/GNOME/totem-pl-parser/-/merge_requests/46
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/totem-pl-parser/-/commit/f4f69c9b99095416aaed18a73f7486ad9eb04aa9.patch";
-      sha256 = "sha256-Uya5fgFgauv5rIpVK3CDGCieyMus7VjcLMMe/vQ2WWY=";
+      hash = "sha256-Uya5fgFgauv5rIpVK3CDGCieyMus7VjcLMMe/vQ2WWY=";
     })
   ];
 

--- a/pkgs/by-name/un/undistract-me/package.nix
+++ b/pkgs/by-name/un/undistract-me/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation {
     # See https://github.com/jml/undistract-me/pull/69
     (fetchpatch {
       url = "https://github.com/jml/undistract-me/commit/2356ebbe8bf2bcb4b95af1ae2bcdc786ce7cc6e8.patch";
-      sha256 = "sha256-Ij3OXTOnIQsYhKVmqjChhN1q4ASZ7waOkfQTTp5XfPo=";
+      hash = "sha256-Ij3OXTOnIQsYhKVmqjChhN1q4ASZ7waOkfQTTp5XfPo=";
     })
 
     # Fix showing notifications when using Wayland apps with XWayland
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation {
     # See https://github.com/jml/undistract-me/pull/71
     (fetchpatch {
       url = "https://github.com/jml/undistract-me/commit/3f4ceaf5a4eba8e3cb02236c48247f87e3d1124f.patch";
-      sha256 = "sha256-9AK9Jp3TXJ75Y+jwZXlwQ6j54FW1rOBddoktrm0VX68=";
+      hash = "sha256-9AK9Jp3TXJ75Y+jwZXlwQ6j54FW1rOBddoktrm0VX68=";
     })
   ];
 

--- a/pkgs/by-name/ut/utsushi/package.nix
+++ b/pkgs/by-name/ut/utsushi/package.nix
@@ -42,19 +42,19 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-3.63.0-autoconf-2.70.patch?id=4fe8a9e6c60f9163cadad830ba4935c069c67b10";
-      sha256 = "sha256-2V4cextjcEQrywe4tvvD5KaVYdXnwdNhTiY/aSNx3mM=";
+      hash = "sha256-2V4cextjcEQrywe4tvvD5KaVYdXnwdNhTiY/aSNx3mM=";
     })
     (fetchpatch {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-3.61.0-imagemagick-7.patch?id=985c92af4730d864e86fa87746185b0246e9db93";
-      sha256 = "sha256-dfdVMp3ZfclYeRxYjMIvl+ZdlLn9S+IwQ+OmlHW8318=";
+      hash = "sha256-dfdVMp3ZfclYeRxYjMIvl+ZdlLn9S+IwQ+OmlHW8318=";
     })
     (fetchpatch {
       url = "https://raw.githubusercontent.com/archlinux/svntogit-community/b3046e0e78b95440f135fcadb19a9eb531729a58/trunk/boost-1.74.patch";
-      sha256 = "sha256-W8R1l7ZPcsfiIy1QBJvh0M8du0w1cnTg3PyAz65v4rE=";
+      hash = "sha256-W8R1l7ZPcsfiIy1QBJvh0M8du0w1cnTg3PyAz65v4rE=";
     })
     (fetchpatch {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-3.65.0-sane-backends-1.1.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
-      sha256 = "sha256-AmMZ+/lrUMR7IU+S8MEn0Ji5pqOiD6izFJBsJ0tCCCw=";
+      hash = "sha256-AmMZ+/lrUMR7IU+S8MEn0Ji5pqOiD6izFJBsJ0tCCCw=";
     })
   ];
 

--- a/pkgs/by-name/va/valgrind/package.nix
+++ b/pkgs/by-name/va/valgrind/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     # see also https://bugs.kde.org/show_bug.cgi?id=454346
     (fetchpatch {
       url = "https://git.yoctoproject.org/poky/plain/meta/recipes-devtools/valgrind/valgrind/use-appropriate-march-mcpu-mfpu-for-ARM-test-apps.patch?id=b7a9250590a16f1bdc8c7b563da428df814d4292";
-      sha256 = "sha256-sBZzn98Sf/ETFv8ubivgA6Y6fBNcyR8beB3ICDAyAH0=";
+      hash = "sha256-sBZzn98Sf/ETFv8ubivgA6Y6fBNcyR8beB3ICDAyAH0=";
     })
   ];
 

--- a/pkgs/by-name/vi/virt-viewer/package.nix
+++ b/pkgs/by-name/vi/virt-viewer/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     # https://gitlab.com/virt-viewer/virt-viewer/-/merge_requests/120
     (fetchpatch {
       url = "https://gitlab.com/virt-viewer/virt-viewer/-/commit/98d9f202ef768f22ae21b5c43a080a1aa64a7107.patch";
-      sha256 = "sha256-3AbnkbhWOh0aNjUkmVoSV/9jFQtvTllOr7plnkntb2o=";
+      hash = "sha256-3AbnkbhWOh0aNjUkmVoSV/9jFQtvTllOr7plnkntb2o=";
     })
   ];
 

--- a/pkgs/by-name/vi/visual-hexdiff/package.nix
+++ b/pkgs/by-name/vi/visual-hexdiff/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     # See https://changelogs.ubuntu.com/changelogs/pool/universe/h/hexdiff/hexdiff_0.0.53-0ubuntu4/changelog
     (fetchpatch {
       url = "mirror://ubuntu/pool/universe/h/hexdiff/hexdiff_0.0.53-0ubuntu4.diff.gz";
-      sha256 = "sha256-X5ONNp9jeACxsulyowDQJ6REX6bty6L4in0/+rq8Wz4=";
+      hash = "sha256-X5ONNp9jeACxsulyowDQJ6REX6bty6L4in0/+rq8Wz4=";
       decode = "gunzip --stdout";
       name = "hexdiff_0.0.53-0ubuntu4.diff";
       stripLen = 1;

--- a/pkgs/by-name/wa/watson/package.nix
+++ b/pkgs/by-name/wa/watson/package.nix
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec {
     (fetchpatch {
       name = "fix-completion.patch";
       url = "https://github.com/jazzband/Watson/commit/43ad061a981eb401c161266f497e34df891a5038.patch";
-      sha256 = "sha256-v8/asP1wooHKjyy9XXB4Rtf6x+qmGDHpRoHEne/ZCxc=";
+      hash = "sha256-v8/asP1wooHKjyy9XXB4Rtf6x+qmGDHpRoHEne/ZCxc=";
     })
   ];
 

--- a/pkgs/by-name/wf/wf-recorder/package.nix
+++ b/pkgs/by-name/wf/wf-recorder/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     # compile fixes from upstream, remove when they stop applying
     (fetchpatch {
       url = "https://github.com/ammen99/wf-recorder/commit/560bb92d3ddaeb31d7af77d22d01b0050b45bebe.diff";
-      sha256 = "sha256-7jbX5k8dh4dWfolMkZXiERuM72zVrkarsamXnd+1YoI=";
+      hash = "sha256-7jbX5k8dh4dWfolMkZXiERuM72zVrkarsamXnd+1YoI=";
     })
   ];
 

--- a/pkgs/by-name/xb/xboard/package.nix
+++ b/pkgs/by-name/xb/xboard/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "fno-common.patch";
       url = "https://savannah.gnu.org/patch/download.php?file_id=53275";
-      sha256 = "sha256-ZOo9jAy1plFjhC5HXJQvXL+Zf7FL14asV3G4AwfgqTY=";
+      hash = "sha256-ZOo9jAy1plFjhC5HXJQvXL+Zf7FL14asV3G4AwfgqTY=";
     })
   ];
 

--- a/pkgs/by-name/xc/xcftools/package.nix
+++ b/pkgs/by-name/xc/xcftools/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2019-5086.CVE-2019-5087.patch";
       url = "https://github.com/gladk/xcftools/commit/59c38e3e45b9112c2bcb4392bccf56e297854f8a.patch";
-      sha256 = "sha256-a1Biv6viXzTSaLDzinOyu0HdDTUPsKITsdKu9B9Y8GE=";
+      hash = "sha256-a1Biv6viXzTSaLDzinOyu0HdDTUPsKITsdKu9B9Y8GE=";
     })
   ];
 

--- a/pkgs/by-name/xo/xorgproto/package.nix
+++ b/pkgs/by-name/xo/xorgproto/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     # small fix for mingw
     (fetchpatch {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/meson.patch?h=mingw-w64-xorgproto&id=7b817efc3144a50e6766817c4ca7242f8ce49307";
-      sha256 = "sha256-Izzz9In53W7CC++k1bLr78iSrmxpFm1cH8qcSpptoUQ=";
+      hash = "sha256-Izzz9In53W7CC++k1bLr78iSrmxpFm1cH8qcSpptoUQ=";
     })
   ];
 

--- a/pkgs/by-name/xt/xtreemfs/package.nix
+++ b/pkgs/by-name/xt/xtreemfs/package.nix
@@ -50,19 +50,19 @@ stdenv.mkDerivation {
       url = "https://github.com/protocolbuffers/protobuf/commit/2ca19bd8066821a56f193e7fca47139b25c617ad.patch";
       stripLen = 1;
       extraPrefix = "cpp/thirdparty/protobuf-2.5.0/";
-      sha256 = "sha256-hlL5ZiJhpO3fPpcSTV+yki4zahg/OhFdIZEGF1TNTe0=";
+      hash = "sha256-hlL5ZiJhpO3fPpcSTV+yki4zahg/OhFdIZEGF1TNTe0=";
     })
     (fetchpatch {
       name = "protobuf-add-aarch64-architecture-to-platform-macros.patch";
       url = "https://github.com/protocolbuffers/protobuf/commit/f0b6a5cfeb5f6347c34975446bda08e0c20c9902.patch";
       stripLen = 1;
       extraPrefix = "cpp/thirdparty/protobuf-2.5.0/";
-      sha256 = "sha256-VRl303x9g5ES/LMODcAdhsPiEmQTq/qXhE/DfvLXF84=";
+      hash = "sha256-VRl303x9g5ES/LMODcAdhsPiEmQTq/qXhE/DfvLXF84=";
     })
     (fetchpatch {
       name = "xtreemfs-fix-for-boost-version-1.66.patch";
       url = "https://github.com/xtreemfs/xtreemfs/commit/aab843cb115ab0739edf7f58fd2d4553a05374a8.patch";
-      sha256 = "sha256-y/vXI/PT1TwSy8/73+RKIgKq4pZ9i22MBxr6jo/M5l8=";
+      hash = "sha256-y/vXI/PT1TwSy8/73+RKIgKq4pZ9i22MBxr6jo/M5l8=";
     })
     (fetchpatch {
       name = "xtreemfs-fix-for-openssl_1_1.patch";

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -199,7 +199,7 @@ in
       (fetchpatch {
         name = "gcc-15-darwin-aarch64-support.patch";
         url = "https://raw.githubusercontent.com/Homebrew/formula-patches/a25079204c1cb3d78ba9dd7dd22b8aecce7ce264/gcc/gcc-15.1.0.diff";
-        sha256 = "sha256-MJxSGv6LEP1sIM8cDqbmfUV7byV0bYgADeIBY/Teyu8=";
+        hash = "sha256-MJxSGv6LEP1sIM8cDqbmfUV7byV0bYgADeIBY/Teyu8=";
       })
     ];
     "14" = [

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -225,7 +225,7 @@ let
               # Support for Coq 8.16.0
               (fetchpatch {
                 url = "https://github.com/AbsInt/CompCert/commit/34be08a23d18d56f2dde24fd24b6dbe3bcb01ec3.patch";
-                sha256 = "sha256-a5YnftGVadVypEqrOYRRxI7YtGOEWyKnO4GqakFhvzI=";
+                hash = "sha256-a5YnftGVadVypEqrOYRRxI7YtGOEWyKnO4GqakFhvzI=";
               })
               # Support for Coq 8.16.1
               (fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -415,7 +415,7 @@ with haskellLib;
   # support for transformers >= 0.6
   lifted-base = appendPatch (fetchpatch {
     url = "https://github.com/basvandijk/lifted-base/commit/6b61483ec7fd0d5d5d56ccb967860d42740781e8.patch";
-    sha256 = "sha256-b29AVDiEMcShceRJyKEauK/411UkOh3ME9AnKEYvcEs=";
+    hash = "sha256-b29AVDiEMcShceRJyKEauK/411UkOh3ME9AnKEYvcEs=";
   }) super.lifted-base;
 
   leveldb-haskell = overrideCabal (drv: {
@@ -455,7 +455,7 @@ with haskellLib;
       (pkgs.fetchpatch {
         name = "hourglass-pr-56.patch";
         url = "https://github.com/vincenthz/hs-hourglass/commit/cfc2a4b01f9993b1b51432f0a95fa6730d9a558a.patch";
-        sha256 = "sha256-gntZf7RkaR4qzrhjrXSC69jE44SknPDBmfs4z9rVa5Q=";
+        hash = "sha256-gntZf7RkaR4qzrhjrXSC69jE44SknPDBmfs4z9rVa5Q=";
       })
     ] super.hourglass
   );
@@ -475,7 +475,7 @@ with haskellLib;
         (pkgs.fetchpatch {
           name = "env-extra-no-parallel-setenv.patch";
           url = "https://github.com/d12frosted/env-extra/commit/4fcbc031b210e71e4243fcfe7c48d381e2f51d78.patch";
-          sha256 = "sha256-EbXk+VOmxMJAMCMTXpTiW8fkbNI9za7f1alzCeaJaV4=";
+          hash = "sha256-EbXk+VOmxMJAMCMTXpTiW8fkbNI9za7f1alzCeaJaV4=";
           excludes = [ "package.yaml" ];
         })
       ]
@@ -904,7 +904,7 @@ with haskellLib;
   xml-picklers = appendPatch (pkgs.fetchpatch {
     name = "xml-picklers-fix-prop-xp-attribute.patch";
     url = "https://github.com/Philonous/xml-picklers/commit/887e5416b5e61c589cadf775d82013eb87751ea2.patch";
-    sha256 = "sha256-EAyTVkAqCvJ0lRD0+q/htzBJ8iD5qP47j5i2fKhRrlw=";
+    hash = "sha256-EAyTVkAqCvJ0lRD0+q/htzBJ8iD5qP47j5i2fKhRrlw=";
   }) super.xml-picklers;
 
   # 2025-08-03: Too strict bounds on open-browser, data-default and containers
@@ -1468,7 +1468,7 @@ with haskellLib;
   optics = appendPatch (fetchpatch {
     name = "optics-fix-inspection-testing-bound";
     url = "https://github.com/well-typed/optics/commit/d16b1ac5476c89cc94fb108fe1be268791affca6.patch";
-    sha256 = "sha256-w0L/EXSWRQkCkFnvXYel0BNgQQhxn6zATkD3GZS5gz8=";
+    hash = "sha256-w0L/EXSWRQkCkFnvXYel0BNgQQhxn6zATkD3GZS5gz8=";
     relative = "optics";
   }) super.optics;
 
@@ -1788,7 +1788,7 @@ with haskellLib;
         (pkgs.fetchpatch {
           name = "dhall-lsp-server-lsp-2.7.patch";
           url = "https://github.com/dhall-lang/dhall-haskell/commit/a621e1438df5865d966597e2e1b0bb37e8311447.patch";
-          sha256 = "sha256-7edxNIeIM/trl2SUXybvSzkscvr1kj5+tZF50IeTOgY=";
+          hash = "sha256-7edxNIeIM/trl2SUXybvSzkscvr1kj5+tZF50IeTOgY=";
           relative = "dhall-lsp-server";
         })
         # Fix build with text >= 2.1.2
@@ -1820,13 +1820,13 @@ with haskellLib;
     name = "fix-on-firefox.patch";
     url = "https://github.com/ghcjs/jsaddle/commit/71ef7f0cbc60a380ba0dc299e758c8f90cc4b526.patch";
     relative = "jsaddle";
-    sha256 = "sha256-IBOX74r+lyywVWp0ZucoseeevFrGiInkq7V6RoWADNU=";
+    hash = "sha256-IBOX74r+lyywVWp0ZucoseeevFrGiInkq7V6RoWADNU=";
   }) super.jsaddle;
   jsaddle-warp = appendPatch (fetchpatch {
     name = "fix-on-firefox.patch";
     url = "https://github.com/ghcjs/jsaddle/commit/71ef7f0cbc60a380ba0dc299e758c8f90cc4b526.patch";
     relative = "jsaddle-warp";
-    sha256 = "sha256-jYEUOkP4Kv3yBjo3SbN7sruV+T5R5XWbRFcCUAa6HvE=";
+    hash = "sha256-jYEUOkP4Kv3yBjo3SbN7sruV+T5R5XWbRFcCUAa6HvE=";
   }) super.jsaddle-warp;
 
   # https://github.com/ghcjs/jsaddle/issues/151
@@ -1902,7 +1902,7 @@ with haskellLib;
   # Support ansi-terminal 1.1: https://github.com/facebookincubator/retrie/pull/73
   retrie = appendPatch (fetchpatch {
     url = "https://github.com/facebookincubator/retrie/commit/b0df07178133b5b049e3e7764acba0e5e3fa57af.patch";
-    sha256 = "sha256-Ea/u6PctSxy4h8VySjOwD2xW3TbwY1qE49dG9Av1SbQ=";
+    hash = "sha256-Ea/u6PctSxy4h8VySjOwD2xW3TbwY1qE49dG9Av1SbQ=";
   }) super.retrie;
 
   # Fails with encoding problems, likely needs locale data.
@@ -1916,7 +1916,7 @@ with haskellLib;
   Spock-core = appendPatches [
     (fetchpatch {
       url = "https://github.com/agrafix/Spock/commit/d0b51fa60a83bfa5c1b5fc8fced18001e7321701.patch";
-      sha256 = "sha256-l9voiczOOdYVBP/BNEUvqARb21t0Rp2kpsNbRFUWSLg=";
+      hash = "sha256-l9voiczOOdYVBP/BNEUvqARb21t0Rp2kpsNbRFUWSLg=";
       stripLen = 1;
     })
   ] (doJailbreak super.Spock-core);
@@ -1997,7 +1997,7 @@ with haskellLib;
       (appendPatches [
         (fetchpatch {
           url = "https://github.com/expipiplus1/update-nix-fetchgit/commit/dfa34f9823e282aa8c5a1b8bc95ad8def0e8d455.patch";
-          sha256 = "sha256-yBjn1gVihVTlLewKgJc2I9gEj8ViNBAmw0bcsb5rh1A=";
+          hash = "sha256-yBjn1gVihVTlLewKgJc2I9gEj8ViNBAmw0bcsb5rh1A=";
           excludes = [ "cabal.project" ];
         })
         # Fix for GHC >= 9.8
@@ -2013,7 +2013,7 @@ with haskellLib;
   binary-strict = appendPatches [
     (fetchpatch {
       url = "https://github.com/idontgetoutmuch/binary-low-level/pull/16/commits/c16d06a1f274559be0dea0b1f7497753e1b1a8ae.patch";
-      sha256 = "sha256-deSbudy+2je1SWapirWZ1IVWtJ0sJVR5O/fnaAaib2g=";
+      hash = "sha256-deSbudy+2je1SWapirWZ1IVWtJ0sJVR5O/fnaAaib2g=";
     })
   ] super.binary-strict;
 
@@ -2071,7 +2071,7 @@ with haskellLib;
   pipes-aeson = appendPatch (fetchpatch {
     url = "https://github.com/k0001/pipes-aeson/commit/08c25865ef557b41d7e4a783f52e655d2a193e18.patch";
     relative = "pipes-aeson";
-    sha256 = "sha256-kFV6CcwKdMq+qSgyc+eIApnaycq5A++pEEVr2A9xvts=";
+    hash = "sha256-kFV6CcwKdMq+qSgyc+eIApnaycq5A++pEEVr2A9xvts=";
   }) super.pipes-aeson;
 
   moto-postgresql = appendPatches [
@@ -2080,7 +2080,7 @@ with haskellLib;
       name = "moto-postgresql-monadfail.patch";
       url = "https://gitlab.com/k0001/moto/-/commit/09cc1c11d703c25f6e81325be6482dc7ec6cbf58.patch";
       relative = "moto-postgresql";
-      sha256 = "sha256-f2JVX9VveShCeV+T41RQgacpUoh1izfyHlE6VlErkZM=";
+      hash = "sha256-f2JVX9VveShCeV+T41RQgacpUoh1izfyHlE6VlErkZM=";
     })
   ] super.moto-postgresql;
 
@@ -2090,7 +2090,7 @@ with haskellLib;
       name = "moto-ghc-9.0.patch";
       url = "https://gitlab.com/k0001/moto/-/commit/5b6f015a1271765005f03762f1f1aaed3a3198ed.patch";
       relative = "moto";
-      sha256 = "sha256-RMa9tk+2ip3Ks73UFv9Ea9GEnElRtzIjdpld1Fx+dno=";
+      hash = "sha256-RMa9tk+2ip3Ks73UFv9Ea9GEnElRtzIjdpld1Fx+dno=";
     })
   ] super.moto;
 
@@ -2213,7 +2213,7 @@ with haskellLib;
         (fetchpatch {
           name = "llvm-hs-pure-bytestring-0.11.patch";
           url = "https://github.com/llvm-hs/llvm-hs/commit/fe8fd556e8d2cc028f61d4d7b4b6bf18c456d090.patch";
-          sha256 = "sha256-1d4wQg6JEJL3GwmXQpvbW7VOY5DwjUPmIsLEEur0Kps=";
+          hash = "sha256-1d4wQg6JEJL3GwmXQpvbW7VOY5DwjUPmIsLEEur0Kps=";
           relative = "llvm-hs-pure";
           excludes = [ "**/Triple.hs" ]; # doesn't exist in 9.0.0
         })
@@ -2486,12 +2486,12 @@ with haskellLib;
       (pkgs.fetchpatch {
         name = "use-crypton-connection.patch";
         url = "https://github.com/minio/minio-hs/commit/786cf1881f0b62b7539e63547e76afc3c1ade36a.patch";
-        sha256 = "sha256-zw0/jhKzShpqV1sUyxWTl73sQOzm6kA/yQOZ9n0L1Ag";
+        hash = "sha256-zw0/jhKzShpqV1sUyxWTl73sQOzm6kA/yQOZ9n0L1Ag";
       })
       (pkgs.fetchpatch {
         name = "compatibility-with-crypton-connection-0-4-0.patch";
         url = "https://github.com/minio/minio-hs/commit/e2169892a5fea444aaf9e551243da811003d3188.patch";
-        sha256 = "sha256-hWphiArv7gZWiDewLHDeU4RASGOE9Z1liahTmAGQIgQ=";
+        hash = "sha256-hWphiArv7gZWiDewLHDeU4RASGOE9Z1liahTmAGQIgQ=";
       })
     ];
   }) (super.minio-hs.override { connection = self.crypton-connection; });
@@ -2671,7 +2671,7 @@ with haskellLib;
     # https://github.com/well-typed/basic-sop/pull/13
     name = "increase-upper-bounds.patch";
     url = "https://github.com/well-typed/basic-sop/commit/f1873487dd3e3955a82d6d9f37a6b164be36851f.patch";
-    sha256 = "sha256-uBH+LmiSO91diVe4uX75/DdWT2wuyqEL+XUlSHnJk5k=";
+    hash = "sha256-uBH+LmiSO91diVe4uX75/DdWT2wuyqEL+XUlSHnJk5k=";
   }) super.basic-sop;
 
   # Unmaintained
@@ -2912,7 +2912,7 @@ with haskellLib;
     (pkgs.fetchpatch {
       name = "heist-fix-ghc-errorr-message-test.patch";
       url = "https://github.com/snapframework/heist/commit/9c8c963021608f09e93d486e5339e45073c757bc.patch";
-      sha256 = "sha256-lenMCb6o0aAJ8D450JB76cZ49o+LVl2UO9hhAZYPacI=";
+      hash = "sha256-lenMCb6o0aAJ8D450JB76cZ49o+LVl2UO9hhAZYPacI=";
     })
   ] super.heist;
 
@@ -3185,15 +3185,15 @@ with haskellLib;
   hailgun = appendPatches [
     (fetchpatch {
       url = "https://bitbucket.org/nh2/hailgun/commits/ac2bc2a3003e4b862625862c4565fece01c0cf57/raw";
-      sha256 = "sha256-MWeK9nzMVP6cQs2GBFkohABgL8iWcT7YzwF+tLOkIjo=";
+      hash = "sha256-MWeK9nzMVP6cQs2GBFkohABgL8iWcT7YzwF+tLOkIjo=";
     })
     (fetchpatch {
       url = "https://bitbucket.org/nh2/hailgun/commits/583daaf87265a7fa67ce5171fe1077e61be9b39c/raw";
-      sha256 = "sha256-6WITonLoONxZzzkS7EI79LwmwSdkt6TCgvHA2Hwy148=";
+      hash = "sha256-6WITonLoONxZzzkS7EI79LwmwSdkt6TCgvHA2Hwy148=";
     })
     (fetchpatch {
       url = "https://bitbucket.org/nh2/hailgun/commits/b9680b82f6d58f807828c1bbb57e26c7af394501/raw";
-      sha256 = "sha256-MnOc51tTNg8+HDu1VS2Ct7Mtu0vuuRd3DjzOAOF+t7Q=";
+      hash = "sha256-MnOc51tTNg8+HDu1VS2Ct7Mtu0vuuRd3DjzOAOF+t7Q=";
     })
   ] super.hailgun;
 
@@ -3244,7 +3244,7 @@ with haskellLib;
     # https://github.com/sjakobi/bsb-http-chunked/pull/49
     (appendPatch (fetchpatch {
       url = "https://github.com/sjakobi/bsb-http-chunked/commit/689bf9ce12b8301d0e13a68e4a515c2779b62947.patch";
-      sha256 = "sha256-ZdCXMhni+RGisRODiElObW5c4hKy2giWQmWnatqeRJo=";
+      hash = "sha256-ZdCXMhni+RGisRODiElObW5c4hKy2giWQmWnatqeRJo=";
     }))
   ];
 
@@ -3255,7 +3255,7 @@ with haskellLib;
     # Fixes syntax error in tests
     (appendPatch (fetchpatch {
       url = "https://bitbucket.org/HList/hlist/commits/e688f11d7432c812c2b238464401a86f588f81e1/raw";
-      sha256 = "sha256-XIBIrR2MFmhKaocZJ4p57CgmAaFmMU5Z5a0rk2CjIcM=";
+      hash = "sha256-XIBIrR2MFmhKaocZJ4p57CgmAaFmMU5Z5a0rk2CjIcM=";
     }))
   ];
 
@@ -3376,7 +3376,7 @@ with haskellLib;
             name = "base-4.20-foldl'.patch";
             url = "https://github.com/GaloisInc/crucible/commit/10f372e4b0389dd3966e04163dcd67d71e651709.patch";
             relative = "crucible";
-            sha256 = "sha256-frxTs5SB1ENjH+X0lIlQ8k6pDIDOANylrqIOQpEtObU=";
+            hash = "sha256-frxTs5SB1ENjH+X0lIlQ8k6pDIDOANylrqIOQpEtObU=";
           }
         ))
       ];
@@ -3528,7 +3528,7 @@ with haskellLib;
   # https://github.com/haskell-cryptography/botan/pull/17
   botan-bindings = appendPatch (pkgs.fetchpatch2 {
     url = "https://github.com/haskell-cryptography/botan/commit/99de68c3938187b7ab740c6534ec032a4a236747.patch";
-    sha256 = "sha256-v255WFO9HsRuTAWFZG27TYbpoK7rJ1AuiCFNFIV18mI=";
+    hash = "sha256-v255WFO9HsRuTAWFZG27TYbpoK7rJ1AuiCFNFIV18mI=";
     stripLen = 1;
   }) super.botan-bindings;
 

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -241,7 +241,7 @@ self: super:
     inline-c-cpp = appendPatch (pkgs.fetchpatch {
       url = "https://github.com/fpco/inline-c/commit/e8dc553b13bb847409fdced649a6a863323cff8a.patch";
       name = "revert-use-system-cxx-std-lib.patch";
-      sha256 = "sha256-ql1/+8bvmWexyCdFR0VS4M4cY2lD0Px/9dHYLqlKyNA=";
+      hash = "sha256-ql1/+8bvmWexyCdFR0VS4M4cY2lD0Px/9dHYLqlKyNA=";
       revert = true;
       stripLen = 1;
     }) super.inline-c-cpp;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -83,7 +83,7 @@ in
   hevm = appendPatch (pkgs.fetchpatch {
     url = "https://github.com/hellwolf/hevm/commit/338674d1fe22d46ea1e8582b24c224d76d47d0f3.patch";
     name = "release-0.54.2-ghc-9.8.4-patch";
-    sha256 = "sha256-Mo65FfP1nh7QTY+oLia22hj4eV2v9hpXlYsrFKljA3E=";
+    hash = "sha256-Mo65FfP1nh7QTY+oLia22hj4eV2v9hpXlYsrFKljA3E=";
   }) super.hevm;
   HaskellNet-SSL = doJailbreak super.HaskellNet-SSL; # bytestring >=0.9 && <0.12
   inflections = doJailbreak super.inflections; # text >=0.2 && <2.1

--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -55,7 +55,7 @@ with haskellLib;
   # https://github.com/haskellari/splitmix/pull/75
   splitmix = appendPatch (pkgs.fetchpatch {
     url = "https://github.com/haskellari/splitmix/commit/7ffb3158f577c48ab5de774abea47767921ef3e9.patch";
-    sha256 = "sha256-n2q4FGf/pPcI1bhb9srHjHLzaNVehkdN6kQgL0F4MMg=";
+    hash = "sha256-n2q4FGf/pPcI1bhb9srHjHLzaNVehkdN6kQgL0F4MMg=";
   }) super.splitmix;
 
   # See https://gitlab.haskell.org/ghc/ghc/-/issues/26019#note_621324, without this flag the build OOMs

--- a/pkgs/development/libraries/abseil-cpp/202103.nix
+++ b/pkgs/development/libraries/abseil-cpp/202103.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     # https://github.com/abseil/abseil-cpp/pull/1110
     (fetchpatch {
       url = "https://github.com/abseil/abseil-cpp/commit/808bc202fc13e85a7948db0d7fb58f0f051200b1.patch";
-      sha256 = "sha256-ayY/aV/xWOdEyFSDqV7B5WDGvZ0ASr/aeBeYwP5RZVc=";
+      hash = "sha256-ayY/aV/xWOdEyFSDqV7B5WDGvZ0ASr/aeBeYwP5RZVc=";
     })
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -44,85 +44,85 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2021-3502.patch";
       url = "https://github.com/lathiat/avahi/commit/9d31939e55280a733d930b15ac9e4dda4497680c.patch";
-      sha256 = "sha256-BXWmrLWUvDxKPoIPRFBpMS3T4gijRw0J+rndp6iDybU=";
+      hash = "sha256-BXWmrLWUvDxKPoIPRFBpMS3T4gijRw0J+rndp6iDybU=";
     })
     # CVE-2021-3468
     (fetchpatch {
       name = "CVE-2021-3468.patch";
       url = "https://github.com/lathiat/avahi/commit/447affe29991ee99c6b9732fc5f2c1048a611d3b.patch";
-      sha256 = "sha256-qWaCU1ZkCg2PmijNto7t8E3pYRN/36/9FrG8okd6Gu8=";
+      hash = "sha256-qWaCU1ZkCg2PmijNto7t8E3pYRN/36/9FrG8okd6Gu8=";
     })
     (fetchpatch {
       name = "CVE-2023-1981.patch";
       url = "https://github.com/lathiat/avahi/commit/a2696da2f2c50ac43b6c4903f72290d5c3fa9f6f.patch";
-      sha256 = "sha256-BEYFGCnQngp+OpiKIY/oaKygX7isAnxJpUPCUvg+efc=";
+      hash = "sha256-BEYFGCnQngp+OpiKIY/oaKygX7isAnxJpUPCUvg+efc=";
     })
     # CVE-2023-38470
     # https://github.com/lathiat/avahi/pull/457 merged Sep 19
     (fetchpatch {
       name = "CVE-2023-38470.patch";
       url = "https://github.com/lathiat/avahi/commit/94cb6489114636940ac683515417990b55b5d66c.patch";
-      sha256 = "sha256-Fanh9bvz+uknr5pAmltqijuUAZIG39JR2Lyq5zGKJ58=";
+      hash = "sha256-Fanh9bvz+uknr5pAmltqijuUAZIG39JR2Lyq5zGKJ58=";
     })
     # https://github.com/avahi/avahi/pull/480 merged Sept 19
     (fetchpatch {
       name = "bail-out-unless-escaped-labels-fit.patch";
       url = "https://github.com/avahi/avahi/commit/20dec84b2480821704258bc908e7b2bd2e883b24.patch";
-      sha256 = "sha256-p/dOuQ/GInIcUwuFhQR3mGc5YBL5J8ho+1gvzcqEN0c=";
+      hash = "sha256-p/dOuQ/GInIcUwuFhQR3mGc5YBL5J8ho+1gvzcqEN0c=";
     })
     # CVE-2023-38473
     # https://github.com/lathiat/avahi/pull/486 merged Oct 18
     (fetchpatch {
       name = "CVE-2023-38473.patch";
       url = "https://github.com/lathiat/avahi/commit/b448c9f771bada14ae8de175695a9729f8646797.patch";
-      sha256 = "sha256-/ZVhsBkf70vjDWWG5KXxvGXIpLOZUXdRkn3413iSlnI=";
+      hash = "sha256-/ZVhsBkf70vjDWWG5KXxvGXIpLOZUXdRkn3413iSlnI=";
     })
     # CVE-2023-38472
     # https://github.com/lathiat/avahi/pull/490 merged Oct 19
     (fetchpatch {
       name = "CVE-2023-38472.patch";
       url = "https://github.com/lathiat/avahi/commit/b024ae5749f4aeba03478e6391687c3c9c8dee40.patch";
-      sha256 = "sha256-FjR8fmhevgdxR9JQ5iBLFXK0ILp2OZQ8Oo9IKjefCqk=";
+      hash = "sha256-FjR8fmhevgdxR9JQ5iBLFXK0ILp2OZQ8Oo9IKjefCqk=";
     })
     # CVE-2023-38471
     # https://github.com/lathiat/avahi/pull/494 merged Oct 24
     (fetchpatch {
       name = "CVE-2023-38471.patch";
       url = "https://github.com/lathiat/avahi/commit/894f085f402e023a98cbb6f5a3d117bd88d93b09.patch";
-      sha256 = "sha256-4dG+5ZHDa+A4/CszYS8uXWlpmA89m7/jhbZ7rheMs7U=";
+      hash = "sha256-4dG+5ZHDa+A4/CszYS8uXWlpmA89m7/jhbZ7rheMs7U=";
     })
     # https://github.com/lathiat/avahi/pull/499 merged Oct 25
     (fetchpatch {
       name = "CVE-2023-38471-2.patch";
       url = "https://github.com/avahi/avahi/commit/b675f70739f404342f7f78635d6e2dcd85a13460.patch";
-      sha256 = "sha256-uDtMPWuz1lsu7n0Co/Gpyh369miQ6GWGyC0UPQB/yI8=";
+      hash = "sha256-uDtMPWuz1lsu7n0Co/Gpyh369miQ6GWGyC0UPQB/yI8=";
     })
     # CVE-2023-38469
     # https://github.com/lathiat/avahi/pull/500 merged Oct 25
     (fetchpatch {
       name = "CVE-2023-38469.patch";
       url = "https://github.com/avahi/avahi/commit/61b9874ff91dd20a12483db07df29fe7f35db77f.patch";
-      sha256 = "sha256-qR7scfQqhRGxg2n4HQsxVxCLkXbwZi+PlYxrOSEPsL0=";
+      hash = "sha256-qR7scfQqhRGxg2n4HQsxVxCLkXbwZi+PlYxrOSEPsL0=";
       excludes = [ ".github/workflows/smoke-tests.sh" ];
     })
     # https://github.com/avahi/avahi/pull/515 merged Nov 3
     (fetchpatch {
       name = "fix-compare-rrs-with-zero-length-rdata.patch";
       url = "https://github.com/avahi/avahi/commit/177d75e8c43be45a8383d794ce4084dd5d600a9e.patch";
-      sha256 = "sha256-uwIyruAWgiWt0yakRrvMdYjjhEhUk5cIGKt6twyXbHw=";
+      hash = "sha256-uwIyruAWgiWt0yakRrvMdYjjhEhUk5cIGKt6twyXbHw=";
     })
     # https://github.com/avahi/avahi/pull/519 merged Nov 8
     (fetchpatch {
       name = "reject-non-utf-8-service-names.patch";
       url = "https://github.com/avahi/avahi/commit/2b6d3e99579e3b6e9619708fad8ad8e07ada8218.patch";
-      sha256 = "sha256-lwSA3eEQgH0g51r0i9/HJMJPRXrhQnTIEDxcYqUuLdI=";
+      hash = "sha256-lwSA3eEQgH0g51r0i9/HJMJPRXrhQnTIEDxcYqUuLdI=";
       excludes = [ "fuzz/fuzz-domain.c" ];
     })
     # https://github.com/avahi/avahi/pull/523 merged Nov 12
     (fetchpatch {
       name = "core-no-longer-supply-bogus-services-to-callbacks.patch";
       url = "https://github.com/avahi/avahi/commit/93b14365c1c1e04efd1a890e8caa01a2a514bfd8.patch";
-      sha256 = "sha256-VBm8vsBZkTbbWAK8FI71SL89lZuYd1yFNoB5o+FvlEU=";
+      hash = "sha256-VBm8vsBZkTbbWAK8FI71SL89lZuYd1yFNoB5o+FvlEU=";
       excludes = [
         ".github/workflows/smoke-tests.sh"
         "fuzz/fuzz-packet.c"

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -173,14 +173,14 @@ stdenv.mkDerivation {
     ++ lib.optional (version == "1.77.0") (fetchpatch {
       url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
       relative = "include";
-      sha256 = "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
+      hash = "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
     })
     # Fixes ABI detection
     ++ lib.optional (version == "1.83.0") (fetchpatch {
       url = "https://github.com/boostorg/context/commit/6fa6d5c50d120e69b2d8a1c0d2256ee933e94b3b.patch";
       stripLen = 1;
       extraPrefix = "libs/context/";
-      sha256 = "sha256-bCfLL7bD1Rn4Ie/P3X+nIcgTkbXdCX6FW7B9lHsmVW8=";
+      hash = "sha256-bCfLL7bD1Rn4Ie/P3X+nIcgTkbXdCX6FW7B9lHsmVW8=";
     })
     # This fixes another issue regarding ill-formed constant expressions, which is a default error
     # in clang 16 and will be a hard error in clang 17.

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "${pname}-${version}.fix-build-against-glib-2.68.patch";
       url = "https://gitlab.gnome.org/GNOME/gstreamermm/-/commit/37116547fb5f9066978e39b4cf9f79f2154ad425.patch";
-      sha256 = "sha256-YHtmOiOl4POwas3eWHsew3IyGK7Aq22MweBm3JPwyBM=";
+      hash = "sha256-YHtmOiOl4POwas3eWHsew3IyGK7Aq22MweBm3JPwyBM=";
     })
   ];
 

--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -26,12 +26,12 @@ mkDerivation rec {
     # fix build with newer QT versions
     (fetchpatch {
       url = "https://github.com/KDE/kdb/commit/b36d74f13a1421437a725fb74502c993c359392a.patch";
-      sha256 = "sha256-ENMZTUZ3yCKUhHPMUcDe1cMY2GLBz0G3ZvMRyj8Hfrw=";
+      hash = "sha256-ENMZTUZ3yCKUhHPMUcDe1cMY2GLBz0G3ZvMRyj8Hfrw=";
     })
     # fix build with newer posgresql versions
     (fetchpatch {
       url = "https://github.com/KDE/kdb/commit/40cdaea4d7824cc1b0d26e6ad2dcb61fa2077911.patch";
-      sha256 = "sha256-cZpX6L/NZX3vztnh0s2+v4J7kBcKgUdecY53LRp8CwM=";
+      hash = "sha256-cZpX6L/NZX3vztnh0s2+v4J7kBcKgUdecY53LRp8CwM=";
     })
   ];
 

--- a/pkgs/development/libraries/libgda/6.x.nix
+++ b/pkgs/development/libraries/libgda/6.x.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "CVE-2021-39359.patch";
       url = "https://gitlab.gnome.org/GNOME/libgda/-/commit/bebdffb4de586fb43fd07ac549121f4b22f6812d.patch";
-      sha256 = "sha256-UjHP1nhb5n6TOdaMdQeE2s828T4wv/0ycG3FAk+I1QA=";
+      hash = "sha256-UjHP1nhb5n6TOdaMdQeE2s828T4wv/0ycG3FAk+I1QA=";
     })
   ];
 

--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     # Work around https://bugs.kde.org/show_bug.cgi?id=445196 until a new release.
     (fetchpatch {
       url = "https://invent.kde.org/libraries/phonon-gstreamer/-/commit/bbbb160f30a394655cff9398d17961142388b0f2.patch";
-      sha256 = "sha256-tNBqVt67LNb9SQogS9ol8/xYIZvVSoVUgXQahMfkFh8=";
+      hash = "sha256-tNBqVt67LNb9SQogS9ol8/xYIZvVSoVUgXQahMfkFh8=";
     })
   ];
 

--- a/pkgs/development/ocaml-modules/chacha/default.nix
+++ b/pkgs/development/ocaml-modules/chacha/default.nix
@@ -25,7 +25,7 @@ buildDunePackage rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/abeaumont/ocaml-chacha/commit/fbe4a0a808226229728a68f278adf370251196fd.patch";
-      sha256 = "sha256-y7X9toFDrgdv3qmFmUs7K7QS+Gy45rRLulKy48m7uqc=";
+      hash = "sha256-y7X9toFDrgdv3qmFmUs7K7QS+Gy45rRLulKy48m7uqc=";
     })
   ];
 

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -620,7 +620,7 @@ with self;
       # remove on next release
       (fetchpatch {
         url = "https://github.com/janestreet/jst-config/commit/e5fdac6e5df9ba93e014a4d2db841fdbf209446f.patch";
-        sha256 = "sha256-8hVC76z5ilYD/++xRHVswy/l+zzDt63jH4hfSJ/rPaA=";
+        hash = "sha256-8hVC76z5ilYD/++xRHVswy/l+zzDt63jH4hfSJ/rPaA=";
       })
     ];
   };

--- a/pkgs/development/ocaml-modules/mldoc/default.nix
+++ b/pkgs/development/ocaml-modules/mldoc/default.nix
@@ -22,7 +22,7 @@ let
       # mldoc requires Angstrom to expose `unsafe_lookahead`
       (fetchpatch {
         url = "https://github.com/logseq/angstrom/commit/bbe36c99c13678937d4c983a427e02a733d6cc24.patch";
-        sha256 = "sha256-RapY1QJ8U0HOqJ9TFDnCYB4tFLFuThESzdBZqjYuDUA=";
+        hash = "sha256-RapY1QJ8U0HOqJ9TFDnCYB4tFLFuThESzdBZqjYuDUA=";
       })
     ];
   });

--- a/pkgs/development/ocaml-modules/ocaml-r/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-r/default.nix
@@ -29,7 +29,7 @@ buildDunePackage rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/pveber/ocaml-r/commit/aa96dc5.patch";
-      sha256 = "sha256-xW33W2ciesyUkDKEH08yfOXv0wP0V6X80or2/n2Nrb4=";
+      hash = "sha256-xW33W2ciesyUkDKEH08yfOXv0wP0V6X80or2/n2Nrb4=";
     })
   ];
 

--- a/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_cmdliner/default.nix
@@ -29,7 +29,7 @@ buildDunePackage rec {
     # remove when a new version is released
     (fetchpatch {
       url = "https://patch-diff.githubusercontent.com/raw/hammerlab/ppx_deriving_cmdliner/pull/50.patch";
-      sha256 = "sha256-FfUfEAsyobwZ99+s5sFAaCE6Xgx7jLr/q79OxDbGcvQ=";
+      hash = "sha256-FfUfEAsyobwZ99+s5sFAaCE6Xgx7jLr/q79OxDbGcvQ=";
     })
   ];
 

--- a/pkgs/development/python-modules/dynd/default.nix
+++ b/pkgs/development/python-modules/dynd/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     # https://github.com/libdynd/dynd-python/issues/746
     (fetchpatch {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/numpy-compatibility.patch?h=python-dynd&id=e626acabd041069861311f314ac3dbe9e6fd24b7";
-      sha256 = "sha256-oA/3G8CGeDhiYXbNX+G6o3QSb7rkKItuCDCbnK3Rt10=";
+      hash = "sha256-oA/3G8CGeDhiYXbNX+G6o3QSb7rkKItuCDCbnK3Rt10=";
       name = "numpy-compatibility.patch";
     })
   ];

--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -43,15 +43,15 @@ buildPythonPackage rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/Emantor/labgrid/commit/4a66b43882811d50600e37aa39b24ec40398d184.patch";
-      sha256 = "sha256-eJMB1qFWiDzQXEB4dYOHYMQqCPHXEWCwWjNNY0yTC2s=";
+      hash = "sha256-eJMB1qFWiDzQXEB4dYOHYMQqCPHXEWCwWjNNY0yTC2s=";
     })
     (fetchpatch {
       url = "https://github.com/Emantor/labgrid/commit/d9933b3ec444c35d98fd41685481ecae8ff28bf4.patch";
-      sha256 = "sha256-Zx5j+CD6Q89dLmTl5QSKI9M1IcZ97OCjEWtEbG+CKWE=";
+      hash = "sha256-Zx5j+CD6Q89dLmTl5QSKI9M1IcZ97OCjEWtEbG+CKWE=";
     })
     (fetchpatch {
       url = "https://github.com/Emantor/labgrid/commit/f0b672afe1e8976c257f0adff9bf6e7ee9760d6f.patch";
-      sha256 = "sha256-M7rg+W9SjWDdViWyWe3ERzbUowxzf09c4w1yG3jQGak=";
+      hash = "sha256-M7rg+W9SjWDdViWyWe3ERzbUowxzf09c4w1yG3jQGak=";
     })
   ];
 

--- a/pkgs/development/python-modules/sip/4.x.nix
+++ b/pkgs/development/python-modules/sip/4.x.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     (fetchpatch {
       name = "sip-4-python3-11.patch";
       url = "https://aur.archlinux.org/cgit/aur.git/plain/python3-11.patch?h=sip4&id=67b5907227e68845cdfafcf050fedb89ed653585";
-      sha256 = "sha256-cmuz2y5+T8EM/h03G2oboSnnOwrUjVKt2TUQaC9YAdE=";
+      hash = "sha256-cmuz2y5+T8EM/h03G2oboSnnOwrUjVKt2TUQaC9YAdE=";
     })
   ];
 

--- a/pkgs/development/python-modules/thriftpy2/default.nix
+++ b/pkgs/development/python-modules/thriftpy2/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/Thriftpy/thriftpy2/commit/0127d259eb4b96acb060cd158ca709f0597b148c.patch";
-      sha256 = "sha256-UBcbd8NTkPyko1s9jTjKlQ7HprwtyOZS0m66u1CPH3A=";
+      hash = "sha256-UBcbd8NTkPyko1s9jTjKlQ7HprwtyOZS0m66u1CPH3A=";
     })
   ];
   build-system = [ setuptools ];

--- a/pkgs/development/python2-modules/pycairo/default.nix
+++ b/pkgs/development/python2-modules/pycairo/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/pygobject/pycairo/commit/678edd94d8a6dfb5d51f9c3549e6ee8c90a73744.patch";
-      sha256 = "sha256-HmP69tUGYxZvJ/M9FJHwHTCjb9Kf4aWRyMT4wSymrT0=";
+      hash = "sha256-HmP69tUGYxZvJ/M9FJHwHTCjb9Kf4aWRyMT4wSymrT0=";
     })
   ];
 

--- a/pkgs/development/python2-modules/pygobject/default.nix
+++ b/pkgs/development/python2-modules/pygobject/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     ./pygobject-2.0-fix-darwin.patch
     (fetchpatch {
       url = "https://github.com/macports/macports-ports/raw/f2975d5bbbc2459c661905c5a850cc661fa32f55/python/py-gobject/files/py-gobject-dynamic_lookup-11.patch";
-      sha256 = "sha256-mtlyu+La3+iC5iQAmVJzDA5E35XGaRQy/EKXzvrWRCg=";
+      hash = "sha256-mtlyu+La3+iC5iQAmVJzDA5E35XGaRQy/EKXzvrWRCg=";
       extraPrefix = "";
     })
   ];

--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -148,17 +148,17 @@ stdenv.mkDerivation (finalAttrs: {
     ./cmake-find-x11-libgl.patch
     (fetchpatch {
       # [PATCH] improve rocclr isa compatibility check
-      sha256 = "sha256-oj1loBEuqzuMihOKoN0wR92Wo25AshN5MpBuTq/9TMw=";
+      hash = "sha256-oj1loBEuqzuMihOKoN0wR92Wo25AshN5MpBuTq/9TMw=";
       url = "https://github.com/GZGavinZhao/clr/commit/f675b9b46d9f7bb8e003f4f47f616fa86a0b7a5e.patch";
     })
     (fetchpatch {
       # [PATCH] improve hipamd isa compatibility check
-      sha256 = "sha256-E3ERoVjUVWCiYHuE1GaVY5jMrAVx3B1cAVHM4/HPuaQ=";
+      hash = "sha256-E3ERoVjUVWCiYHuE1GaVY5jMrAVx3B1cAVHM4/HPuaQ=";
       url = "https://github.com/GZGavinZhao/clr/commit/aec0fc56ee2d10a2bc269c418fa847da2ee9969a.patch";
     })
     (fetchpatch {
       # [PATCH] SWDEV-507104 - Removes alignment requirement for Semaphore class to resolve runtime misaligned memory issues
-      sha256 = "sha256-nStJ22B/CM0fzQTvYjbHDbQt0GlE8DXxVK+UDU9BAx4=";
+      hash = "sha256-nStJ22B/CM0fzQTvYjbHDbQt0GlE8DXxVK+UDU9BAx4=";
       url = "https://github.com/ROCm/clr/commit/21d764518363d74187deaef2e66c1a127bc5aa64.patch";
     })
     (fetchpatch {

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -276,7 +276,7 @@ rec {
       (fetchpatch {
         # fix tools/llvm-exegesis/X86/latency/ failing with glibc 2.4+
         name = "exegesis-latency-glibc-fix.patch";
-        sha256 = "sha256-CjKxQlYwHXTM0mVnv8k/ssg5OXuKpJxRvBZGXjrFZAg=";
+        hash = "sha256-CjKxQlYwHXTM0mVnv8k/ssg5OXuKpJxRvBZGXjrFZAg=";
         url = "https://github.com/llvm/llvm-project/commit/1e8df9e85a1ff213e5868bd822877695f27504ad.patch";
         relative = "llvm";
       })
@@ -369,7 +369,7 @@ rec {
             ./perf-shorten-gcclib-include-paths.patch
             (fetchpatch {
               # [ClangOffloadBundler]: Add GetBundleIDsInFile to OffloadBundler
-              sha256 = "sha256-G/mzUdFfrJ2bLJgo4+mBcR6Ox7xGhWu5X+XxT4kH2c8=";
+              hash = "sha256-G/mzUdFfrJ2bLJgo4+mBcR6Ox7xGhWu5X+XxT4kH2c8=";
               url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/6d296f879b0fed830c54b2a9d26240da86c8bb3a.patch";
               relative = "clang";
             })

--- a/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
@@ -30,13 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # [Comgr] Extend ISA compatibility
     (fetchpatch {
-      sha256 = "sha256-dgow0kwSWM1TnkqWOZDRQrh5nuF8p5jbYyOLCpQsH4k=";
+      hash = "sha256-dgow0kwSWM1TnkqWOZDRQrh5nuF8p5jbYyOLCpQsH4k=";
       url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/a439e4f37ce71de48d4a979594276e3be0e6278f.patch";
       relative = "amd/comgr";
     })
     #[Comgr] Extend ISA compatibility for CCOB
     (fetchpatch {
-      sha256 = "sha256-PCi0QHLiEQCTIYRtSSbhOjXANJ3zC3VLdMED1BEfQeg=";
+      hash = "sha256-PCi0QHLiEQCTIYRtSSbhOjXANJ3zC3VLdMED1BEfQeg=";
       url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/fa80abb77d5ae6f8d89ab956e7ebda9c802a804f.patch";
       relative = "amd/comgr";
     })

--- a/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (fetchpatch {
       # rocr: Extend HIP ISA compatibility check
-      sha256 = "sha256-8r2Lb5lBfFaZC3knCxfXGcnkzNv6JxOKyJn2rD5gus4=";
+      hash = "sha256-8r2Lb5lBfFaZC3knCxfXGcnkzNv6JxOKyJn2rD5gus4=";
       url = "https://github.com/GZGavinZhao/ROCR-Runtime/commit/7c63e7185d8fcf08537a278908946145f6231121.patch";
     })
     # Patches for UB at runtime https://github.com/ROCm/ROCR-Runtime/issues/272

--- a/pkgs/development/rocm-modules/6/tensile/default.nix
+++ b/pkgs/development/rocm-modules/6/tensile/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     ./tensile-create-library-dont-copy-twice.diff
     (fetchpatch {
       # [PATCH] Extend Tensile HIP ISA compatibility
-      sha256 = "sha256-d+fVf/vz+sxGqJ96vuxe0jRMgbC5K6j5FQ5SJ1e3Sl8=";
+      hash = "sha256-d+fVf/vz+sxGqJ96vuxe0jRMgbC5K6j5FQ5SJ1e3Sl8=";
       url = "https://github.com/GZGavinZhao/Tensile/commit/855cb15839849addb0816a6dde45772034a3e41f.patch";
     })
   ];

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -42,7 +42,7 @@ mkDerivation rec {
     (fetchpatch {
       name = "include-missing-cstdint.patch";
       url = "https://github.com/BoomerangDecompiler/boomerang/commit/3342b0eac6b7617d9913226c06c1470820593e74.patch";
-      sha256 = "sha256-941IydcV3mqj7AWvXTM6GePW5VgawEcL0wrBCXqeWvc=";
+      hash = "sha256-941IydcV3mqj7AWvXTM6GePW5VgawEcL0wrBCXqeWvc=";
     })
   ];
 

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -38,7 +38,7 @@ mkKdeDerivation {
     (fetchpatch {
       name = "fix-media-applet-crash.diff";
       url = "https://invent.kde.org/plasma/plasma-workspace/-/commit/30273fb2afcc6e304951c8895bb17d38255fed39.diff";
-      sha256 = "sha256-1p1CjxRioCDm5ugoI8l6kDlOse5FbDJ71tTAY9LPvRc=";
+      hash = "sha256-1p1CjxRioCDm5ugoI8l6kDlOse5FbDJ71tTAY9LPvRc=";
     })
   ];
 

--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   patches = [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/archlinux/svntogit-community/0bd986055ba52887b81048de5c61e618eec06eb0/trunk/0003-kernel-5.18.patch";
-      sha256 = "sha256-va62/bR1qyBBMPg0lUwCH7slGG0XijxVCsFa4FCoHEQ=";
+      hash = "sha256-va62/bR1qyBBMPg0lUwCH7slGG0XijxVCsFa4FCoHEQ=";
     })
   ];
 

--- a/pkgs/os-specific/linux/cpupower-gui/default.nix
+++ b/pkgs/os-specific/linux/cpupower-gui/default.nix
@@ -46,7 +46,7 @@ buildPythonApplication rec {
     # Fixes https://github.com/vagnum08/cpupower-gui/issues/86
     (fetchpatch {
       url = "https://github.com/vagnum08/cpupower-gui/commit/22ea668aa4ecf848149ea4c150aa840a25dc6ff8.patch";
-      sha256 = "sha256-Mri7Af1Y79lt2pvZl4DQSvrqSLIJLIjzyXwMPFEbGVI=";
+      hash = "sha256-Mri7Af1Y79lt2pvZl4DQSvrqSLIJLIjzyXwMPFEbGVI=";
     })
   ];
 

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
           ./fuse2-Do-not-set-FUSERMOUNT_DIR.patch
           (fetchpatch {
             url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/fuse/files/fuse-2.9.9-closefrom-glibc-2-34.patch?id=8a970396fca7aca2d5a761b8e7a8242f1eef14c9";
-            sha256 = "sha256-ELYBW/wxRcSMssv7ejCObrpsJHtOPJcGq33B9yHQII4=";
+            hash = "sha256-ELYBW/wxRcSMssv7ejCObrpsJHtOPJcGq33B9yHQII4=";
           })
           ./fuse2-gettext-0.25.patch
         ]

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -29,7 +29,7 @@
     patch = fetchpatch {
       name = "Revert-101bd907b424-misc-rtsx-judge-ASPM-Mode-to-set.patch";
       url = "https://raw.githubusercontent.com/openSUSE/kernel-source/1b02b1528a26f4e9b577e215c114d8c5e773ee10/patches.suse/Revert-101bd907b424-misc-rtsx-judge-ASPM-Mode-to-set.patch";
-      sha256 = "sha256-RHJdQ4p0msTOVPR+/dYiKuwwEoG9IpIBqT4dc5cJjf8=";
+      hash = "sha256-RHJdQ4p0msTOVPR+/dYiKuwwEoG9IpIBqT4dc5cJjf8=";
     };
   };
 

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -241,7 +241,7 @@ stdenv.mkDerivation {
         })
         (fetchpatch {
           url = "https://raw.githubusercontent.com/openwrt/packages/c057dfb09c7027287c7862afab965a4cd95293a3/net/nginx/patches/104-endianness_fix.patch";
-          sha256 = "sha256-M7V3ZJfKImur2OoqXcoL+CbgFj/huWnfZ4xMCmvkqfc=";
+          hash = "sha256-M7V3ZJfKImur2OoqXcoL+CbgFj/huWnfZ4xMCmvkqfc=";
         })
       ]
       ++ mapModules "patches"

--- a/pkgs/tools/inputmethods/interception-tools/caps2esc.nix
+++ b/pkgs/tools/inputmethods/interception-tools/caps2esc.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://gitlab.com/interception/linux/plugins/caps2esc/-/commit/47ea8022df47b23d5d9603f9fe71b3715e954e4c.patch";
-      sha256 = "sha256-lB+pDwmFWW1fpjOPC6GLpxvrs87crDCNk1s9KnfrDD4=";
+      hash = "sha256-lB+pDwmFWW1fpjOPC6GLpxvrs87crDCNk1s9KnfrDD4=";
     })
   ];
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -23,16 +23,16 @@ stdenv.mkDerivation rec {
     # Fix cross-compilation
     (fetchpatch {
       url = "https://salsa.debian.org/debian/libotf/-/raw/1be04cedf887720eb8f5efb3594dc2cefd96b1f1/debian/patches/0002-use-pkg-config-not-freetype-config.patch";
-      sha256 = "sha256-VV9iGoNWIEie6UiLLTJBD+zxpvj0acgqkcBeAN1V6Kc=";
+      hash = "sha256-VV9iGoNWIEie6UiLLTJBD+zxpvj0acgqkcBeAN1V6Kc=";
     })
     # these 2 are required by the above patch
     (fetchpatch {
       url = "https://salsa.debian.org/debian/libotf/-/raw/1be04cedf887720eb8f5efb3594dc2cefd96b1f1/debian/patches/0001-do-not-add-flags-for-required-packages-to-pc-file.patch";
-      sha256 = "sha256-3kzqNPAHNVJQ1F4fyifq3AqLdChWli/k7wOq+ha+iDs=";
+      hash = "sha256-3kzqNPAHNVJQ1F4fyifq3AqLdChWli/k7wOq+ha+iDs=";
     })
     (fetchpatch {
       url = "https://salsa.debian.org/debian/libotf/-/raw/1be04cedf887720eb8f5efb3594dc2cefd96b1f1/debian/patches/0001-libotf-config-modify-to-support-multi-arch.patch";
-      sha256 = "sha256-SUlI87h+MtYWWtrAegzAnSds8JhxZwTJltDcj/se/Qc=";
+      hash = "sha256-SUlI87h+MtYWWtrAegzAnSds8JhxZwTJltDcj/se/Qc=";
     })
   ];
 

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     # fix typeerror, remove on next release
     (fetchpatch {
       url = "https://github.com/OpenPrinting/system-config-printer/commit/399b3334d6519639cfe7f1c0457e2475b8ee5230.patch";
-      sha256 = "sha256-JCdGmZk2vRn3X1BDxOJaY3Aw8dr0ODVzi0oY20ZWfRs=";
+      hash = "sha256-JCdGmZk2vRn3X1BDxOJaY3Aw8dr0ODVzi0oY20ZWfRs=";
       excludes = [ "NEWS" ];
     })
 

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -55,13 +55,13 @@ buildPythonPackage rec {
     (fetchpatch {
       name = "avoid-crashing-if-nsig-decode-fails.patch";
       url = "https://github.com/ytdl-org/youtube-dl/commit/41f0043983c831b7c0c3614340d2f66ec153087b.diff";
-      sha256 = "sha256-a72gWhBXCLjuBBD36PpZ5F/AHBdiBv4W8Wf9g4P/aBY=";
+      hash = "sha256-a72gWhBXCLjuBBD36PpZ5F/AHBdiBv4W8Wf9g4P/aBY=";
     })
     # YouTube changed the n-parameter format in April 2022, so decoder updates are required.
     (fetchpatch {
       name = "fix-n-descrambling.patch";
       url = "https://github.com/ytdl-org/youtube-dl/commit/a0068bd6bec16008bda7a39caecccbf84881c603.diff";
-      sha256 = "sha256-tSuEns4jputa2nOOo6JsFXpK3hvJ/+z1/ymcLsd3A6w=";
+      hash = "sha256-tSuEns4jputa2nOOo6JsFXpK3hvJ/+z1/ymcLsd3A6w=";
     })
   ];
 

--- a/pkgs/tools/networking/privoxy/default.nix
+++ b/pkgs/tools/networking/privoxy/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://www.privoxy.org/gitweb/?p=privoxy.git;a=commitdiff_plain;h=19d7684ca10f6c1279568aa19e9a9da2276851f1";
-      sha256 = "sha256-bCb0RUVrWeGfqZYFHXDEEx+76xiNyVqehtLvk9C1j+4=";
+      hash = "sha256-bCb0RUVrWeGfqZYFHXDEEx+76xiNyVqehtLvk9C1j+4=";
     })
   ];
 

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -387,7 +387,7 @@ rec {
       (fetchpatch {
         name = "lua_fixed_hash.patch";
         url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=1009196;filename=lua_fixed_hash.patch;msg=45";
-        sha256 = "sha256-FTu1eRd3AUU7IRs2/7e7uwHuvZsrzTBPypbcEZkU7y4=";
+        hash = "sha256-FTu1eRd3AUU7IRs2/7e7uwHuvZsrzTBPypbcEZkU7y4=";
       })
       # The original LuaJIT version number used here is 2.1.1736781742.
       # The patch number in this is the unix epoch timestamp of the commit used.


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
