### PR TITLE
drat: init at 0.1.3-unstable-2024-01-07

### DIFF
--- a/pkgs/by-name/dr/drat/package.nix
+++ b/pkgs/by-name/dr/drat/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "drat";
+  version = "0.1.3-unstable-2024-01-07";
+
+  src = fetchFromGitHub {
+    owner = "jivanpal";
+    repo = "drat";
+    rev = "af573b9e067e8b6cbcc4825946e7e636b30c748f";
+    hash = "sha256-1NmqG73sP25Uqf7DiSPgt7drONOg9ZkrtCS0tYVjSU0=";
+  };
+
+  # Don't blow up on warnings; it makes upgrading the compiler difficult.
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "-Werror" ""
+  '';
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "LD=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install drat $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Utility for performing data recovery and analysis of APFS partitions/containers";
+    homepage = "https://github.com/jivanpal/drat";
+    changelog = "https://github.com/jivanpal/drat/blob/main/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ philiptaron ];
+    mainProgram = "drat";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Packaged after a question from @waltmck on Matrix.

> Drat is a tool for analysing and recovering data from [APFS (Apple File System)](https://en.wikipedia.org/wiki/Apple_File_System) partitions. Its creation was inspired by a [personal data loss incident](https://apple.stackexchange.com/questions/373718) and [Jonathan Levin's](https://twitter.com/Morpheus______) closed-source `fsleuth` tool, which he demonstrated in [this lecture](http://docs.macsysadmin.se/2018/video/Day4Session2.mp4).
>
> The name "Drat" is a loose acronym for "Disaster Recovery APFS Tools", and a bad pun on how one might say "drat!" after discovering that their data is corrupted.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
