### PR TITLE
fastmail-desktop: init at 1.0.0

### DIFF
--- a/pkgs/by-name/fa/fastmail-desktop/package.nix
+++ b/pkgs/by-name/fa/fastmail-desktop/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fastmail-desktop";
+  version = "1.0.0";
+
+  src = fetchzip {
+    url = "https://dl.fastmailcdn.com/desktop/production/mac/arm64/Fastmail-${finalAttrs.version}-arm64-mac.zip";
+    hash = "sha256-wIWU0F08wEQeLjbZz2LqahfyeOfowC+dDQkeMZI6gbk=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -R Fastmail.app $out/Applications/
+  '';
+
+  dontBuild = true;
+
+  # Fastmail is notarized
+  dontFixup = true;
+
+  meta = {
+    description = "Dedicated desktop app for Fastmail";
+    homepage = "https://www.fastmail.com/blog/desktop-app/";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = [ lib.maintainers.Enzime ];
+    platforms = [ "aarch64-darwin" ];
+  };
+})


### PR DESCRIPTION
Currently only the Windows and macOS versions have been released, the Linux version will be released later

https://www.fastmail.com/blog/desktop-app/

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
