### PR TITLE
nixos/immich: add immich-admin wrapper

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -14,6 +14,35 @@ let
     loadCredential = true;
   } cfg.settings "/run/immich/config.json";
 
+  adminWrapper = pkgs.writeShellApplication {
+    name = "immich-admin";
+
+    text = ''
+      echo "This is a wrapper provided by NixOS that tries to mimic the execution environment of Immich itself."
+      echo "However, not all aspects are replicated fully at the moment, so some commands might fail, especially new additions."
+      echo "Therefore, please report issues with this wrapper in the Nixpkgs issue tracker: github.com/NixOS/nixpkgs/issues"
+      echo
+
+      exec ${lib.getExe' config.systemd.package "systemd-run"} \
+        --collect \
+        --pty \
+        --service-type=exec \
+        --quiet \
+        ${lib.optionalString (cfg.secretsFile != null) "-p EnvironmentFile=${cfg.secretsFile}"} \
+        ${lib.concatMapAttrsStringSep " " (n: v: "-E ${n}=${v}") config.services.immich.environment} \
+        -p User="${cfg.user}" \
+        -p Group="${cfg.group}" \
+        ${
+          lib.optionalString (
+            cfg.redis.enable && isRedisUnixSocket
+          ) "-p SupplementaryGroups=${config.services.redis.servers.immich.group}"
+        } \
+        -- \
+        ${lib.getExe' config.services.immich.package "immich-admin"} \
+        "$@"
+    '';
+  };
+
   commonServiceConfig = {
     Type = "simple";
     Restart = "on-failure";
@@ -98,6 +127,12 @@ in
   options.services.immich = {
     enable = mkEnableOption "Immich";
     package = lib.mkPackageOption pkgs "immich" { };
+
+    enableAdminWrapper =
+      mkEnableOption "the immich-admin wrapper that mimics the execution environment of the systemd service"
+      // {
+        default = true;
+      };
 
     mediaLocation = mkOption {
       type = types.path;
@@ -443,6 +478,8 @@ in
         Group = cfg.group;
       };
     };
+
+    environment.systemPackages = lib.optional cfg.enableAdminWrapper adminWrapper;
 
     systemd.tmpfiles.settings = {
       immich = {

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -1,14 +1,11 @@
-{ ... }:
 {
   name = "immich-nixos";
 
-  nodes.machine =
+  containers.machine =
     { pkgs, ... }:
     {
       # These tests need a little more juice
       virtualisation = {
-        cores = 2;
-        memorySize = 4096;
         diskSize = 4096;
       };
 

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -82,5 +82,11 @@
     """ % token)
     assert sum(json.loads(res)["backupDatabase"]["jobCounts"].values()) >= 1
     machine.wait_until_succeeds("ls /var/lib/immich/backups/*.sql.gz")
+
+    with subtest("Test immich-admin"):
+      machine.succeed("echo admin2 | immich-admin reset-admin-password")
+      machine.succeed("""
+        curl -f --json '{ "email": "test@example.com", "password": "admin2" }' http://localhost:2283/api/auth/login
+      """)
   '';
 }


### PR DESCRIPTION
The immich-admin tool shipped with the Immich package is currently unusable for Immich as configured by the NixOS module since it needs to have the correct execution environment (especially environment variables) set up. Therefore, add a wrapper that is optionally added to the system path that allows actually running immich-admin commands.

Disclaimer: I've only tested reset-admin-password personally. Other commands might need further additions to match the service environment.

I've added a disclaimer to the command that points out the limitations of the wrapper.

All names are open for bikeshedding, I have no strong feelings about them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
