### PR TITLE
nixos/gitwatch: add message option

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28817,6 +28817,12 @@
     githubId = 450885;
     name = "Francesco Zanini";
   };
+  zareix = {
+    email = "contact@raphael-catarino.fr";
+    github = "zareix";
+    githubId = 29818713;
+    name = "Raphaël Catarino";
+  };
   zarelit = {
     email = "david@zarel.net";
     github = "zarelit";

--- a/nixos/modules/services/monitoring/gitwatch.nix
+++ b/nixos/modules/services/monitoring/gitwatch.nix
@@ -21,6 +21,7 @@ let
         getvar = flag: var: optionalString (cfg."${var}" != null) "${flag} ${cfg."${var}"}";
         branch = getvar "-b" "branch";
         remote = getvar "-r" "remote";
+        message = getvar "-m" "message";
       in
       rec {
         inherit (cfg) enable;
@@ -37,7 +38,7 @@ let
           if [ -n "${cfg.remote}" ] && ! [ -d "${cfg.path}" ]; then
             git clone ${branch} "${cfg.remote}" "${cfg.path}"
           fi
-          gitwatch ${remote} ${branch} ${cfg.path}
+          gitwatch ${remote} ${message} ${branch} ${cfg.path}
         '';
         serviceConfig.User = cfg.user;
       }
@@ -56,6 +57,7 @@ in
         user = "user";
         path = "/home/user/watched-project";
         remote = "git@github.com:me/my-project.git";
+        message = "Auto-commit by gitwatch on %d";
       };
       disabled-repo = {
         enable = false;
@@ -81,6 +83,11 @@ in
           };
           remote = mkOption {
             description = "Optional url of remote repository";
+            type = nullOr str;
+            default = null;
+          };
+          message = lib.mkOption {
+            description = "Optional text to use in as commit message; all occurrences of `%d` will be replaced by formatted date/time";
             type = nullOr str;
             default = null;
           };

--- a/nixos/modules/services/monitoring/gitwatch.nix
+++ b/nixos/modules/services/monitoring/gitwatch.nix
@@ -100,5 +100,8 @@ in
       });
   };
   config.systemd.services = mapAttrs' mkSystemdService config.services.gitwatch;
-  meta.maintainers = with maintainers; [ shved ];
+  meta.maintainers = with maintainers; [
+    shved
+    zareix
+  ];
 }


### PR DESCRIPTION
Add an option (message) to gitwatch
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
