### PR TITLE
pnmixer: fix build with CMake 4 and modernize derivation

### DIFF
--- a/pkgs/by-name/pn/pnmixer/fix-cmake-version.patch
+++ b/pkgs/by-name/pn/pnmixer/fix-cmake-version.patch
@@ -1,0 +1,33 @@
+From 3a4a988f6c69abece44fe2c77eab5f0a9ae7bbd2 Mon Sep 17 00:00:00 2001
+From: Stefan Frijters <sfrijters@gmail.com>
+Date: Mon, 13 Oct 2025 10:53:14 +0200
+Subject: [PATCH] Update minimum CMake version
+
+And fix compatibility with https://cmake.org/cmake/help/v4.1/policy/CMP0065.html
+---
+ CMakeLists.txt     | 2 +-
+ src/CMakeLists.txt | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 10192bf..1bb3e0c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.10)
+ project(PNMixer)
+ 
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index eb04c2b..8630a21 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -56,6 +56,7 @@ target_link_libraries(pnmixer "${PNMixer_DEPS_LDFLAGS}")
+ target_link_libraries(pnmixer m)
+ target_compile_options(pnmixer PUBLIC "${PNMixer_DEPS_CFLAGS}")
+ target_compile_definitions(pnmixer PUBLIC -DHAVE_CONFIG_H)
++set_property(TARGET pnmixer PROPERTY ENABLE_EXPORTS 1)
+ 
+ install(TARGETS pnmixer DESTINATION "${CMAKE_INSTALL_BINDIR}")
+ 

--- a/pkgs/by-name/pn/pnmixer/package.nix
+++ b/pkgs/by-name/pn/pnmixer/package.nix
@@ -13,14 +13,14 @@
   pcre,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pnmixer";
   version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "nicklan";
     repo = "pnmixer";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0416pa933ddf4b7ph9zxhk5jppkk7ppcq1aqph6xsrfnka4yb148";
   };
 

--- a/pkgs/by-name/pn/pnmixer/package.nix
+++ b/pkgs/by-name/pn/pnmixer/package.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nicklan";
     repo = "pnmixer";
-    rev = "v${finalAttrs.version}";
-    sha256 = "0416pa933ddf4b7ph9zxhk5jppkk7ppcq1aqph6xsrfnka4yb148";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iITliZrWZd0NvFgFzO49c94ry4T9J3jPIq61MZK6JhA=";
   };
 
   patches = [

--- a/pkgs/by-name/pn/pnmixer/package.nix
+++ b/pkgs/by-name/pn/pnmixer/package.nix
@@ -44,15 +44,15 @@ stdenv.mkDerivation (finalAttrs: {
     pcre
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/nicklan/pnmixer";
     description = "ALSA volume mixer for the system tray";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       campadrenalin
       romildo
     ];
     mainProgram = "pnmixer";
   };
-}
+})

--- a/pkgs/by-name/pn/pnmixer/package.nix
+++ b/pkgs/by-name/pn/pnmixer/package.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
     sha256 = "0416pa933ddf4b7ph9zxhk5jppkk7ppcq1aqph6xsrfnka4yb148";
   };
 
+  patches = [
+    # https://github.com/nicklan/pnmixer/pull/197
+    ./fix-cmake-version.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
