### PR TITLE
add desktop files

### DIFF
--- a/pkgs/by-name/mg/mgba/package.nix
+++ b/pkgs/by-name/mg/mgba/package.nix
@@ -82,6 +82,15 @@ stdenv.mkDerivation (finalAttrs: {
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/applications
+    mv $src/res/mgba-qt.desktop $out/share/applications
+
+    runHook postInstall
+  '';
+
   meta = {
     homepage = "https://mgba.io";
     description = "Modern GBA emulator with a focus on accuracy";


### PR DESCRIPTION
Resolves #36953

- Apps that need desktop files
  - [x] mgba
  - [ ] clementine
  - [ ] zandronum
  - [x] urban terror (already present)
  - [x] openarena (already present)
  - [x] logisim (already present)
  - [ ] dwarf-fortress
  - [ ] xonotic
  - [ ] gzdoom
  - [ ] puddletag
  - [ ] opentyrian
  
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [Package tests] at `passthru.tests`.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
