### PR TITLE
evil-winrm: 3.5 -> 3.7, fix kerberos issue, add ssl provider support

### DIFF
--- a/pkgs/by-name/ev/evil-winrm/Gemfile.lock
+++ b/pkgs/by-name/ev/evil-winrm/Gemfile.lock
@@ -1,11 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
-    bigdecimal (3.1.9)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
     builder (3.3.0)
     erubi (1.13.1)
-    ffi (1.17.1)
+    ffi (1.17.2)
     fileutils (1.7.3)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
@@ -15,19 +15,19 @@ GEM
     httpclient (2.9.0)
       mutex_m
     little-plugger (1.1.4)
-    logger (1.6.6)
+    logger (1.7.0)
     logging (2.4.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
-    multi_json (1.15.0)
+    multi_json (1.17.0)
     mutex_m (0.3.0)
     nori (2.7.1)
       bigdecimal
-    rexml (3.4.1)
+    rexml (3.4.4)
     rubyntlm (0.6.5)
       base64
     rubyzip (2.4.1)
-    stringio (3.1.5)
+    stringio (3.1.7)
     winrm (2.3.9)
       builder (>= 2.1.2)
       erubi (~> 1.8)
@@ -55,4 +55,4 @@ DEPENDENCIES
   winrm-fs
 
 BUNDLED WITH
-   2.6.2
+   2.7.1

--- a/pkgs/by-name/ev/evil-winrm/gemset.nix
+++ b/pkgs/by-name/ev/evil-winrm/gemset.nix
@@ -4,20 +4,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "01qml0yilb9basf7is2614skjp8384h2pycfx86cr8023arfj98g";
+      sha256 = "0yx9yn47a8lkfcjmigk79fykxvr80r4m1i35q82sxzynpbm7lcr7";
       type = "gem";
     };
-    version = "0.2.0";
+    version = "0.3.0";
   };
   bigdecimal = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1k6qzammv9r6b2cw3siasaik18i6wjc5m0gw5nfdc6jj64h79z1g";
+      sha256 = "0612spks81fvpv2zrrv3371lbs6mwd7w6g5zafglyk75ici1x87a";
       type = "gem";
     };
-    version = "3.1.9";
+    version = "3.3.1";
   };
   builder = {
     groups = [ "default" ];
@@ -44,10 +44,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0fgwn1grxf4zxmyqmb9i4z2hr111585n9jnk17y6y7hhs7dv1xi6";
+      sha256 = "19kdyjg3kv7x0ad4xsd4swy5izsbb1vl1rpb6qqcqisr5s23awi9";
       type = "gem";
     };
-    version = "1.17.1";
+    version = "1.17.2";
   };
   fileutils = {
     groups = [ "default" ];
@@ -110,10 +110,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "05s008w9vy7is3njblmavrbdzyrwwc1fsziffdr58w9pwqj8sqfx";
+      sha256 = "00q2zznygpbls8asz5knjvvj2brr3ghmqxgr83xnrdj4rk3xwvhr";
       type = "gem";
     };
-    version = "1.6.6";
+    version = "1.7.0";
   };
   logging = {
     dependencies = [
@@ -134,10 +134,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0pb1g1y3dsiahavspyzkdy39j4q377009f6ix0bh1ag4nqw43l0z";
+      sha256 = "06sabsvnw0x1aqdcswc6bqrqz6705548bfd8z22jxgxfjrn1yn3n";
       type = "gem";
     };
-    version = "1.15.0";
+    version = "1.17.0";
   };
   mutex_m = {
     groups = [ "default" ];
@@ -165,10 +165,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1jmbf6lf7pcyacpb939xjjpn1f84c3nw83dy3p1lwjx0l2ljfif7";
+      sha256 = "0hninnbvqd2pn40h863lbrn9p11gvdxp928izkag5ysx8b1s5q0r";
       type = "gem";
     };
-    version = "3.4.1";
+    version = "3.4.4";
   };
   rubyntlm = {
     dependencies = [ "base64" ];
@@ -196,10 +196,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1j1mgvrgkxhadi6nb6pz1kcff7gsb5aivj1vfhsia4ssa5hj9adw";
+      sha256 = "1yh78pg6lm28c3k0pfd2ipskii1fsraq46m6zjs5yc9a4k5vfy2v";
       type = "gem";
     };
-    version = "3.1.5";
+    version = "3.1.7";
   };
   winrm = {
     dependencies = [

--- a/pkgs/by-name/ev/evil-winrm/package.nix
+++ b/pkgs/by-name/ev/evil-winrm/package.nix
@@ -6,6 +6,7 @@
   bundlerEnv,
   bundlerUpdateScript,
   writeText,
+  krb5,
   sslLegacyProvider ? false,
 }:
 let
@@ -57,7 +58,9 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = lib.optionalString sslLegacyProvider ''
-    wrapProgram $out/bin/evil-winrm --prefix OPENSSL_CONF : "${openssl_conf}"
+    wrapProgram $out/bin/evil-winrm \
+      --prefix OPENSSL_CONF : "${openssl_conf}" \
+      --prefix LD_LIBRARY_PATH : ${krb5.lib}/lib
   '';
 
   passthru.updateScript = bundlerUpdateScript "evil-winrm";

--- a/pkgs/by-name/ev/evil-winrm/package.nix
+++ b/pkgs/by-name/ev/evil-winrm/package.nix
@@ -35,13 +35,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "evil-winrm";
-  version = "3.5";
+  version = "3.7";
 
   src = fetchFromGitHub {
     owner = "Hackplayers";
     repo = "evil-winrm";
     tag = "v${version}";
-    hash = "sha256-8Lyo7BgypzrHMEcbYlxo/XWwOtBqs2tczYnc3+XEbeA=";
+    hash = "sha256-jr8glS732UvSt+qFkhhLFZUB7OIRpRj3SzXm6mVikrE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- I continue with [Iynaix's PR](https://github.com/NixOS/nixpkgs/pull/324530). That pr solves the following [ISSUE](https://github.com/NixOS/nixpkgs/issues/255276).

- Fixed a kerberos Issue related to `libgssapi_krb5.so.2`.

- Updated evil-winrm package to the [latest available version (3.7)
](https://github.com/Hackplayers/evil-winrm/releases/tag/v3.7)

```nushell
Error: An error of type LoadError happened, message is Could not open library 'libgssapi_krb5.so.2': libgssapi_krb5.so.2: cannot open shared object file: No such file or directory.
Searched in <system library path>
```
To reproduce the bug:

```nu
# This need a krb5.conf available
evil-winrm -i <IP> -k -u <USER> -r <DOMAIN>
```


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.