### PR TITLE
gonic: 0.18.0 -> 0.19.0

### DIFF
--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -10,6 +10,10 @@ let
     mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
     listsAsDuplicateKeys = true;
   };
+  assertKey = key: {
+    assertion = cfg.settings ? ${key};
+    message = "Please set services.gonic.settings.${key}. See https://github.com/sentriz/gonic#configuration-options for supported values.";
+  };
 in
 {
   options = {
@@ -29,6 +33,7 @@ in
         example = {
           music-path = [ "/mnt/music" ];
           podcast-path = "/mnt/podcasts";
+          playlists-path = "/mnt/playlists";
         };
         description = ''
           Configuration for Gonic, see <https://github.com/sentriz/gonic#configuration-options> for supported values.
@@ -39,6 +44,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      (assertKey "music-path")
+      (assertKey "podcast-path")
+      (assertKey "playlists-path")
+    ];
+
     systemd.services.gonic = {
       description = "Gonic Media Server";
       after = [ "network.target" ];

--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -73,6 +73,7 @@ in
         BindPaths = [
           cfg.settings.playlists-path
           cfg.settings.podcast-path
+          cfg.settings.cache-path
         ];
         BindReadOnlyPaths = [
           # gonic can access scrobbling services

--- a/nixos/modules/services/audio/gonic.nix
+++ b/nixos/modules/services/audio/gonic.nix
@@ -94,7 +94,6 @@ in
         ];
         RestrictRealtime = true;
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
         UMask = "0066";
         ProtectHostname = true;
       };

--- a/pkgs/by-name/go/gonic/package.nix
+++ b/pkgs/by-name/go/gonic/package.nix
@@ -20,20 +20,15 @@
 
 buildGoModule rec {
   pname = "gonic";
-  version = "0.18.0";
+  version = "0.19.0";
   src = fetchFromGitHub {
     owner = "sentriz";
     repo = "gonic";
     rev = "v${version}";
-    sha256 = "sha256-qWUADZntJg8722Kxt3z1cwIOTcjxS0PYC0RHzselkdI=";
+    sha256 = "sha256-la3xBECo4zZfkp5BlXuUzFEUGtxMl8ZAQdwgjFXIuSM=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    taglib
-    zlib
-  ];
-  vendorHash = "sha256-HY+57SJsz/kPxSadjFl4LQ1Jlu3A5I+rpih67cMMGHA=";
+  vendorHash = "sha256-HrYS7c0MtiOYRyiSg7eLbiSIUkHeRikJ0Rwf4EoZIsQ=";
 
   # TODO(Profpatsch): write a test for transcoding support,
   # since it is prone to break


### PR DESCRIPTION
Manually updates gonic to 0.19 to handle the new vendored wasm lib changes.
Also includes module fixes that close #313254 and #399348. Supersedes #451105.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
