### PR TITLE
maintainers: drop maggesi

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15547,12 +15547,6 @@
     githubId = 1140462;
     name = "magenbluten";
   };
-  maggesi = {
-    email = "marco.maggesi@gmail.com";
-    github = "maggesi";
-    githubId = 1809783;
-    name = "Marco Maggesi";
-  };
   magicquark = {
     name = "magicquark";
     github = "magicquark";

--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation {
     platforms = platforms.unix;
     maintainers = with maintainers; [
       thoughtpolice
-      maggesi
       vbgl
     ];
   };

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -79,7 +79,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://www.fossil-scm.org/";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ maggesi ];
     platforms = platforms.all;
     mainProgram = "fossil";
   };

--- a/pkgs/by-name/fd/fdupes/package.nix
+++ b/pkgs/by-name/fd/fdupes/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/adrianlopezroche/fdupes";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ maintainers.maggesi ];
     mainProgram = "fdupes";
   };
 }

--- a/pkgs/by-name/io/io/package.nix
+++ b/pkgs/by-name/io/io/package.nix
@@ -115,7 +115,6 @@ stdenv.mkDerivation {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       raskin
-      maggesi
     ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/ya/yajl/package.nix
+++ b/pkgs/by-name/ya/yajl/package.nix
@@ -41,6 +41,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.isc;
     pkgConfigModules = [ "yajl" ];
     platforms = with lib.platforms; linux ++ darwin;
-    maintainers = with lib.maintainers; [ maggesi ];
   };
 })

--- a/pkgs/development/compilers/polyml/5.6.nix
+++ b/pkgs/development/compilers/polyml/5.6.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation {
     platforms = with lib.platforms; linux;
     maintainers = [
       # Add your name here!
-      lib.maintainers.maggesi
     ];
   };
 }

--- a/pkgs/development/compilers/polyml/5.7.nix
+++ b/pkgs/development/compilers/polyml/5.7.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.polyml.org/";
     license = licenses.lgpl21;
     platforms = with platforms; (linux ++ darwin);
-    maintainers = with maintainers; [ maggesi ];
     # never built on aarch64-darwin since first introduction in nixpkgs
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };

--- a/pkgs/development/compilers/polyml/default.nix
+++ b/pkgs/development/compilers/polyml/default.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;
     platforms = with platforms; (linux ++ darwin);
     maintainers = with maintainers; [
-      maggesi
       kovirobi
     ];
   };

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -46,8 +46,5 @@ buildDunePackage (finalAttrs: {
       language.
     '';
     license = lib.licenses.lgpl21Plus;
-    maintainers = [
-      lib.maintainers.maggesi
-    ];
   };
 })

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -95,6 +95,5 @@ stdenv.mkDerivation {
       ocamlLgplLinkingException
     ];
     inherit (ocaml.meta) platforms;
-    maintainers = with maintainers; [ maggesi ];
   };
 }

--- a/pkgs/development/ocaml-modules/camomile/0.8.5.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.5.nix
@@ -39,8 +39,5 @@ stdenv.mkDerivation {
     description = "Comprehensive Unicode library for OCaml";
     license = lib.licenses.lgpl21;
     inherit (ocaml.meta) platforms;
-    maintainers = [
-      lib.maintainers.maggesi
-    ];
   };
 }

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -41,8 +41,5 @@ else
       '';
       license = lib.licenses.mit;
       inherit (ocaml.meta) platforms;
-      maintainers = [
-        lib.maintainers.maggesi
-      ];
     };
   }

