### PR TITLE
linuxPackages.broadcom_sta: 6.30.223.271-57 -> 6.30.223.271-59 (patches for kernel 6.17)

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -11,7 +11,7 @@ let
   # Patchset release number from rpmfusion, to more easily differentiate
   # versions and updates. See `wl-kmod.spec` file:
   # https://github.com/rpmfusion/wl-kmod/blob/master/wl-kmod.spec#L19
-  release = "57";
+  release = "59";
   hashes = {
     i686-linux = "sha256-T4twspOsjMXHDlca1dGHjQ8p0TOkb+eGmGjZwZtQWM0=";
     x86_64-linux = "sha256-X3l3TVvuyPdja1nA+wegMQju8eP9MkVjiyCFjHFBRL4=";
@@ -24,8 +24,8 @@ let
   rpmFusionPatches = fetchFromGitHub {
     owner = "rpmfusion";
     repo = "wl-kmod";
-    rev = "b0d19578ebd0daae9c5b7f9e9511a6d73ac4d957";
-    hash = "sha256-v7mZ2S/eVfGTEXrxpdiemHhrC+P3/sPOZqTBhRtins4=";
+    rev = "7786b3a3e54962124d24b4b61a6472bb0c4bbd94";
+    hash = "sha256-yEMsFaGBVs/rtDZLG8j8ZW1CV9SDtt00avoWxkJdLAU=";
   };
   patchset = [
     "wl-kmod-001_wext_workaround.patch"
@@ -62,6 +62,7 @@ let
     "wl-kmod-032_add_MODULE_DESCRIPTION_macro.patch"
     "wl-kmod-033_disable_objtool_add_warning_unmaintained.patch"
     "wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_delete.patch"
+    "wl-kmod-035_kernel_6.17_adaptation_fix_functions_prototypes.patch"
   ];
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
broadcom_sta currently can't be built with kernel 6.17. This fixes that.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
