### PR TITLE
[25.05] nixos/ups: remove Slice from UPS shutdown service

### DIFF
--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -359,7 +359,7 @@ let
           {
             MINSUPPLIES = 1;
             MONITOR = <generated from config.power.ups.upsmon.monitor>
-            NOTIFYCMD = "''${pkgs.nut}/bin/upssched";
+            NOTIFYCMD = "''${cfg.package}/bin/upssched";
             POWERDOWNFLAG = "/run/killpower";
             SHUTDOWNCMD = "''${pkgs.systemd}/bin/shutdown now";
           }
@@ -396,7 +396,7 @@ let
             type
           ]
         );
-        NOTIFYCMD = lib.mkDefault "${pkgs.nut}/bin/upssched";
+        NOTIFYCMD = lib.mkDefault "${cfg.package}/bin/upssched";
         POWERDOWNFLAG = lib.mkDefault "/run/killpower";
         SHUTDOWNCMD = lib.mkDefault "${pkgs.systemd}/bin/shutdown now";
       };
@@ -458,6 +458,8 @@ in
         support for Power Devices, such as Uninterruptible Power
         Supplies, Power Distribution Units and Solar Controllers
       '';
+
+      package = lib.mkPackageOption pkgs "nut" { };
 
       mode = lib.mkOption {
         default = "standalone";
@@ -577,7 +579,7 @@ in
     ];
 
     # For interactive use.
-    environment.systemPackages = [ pkgs.nut ];
+    environment.systemPackages = [ cfg.package ];
     environment.variables = envVars;
 
     networking.firewall = lib.mkIf cfg.openFirewall {
@@ -606,8 +608,8 @@ in
         serviceConfig = {
           Type = "forking";
           ExecStartPre = "${createUpsmonConf}";
-          ExecStart = "${pkgs.nut}/sbin/upsmon -u ${cfg.upsmon.user}";
-          ExecReload = "${pkgs.nut}/sbin/upsmon -c reload";
+          ExecStart = "${cfg.package}/sbin/upsmon -u ${cfg.upsmon.user}";
+          ExecReload = "${cfg.package}/sbin/upsmon -c reload";
           LoadCredential = lib.mapAttrsToList (
             name: monitor: "upsmon_password_${name}:${monitor.passwordFile}"
           ) cfg.upsmon.monitor;
@@ -633,8 +635,8 @@ in
           Type = "forking";
           ExecStartPre = "${createUpsdUsers}";
           # TODO: replace 'root' by another username.
-          ExecStart = "${pkgs.nut}/sbin/upsd -u root";
-          ExecReload = "${pkgs.nut}/sbin/upsd -c reload";
+          ExecStart = "${cfg.package}/sbin/upsd -u root";
+          ExecReload = "${cfg.package}/sbin/upsd -c reload";
           LoadCredential = lib.mapAttrsToList (
             name: user: "upsdusers_password_${name}:${user.passwordFile}"
           ) cfg.users;
@@ -655,7 +657,7 @@ in
         Type = "oneshot";
         RemainAfterExit = true;
         # TODO: replace 'root' by another username.
-        ExecStart = "${pkgs.nut}/bin/upsdrvctl -u root start";
+        ExecStart = "${cfg.package}/bin/upsdrvctl -u root start";
         Slice = "system-ups.slice";
       };
       environment = envVars;
@@ -677,7 +679,7 @@ in
       environment = envVars;
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${pkgs.nut}/bin/upsdrvctl shutdown";
+        ExecStart = "${cfg.package}/bin/upsdrvctl shutdown";
         Slice = "system-ups.slice";
       };
     };
@@ -702,14 +704,14 @@ in
       "nut/upsmon.conf".source = "/run/nut/upsmon.conf";
     };
 
-    power.ups.schedulerRules = lib.mkDefault "${pkgs.nut}/etc/upssched.conf.sample";
+    power.ups.schedulerRules = lib.mkDefault "${cfg.package}/etc/upssched.conf.sample";
 
     systemd.tmpfiles.rules = [
       "d /var/state/ups -"
       "d /var/lib/nut 700"
     ];
 
-    services.udev.packages = [ pkgs.nut ];
+    services.udev.packages = [ cfg.package ];
 
     users.users.nutmon = lib.mkIf (cfg.upsmon.user == "nutmon") {
       isSystemUser = true;

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -680,7 +680,6 @@ in
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${cfg.package}/bin/upsdrvctl shutdown";
-        Slice = "system-ups.slice";
       };
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Backport "nixos/ups: remove Slice from UPS shutdown service" to fix
ups-killpower.service not getting run at shutdown.

Also backport "nixos/ups: add package option" while at it, because it's a dependency of the above, and a simple change.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
