### PR TITLE
flatcc: fix build with cmake4

### DIFF
--- a/pkgs/by-name/fl/flatcc/package.nix
+++ b/pkgs/by-name/fl/flatcc/package.nix
@@ -24,6 +24,24 @@ stdenv.mkDerivation rec {
       url = "https://github.com/dvidelabs/flatcc/commit/5885e50f88248bc7ed398880c887ab23db89f05a.patch";
       hash = "sha256-z2HSxNXerDFKtMGu6/vnzGRlqfz476bFMjg4DVfbObQ";
     })
+    # Bump cmake to 2.8.12, required fox 3.16 patch
+    (fetchpatch {
+      name = "bump-cmake-version.patch";
+      url = "https://github.com/dvidelabs/flatcc/commit/5f07eda43caabd81a2bfa2857af0e3f26dc6d4ee.patch?full_index=1";
+      hash = "sha256-eRlkQw+YGRgCUjrlYB3I8w+/cPuJhgEfNUW/+TZhHlI=";
+    })
+    # Bump min. CMake to 3.16 and fix custom build rules
+    (fetchpatch {
+      name = "fix-cmake-version.patch";
+      url = "https://github.com/dvidelabs/flatcc/commit/385c27b23236dff7ad4fa35c59fd4f9143dcaae6.patch?full_index=1";
+      hash = "sha256-ORDby2LRRQdFrNc1owHKxo0TfMIxISj5SuD5oqvDFFo=";
+      excludes = [
+        "README.md"
+        "CHANGELOG.md"
+        "test/doublevec_test/CMakeLists.txt"
+        "test/monster_test_cpp/CMakeLists.txt"
+      ];
+    })
   ];
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
- #445447
- Fetches https://github.com/dvidelabs/flatcc/commit/5f07eda43caabd81a2bfa2857af0e3f26dc6d4ee & https://github.com/dvidelabs/flatcc/commit/385c27b23236dff7ad4fa35c59fd4f9143dcaae6 from upstream

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
