### PR TITLE
python3Packages.opentype-feature-freezer: 0-unstable-2022-07-09 -> 1.0.1

### DIFF
--- a/pkgs/development/python-modules/opentype-feature-freezer/default.nix
+++ b/pkgs/development/python-modules/opentype-feature-freezer/default.nix
@@ -2,35 +2,27 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  unstableGitUpdater,
+  gitUpdater,
   pytestCheckHook,
   fonttools,
-  poetry-core,
-  configparser,
+  hatchling,
   biplist,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "opentype-feature-freezer";
-  version = "0-unstable-2022-07-09";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "twardoch";
     repo = "fonttools-opentype-feature-freezer";
-    rev = "2ae16853bc724c3e377726f81d9fc661d3445827";
-    hash = "sha256-mIWQF9LTVKxIkwHLCTVK1cOuiaduJyX8pyBZ/0RKIVE=";
+    tag = "v${version}";
+    hash = "sha256-8aJYQyUpcEOyzVHZ0LXfGJ1Tsxe5HICcfkFUdsI+/GI=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail poetry.masonry.api poetry.core.masonry.api \
-      --replace-fail "poetry>=" "poetry-core>="
-  '';
-
   build-system = [
-    poetry-core
-    configparser
+    hatchling
   ];
 
   dependencies = [ fonttools ];
@@ -41,17 +33,24 @@ buildPythonPackage {
   ];
 
   disabledTestPaths = [
-    # Wants to check path outside of nix store
+    # import file mismatch
     "src/opentype_feature_freezer/cli.py"
     # NameError: name 'defines' is not defined
     "app/dmgbuild_settings.py"
     # Missing module
     "app/OTFeatureFreezer.py"
-    # AttributeError: 'types.SimpleNamespace' object has no attribute 'suffix'
-    "tests/test_rename.py"
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  disabledTests = [
+    # File not found
+    "test_freeze"
+    # AssertionError: assert '' == '# Scripts an...m,pnum,tnum\n'
+    "test_report"
+    # assert False
+    "test_warn_substituting_glyphs_without_unicode"
+  ];
+
+  passthru.updateScript = gitUpdater { rev = "v"; };
 
   meta = {
     description = "Permanently \"apply\" OpenType features to fonts, by remapping their Unicode assignments";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
