### PR TITLE
pg-schema-diff: init at 1.0.2, add maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3400,6 +3400,11 @@
     githubId = 10164833;
     name = "Birk Bohne";
   };
+  bitbloxhub = {
+    name = "bitbloxhub";
+    github = "bitbloxhub";
+    githubId = 45184892;
+  };
   bizmyth = {
     email = "andrew.p.council@gmail.com";
     github = "bizmythy";

--- a/pkgs/by-name/pg/pg-schema-diff/package.nix
+++ b/pkgs/by-name/pg/pg-schema-diff/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  postgresql,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pg-schema-diff";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "stripe";
+    repo = "pg-schema-diff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u0niTTqrzsI4u0OGY5qkgbitadcbEK/ElFGnPJsEMwo=";
+  };
+
+  nativeCheckInputs = [
+    postgresql
+  ];
+
+  vendorHash = "sha256-Hs3xrGP8eJwW3rQ9nViB9sqC8spjHV6rCoy1u/SYHak=";
+
+  meta = {
+    description = "Go library for diffing Postgres schemas and generating SQL migrations";
+    homepage = "https://github.com/stripe/pg-schema-diff";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bitbloxhub ];
+    mainProgram = "pg-schema-diff";
+  };
+})


### PR DESCRIPTION
Add [`pg-schema-diff`](https://github.com/stripe/pg-schema-diff), a  Go library (and CLI) for diffing Postgres schemas and generating SQL migrations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
