### PR TITLE
python3Packages.beangulp: fix build, fava: 1.30.6 -> 1.30.7

### DIFF
--- a/pkgs/by-name/fa/fava/package.nix
+++ b/pkgs/by-name/fa/fava/package.nix
@@ -8,17 +8,17 @@
 let
   src = buildNpmPackage (finalAttrs: {
     pname = "fava-frontend";
-    version = "1.30.6";
+    version = "1.30.7";
 
     src = fetchFromGitHub {
       owner = "beancount";
       repo = "fava";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-AMbKGIfR/URu7RpyBKSR3lzfIliRWjnUNNjLvu9KmfM=";
+      hash = "sha256-gO6eJIFp/yWAXFWhUcqkkfk2pA8/vyTxgPRPBmv4a6Q=";
     };
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
-    npmDepsHash = "sha256-geou0+Ges0jjrlXG9m3u1GMdf0Qt2pTd8vRGh9gAWJ4=";
+    npmDepsHash = "sha256-cXIhEzYFpLOxUEY7lhTWW7R3/ptkx7hB9K92Fd2m1Ng=";
     makeCacheWritable = true;
 
     preBuild = ''
@@ -34,7 +34,7 @@ let
 in
 python3Packages.buildPythonApplication {
   pname = "fava";
-  version = "1.30.6";
+  inherit (src) version;
   pyproject = true;
 
   inherit src;
@@ -77,10 +77,6 @@ python3Packages.buildPythonApplication {
     # Disable some tests when building with beancount2
     SNAPSHOT_IGNORE = lib.versions.major python3Packages.beancount.version == "2";
   };
-
-  preCheck = ''
-    export HOME=$TEMPDIR
-  '';
 
   meta = {
     description = "Web interface for beancount";

--- a/pkgs/development/python-modules/beangulp/default.nix
+++ b/pkgs/development/python-modules/beangulp/default.nix
@@ -6,6 +6,7 @@
   chardet,
   click,
   fetchFromGitHub,
+  fetchpatch2,
   lxml,
   petl,
   python-magic,
@@ -24,6 +25,13 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-h7xLHwEyS+tOI7v6Erp12VfVnxOf4930++zghhC3in4=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/beancount/beangulp/commit/254bfb38ffed049ef8f3041bfaf01b3f5a8aa771.patch?full_index=1";
+      hash = "sha256-ojysT23K0xmFafzTnRZiHkLS2ioDR/tVK02mfF7N9so=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Fixes python3Packages.beangulp (Hydra failure at https://hydra.nixos.org/build/310694938), which broke fava.  Also update fava.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
