### PR TITLE
rtags: 2.38 -> 2.41-unstable-2025-09-23

### DIFF
--- a/pkgs/by-name/rt/rtags/package.nix
+++ b/pkgs/by-name/rt/rtags/package.nix
@@ -2,17 +2,17 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   llvmPackages,
   openssl,
   emacs,
   pkg-config,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rtags";
-  version = "2.38";
+  version = "2.41-unstable-2025-09-23";
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -22,15 +22,15 @@ stdenv.mkDerivation rec {
     llvmPackages.llvm
     llvmPackages.libclang
     openssl
-    emacs
+    (emacs.override { withNativeCompilation = false; })
   ]
   ++ lib.optionals stdenv.cc.isGNU [ llvmPackages.clang-unwrapped ];
 
   src = fetchFromGitHub {
     owner = "andersbakken";
     repo = "rtags";
-    tag = "v${version}";
-    hash = "sha256-EJ5pC53S36Uu7lM6KuLvLN6MAyrQW/Yk5kPqZNS5m8c=";
+    rev = "836e4f30ea51ef2074d3231d2118f43e8e32042f";
+    hash = "sha256-dPCXGDDK3sC0oYCTX3Ph3MYxAZqOSaRG7c4+LB/n+Rs=";
     fetchSubmodules = true;
     # unicode file names lead to different checksums on HFS+ vs. other
     # filesystems because of unicode normalisation
@@ -39,25 +39,19 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  # This should be fixed with the next version bump
-  # https://github.com/Andersbakken/rtags/issues/1411
-  patches = [
-    (fetchpatch {
-      name = "define-obsolete-function-alias.patch";
-      url = "https://github.com/Andersbakken/rtags/commit/63f18acb21e664fd92fbc19465f0b5df085b5e93.patch";
-      sha256 = "sha256-dmEPtnk8Pylmf5479ovHKItRZ+tJuOWuYOQbWB/si/Y=";
-    })
-  ];
-
   preConfigure = ''
     export LIBCLANG_CXXFLAGS="-isystem ${llvmPackages.clang.cc}/include $(llvm-config --cxxflags) -fexceptions" \
            LIBCLANG_LIBDIR="${llvmPackages.clang.cc}/lib"
   '';
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
   meta = {
     description = "C/C++ client-server indexer based on clang";
     homepage = "https://github.com/andersbakken/rtags";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     platforms = with lib.platforms; x86_64 ++ aarch64;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Andersbakken/rtags/commit/836e4f30ea51ef2074d3231d2118f43e8e32042f
https://github.com/Andersbakken/rtags/compare/v2.38...836e4f30ea51ef2074d3231d2118f43e8e32042f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
