### PR TITLE
nixos/cd-dvd: Add Memtest86+ entry to ISO GRUB

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -62,6 +62,11 @@ let
           }
         ) cfg.specialisation
       )}
+      ${lib.optionalString config.boot.loader.grub.memtest86.enable ''
+        menuentry 'Memtest86+' --class debug {
+          linux /boot/memtest.bin ${toString config.boot.loader.grub.memtest86.params}
+        }
+      ''}
     '';
 
   targetArch = if config.boot.loader.grub.forcei686 then "ia32" else pkgs.stdenv.hostPlatform.efiArch;


### PR DESCRIPTION
`memtest86.bin` was already being copied to the installer ISO, and available in the isolinux bootloader entries, but there was simply no Grub entry created. In fact, [memtest86 is enabled by default for ISOs](https://github.com/NixOS/nixpkgs/blob/3faf92ef0130c7229af896514044608e7f9a37b7/nixos/modules/installer/cd-dvd/installation-cd-base.nix#L31), which means that right now ISOs are being shipped with `/boot/memtest86.bin` but without a corresponding GRUB entry.

Fixes https://github.com/NixOS/nixpkgs/issues/136891

I've generated an installer ISO with this PR with `boot.loader.grub.memtest86.enable` set to true and false and confirmed both configurations work properly (memtest86+ appears as an option by default and loads correctly, but when disabled the option disappears from grub).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
