### PR TITLE
ltchiptool: init at 4.12.2

### DIFF
--- a/pkgs/by-name/lt/ltchiptool/package.nix
+++ b/pkgs/by-name/lt/ltchiptool/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  wrapGAppsHook3,
+}:
+let
+  libretiny = fetchFromGitHub {
+    name = "libretiny";
+    owner = "libretiny-eu";
+    repo = "libretiny";
+    rev = "c6b06d4be6f4b8b8069e7b7551fc96f957ccc99c";
+    hash = "sha256-JHcS3/G8NSE6pj2yadnfVplzYJEHrFE4PBh0vaBZVOE=";
+  };
+in
+python3Packages.buildPythonApplication rec {
+  pname = "ltchiptool";
+  version = "4.12.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    name = "ltchiptool";
+    owner = "libretiny-eu";
+    repo = "ltchiptool";
+    tag = "v${version}";
+    hash = "sha256-PTb7HL+tU7jQq42aK9+AjeqFp9Vx6LsDW8zfdX/yA64=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
+
+  preBuild = ''
+    # Copy required data
+    install -Dm444 ${libretiny}/{platform,families}.json -t ltchiptool
+    install -Dm444 ${libretiny}/boards/*.json -t ltchiptool/boards
+    cp -r ${libretiny}/boards/_base/ ltchiptool/boards/
+  '';
+
+  build-system = with python3Packages; [ poetry-core ];
+
+  pythonRelaxDeps = [ "py-datastruct" ];
+
+  dependencies = with python3Packages; [
+    bitstruct
+    bk7231tools
+    click
+    colorama
+    hexdump
+    importlib-metadata
+    prettytable
+    pyaes
+    py-datastruct
+    requests
+    semantic-version
+    wxpython
+    xmodem
+    ymodem
+    zeroconf
+  ];
+
+  # Application has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "ltchiptool" ];
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "ltchiptool";
+      desktopName = name;
+      genericName = "Flashing & dumping tool";
+      comment = meta.description;
+      icon = "ltchiptool";
+      exec = "ltchiptool gui";
+      categories = [ "Utility" ];
+      keywords = [
+        "dump"
+        "esphome"
+        "firmware"
+        "flash"
+        "libretiny"
+      ];
+      singleMainWindow = true;
+      terminal = false;
+    })
+  ];
+
+  postInstall = ''
+    install -Dm444 ltchiptool/gui/ltchiptool-192x192.png $out/share/icons/hicolor/192x192/apps/ltchiptool.png
+  '';
+
+  meta = {
+    description = "Flashing/dumping tool for BK7231, RTL8710B and RTL8720C";
+    homepage = "https://github.com/libretiny-eu/ltchiptool";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "ltchiptool";
+  };
+}

--- a/pkgs/development/python-modules/ymodem/default.nix
+++ b/pkgs/development/python-modules/ymodem/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  ordered-set,
+  pyserial,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "ymodem";
+  version = "1.5.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-5Dc81sjSlilJXb/92e0Yewfyc4EjHVXToTcCUyDVzmc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    ordered-set
+    pyserial
+  ];
+
+  # Module has no test
+  doCheck = false;
+
+  pythonImportsCheck = [ "ymodem" ];
+
+  meta = {
+    description = "YMODEM protocol implementation for Python";
+    homepage = "https://github.com/alexwoo1900/ymodem";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "ymodem";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20476,6 +20476,8 @@ self: super: with self; {
 
   yfinance = callPackage ../development/python-modules/yfinance { };
 
+  ymodem = callPackage ../development/python-modules/ymodem { };
+
   yoda = toPythonModule (pkgs.yoda.override { python3 = python; });
 
   yolink-api = callPackage ../development/python-modules/yolink-api { };


### PR DESCRIPTION
Add ltchiptool, a tool for flashing various Tuya smart home devices along with its dependency ymodem

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
