### PR TITLE
nixos/tests: set proper derivation names for various tests

### DIFF
--- a/nixos/tests/akkoma.nix
+++ b/nixos/tests/akkoma.nix
@@ -129,7 +129,7 @@ let
     };
 in
 {
-  name = "akkoma";
+  name = "akkoma-${if confined then "confined" else "nonconfined"}";
   nodes = {
     client-a =
       { ... }:

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -285,10 +285,12 @@ in
   };
   bind = runTest ./bind.nix;
   bird2 = import ./bird.nix {
+    inherit (pkgs) lib;
     inherit runTest;
     package = pkgs.bird2;
   };
   bird3 = import ./bird.nix {
+    inherit (pkgs) lib;
     inherit runTest;
     package = pkgs.bird3;
   };
@@ -1051,11 +1053,18 @@ in
   mollysocket = runTest ./mollysocket.nix;
   monado = runTest ./monado.nix;
   monetdb = runTest ./monetdb.nix;
-  mongodb = runTest ./mongodb.nix;
+  mongodb = runTest (
+    { config, ... }:
+    {
+      imports = [ ./mongodb.nix ];
+      _module.args.testName = "mongodb";
+    }
+  );
   mongodb-ce = runTest (
     { config, ... }:
     {
       imports = [ ./mongodb.nix ];
+      _module.args.testName = "mongodb-ce";
       defaults.services.mongodb.package = config.node.pkgs.mongodb-ce;
     }
   );
@@ -1105,13 +1114,18 @@ in
   navidrome = runTest ./navidrome.nix;
   nbd = runTest ./nbd.nix;
   ncdns = runTest ./ncdns.nix;
-  ncps = runTest ./ncps.nix;
+  ncps = runTest {
+    imports = [ ./ncps.nix ];
+    _module.args.testName = "ncps";
+  };
   ncps-custom-sqlite-directory = runTest {
     imports = [ ./ncps.nix ];
+    _module.args.testName = "ncps-custom-sqlite-directory";
     defaults.services.ncps.cache.databaseURL = "sqlite:/path/to/ncps/db.sqlite";
   };
   ncps-custom-storage-local = runTest {
     imports = [ ./ncps.nix ];
+    _module.args.testName = "ncps-custom-storage-local";
     defaults.services.ncps.cache.storage.local = "/path/to/ncps";
   };
   ncps-ha-pg-redis = runTest ./ncps-ha-pg-redis.nix;
@@ -1405,21 +1419,25 @@ in
   pretix = runTest ./web-apps/pretix.nix;
   printing-service = runTest {
     imports = [ ./printing.nix ];
+    _module.args.testName = "printing-service";
     _module.args.socket = false;
     _module.args.listenTcp = true;
   };
   printing-service-notcp = runTest {
     imports = [ ./printing.nix ];
+    _module.args.testName = "printing-service-notcp";
     _module.args.socket = false;
     _module.args.listenTcp = false;
   };
   printing-socket = runTest {
     imports = [ ./printing.nix ];
+    _module.args.testName = "printing-socket";
     _module.args.socket = true;
     _module.args.listenTcp = true;
   };
   printing-socket-notcp = runTest {
     imports = [ ./printing.nix ];
+    _module.args.testName = "printing-socket-notcp";
     _module.args.socket = true;
     _module.args.listenTcp = false;
   };

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   pkgs,
   # bool: whether to use networkd in the tests
   networkd ? false,
@@ -7,7 +8,7 @@
 
 # Test whether `avahi-daemon' and `libnss-mdns' work as expected.
 {
-  name = "avahi";
+  name = "avahi${lib.optionalString networkd "-with-resolved"}";
   meta.maintainers = [ ];
 
   nodes =

--- a/nixos/tests/bird.nix
+++ b/nixos/tests/bird.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   runTest,
   package,
 }:
@@ -101,7 +102,7 @@ let
 in
 {
   twoNodeOSPF = runTest {
-    name = "bird-twoNodeOSPF";
+    name = "bird${lib.versions.major package.version}-twoNodeOSPF";
 
     nodes.host1 = makeBirdHost "1";
     nodes.host2 = makeBirdHost "2";

--- a/nixos/tests/clickhouse/base.nix
+++ b/nixos/tests/clickhouse/base.nix
@@ -1,6 +1,6 @@
 { pkgs, package, ... }:
 {
-  name = "clickhouse";
+  name = "clickhouse-${package.version}";
   meta.maintainers = with pkgs.lib.maintainers; [
     jpds
     thevar1able

--- a/nixos/tests/clickhouse/kafka.nix
+++ b/nixos/tests/clickhouse/kafka.nix
@@ -27,7 +27,7 @@ let
   kafkaNamedCollection = pkgs.writeText "kafka.xml" kafkaNamedCollectionConfig;
 in
 {
-  name = "clickhouse-kafka";
+  name = "clickhouse-${package.version}-kafka";
   meta.maintainers = with pkgs.lib.maintainers; [
     jpds
     thevar1able

--- a/nixos/tests/clickhouse/keeper.nix
+++ b/nixos/tests/clickhouse/keeper.nix
@@ -5,7 +5,7 @@
   ...
 }:
 rec {
-  name = "clickhouse-keeper";
+  name = "clickhouse-${package.version}-keeper";
   meta.maintainers = with pkgs.lib.maintainers; [
     jpds
     thevar1able

--- a/nixos/tests/clickhouse/s3.nix
+++ b/nixos/tests/clickhouse/s3.nix
@@ -40,7 +40,7 @@ let
   '';
 in
 {
-  name = "clickhouse-s3";
+  name = "clickhouse-${package.version}-s3";
   meta.maintainers = with pkgs.lib.maintainers; [
     jpds
     thevar1able

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -23,7 +23,7 @@ let
   };
 in
 {
-  name = "discourse";
+  name = "discourse-${package.version}";
   meta.maintainers = with lib.maintainers; [ talyz ];
 
   nodes.discourse =

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -30,7 +30,7 @@ let
     }:
 
     {
-      name = "forgejo-${type}";
+      name = "forgejo-${forgejoPackage.version}-${type}";
       meta.maintainers = lib.teams.forgejo.members;
 
       nodes = {

--- a/nixos/tests/fsck.nix
+++ b/nixos/tests/fsck.nix
@@ -1,7 +1,7 @@
-{ systemdStage1, ... }:
+{ lib, systemdStage1, ... }:
 
 {
-  name = "fsck";
+  name = "fsck" + lib.optionalString systemdStage1 "-systemd-stage-1";
 
   nodes.machine = {
     virtualisation.emptyDiskImages = [ 1 ];

--- a/nixos/tests/garage/basic.nix
+++ b/nixos/tests/garage/basic.nix
@@ -6,7 +6,7 @@
   ...
 }:
 {
-  name = "garage-basic";
+  name = "garage-${package.version}-basic";
 
   nodes = {
     single_node = mkNode {

--- a/nixos/tests/garage/with-3node-replication.nix
+++ b/nixos/tests/garage/with-3node-replication.nix
@@ -18,7 +18,7 @@ let
       };
 in
 {
-  name = "garage-3node-replication";
+  name = "garage-${package.version}-3node-replication";
 
   nodes = {
     node1 = mkNode {

--- a/nixos/tests/hadoop/hadoop.nix
+++ b/nixos/tests/hadoop/hadoop.nix
@@ -4,7 +4,7 @@
 import ../make-test-python.nix (
   { package, ... }:
   {
-    name = "hadoop-combined";
+    name = "hadoop-${package.version}-combined";
 
     nodes =
       let

--- a/nixos/tests/hadoop/hbase.nix
+++ b/nixos/tests/hadoop/hbase.nix
@@ -1,8 +1,8 @@
 # Test a minimal hbase cluster
-{ pkgs, ... }:
+{ package, pkgs, ... }:
 import ../make-test-python.nix (
   {
-    hadoop ? pkgs.hadoop,
+    hadoop ? package,
     hbase ? pkgs.hbase,
     ...
   }:

--- a/nixos/tests/hadoop/hbase.nix
+++ b/nixos/tests/hadoop/hbase.nix
@@ -8,7 +8,7 @@ import ../make-test-python.nix (
   }:
   with pkgs.lib;
   {
-    name = "hadoop-hbase";
+    name = "hadoop-${package.version}-hbase";
 
     nodes =
       let

--- a/nixos/tests/hadoop/hdfs.nix
+++ b/nixos/tests/hadoop/hdfs.nix
@@ -2,7 +2,7 @@
 import ../make-test-python.nix (
   { package, lib, ... }:
   {
-    name = "hadoop-hdfs";
+    name = "hadoop-${package.version}-hdfs";
 
     nodes =
       let

--- a/nixos/tests/hadoop/yarn.nix
+++ b/nixos/tests/hadoop/yarn.nix
@@ -2,7 +2,7 @@
 import ../make-test-python.nix (
   { package, ... }:
   {
-    name = "hadoop-yarn";
+    name = "hadoop-${package.version}-yarn";
 
     nodes = {
       resourcemanager =

--- a/nixos/tests/hbase.nix
+++ b/nixos/tests/hbase.nix
@@ -1,6 +1,11 @@
-{ getPackage, lib, ... }:
 {
-  name = "hbase-standalone";
+  pkgs,
+  getPackage,
+  lib,
+  ...
+}:
+{
+  name = "hbase-${(getPackage pkgs).version}-standalone";
 
   meta = with lib.maintainers; {
     maintainers = [ illustris ];

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -10,7 +10,7 @@
 with import ../lib/testing-python.nix { inherit system pkgs; };
 
 makeTest {
-  name = "hibernate";
+  name = "hibernate" + pkgs.lib.optionalString systemdStage1 "-systemd-stage-1";
 
   nodes = {
     machine =

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,5 +1,10 @@
 # This test starts mongodb and runs a query using mongo shell
-{ config, lib, ... }:
+{
+  testName,
+  config,
+  lib,
+  ...
+}:
 let
   # required for test execution on darwin
   pkgs = config.node.pkgs;
@@ -10,7 +15,7 @@ let
   mongoshExe = lib.getExe pkgs.mongosh;
 in
 {
-  name = "mongodb";
+  name = testName;
   meta.maintainers = with pkgs.lib.maintainers; [
     phile314
     niklaskorz

--- a/nixos/tests/ncps.nix
+++ b/nixos/tests/ncps.nix
@@ -1,11 +1,12 @@
 {
+  testName,
   lib,
   pkgs,
   ...
 }:
 
 {
-  name = "ncps";
+  name = testName;
   meta = with lib.maintainers; {
     maintainers = [
       aciceri

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -24,7 +24,7 @@ import ../make-test-python.nix (
   in
 
   {
-    name = "nfs";
+    name = "nfsv${toString version}-simple";
     meta = {
       maintainers = [ ];
     };

--- a/nixos/tests/nixos-rebuild-target-host.nix
+++ b/nixos/tests/nixos-rebuild-target-host.nix
@@ -1,4 +1,4 @@
-{ hostPkgs, ... }:
+{ hostPkgs, lib, ... }:
 {
   name = "nixos-rebuild-target-host";
 

--- a/nixos/tests/odoo/single-process.nix
+++ b/nixos/tests/odoo/single-process.nix
@@ -4,7 +4,7 @@
   ...
 }:
 {
-  name = "odoo-single-process";
+  name = "odoo-single-process-${package.version}";
   meta.maintainers = with lib.maintainers; [
     mkg20001
     xanderio

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -1,6 +1,7 @@
 # Test printing via CUPS.
 {
   pkgs,
+  testName,
   socket ? true, # whether to use socket activation
   listenTcp ? true, # whether to open port 631 on client
   ...
@@ -11,7 +12,7 @@ let
 in
 
 {
-  name = "printing";
+  name = testName;
   meta = {
     maintainers = [ ];
   };

--- a/nixos/tests/qgis.nix
+++ b/nixos/tests/qgis.nix
@@ -13,7 +13,7 @@ import ./make-test-python.nix (
     };
   in
   {
-    name = "qgis";
+    name = "qgis-${package.version}";
     meta = {
       maintainers = lib.teams.geospatial.members;
     };

--- a/nixos/tests/varnish.nix
+++ b/nixos/tests/varnish.nix
@@ -6,7 +6,7 @@ let
   stateDir = "/var/run/varnishd";
 in
 {
-  name = "varnish";
+  name = "varnish-${package.version}";
   meta = {
     maintainers = [ ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When building multiple tests at once, it can be hard to differentiate between the variations when they only differ by hash. This PR fixes up a bunch of parameterized tests to have unique derivation names.

There is also a fix for `hadoop.hbase` to actually test the provided package, ping @illustris

**Affected tests:**

- akkoma
- akkoma-confined
- avahi
- avahi-with-resolved
- bird2.twoNodeOSPF
- bird3.twoNodeOSPF
- clickhouse-lts.base
- clickhouse-lts.kafka
- clickhouse-lts.keeper
- clickhouse-lts.s3
- clickhouse.base
- clickhouse.kafka
- clickhouse.keeper
- clickhouse.s3
- discourse
- discourseAllPlugins
- forgejo-lts.mysql
- forgejo-lts.postgres
- forgejo-lts.sqlite3
- forgejo.mysql
- forgejo.postgres
- forgejo.sqlite3
- fsck
- fsck-systemd-stage-1
- garage_1.basic
- garage_1.with-3node-replication
- garage_2.basic
- garage_2.with-3node-replication
- hadoop.all
- hadoop.hbase
- hadoop.hdfs
- hadoop.yarn
- hadoop2.all
- hadoop2.hbase
- hadoop2.hdfs
- hadoop2.yarn
- hadoop_3_3.all
- hadoop_3_3.hbase
- hadoop_3_3.hdfs
- hadoop_3_3.yarn
- hbase2
- hbase3
- hbase_2_4
- hbase_2_5
- hibernate
- hibernate-systemd-stage-1

<s>

- incus-lts.all
- incus-lts.appArmor
- incus-lts.container
- incus-lts.lvm
- incus-lts.openvswitch
- incus-lts.ui
- incus-lts.virtual-machine
- incus-lts.zfs
- incus.all
- incus.appArmor
- incus.container
- incus.lvm
- incus.openvswitch
- incus.ui
- incus.virtual-machine
- incus.zfs

</s>

- mongodb
- mongodb-ce
- ncps
- ncps-custom-cache-datapath
- nfs3.simple
- nfs4.simple
- nixos-rebuild-install-bootloader
- nixos-rebuild-install-bootloader-ng
- nixos-rebuild-specialisations
- nixos-rebuild-specialisations-ng
- nixos-rebuild-target-host
- nixos-rebuild-target-host-ng
- odoo
- odoo16
- odoo17
- printing-service
- printing-service-notcp
- printing-socket
- printing-socket-notcp
- qgis
- qgis-ltr
- transmission_3
- transmission_4
- varnish60
- varnish77

I ran this command to ensure everything evals correctly:

```console
NIXPKGS_ALLOW_UNFREE=1 nix derivation show .#nixosTests.akkoma .#nixosTests.akkoma-confined .#nixosTests.bird2.twoNodeOSPF .#nixosTests.bird3.twoNodeOSPF .#nixosTests.mongodb .#nixosTests.mongodb-ce .#nixosTests.ncps .#nixosTests.ncps-custom-cache-datapath .#nixosTests.printing-service .#nixosTests.printing-service-notcp .#nixosTests.printing-socket .#nixosTests.printing-socket-notcp .#nixosTests.avahi .#nixosTests.avahi-with-resolved .#nixosTests.clickhouse.base .#nixosTests.clickhouse.kafka .#nixosTests.clickhouse.keeper .#nixosTests.clickhouse.s3 .#nixosTests.clickhouse-lts.base .#nixosTests.clickhouse-lts.kafka .#nixosTests.clickhouse-lts.keeper .#nixosTests.clickhouse-lts.s3 .#nixosTests.discourse .#nixosTests.discourseAllPlugins .#nixosTests.forgejo.mysql .#nixosTests.forgejo.postgres .#nixosTests.forgejo.sqlite3 .#nixosTests.forgejo-lts.mysql .#nixosTests.forgejo-lts.postgres .#nixosTests.forgejo-lts.sqlite3 .#nixosTests.fsck .#nixosTests.fsck-systemd-stage-1 .#nixosTests.garage_1.basic .#nixosTests.garage_1.with-3node-replication .#nixosTests.garage_2.basic .#nixosTests.garage_2.with-3node-replication .#nixosTests.hadoop.all .#nixosTests.hadoop.hdfs .#nixosTests.hadoop.yarn .#nixosTests.hadoop.hbase .#nixosTests.hadoop2.all .#nixosTests.hadoop2.hdfs .#nixosTests.hadoop2.yarn .#nixosTests.hadoop2.hbase .#nixosTests.hadoop_3_3.all .#nixosTests.hadoop_3_3.hdfs .#nixosTests.hadoop_3_3.yarn .#nixosTests.hadoop_3_3.hbase .#nixosTests.hbase2 .#nixosTests.hbase3 .#nixosTests.hbase_2_4 .#nixosTests.hbase_2_5 .#nixosTests.hibernate .#nixosTests.hibernate-systemd-stage-1 .#nixosTests.nfs3.simple .#nixosTests.nfs4.simple .#nixosTests.nixos-rebuild-install-bootloader .#nixosTests.nixos-rebuild-install-bootloader-ng .#nixosTests.nixos-rebuild-specialisations .#nixosTests.nixos-rebuild-specialisations-ng .#nixosTests.nixos-rebuild-target-host .#nixosTests.nixos-rebuild-target-host-ng .#nixosTests.odoo .#nixosTests.odoo16 .#nixosTests.odoo17 .#nixosTests.qgis .#nixosTests.qgis-ltr .#nixosTests.transmission_3 .#nixosTests.transmission_4 .#nixosTests.varnish60 .#nixosTests.varnish77 --impure
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
