### PR TITLE
seagoat: Fix server startup

### DIFF
--- a/pkgs/by-name/se/seagoat/package.nix
+++ b/pkgs/by-name/se/seagoat/package.nix
@@ -30,6 +30,7 @@ python3Packages.buildPythonApplication rec {
     "chromadb"
     "psutil"
     "setuptools"
+    "ollama"
   ];
 
   dependencies = with python3Packages; [
@@ -46,6 +47,7 @@ python3Packages.buildPythonApplication rec {
     ollama
     psutil
     pygments
+    python-dotenv
     requests
     stop-words
     waitress


### PR DESCRIPTION
Running `seagoat-server start .` appears to work, but doesn't actually work as expected. The server prints an error message on the logs and doesn't follow up with the usual startup (i.e. download a model and start indexing the repository).
Logs:
```
2025-10-14 01:54:22,641 Creating server...
2025-10-14 01:54:22,643 Starting worker thread...
2025-10-14 01:54:22,657 Serving on http://0.0.0.0:59881
Exception in thread Thread-1 (_worker_function):
Traceback (most recent call last):
  File "/nix/store/cxp65j4rbj070c5qbzj4vfpnmgs85vr7-python3.12-pydantic-2.11.4/lib/python3.12/site-packages/pydantic/v1/env_settings.py", line 330, in read_env_file
    from dotenv import dotenv_values
ModuleNotFoundError: No module named 'dotenv'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/nix/store/vxl8pzgkkw8vdb4agzwm58imrfclmfrx-python3-3.12.11/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/nix/store/vxl8pzgkkw8vdb4agzwm58imrfclmfrx-python3-3.12.11/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/nix/store/sxpcz0wsgzhcn97l6qbhmrnrax34llhq-seagoat-0.54.17/lib/python3.12/site-packages/seagoat/queue/base_queue.py", line 74, in _worker_function
    context = self._get_context()
              ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/sxpcz0wsgzhcn97l6qbhmrnrax34llhq-seagoat-0.54.17/lib/python3.12/site-packages/seagoat/queue/task_queue.py", line 40, in _get_context
    from seagoat.engine import Engine
  File "/nix/store/sxpcz0wsgzhcn97l6qbhmrnrax34llhq-seagoat-0.54.17/lib/python3.12/site-packages/seagoat/engine.py", line 20, in <module>
    from seagoat.sources import chroma, ripgrep
  File "/nix/store/sxpcz0wsgzhcn97l6qbhmrnrax34llhq-seagoat-0.54.17/lib/python3.12/site-packages/seagoat/sources/chroma.py", line 3, in <module>
    import chromadb
  File "/nix/store/4bhp6sss6246r2g9c8p5dxc9mjsxwx94-python3.12-chromadb-0.5.20/lib/python3.12/site-packages/chromadb/__init__.py", line 3, in <module>
    from chromadb.api.client import Client as ClientCreator
  File "/nix/store/4bhp6sss6246r2g9c8p5dxc9mjsxwx94-python3.12-chromadb-0.5.20/lib/python3.12/site-packages/chromadb/api/client.py", line 8, in <module>
    from chromadb.api.shared_system_client import SharedSystemClient
  File "/nix/store/4bhp6sss6246r2g9c8p5dxc9mjsxwx94-python3.12-chromadb-0.5.20/lib/python3.12/site-packages/chromadb/api/shared_system_client.py", line 10, in <module>
    class SharedSystemClient:
  File "/nix/store/4bhp6sss6246r2g9c8p5dxc9mjsxwx94-python3.12-chromadb-0.5.20/lib/python3.12/site-packages/chromadb/api/shared_system_client.py", line 16, in SharedSystemClient
    settings: Settings = Settings(),
                         ^^^^^^^^^^
  File "/nix/store/cxp65j4rbj070c5qbzj4vfpnmgs85vr7-python3.12-pydantic-2.11.4/lib/python3.12/site-packages/pydantic/v1/env_settings.py", line 41, in __init__
    **__pydantic_self__._build_values(
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/cxp65j4rbj070c5qbzj4vfpnmgs85vr7-python3.12-pydantic-2.11.4/lib/python3.12/site-packages/pydantic/v1/env_settings.py", line 76, in _build_values
    return deep_update(*reversed([source(self) for source in sources]))
                                  ^^^^^^^^^^^^
  File "/nix/store/cxp65j4rbj070c5qbzj4vfpnmgs85vr7-python3.12-pydantic-2.11.4/lib/python3.12/site-packages/pydantic/v1/env_settings.py", line 177, in __call__
    dotenv_vars = self._read_env_files(settings.__config__.case_sensitive)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/cxp65j4rbj070c5qbzj4vfpnmgs85vr7-python3.12-pydantic-2.11.4/lib/python3.12/site-packages/pydantic/v1/env_settings.py", line 226, in _read_env_files
    read_env_file(env_path, encoding=self.env_file_encoding, case_sensitive=case_sensitive)
  File "/nix/store/cxp65j4rbj070c5qbzj4vfpnmgs85vr7-python3.12-pydantic-2.11.4/lib/python3.12/site-packages/pydantic/v1/env_settings.py", line 332, in read_env_file
    raise ImportError('python-dotenv is not installed, run `pip install pydantic[dotenv]`') from e
ImportError: python-dotenv is not installed, run `pip install pydantic[dotenv]`
```
I added python-dotenv to fix this and also relaxed the dependency on python-ollama since it's a fast moving target and it currently breaks #444778.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
