### PR TITLE
vscode-solidity-server: fix keytar issue on darwin

### DIFF
--- a/pkgs/by-name/vs/vscode-solidity-server/package.nix
+++ b/pkgs/by-name/vs/vscode-solidity-server/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   pkg-config,
   libsecret,
+  stdenv,
+  clang_20,
 }:
 
 buildNpmPackage {
@@ -19,7 +21,7 @@ buildNpmPackage {
 
   npmDepsHash = "sha256-zXhWtPuiu+CRk712KskuHP4vglogJmFoCak6qWczPFM=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks keytar
 
   buildInputs = [ libsecret ];
 


### PR DESCRIPTION
Similarly to #449891 vscode-solidity-server (solidity-language-server) fails building on darwin:

```
error: builder for '/nix/store/cwxpbgnasv9kc61gaks6llb25wlf4lzy-solidity-language-server-0.0.185.drv' failed with exit code 1;
       last 25 log lines:
       > npm error gyp info spawn args 'build',
       > npm error gyp info spawn args '-Goutput_dir=.'
       > npm error gyp info spawn args ]
       > npm error gyp info spawn make
       > npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
       > npm error In file included from ../src/async.cc:4:
       > npm error ../../node-addon-api/napi.h:1147:39: error: in-class initializer for static data member is not a constant expression
       > npm error  1147 |     static const napi_typedarray_type unknown_array_type = static_cast<napi_typedarray_type>(-1);
       > npm error       |                                       ^                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > npm error ../../node-addon-api/napi.h:1147:60: note: integer value -1 is outside the valid range of values [0, 15] for the enumeration type 'napi_typedarray_type'
       > npm error  1147 |     static const napi_typedarray_type unknown_array_type = static_cast<napi_typedarray_type>(-1);
       > npm error       |                                                            ^
       > npm error 1 error generated.
       > npm error make: *** [keytar.target.mk:126: Release/obj.target/keytar/src/async.o] Error 1
       > npm error gyp ERR! build error
       > npm error gyp ERR! stack Error: `make` failed with exit code: 2
       > npm error gyp ERR! stack at ChildProcess.<anonymous> (/nix/store/7hnbd3z2flnqh17fh3sbk0srpn6zvzck-nodejs-22.19.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:219:23)
       > npm error gyp ERR! System Darwin 24.6.0
       > npm error gyp ERR! command "/nix/store/7hnbd3z2flnqh17fh3sbk0srpn6zvzck-nodejs-22.19.0/bin/node" "/nix/store/7hnbd3z2flnqh17fh3sbk0srpn6zvzck-nodejs-22.19.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
       > npm error gyp ERR! cwd /private/tmp/nix-build-solidity-language-server-0.0.185.drv-0/source/node_modules/keytar
       > npm error gyp ERR! node -v v22.19.0
       > npm error gyp ERR! node-gyp -v v11.2.0
       > npm error gyp ERR! not ok
       > npm error Log files were not written due to an error writing to the directory: /nix/store/zxxv9hg40fm76qm5fp36zsgk3cdb768x-solidity-language-server-0.0.185-npm-deps/_logs
       > npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
       For full logs, run:
         nix log /nix/store/cwxpbgnasv9kc61gaks6llb25wlf4lzy-solidity-language-server-0.0.185.drv
```

The fix from #450202 works here as well until upstream can fix the problem

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
