### PR TITLE
Revert "matrix-synapse-plugins.matrix-synapse-s3-storage-provider: 1.5.0 -> 1.6.0"

### DIFF
--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/s3-storage-provider.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/s3-storage-provider.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "matrix-synapse-s3-storage-provider";
-  version = "1.6.0";
+  version = "1.5.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "matrix-org";
     repo = "synapse-s3-storage-provider";
     rev = "refs/tags/v${version}";
-    hash = "sha256-aeacw6Fpv4zFhZI4LdsJiV2pcOAMv3aV5CicnwYRxw8=";
+    hash = "sha256-Nv8NkzOcUDX17N7Lyx/NT1vXztiRNaTYIAWNPHxgxJ4=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Reverts NixOS/nixpkgs#450910

Version 1.6.0 only works together with matrix-synapse 1.140
