### PR TITLE
osdlyrics: fix glib introspection

### DIFF
--- a/pkgs/by-name/os/osdlyrics/package.nix
+++ b/pkgs/by-name/os/osdlyrics/package.nix
@@ -4,8 +4,10 @@
   fetchFromGitHub,
 
   autoreconfHook,
-  pkg-config,
+  gobject-introspection,
   intltool,
+  pkg-config,
+  wrapGAppsNoGuiHook,
 
   glib,
   gtk2,
@@ -29,8 +31,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
-    pkg-config
+    gobject-introspection
     intltool
+    pkg-config
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [
@@ -49,6 +53,8 @@ stdenv.mkDerivation rec {
       ]
     ))
   ];
+
+  dontWrapGApps = true;
 
   postFixup = ''
     extractExecLine() {
@@ -75,6 +81,7 @@ stdenv.mkDerivation rec {
 
     for p in "$out/bin/osdlyrics-create-lyricsource" "$out/bin/osdlyrics-daemon" "$out/libexec/osdlyrics"/*; do
       wrapProgram "$p" \
+        ''${gappsWrapperArgs[@]} \
         --prefix PYTHONPATH : "$out/${python3.sitePackages}"
     done
   '';


### PR DESCRIPTION
This is an old codebase with GTK2 and a compilation mixing C with Python. Nixpkgs might end up killing this package once we kill GTK2, but it's worth it to keep it working until then.

Needs to be in `services.dbus.packages` and needs you to re-login. Or run `dbus-run-session osdlyrics`, but it will create an isolated sandboxed dbus session for your testing, so make sure to close the audio player and let osdlyrics start it.

Closes #431993

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
