### PR TITLE
pingu: 0.0.5 -> 0.0.6 (forked)

### DIFF
--- a/pkgs/by-name/pi/pingu/package.nix
+++ b/pkgs/by-name/pi/pingu/package.nix
@@ -6,25 +6,37 @@
 
 buildGoModule rec {
   pname = "pingu";
-  version = "0.0.5";
+  version = "0.0.6";
 
   src = fetchFromGitHub {
-    owner = "sheepla";
+    owner = "CactiChameleon9";
     repo = "pingu";
     rev = "v${version}";
-    sha256 = "sha256-iAHj6/qaZgpTfrUZZ9qdsjiNMJ2zH0CzhR4TVSC9oLE=";
+    sha256 = "sha256-pXC/y+piLhSWIcJ1/+UaC3sjHPKG3XvTuHzWENsXME0=";
+    # Get values that require us to use git, then delete .git
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git rev-parse --short HEAD > ldflags_revision
+      find . -type d -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
-  vendorHash = "sha256-xn6la6E0C5QASXxNee1Py/rBs4ls9X/ePeg4Q1e2UyU=";
+  vendorHash = "sha256-8d0pKweumnJH49HSBCfEF8cwEXLGMAk2WbhS10T/Cmc=";
+  ldflags = [
+    "-w"
+    "-s"
+    "-X main.appVersion=${version}"
+  ];
+  preBuild = ''
+    ldflags+=" -X main.appRevision=$(cat ldflags_revision)"
+  '';
 
   meta = with lib; {
     description = "Ping command implementation in Go but with colorful output and pingu ascii art";
-    homepage = "https://github.com/sheepla/pingu/";
+    homepage = "https://github.com/CactiChameleon9/pingu/";
     license = licenses.mit;
     maintainers = with maintainers; [ CactiChameleon9 ];
     mainProgram = "pingu";
-    # Doesn't build with Go toolchain >1.22, build error:
-    # 'link: golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg'.
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updaing pingu to a newer version to a fork I am now maintaining.

I don't know if this is standard practice, but the original version has not been updated in 2 years and no longer builds with current golang, and so this seemed like the most logical step to me.

I have:
- Forked pingu, and then updated it's dependencies
- Updated nixpkgs to my repo
- Fixed broken `--version` flag by including the same `ldflags` as the Makefile

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
*I ran it, but it took too long building everything, so canceled it. No immediate failures*
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
