### PR TITLE
rofi-file-browser: fix cmake 4 compatiblity

### DIFF
--- a/pkgs/by-name/ro/rofi-file-browser/fix_cmake_min_version.patch
+++ b/pkgs/by-name/ro/rofi-file-browser/fix_cmake_min_version.patch
@@ -1,0 +1,21 @@
+From 4b5e65169f2cc5654685841fa7e7553d3aacce3f Mon Sep 17 00:00:00 2001
+From: Bob van der Linden <bobvanderlinden@gmail.com>
+Date: Mon, 13 Oct 2025 17:19:52 +0200
+Subject: [PATCH] cmake: minimum version 2.8 -> 3.10
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d8b58f..6dff2c0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ include(CheckSymbolExists)
+ 
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10)
+ project(rofi-file-browser-extended)
+ 
+ 

--- a/pkgs/by-name/ro/rofi-file-browser/package.nix
+++ b/pkgs/by-name/ro/rofi-file-browser/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     ./fix_incompatible_pointer_type.patch
     ./fix_build_on_i686.patch
     ./fix_recent_glib_deprecation_warning.patch
+    ./fix_cmake_min_version.patch
   ];
 
   prePatch = ''


### PR DESCRIPTION
## Things done

This adds a patch for rofi-file-browser to fix cmake4 compatiblity as tracked in https://github.com/NixOS/nixpkgs/issues/445447.
I've also submitted the patch upstream: https://github.com/marvinkreis/rofi-file-browser-extended/pull/60


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
