### PR TITLE
teams: 1.6.00.4464 -> 25255.703.3981.5698

### DIFF
--- a/pkgs/by-name/te/teams/package.nix
+++ b/pkgs/by-name/te/teams/package.nix
@@ -3,17 +3,17 @@
   stdenv,
   fetchurl,
   xar,
+  pbzx,
   cpio,
-  makeWrapper,
 }:
 
 let
   pname = "teams";
   versions = {
-    darwin = "1.6.00.4464";
+    darwin = "25255.703.3981.5698";
   };
   hashes = {
-    darwin = "sha256-DvXMrXotKWUqFCb7rZj8wU7mmZJKuTLGyx8qOB/aQtg=";
+    darwin = "sha256-p9tAvOJxoIO0d8z0qdfc4sokUNfaYKq2NtBHKOWYBM4=";
   };
   meta = with lib; {
     description = "Microsoft Teams";
@@ -28,39 +28,37 @@ let
     ];
     mainProgram = "teams";
   };
-
-  appName = "Teams.app";
 in
 stdenv.mkDerivation {
   inherit pname meta;
   version = versions.darwin;
 
   src = fetchurl {
-    url = "https://statics.teams.cdn.office.net/production-osx/${versions.darwin}/Teams_osx.pkg";
+    url = "https://statics.teams.cdn.office.net/production-osx/${versions.darwin}/MicrosoftTeams.pkg";
     hash = hashes.darwin;
   };
 
   nativeBuildInputs = [
     xar
+    pbzx
     cpio
-    makeWrapper
   ];
 
   unpackPhase = ''
     xar -xf $src
-    zcat < Teams_osx_app.pkg/Payload | cpio -i
   '';
 
-  sourceRoot = "Microsoft Teams.app";
   dontPatch = true;
   dontConfigure = true;
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/{Applications/${appName},bin}
-    cp -R . $out/Applications/${appName}
-    makeWrapper $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
+    workdir=$(pwd)
+    APP_DIR=$out/Applications
+    mkdir -p $APP_DIR
+    cd $APP_DIR
+    pbzx -n "$workdir/MicrosoftTeams_app.pkg/Payload" | cpio -idm
     runHook postInstall
   '';
 }


### PR DESCRIPTION
Microsoft Teams moves to a new App. This PR moves teams to the new version of the App.

Version History:
https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning

This is my first PR to Nixpkgs. I built the derivation not within the Nixpkgs repo but in a separate flake, so I don't know, which of the following to check.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
