### PR TITLE
ddhx: init at 0.9.1

### DIFF
--- a/pkgs/by-name/dd/ddhx/dub-lock.json
+++ b/pkgs/by-name/dd/ddhx/dub-lock.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/pkgs/by-name/dd/ddhx/package.nix
+++ b/pkgs/by-name/dd/ddhx/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildDubPackage,
+  fetchFromGitHub,
+}:
+buildDubPackage (finalAttrs: {
+  pname = "ddhx";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "dd86k";
+    repo = "ddhx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AFhxrYncqVnHfro4sUgCT1ZBeL3CUwcwhnGXVuFQ9ak=";
+  };
+
+  dubLock = ./dub-lock.json;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ddhx -t $out/bin
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  meta = {
+    description = "Console text-mode hex editor, inspired by GNU nano and vim";
+    homepage = "https://github.com/dd86k/ddhx";
+    changelog = "https://github.com/dd86k/ddhx/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ryand56 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [ddhx](https://github.com/dd86k/ddhx), a console text-mode hex editor. Based on vim.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
