### PR TITLE
speakeasy-cli: init at 1.636.3

### DIFF
--- a/pkgs/by-name/sp/speakeasy-cli/package.nix
+++ b/pkgs/by-name/sp/speakeasy-cli/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  curl,
+  jq,
+  installShellFiles,
+  writeShellScript,
+  common-updater-scripts,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "speakeasy-cli";
+  version = "1.636.3";
+
+  sourceRoot = ".";
+  src =
+    finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported System: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [
+    unzip
+    installShellFiles
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 ./speakeasy $out/bin/speakeasy
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-darwin" = fetchurl {
+        url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_darwin_amd64.zip";
+        hash = "sha256-Q1m4g5XBNAaxJZyYz6cD/7asTUGZMa493XVVJ9s0byE=";
+      };
+      "x86_64-linux" = fetchurl {
+        url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_linux_amd64.zip";
+        hash = "sha256-H1c+b4/fBWudc3tAHTNdWwa9aoe8HpffRaLRU7OOWs4=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_darwin_arm64.zip";
+        hash = "sha256-xO9S9gjiMel2ZB8Dq2nN5O+zIB/4qf5Z2xeXS0wiprc=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_linux_arm64.zip";
+        hash = "sha256-zH/HyA6MrrCh9j53hoqfVSiRqIoL6IOCV/nsAwRlgjg=";
+      };
+    };
+    updateScript = writeShellScript "update-speakeasy" ''
+      set -o errxt
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          jq
+          common-updater-scripts
+        ]
+      }"
+
+      NEW_VERSION=$(curl --silent https://api.github.com/repos/speakeasy-api/speakeasy/releases/latest | jq '.tag_name' | ltrimstr("v") --raw-output)
+      if [[ ${finalAttrs.version} = "$NEW_VERSION"]]; then
+        echo "The new version is the same as old"
+        exit 0
+      fi
+      for platfrom in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        update-source-version "speakeasy-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+    '';
+  };
+
+  meta = {
+    description = "CLI tool for Speakeasy";
+    homepage = "https://www.speakeasyapi.dev/";
+    changelog = "https://github.com/speakeasy-api/speakeasy/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.elastic20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      eveeifyeve
+    ];
+    mainProgram = "speakeasy";
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pr creates a better package of speakeasy-cli with overide ability to sources.
This also includes update script that allows the package to be automatically updated which is useful for maintainability.

Closes #370293 #278467
Fixes https://github.com/speakeasy-api/speakeasy/issues/388 

Work is provided by [DigitalBrewStudios](https://digitalbrewstudios.com)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
