### PR TITLE
go-pray: init at 0.1.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -147,6 +147,13 @@
     githubId = 105598867;
     matrix = "@0xmrtt:envs.net";
   };
+  _0xzer0x = {
+    name = "Youssef Fathy";
+    github = "0xzer0x";
+    githubId = 32334265;
+    email = "youssefessamasu@gmail.com";
+    keys = [ { fingerprint = "71C6 D036 2A29 9D24 B922  A32B 2193 3929 2935 0DDC"; } ];
+  };
   _1000101 = {
     email = "b1000101@pm.me";
     github = "1000101";

--- a/pkgs/by-name/go/go-pray/package.nix
+++ b/pkgs/by-name/go/go-pray/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  alsa-lib,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-pray";
+  version = "0.1.13";
+
+  src = fetchFromGitHub {
+    owner = "0xzer0x";
+    repo = "go-pray";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wi/sUjzNbVLbqwtM1BglmXgkaqMamjIsGS6EjlyeC9Y=";
+  };
+
+  vendorHash = "sha256-qMTg2Vsk0nte1O8sbNWN5CCCpgpWLvcb2RuGMoEngYE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [ alsa-lib ];
+
+  ldflags = [
+    "-X github.com/0xzer0x/go-pray/internal/version.version=${finalAttrs.version}"
+    "-X github.com/0xzer0x/go-pray/internal/version.buildTime=1980-01-01T00:00:00Z"
+  ];
+
+  # NOTE: Create temporary config file to supress missing config error
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    printf 'calculation: { method: "UAQ" }\nlocation: { lat: 0, long: 0 }\n' > tmpconfig.yml
+    installShellCompletion --cmd go-pray \
+      --bash <($out/bin/go-pray --config=tmpconfig.yml completion bash) \
+      --fish <($out/bin/go-pray --config=tmpconfig.yml completion fish) \
+      --zsh <($out/bin/go-pray --config=tmpconfig.yml completion zsh)
+    rm tmpconfig.yml
+  '';
+
+  meta = {
+    description = "Prayer times CLI to remind you to Go pray";
+    homepage = "https://github.com/0xzer0x/go-pray";
+    changelog = "https://github.com/0xzer0x/go-pray/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ _0xzer0x ];
+    platforms = lib.platforms.linux;
+    mainProgram = "go-pray";
+  };
+})


### PR DESCRIPTION
Powerful and user-friendly command-line interface (CLI) application that helps Muslims stay on top of their daily prayers. With features like prayer time notifications, prayer calendars, and flexible configuration options.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
