### PR TITLE
tint2: fix build with CMake 4

### DIFF
--- a/pkgs/by-name/ti/tint2/fix-cmake-version.patch
+++ b/pkgs/by-name/ti/tint2/fix-cmake-version.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 336dff9..8b8a853 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
++cmake_minimum_required( VERSION 3.10 )
+ project( tint2 )
+-cmake_minimum_required( VERSION 2.8.5 )
+ 
+ option( ENABLE_BATTERY "Enable battery status plugin" ON )
+ option( ENABLE_TINT2CONF "Enable tint2conf build, a GTK+3 theme configurator for tint2" ON )
+diff --git a/src/tint2conf/CMakeLists.txt b/src/tint2conf/CMakeLists.txt
+index 747b9ac..cbe13bb 100644
+--- a/src/tint2conf/CMakeLists.txt
++++ b/src/tint2conf/CMakeLists.txt
+@@ -1,5 +1,5 @@
++cmake_minimum_required(VERSION 3.10)
+ project(tint2conf)
+-cmake_minimum_required(VERSION 2.6)
+ 
+ include( FindPkgConfig )
+ pkg_check_modules( X11_T2C REQUIRED x11 xcomposite xdamage xinerama xrender xrandr>=1.3 )

--- a/pkgs/by-name/ti/tint2/package.nix
+++ b/pkgs/by-name/ti/tint2/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/nick87720z/tint2/uploads/7de4501a4fa4fffa5ba8bb0fa3d19f78/glib.patch";
       hash = "sha256-K547KYlRkVl1s2THi3ZCRuM447EFJwTqUEBjKQnV8Sc=";
     })
+    # https://gitlab.com/nick87720z/tint2/-/merge_requests/4
     ./fix-cmake-version.patch
   ];
 
@@ -81,6 +82,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # Add missing dependency on libm
+    # https://gitlab.com/nick87720z/tint2/-/merge_requests/3
     substituteInPlace src/tint2conf/CMakeLists.txt \
       --replace-fail "RSVG_LIBRARIES} )" "RSVG_LIBRARIES} m)"
 

--- a/pkgs/by-name/ti/tint2/package.nix
+++ b/pkgs/by-name/ti/tint2/package.nix
@@ -91,11 +91,12 @@ stdenv.mkDerivation rec {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  meta = with lib; {
+  meta = {
+    mainProgram = "tint2";
     homepage = "https://gitlab.com/nick87720z/tint2";
     description = "Simple panel/taskbar unintrusive and light (memory, cpu, aestetic)";
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.romildo ];
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.romildo ];
   };
 }

--- a/pkgs/by-name/ti/tint2/package.nix
+++ b/pkgs/by-name/ti/tint2/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/nick87720z/tint2/uploads/7de4501a4fa4fffa5ba8bb0fa3d19f78/glib.patch";
       hash = "sha256-K547KYlRkVl1s2THi3ZCRuM447EFJwTqUEBjKQnV8Sc=";
     })
+    ./fix-cmake-version.patch
   ];
 
   # Fix build with gcc14


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/445447

I have an upstream PR for another (CMake) issue from seven months ago that was never responded to, so I figure we need to just fix this on our side as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
