### PR TITLE
ocamlPackages.ppx_import: 1.11.0 → 1.12.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -2,54 +2,56 @@
   lib,
   fetchurl,
   buildDunePackage,
-  ocaml,
   ounit,
   ppx_deriving,
   ppx_sexp_conv,
   ppxlib,
-  version ? if lib.versionAtLeast ocaml.version "4.11" then "1.11.0" else "1.9.1",
+  version ?
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      "1.12.0"
+    else if lib.versionAtLeast ppxlib.version "0.26" then
+      "1.11.0"
+    else if lib.versionAtLeast ppxlib.version "0.24.0" then
+      "1.9.1"
+    else
+      throw "ppx_import is not available with ppxlib-${ppxlib.version}",
 }:
 
-lib.throwIfNot (lib.versionAtLeast ppxlib.version "0.24.0")
-  "ppx_import is not available with ppxlib-${ppxlib.version}"
+buildDunePackage {
+  pname = "ppx_import";
+  inherit version;
 
-  buildDunePackage
-  rec {
-    pname = "ppx_import";
-    inherit version;
+  src = fetchurl {
+    url =
+      let
+        dir = if lib.versionAtLeast version "1.11" then "v${version}" else "${version}";
+      in
+      "https://github.com/ocaml-ppx/ppx_import/releases/download/${dir}/ppx_import-${version}.tbz";
 
-    minimalOCamlVersion = "4.05";
+    hash =
+      {
+        "1.9.1" = "sha256-0bSY4u44Ds84XPIbcT5Vt4AG/4PkzFKMl9CDGFZyIdI=";
+        "1.11.0" = "sha256-Jmfv1IkQoaTkyxoxp9FI0ChNESqCaoDsA7D4ZUbOrBo=";
+        "1.12.0" = "sha256-1vpYHFl0rEdG3hE+6BCpWmfLvdLvoEx+Jxq0DFrRdJc=";
+      }
+      ."${version}";
+  };
 
-    src = fetchurl {
-      url =
-        let
-          dir = if lib.versionAtLeast version "1.11" then "v${version}" else "${version}";
-        in
-        "https://github.com/ocaml-ppx/ppx_import/releases/download/${dir}/ppx_import-${version}.tbz";
+  propagatedBuildInputs = [
+    ppxlib
+  ];
 
-      hash =
-        {
-          "1.9.1" = "sha256-0bSY4u44Ds84XPIbcT5Vt4AG/4PkzFKMl9CDGFZyIdI=";
-          "1.11.0" = "sha256-Jmfv1IkQoaTkyxoxp9FI0ChNESqCaoDsA7D4ZUbOrBo=";
-        }
-        ."${version}";
-    };
+  checkInputs = [
+    ounit
+    ppx_deriving
+    ppx_sexp_conv
+  ];
 
-    propagatedBuildInputs = [
-      ppxlib
-    ];
+  doCheck = true;
 
-    checkInputs = [
-      ounit
-      ppx_deriving
-      ppx_sexp_conv
-    ];
-
-    doCheck = true;
-
-    meta = {
-      description = "Syntax extension for importing declarations from interface files";
-      license = lib.licenses.mit;
-      homepage = "https://github.com/ocaml-ppx/ppx_import";
-    };
-  }
+  meta = {
+    description = "Syntax extension for importing declarations from interface files";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/ocaml-ppx/ppx_import";
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
