### PR TITLE
Add package: Fladder

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23461,6 +23461,12 @@
     githubId = 56278796;
     name = "Sergio Ribera";
   };
+  serhao = {
+    github = "shobu13";
+    githubId = 21972673;
+    name = "Sin Ser'hao";
+    email = "shobu_serhao@proton.me";
+  };
   servalcatty = {
     email = "servalcat@pm.me";
     github = "servalcatty";

--- a/pkgs/by-name/fl/fladder/package.nix
+++ b/pkgs/by-name/fl/fladder/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchurl,
+  appimageTools,
+  makeDesktopItem,
+
+  xdg-user-dirs,
+  mpv-unwrapped,
+  libepoxy,
+  stdenv,
+  lib,
+}:
+let
+  pname = "fladder";
+  version = "0.7.5";
+  src = fetchurl {
+    url = "https://github.com/DonutWare/Fladder/releases/download/v${version}/Fladder-Linux-${version}.AppImage";
+    hash = "sha256:6955e7634d29c588991ed19f24c837e3cb6a51be80a7e0ca152f443c4f92add3";
+  };
+  appImageContent = appimageTools.extract { inherit pname version src; };
+  desktopItem = makeDesktopItem {
+    name = "nl.jknaapen.fladder";
+    desktopName = "Fladder";
+    genericName = "Video Player";
+    exec = "fladder";
+    icon = "fladder";
+    startupWMClass = "fladder";
+    comment = "A Simple Jellyfin frontend built on top of Flutter";
+    categories = [
+      "AudioVideo"
+      "Video"
+      "Player"
+    ];
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraPkgs = pkgs: [
+    xdg-user-dirs
+    mpv-unwrapped
+    libepoxy
+  ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications/
+    install -Dm444 ${appImageContent}/fladder_icon_desktop.png \
+      $out/share/icons/hicolor/scalable/apps/fladder.png
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
+  '';
+
+  meta = {
+    # Fladder depends on `ìsar`, which for Linux is only compiled for x86_64. https://github.com/jmshrv/finamp/issues/766
+    # stolen from finamp
+    broken = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isx86_64;
+    description = "A Simple Jellyfin frontend built on top of Flutter";
+    homepage = "https://github.com/DonutWare/Fladder";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ serhao ];
+    mainProgram = "fladder";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Add fladder package to nixpkgs
* package is usable in it's current state
  * personally use it daily without noticable bugs
* licensed under gpl3
* starred by over 900 peoples, so probably a correlated user base
* Package is actively developped an show plenty meaningfull commits in last weeks
* I uses this package daily and use nixos daily, and i'm willing to maintain it.

## Things done

Added a package.nix building the application based on appimage instead of flutter framework due to lack of flutter knowledge, loosely based on finamp packaging.  
Added myself as maintainer.
Built the binary using a flake and ported the code under package.nix

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
