### PR TITLE
Revert "devShellTools.unstructuredDerivationInputEnv: Match passAsFile basename"

### DIFF
--- a/pkgs/build-support/dev-shell-tools/default.nix
+++ b/pkgs/build-support/dev-shell-tools/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  writeTextFile,
+  writeText,
 }:
 let
   inherit (builtins) typeOf;
@@ -36,24 +36,7 @@ rec {
           str = valueToString value;
         in
         if lib.elem name (drvAttrs.passAsFile or [ ]) then
-          let
-            nameHash =
-              if builtins ? convertHash then
-                builtins.convertHash {
-                  hash = "sha256:" + builtins.hashString "sha256" name;
-                  toHashFormat = "nix32";
-                }
-              else
-                builtins.hashString "sha256" name;
-            basename = ".attr-${nameHash}";
-          in
-          lib.nameValuePair "${name}Path" "${
-            writeTextFile {
-              name = "shell-passAsFile-${name}";
-              text = str;
-              destination = "/${basename}";
-            }
-          }/${basename}"
+          lib.nameValuePair "${name}Path" "${writeText "shell-passAsFile-${name}" str}"
         else
           lib.nameValuePair name str
       )

--- a/pkgs/build-support/dev-shell-tools/tests/default.nix
+++ b/pkgs/build-support/dev-shell-tools/tests/default.nix
@@ -170,10 +170,6 @@ lib.recurseIntoAttrs {
             set -x
 
             diff $exampleBarPathString $barPath
-
-            ${lib.optionalString (builtins ? convertHash) ''
-              [[ "$(basename $exampleBarPathString)" = "$(basename $barPath)" ]]
-            ''}
           )
 
           ''${args:+fail "args should not be set by Nix. We don't expect it to and unstructuredDerivationInputEnv removes it."}


### PR DESCRIPTION
This reverts commit 1cf3103bcaf3b45aed2e8e0801f96207d2e98745 introduced in #324789.

The commit implemented a "nice to have" TODO, which ultimately causes hash differences between Lix and Nix. We can't conditionally use the `convertHash` builtin, because we don't have an alternative to produce the same results.

We could, alternatively, only use the fallback path with `builtins.hashString "sha256" name;` and keep `writeTextFile`, if that's desirable.

Required to do #451926.

## Things done

- [x] Confirmed that the following now returns the same hash on latest Lix and latest NIx:
  - `tests.devShellTools.nixos`
  - `tests.devShellTools.unstructuredDerivationInputEnv`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
