### PR TITLE
freifunk-meshviewer: init at 12.6.0

### DIFF
--- a/pkgs/by-name/fr/freifunk-meshviewer/package.nix
+++ b/pkgs/by-name/fr/freifunk-meshviewer/package.nix
@@ -1,0 +1,35 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "freifunk-meshviewer";
+
+  version = "12.6.0";
+
+  src = fetchFromGitHub {
+    owner = "freifunk";
+    repo = "meshviewer";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-h+0f6RwJip3V7XJ8q8eEov2k09wNwdHOJgR2XUZqkgw=";
+  };
+
+  npmDepsHash = "sha256-QgUEoUF2qEtplx2YaMO81g9cY7a+oXCX5dF6V54waD8=";
+
+  installPhase = ''
+    mkdir -p $out/share/freifunk-meshviewer/
+    cp -r build/* $out/share/freifunk-meshviewer/
+  '';
+
+  meta = {
+    homepage = "https://github.com/freifunk/meshviewer";
+    changelog = "https://github.com/freifunk/meshviewer/releases/tag/v${finalAttrs.version}";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      felixsinger
+    ];
+    license = lib.licenses.agpl3Only;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
