### PR TITLE
home-assistant-custom-components.systemair: 0.2.0 -> 1.0.11

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/systemair/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/systemair/package.nix
@@ -1,25 +1,39 @@
 {
   lib,
+  pymodbus,
   buildHomeAssistantComponent,
   fetchFromGitHub,
+  async-timeout,
+  aiohttp,
 }:
 
 buildHomeAssistantComponent rec {
-  owner = "tesharp";
+  owner = "AN3Orik";
   domain = "systemair";
-  version = "0.2.0";
+  version = "1.0.11";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "systemair";
     tag = "v${version}";
-    hash = "sha256-lzFnKPkBOt2fkVGWCj1M/skSr8V39GgDHS+0HD4ACAw=";
+    hash = "sha256-/M9ErhtggyaY8ZZyhdPSoVCGqrhAQ9/RMRyl34Ks3mc=";
   };
 
+  postPatch = ''
+    substituteInPlace custom_components/systemair/manifest.json \
+      --replace-fail "pymodbus==" "pymodbus>=" \
+  '';
+
+  dependencies = [
+    pymodbus
+    async-timeout
+    aiohttp
+  ];
+
   meta = with lib; {
-    changelog = "https://github.com/tesharp/systemair/releases/tag/v${version}";
-    description = "Home Assistant component for Systemair SAVE Connect 2";
-    homepage = "https://github.com/tesharp/systemair";
+    changelog = "https://github.com/AN3Orik/systemair/releases/tag/v${version}";
+    description = "Home Assistant component for Systemair SAVE ventilation units";
+    homepage = "https://github.com/AN3Orik/systemair";
     maintainers = with maintainers; [ uvnikita ];
     license = licenses.mit;
   };


### PR DESCRIPTION
Switch to active fork by AN3Orik since original repository is stale.

This fork added a few nice to have features like:

 - Support for multiple connection methods (Modbus TCP, Modbus Serial, Web API) -- main improvement
 - Free Cooling support
 - Calculated power consumption
 - Extra diagnostic sensors


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
