### PR TITLE
python3Packages.macfsevents, python3Packages.tabcmd: fix compilation

### DIFF
--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "macfsevents";
   version = "0.8.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "MacFSEvents";
@@ -17,17 +18,24 @@ buildPythonPackage rec {
 
   patches = [ ./fix-packaging.patch ];
 
+  build-system = [ setuptools ];
+
+  # PyEval_InitThreads is deprecated in Python 3.9, to be removed in Python 3.14
+  # and breaks the build under clang 16.
+  # https://github.com/malthe/macfsevents/issues/49
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
+
   # Some tests fail under nix build directory
   doCheck = false;
 
   pythonImportsCheck = [ "fsevents" ];
 
-  meta = with lib; {
+  meta = {
     description = "Thread-based interface to file system observation primitives";
     homepage = "https://github.com/malthe/macfsevents";
     changelog = "https://github.com/malthe/macfsevents/blob/${version}/CHANGES.rst";
-    license = licenses.bsd2;
+    license = lib.licenses.bsd2;
     maintainers = [ ];
-    platforms = platforms.darwin;
+    platforms = lib.platforms.darwin;
   };
 }

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -1,13 +1,11 @@
 {
   lib,
   appdirs,
-  argparse,
   buildPythonPackage,
   doit,
-  fetchPypi,
+  fetchFromGitHub,
   ftfy,
   mock,
-  pyinstaller-versionfile,
   pytest-order,
   pytestCheckHook,
   python,
@@ -28,9 +26,11 @@ buildPythonPackage rec {
   version = "2.0.18";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-erGngJ3CW+c3PuVq4BTrPGSZ2L/M0EykSoZocku0lOE=";
+  src = fetchFromGitHub {
+    owner = "tableau";
+    repo = "tabcmd";
+    tag = "v${version}";
+    hash = "sha256-Eb9ZboYdco6opKW3Tz0+U9VREWdEyt2xuG62n9WIXPk=";
   };
 
   prePatch = ''

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -28,8 +28,6 @@ buildPythonPackage rec {
   version = "2.0.18";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-erGngJ3CW+c3PuVq4BTrPGSZ2L/M0EykSoZocku0lOE=";
@@ -39,6 +37,8 @@ buildPythonPackage rec {
     # Remove an unneeded dependency that can't be resolved
     # https://github.com/tableau/tabcmd/pull/282
     sed -i "/'argparse',/d" pyproject.toml
+    # Uses setuptools-scm instead
+    sed -i "/'pyinstaller_versionfile',/d" pyproject.toml
   '';
 
   pythonRelaxDeps = [
@@ -46,14 +46,19 @@ buildPythonPackage rec {
     "urllib3"
   ];
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRemoveDeps = [
+    "pyinstaller_versionfile"
+  ];
 
   dependencies = [
     appdirs
-    argparse
     doit
     ftfy
-    pyinstaller-versionfile
     requests
     setuptools-scm
     tableauserverclient


### PR DESCRIPTION
1. `python3Packages.macfsevents` build breaks under clang 16 to to the use of a deprecated python API. Added the appropriate clang flag to fix.
2. `python3Packages.tabcmd`: was looking for a non-existent requirements.txt (due to the use of setuptools' defaults). Build from github source and use setuptools-scm instead.

`nixpkgs-review` gives a clean bill of health. No broken packages downstream of these.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
