### PR TITLE
libks: Enable tests, adopt by NGI team

### DIFF
--- a/pkgs/by-name/li/libks/1001-tests-testhash.c-Properly-request-shutdown-of-test2-threads.patch
+++ b/pkgs/by-name/li/libks/1001-tests-testhash.c-Properly-request-shutdown-of-test2-threads.patch
@@ -1,0 +1,31 @@
+From 61f2d2f7e308c42cce652db4a172cfa4b0ff6bf1 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sat, 18 Oct 2025 22:45:37 +0200
+Subject: [PATCH] tests/testhash.c: Properly request shutdown of test2 threads
+
+So they can be destroyed properly. Fixes sometimes-occuring SIGSEGVs.
+---
+ tests/testhash.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/tests/testhash.c b/tests/testhash.c
+index 0769aa6..cb6ed24 100644
+--- a/tests/testhash.c
++++ b/tests/testhash.c
+@@ -134,7 +134,12 @@ int test2(void)
+ 	}
+ 
+ 	for (i = 0; i < ttl; i++) {
+-		ks_thread_destroy(&threads[i]);
++		ks_thread_request_stop(threads[i]);
++	}
++
++	for (i = 0; i < ttl; i++) {
++		ks_thread_join(threads[i]);
++		if (ks_thread_destroy(&threads[i]) != KS_STATUS_SUCCESS) return 0;
+ 	}
+ 
+ 
+-- 
+2.51.0
+

--- a/pkgs/by-name/li/libks/package.nix
+++ b/pkgs/by-name/li/libks/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  ctestCheckHook,
   pkg-config,
   libuuid,
   openssl,
@@ -28,6 +29,9 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/openwrt/telephony/5ced7ea4fc9bd746273d564bf3c102f253d2182e/libs/libks/patches/01-find-libm.patch";
       sha256 = "1hyrsdxg69d08qzvf3mbrx2363lw52jcybw8i3ynzqcl228gcg8a";
     })
+
+    # Remove when https://github.com/signalwire/libks/pull/246 merged & in release
+    ./1001-tests-testhash.c-Properly-request-shutdown-of-test2-threads.patch
   ];
 
   dontUseCmakeBuildDir = true;
@@ -42,6 +46,25 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libuuid
   ++ lib.optional stdenv.hostPlatform.isDarwin libossp_uuid;
+
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  disabledTests = [
+    # Runs into certificate error on aarch64
+    # [ERROR] [...] testhttp.c:95    init_ssl [...] SSL ERR: CERT CHAIN FILE ERROR
+    "testhttp"
+
+    # Runs into what seems like an overflow / memory corruption in the testing framework on the community runner.
+    # Doesn't happen on local ARM hardware, maybe due to unexpectedly high core count?
+    "testthreadmutex"
+  ];
+
+  # Something seems to go wrong with testwebsock2 when using parallelism
+  enableParallelChecking = false;
 
   passthru = {
     tests.freeswitch = freeswitch;

--- a/pkgs/by-name/li/libks/package.nix
+++ b/pkgs/by-name/li/libks/package.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
     description = "Foundational support for signalwire C products";
     homepage = "https://github.com/signalwire/libks";
     maintainers = with lib.maintainers; [ misuzu ];
+    teams = [ lib.teams.ngi ];
     platforms = platforms.unix;
     license = licenses.mit;
   };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
