### PR TITLE
vscode-extensions.rust-lang.rust-analyzer: fix keytar issue on darwin

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix
@@ -1,4 +1,5 @@
 {
+  clang_20,
   pkgsBuildBuild,
   lib,
   fetchFromGitHub,
@@ -9,7 +10,7 @@
   moreutils,
   esbuild,
   pkg-config,
-  libsecret,
+  stdenv,
   setDefaultServerPath ? true,
 }:
 
@@ -43,7 +44,9 @@ let
       esbuild
       # Required by `keytar`, which is a dependency of `vsce`.
       pkg-config
-    ];
+
+    ]
+    ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks keytar
 
     # Follows https://github.com/rust-lang/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65
     installPhase = ''


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/450149
Refer to https://github.com/NixOS/nixpkgs/pull/450202

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
