### PR TITLE
scantailor-universal: fix build with cmake4

### DIFF
--- a/pkgs/applications/graphics/scantailor/universal.nix
+++ b/pkgs/applications/graphics/scantailor/universal.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   libsForQt5,
   zlib,
@@ -24,6 +25,20 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
     hash = "sha256-n8NbokK+U0FAuYXtjRJcxlI1XAmI4hk5zV3sF86hB/s=";
   };
+
+  patches = [
+    # Bump CMAKE_MINIMUM_REQUIRED
+    (fetchpatch {
+      url = "https://github.com/trufanov-nok/scantailor-universal/commit/f90b1c6bb2954ca5c4d0c5b310f359c522fe538c.patch?full_index=1";
+      hash = "sha256-c/mynpM4XNbQ6TcxzZvwwujnfwwA1TPogNU9393gcY4=";
+    })
+    # Remove outdated CMP0043 policy
+    (fetchpatch {
+      url = "https://github.com/trufanov-nok/scantailor-universal/commit/248fdf0fc2dc014d76d4ec9e27a7ad340ff7aaf5.patch?full_index=1";
+      hash = "sha256-xK0hNr6YHgMK4fghc07CTRwcsizTsnGSdDwqcUf9wsY=";
+    })
+
+  ];
 
   buildInputs = [
     libsForQt5.qtbase


### PR DESCRIPTION
- #445447
- Apply commits from upstream:
  - https://github.com/trufanov-nok/scantailor-universal/commit/f90b1c6bb2954ca5c4d0c5b310f359c522fe538c
  - https://github.com/trufanov-nok/scantailor-universal/commit/248fdf0fc2dc014d76d4ec9e27a7ad340ff7aaf5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
