### PR TITLE
percona-xtrabackup_{8_4,8_0}: update to fix build with cmake4

### DIFF
--- a/pkgs/tools/backup/percona-xtrabackup/8_0.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_0.nix
@@ -3,8 +3,8 @@
 callPackage ./generic.nix (
   args
   // {
-    version = "8.0.35-32";
-    hash = "sha256-aNnAlhhzZ6636dzOz4FFDEE4Mb450HGU42cJrM21GdQ=";
+    version = "8.0.35-34";
+    hash = "sha256-DqjDBLSQqlWazWJjdb+n7RwqSe/OMlZI2ca/JNTX2W8=";
 
     # includes https://github.com/Percona-Lab/libkmip.git
     fetchSubmodules = true;
@@ -12,9 +12,5 @@ callPackage ./generic.nix (
     extraPatches = [
       ./abi-check.patch
     ];
-
-    extraPostInstall = ''
-      rm -r "$out"/docs
-    '';
   }
 )

--- a/pkgs/tools/backup/percona-xtrabackup/8_4.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_4.nix
@@ -3,8 +3,8 @@
 callPackage ./generic.nix (
   args
   // {
-    version = "8.4.0-2";
-    hash = "sha256-ClW/B175z/sxF/MT9iHW1Wtr0ere63tIgUpcMp1IfTs=";
+    version = "8.4.0-4";
+    hash = "sha256-ws+si8bpalL8y7l9W+R4B02GnnGOou50txtS6ktntP4=";
 
     # includes https://github.com/Percona-Lab/libkmip.git
     fetchSubmodules = true;


### PR DESCRIPTION
- #445447

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
