### PR TITLE
dislocker: 0.7.3 -> 0.7.3-unstable-2025-09-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28662,6 +28662,12 @@
     githubId = 7040031;
     name = "Yannik Sander";
   };
+  yuannan = {
+    email = "brandon@emergence.ltd";
+    github = "yuannan";
+    githubId = 8006928;
+    name = "Yuannan (Brandon) Lin";
+  };
   yuka = {
     email = "yuka@yuka.dev";
     matrix = "@yuka:yuka.dev";

--- a/pkgs/by-name/di/dislocker/package.nix
+++ b/pkgs/by-name/di/dislocker/package.nix
@@ -2,44 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
-  mbedtls_2,
-  fuse,
+  fuse3,
+  mbedtls,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dislocker";
-  version = "0.7.3";
+  version = "0.7.3-unstable-2025-09-07";
 
   src = fetchFromGitHub {
     owner = "Aorimn";
     repo = "dislocker";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-U8BD3kE1CH+Mjh/7SlXG9gKY6/LyF9+ER5C3soNGZqo=";
+    rev = "4ff070f0ea9e56948ab316fb76b91f54dd6727aa";
+    hash = "sha256-hrIt5D9YjBWs0Q9chWGQM2bo1SZ7qLCd898zFHWWcqA=";
   };
-
-  patches = [
-    # This patch
-    #   1. adds support for the latest FUSE on macOS
-    #   2. uses pkg-config to find libfuse instead of searching in predetermined
-    #      paths
-    #
-    # https://github.com/Aorimn/dislocker/pull/246
-    (fetchpatch {
-      name = "feat-support-the-latest-FUSE-on-macOS.patch";
-      url = "https://github.com/Aorimn/dislocker/commit/7744f87c75fcfeeb414d0957771042b10fb64e62.patch";
-      hash = "sha256-JX+4DJLcw9qP1nIs+sZDcduSFvU4YdGyblFLtxZj/i4=";
-    })
-    # fix compatibility with CMake (https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html)
-    # https://github.com/Aorimn/dislocker/pull/346
-    (fetchpatch {
-      name = "cmake-raise-minimum-required-version-to-3.5.patch";
-      url = "https://github.com/Aorimn/dislocker/commit/337d05dc7447436539f2fb481eef0e528a000b66.patch";
-      hash = "sha256-6LTRjaZfyGS2BCdpcJy/qo0r8soXJSZqWjZRbaKvcQk=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -47,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    fuse
-    mbedtls_2
+    fuse3
+    mbedtls
   ];
 
   meta = {
@@ -56,7 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Aorimn/dislocker";
     changelog = "https://github.com/Aorimn/dislocker/raw/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ elitak ];
+    maintainers = with lib.maintainers; [
+      elitak
+      yuannan
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Dislocker hasn't had a release since 0.7.3 which was in 2020, but dislocker has been getting updates. Because of this major patches that we need such as compat for CMAKE 4 need to be pulled in one by one. The package in master currently has individual patches to bring it more up to date, or we can just have the latest hash like I've done here.

We won't need patches like:
https://github.com/NixOS/nixpkgs/pull/449377

If we just follow the latest commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