--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -38,8 +38,5 @@ buildDunePackage rec {
     homepage = "http://pauillac.inria.fr/~xleroy/software.html";
     description = "Library of cryptographic primitives for OCaml";
     license = lib.licenses.lgpl2Only;
-    maintainers = [
-      lib.maintainers.maggesi
-    ];
   };
 }

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -86,7 +86,6 @@ stdenv.mkDerivation {
     homepage = "http://lablgtk.forge.ocamlcore.org/";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [
-      maggesi
       roconnor
       vbgl
     ];

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -70,8 +70,5 @@ lib.throwIf (lib.versionOlder ocaml.version "4.02" || lib.versionAtLeast ocaml.v
       description = "Library implementing Internet protocols (http, cgi, email, etc.) for OCaml";
       license = "Most Ocamlnet modules are released under the zlib/png license. The HTTP server module Nethttpd is, however, under the GPL.";
       inherit (ocaml.meta) platforms;
-      maintainers = [
-        lib.maintainers.maggesi
-      ];
     };
   }

--- a/pkgs/development/ocaml-modules/pcre/default.nix
+++ b/pkgs/development/ocaml-modules/pcre/default.nix
@@ -28,7 +28,6 @@ buildDunePackage rec {
     description = "Efficient C-library for pattern matching with Perl-style regular expressions in OCaml";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [
-      maggesi
       vbmithr
     ];
   };

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     inherit (ocaml.meta) platforms;
     maintainers = with maintainers; [
-      maggesi
       vbmithr
       gal_bolle
     ];

--- a/pkgs/development/ocaml-modules/sqlite3/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3/default.nix
@@ -29,7 +29,6 @@ buildDunePackage rec {
     description = "OCaml bindings to the SQLite 3 database access library";
     license = licenses.mit;
     maintainers = with maintainers; [
-      maggesi
       vbgl
     ];
   };

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -44,7 +44,6 @@ buildDunePackage rec {
     maintainers = with lib.maintainers; [
       anmonteiro
       dandellion
-      maggesi
     ];
   };
 }

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -98,7 +98,6 @@ else
         license = licenses.bsd3;
         platforms = ocaml.meta.platforms or [ ];
         maintainers = with maintainers; [
-          maggesi
           vbgl
         ];
       };

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -91,7 +91,6 @@ stdenv.mkDerivation rec {
     homepage = "http://projects.camlcity.org/projects/findlib.html";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      maggesi
       vbmithr
     ];
     mainProgram = "ocamlfind";

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -57,7 +57,6 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.0") "oasis is not available for
       license = licenses.lgpl21;
       maintainers = with maintainers; [
         vbgl
-        maggesi
       ];
       mainProgram = "oasis";
       inherit (ocaml.meta) platforms;

--- a/pkgs/development/tools/ocaml/ocamlify/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlify/default.nix
@@ -25,9 +25,6 @@ buildDunePackage (finalAttrs: {
     homepage = "https://github.com/gildor478/ocamlify";
     description = "Include files in OCaml code";
     license = lib.licenses.lgpl21;
-    maintainers = with lib.maintainers; [
-      maggesi
-    ];
     mainProgram = "ocamlify";
   };
 })

--- a/pkgs/development/tools/ocaml/ocamlmod/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlmod/default.nix
@@ -25,9 +25,6 @@ buildDunePackage (finalAttrs: {
   meta = {
     homepage = "https://github.com/gildor478/ocamlmod";
     description = "Generate OCaml modules from source files";
-    maintainers = with lib.maintainers; [
-      maggesi
-    ];
     mainProgram = "ocamlmod";
   };
 })

--- a/pkgs/servers/openafs/1.8/default.nix
+++ b/pkgs/servers/openafs/1.8/default.nix
@@ -154,7 +154,6 @@ stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = [
-      maintainers.maggesi
       maintainers.spacefrogg
     ];
   };

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -162,7 +162,6 @@ stdenv.mkDerivation {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       andersk
-      maggesi
       spacefrogg
     ];
     broken = kernel.isHardened;


### PR DESCRIPTION
Inactive since 2019/2020. Not reacting to maintainer pings for at least 4 years.

Dropping according to https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#losing-maintainer-status. @maggesi, if you'd like to stay a maintainer, please respond within a week.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
