### PR TITLE
openfire: init at 5.0.2

### DIFF
--- a/pkgs/by-name/op/openfire/package.nix
+++ b/pkgs/by-name/op/openfire/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  maven,
+  fetchFromGitHub,
+  jdk_headless,
+  makeWrapper,
+}:
+maven.buildMavenPackage rec {
+  pname = "openfire";
+  version = "5.0.2";
+
+  src = fetchFromGitHub {
+    owner = "igniterealtime";
+    repo = "Openfire";
+    tag = "v${version}";
+    hash = "sha256-VwHDujd3A2f1MtLnbmg6Zp9ITKumg7idQ2RC+gioErU=";
+  };
+
+  mvnJdk = jdk_headless;
+  mvnHash = "sha256-chUGNP0h9Qpxa3Rfc7awHY3BtLsi0S/Ps3T7p4/QiGs=";
+
+  # some deps require internet for tests
+  mvnParameters = "-Dmaven.test.skip";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt}
+
+    cp -R ./distribution/target/distribution-base/* $out/opt
+    ln -s $out/opt/lib $out/lib
+
+    for file in openfire.sh openfirectl; do
+      wrapProgram $out/opt/bin/$file \
+        --set JAVA_HOME ${jdk_headless.home}
+
+      install -Dm555 $out/opt/bin/$file -t $out/bin
+    done
+
+    # Used to determine if the Openfire state directory needs updating
+    echo ${version} > $out/opt/version
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "XMPP server licensed under the Open Source Apache License";
+    homepage = "https://github.com/igniterealtime/Openfire";
+    changelog = "https://github.com/igniterealtime/Openfire/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "openfire";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Homepage: https://github.com/igniterealtime/Openfire



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
