### PR TITLE
python3Packages.entsoe-apy: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/entsoe-apy/default.nix
+++ b/pkgs/development/python-modules/entsoe-apy/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  isodate,
+  httpx,
+  loguru,
+  xsdata-pydantic,
+}:
+
+buildPythonPackage rec {
+  pname = "entsoe-apy";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "berrij";
+    repo = "entsoe-apy";
+    tag = "v${version}";
+    hash = "sha256-aOZsD8Cio7TjYHnUlgfgVWLB2+AnDw1J2fTcD8PFioE=";
+  };
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  dependencies = [
+    httpx
+    loguru
+    xsdata-pydantic
+    isodate
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "entsoe"
+  ];
+
+  meta = {
+    description = "Python Package to Query the ENTSO-E API";
+    homepage = "https://github.com/berrij/entsoe-apy";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ berrij ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/xsdata-pydantic/default.nix
+++ b/pkgs/development/python-modules/xsdata-pydantic/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  xsdata,
+  pydantic,
+  click,
+  click-default-group,
+  jinja2,
+  docformatter,
+  toposort,
+}:
+
+buildPythonPackage rec {
+  pname = "xsdata-pydantic";
+  version = "24.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tefra";
+    repo = "xsdata-pydantic";
+    tag = "v${version}";
+    hash = "sha256-ExgAXQRNfGQRSZdMuWc8ldJPqz+3c4Imgu75KXLXHNk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    xsdata
+    pydantic
+  ];
+
+  nativeCheckInputs = [
+    click
+    click-default-group
+    docformatter
+    jinja2
+    toposort
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "xsdata_pydantic"
+  ];
+
+  meta = {
+    description = "Naive XML & JSON Bindings for python pydantic classes!";
+    homepage = "https://github.com/tefra/xsdata-pydantic";
+    maintainers = with lib.maintainers; [ berrij ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4784,6 +4784,8 @@ self: super: with self; {
 
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
+  entsoe-apy = callPackage ../development/python-modules/entsoe-apy { };
+
   enturclient = callPackage ../development/python-modules/enturclient { };
 
   env-canada = callPackage ../development/python-modules/env-canada { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20471,6 +20471,8 @@ self: super: with self; {
 
   xsdata = callPackage ../development/python-modules/xsdata { };
 
+  xsdata-pydantic = callPackage ../development/python-modules/xsdata-pydantic { };
+
   xstatic = callPackage ../development/python-modules/xstatic { };
 
   xstatic-asciinema-player = callPackage ../development/python-modules/xstatic-asciinema-player { };


### PR DESCRIPTION
This adds [entsoe-apy](https://github.com/BerriJ/entsoe-apy) and one of its dependencies [xsdata-pydantic](https://github.com/tefra/xsdata-pydantic).

[entsoe-apy](https://github.com/BerriJ/entsoe-apy) is a Package to easily obtain data from the [ENTSOE](https://transparency.entsoe.eu/) RESTful API.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
