### PR TITLE
ffda-network-setup-mode-send-request: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ff/ffda-network-setup-mode-send-request/package.nix
+++ b/pkgs/by-name/ff/ffda-network-setup-mode-send-request/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+}:
+
+stdenv.mkDerivation {
+  pname = "ffda-network-setup-mode-send-request";
+  version = "1.0.0";
+
+  src = fetchgit {
+    url = "https://github.com/freifunk-gluon/community-packages.git";
+    rev = "1493e17ff7574dd0fd0bbab7b4d4e3a6ac83656f";
+    sha256 = "sha256-/2WvdQULS8d+PVJuHvod7AL2VF8RQ4hgzIGBu+KR5ME=";
+    sparseCheckout = [
+      "ffda-network-setup-mode/src"
+    ];
+    deepClone = false;
+  };
+
+  buildPhase = ''
+    cd ffda-network-setup-mode/src
+    make send-network-request
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp send-network-request $out/bin/ffda-network-setup-mode-send-request
+  '';
+
+  meta = {
+    description = "Activate freifunk-gluon setup-mode using a magic packet.";
+    homepage = "https://github.com/freifunk-gluon/community-packages/tree/main/ffda-network-setup-mode";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ herbetom ];
+    mainProgram = "ffda-network-setup-mode-send-request";
+  };
+}


### PR DESCRIPTION
This is a small helper program which is needed to return Freifunk Nodes running with [freifunk-gluon](https://github.com/freifunk-gluon/gluon/) and the [ffda-network-setup-mode](https://github.com/freifunk-gluon/community-packages/tree/main/ffda-network-setup-mode) package back into Setup mode. Usually this is done via the reset button on the devices but some models don't have that and in those cases this tool is an option to do it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
