### PR TITLE
nixos/neo4j: add ssl.policies.<name>.enable

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4433,6 +4433,14 @@
     githubId = 510553;
     name = "Jos van Bakel";
   };
+  c2fc2f = {
+    name = "c2fc2f";
+    github = "c2fc2f";
+    githubId = 59392138;
+    email = "contact@c2fc2f.com";
+    matrix = "@c2fc2f:sagbot.com";
+    keys = [ { fingerprint = "6EF1 8507 76B5 ABCE 5BF0  C0F8 42E0 E1D1 0B61 1208"; } ];
+  };
   c31io = {
     email = "celiogrand@outlook.com";
     github = "c31io";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -186,6 +186,8 @@
 
 - `fail2ban` has been updated to 1.1.1, which has a few breaking changes compared to 1.1.0 ([changelog](https://github.com/fail2ban/fail2ban/blob/1.1.1/ChangeLog))
 
+- `services.neo4j.tls.<policy_name>`: This policy is no longer enabled by default. If you rely on this policy, you must now explicitly opt-in by setting `services.neo4j.tls.<policy_name>.enable = true;`.
+
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.
 
 - `matrix-appservice-discord` was removed from nixpkgs along with its NixOS module (`services.matrix-appservice-discord`) as it is no longer actively maintained upstream. Use the actively-maintained puppeting bridge [`mautrix-discord`](#opt-services.mautrix-discord.enable) instead.

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -717,6 +717,6 @@ in
     };
 
   meta = {
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.c2fc2f ];
   };
 }

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -13,6 +13,7 @@ let
     opt: lib.isOption opt && opt.type == lib.types.path && opt.highestPrio >= 1500;
 
   sslPolicies = lib.mapAttrsToList (name: conf: ''
+    dbms.ssl.policy.${name}.enabled=${lib.boolToString conf.enable}
     dbms.ssl.policy.${name}.allow_key_generation=${lib.boolToString conf.allowKeyGeneration}
     dbms.ssl.policy.${name}.base_directory=${conf.baseDirectory}
     ${lib.optionalString (conf.ciphers != null) ''
@@ -35,7 +36,7 @@ let
     dbms.ssl.policy.${name}.tls_versions=${lib.concatStringsSep "," conf.tlsVersions}
     dbms.ssl.policy.${name}.trust_all=${lib.boolToString conf.trustAll}
     dbms.ssl.policy.${name}.trusted_dir=${conf.trustedDir}
-  '') cfg.ssl.policies;
+  '') (lib.filterAttrs (_: v: v.enable) cfg.ssl.policies);
 
   serverConfig = pkgs.writeText "neo4j.conf" ''
     # General
@@ -467,6 +468,8 @@ in
             }:
             {
               options = {
+                enable = lib.mkEnableOption "this policy";
+
                 allowKeyGeneration = lib.mkOption {
                   type = lib.types.bool;
                   default = false;

--- a/pkgs/by-name/ne/neo4j/package.nix
+++ b/pkgs/by-name/ne/neo4j/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Highly scalable, robust (fully ACID) native graph database";
     homepage = "https://neo4j.com/";
     license = lib.licenses.gpl3;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.c2fc2f ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This commit adds the `enable` option to the SSL policy configuration. This allows for explicitly enabling or disabling a specific policy (e.g., `https`, `bolt`).

Following the [official Neo4j documentation](https://neo4j.com/docs/operations-manual/current/security/ssl-framework/#ssl-configuration), this setting defaults to `false`. An SSL policy will only be activated if it is explicitly set to `services.neo4j.tls.<policy_name>.enable = true;`.

---

I am also adding myself to the list of maintainers for this module and the `neo4j` package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
