### PR TITLE
fheroes2: drop `FHEROES2_STRICT_COMPILATION=1`

### DIFF
--- a/pkgs/by-name/fh/fheroes2/package.nix
+++ b/pkgs/by-name/fh/fheroes2/package.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   makeFlags = [
-    "FHEROES2_STRICT_COMPILATION=1"
     "FHEROES2_DATA=\"${placeholder "out"}/share/fheroes2\""
   ];
 


### PR DESCRIPTION
The only effect `FHEROES2_STRICT_COMPILATION=1` on `fheroes2` is to add `-Werror` to the compiler flags. Unfortunately blanket `-Werror` usually breaks the builds with every major compiler update.

For example right now `fheroes2` currently fails on `gcc-16` from `gcc` `master` as:

```
fheroes2> In file included from /nix/store/nq52d716cprkic7kvb68izz590lyznjf-gcc-16.0.0.99999999/include/c++/16.0.0.99999999/memory:80,
fheroes2>                  from ../../fheroes2/gui/ui_button.h:26,
fheroes2>                  from ../../fheroes2/gui/ui_button.cpp:21:
fheroes2> In member function 'std::__uniq_ptr_impl<_Tp, _Dp>::pointer std::__uniq_ptr_impl<_Tp, _Dp>::_M_ptr() const [with _Tp = unsigned char; _Dp = std::default_delete<unsigned char []>]',
fheroes2>     inlined from 'std::unique_ptr<_Tp [], _Dp>::pointer std::unique_ptr<_Tp [], _Dp>::get() const [with _Tp = unsigned char; _Dp = std::default_delete<unsigned char []>]' at /nix/store/nq52d716cprkic7kvb68izz590lyznjf-gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:742:27,
fheroes2>     inlined from 'std::unique_ptr<_Tp [], _Dp>::operator bool() const [with _Tp = unsigned char; _Dp = std::default_delete<unsigned char []>]' at /nix/store/nq52d716cprkic7kvb68izz590lyznjf-gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:759:19,
fheroes2>     inlined from 'bool fheroes2::Image::empty() const' at ../../engine/image.h:86:21,
fheroes2>     inlined from 'virtual const fheroes2::Sprite& fheroes2::ButtonSprite::_getDisabled() const' at ../../fheroes2/gui/ui_button.cpp:524:29,
fheroes2>     inlined from 'void fheroes2::ButtonBase::_updateReleasedArea()' at ../../fheroes2/gui/ui_button.h:171:82,
fheroes2>     inlined from 'void fheroes2::ButtonBase::_updateButtonAreas()' at ../../fheroes2/gui/ui_button.h:149:32,
fheroes2>     inlined from 'fheroes2::Button::Button(int32_t, int32_t, int, uint32_t, uint32_t)' at ../../fheroes2/gui/ui_button.h:194:31,
fheroes2>     inlined from 'std::__detail::__unique_ptr_t<_Tp> std::make_unique(_Args&& ...) [with _Tp = fheroes2::Button; _Args = {const int&, const int&, const int&, const unsigned int&, const unsigned int&}]' at /nix/store/nq52d716cprkic7kvb68izz590lyznjf-gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:1086:30,
fheroes2>     inlined from 'void fheroes2::ButtonGroup::createButton(int32_t, int32_t, int, uint32_t, uint32_t, int)' at ../../fheroes2/gui/ui_button.cpp:626:52:
fheroes2> /nix/store/nq52d716cprkic7kvb68izz590lyznjf-gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:192:67: error: array subscript 22 is outside array bounds of 'void [96]' [-Werror=array-bounds=]
fheroes2>   192 |       pointer    _M_ptr() const noexcept { return std::get<0>(_M_t); }
fheroes2>       |                                                                   ^
fheroes2> In function 'std::__detail::__unique_ptr_t<_Tp> std::make_unique(_Args&& ...) [with _Tp = fheroes2::Button; _Args = {const int&, const int&, const int&, const unsigned int&, const unsigned int&}]',
fheroes2>     inlined from 'void fheroes2::ButtonGroup::createButton(int32_t, int32_t, int, uint32_t, uint32_t, int)' at ../../fheroes2/gui/ui_button.cpp:626:52:
fheroes2> /nix/store/nq52d716cprkic7kvb68izz590lyznjf-gcc-16.0.0.99999999/include/c++/16.0.0.99999999/bits/unique_ptr.h:1086:30: note: at offset 176 into object of size 96 allocated by 'operator new'
fheroes2>  1086 |     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
fheroes2>       |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

While these errors are useful for developers they
usualllly do more harm than good for distributions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
