### PR TITLE
initrd-network: add /etc/hosts to initrd as well

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -160,6 +160,12 @@ in
       )
     );
 
+    # Ensure that /etc/hosts is available like on the final system;
+    # this is useful especially for the test driver, where hosts
+    # entries are injected for the other nodes in the test network.
+    boot.initrd.systemd.contents."/etc/hosts".source = config.environment.etc.hosts.source;
+    boot.initrd.extraFiles."/etc/hosts".source = config.environment.etc.hosts.source;
+
     boot.initrd.postMountCommands =
       mkIf (cfg.flushBeforeStage2 && !config.boot.initrd.systemd.enable)
         ''

--- a/nixos/tests/systemd-initrd-networkd-ssh.nix
+++ b/nixos/tests/systemd-initrd-networkd-ssh.nix
@@ -10,6 +10,7 @@
         testing.initrdBackdoor = true;
         boot.initrd.systemd.enable = true;
         boot.initrd.systemd.contents."/etc/msg".text = "foo";
+        boot.initrd.systemd.extraBin.ping = "${pkgs.iputils}/bin/ping";
         boot.initrd.network = {
           enable = true;
           ssh = {
@@ -51,6 +52,8 @@
     with client.nested("waiting for SSH server to come up"):
         retry(ssh_is_up)
 
+    # Ensure that the server can resolve hosts in initrd
+    server.succeed("ping -c1 client")
     msg = client.succeed(
         "ssh -i /etc/sshKey -o UserKnownHostsFile=/etc/knownHosts server 'cat /etc/msg'"
     )


### PR DESCRIPTION
Re-opened https://github.com/NixOS/nixpkgs/pull/311624 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
