### PR TITLE
fortitude: init at 0.7.5-unstable-2025-10-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14897,7 +14897,7 @@
     name = "Isaac Silverstein";
   };
   loicreynier = {
-    email = "loic@loicreynier.fr";
+    email = "contact@loicreynier.fr";
     github = "loicreynier";
     githubId = 88983487;
     name = "Loïc Reynier";

--- a/pkgs/by-name/fo/fortitude/package.nix
+++ b/pkgs/by-name/fo/fortitude/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "fortitude";
+  version = "0.7.5-unstable-2025-10-14";
+
+  src = fetchFromGitHub {
+    owner = "PlasmaFAIR";
+    repo = "fortitude";
+    rev = "ca65546d69947500eeb37a2bbc58151012ab40d9";
+    hash = "sha256-PKOPQnVQbvqEoCPO9K3ofajbcId83uLbma6R9RiBzys=";
+  };
+
+  cargoHash = "sha256-hNAONXSy1uxm7AHvMHWNboL9NpQfvEOfTQivushp7S4=";
+
+  meta = {
+    description = "Fortran linter written in Rust inspired by Ruff";
+    homepage = "https://fortitude.readthedocs.io/en/stable/";
+    downloadPage = "https://github.com/PlasmaFAIR/fortitude";
+    changelog = "https://github.com/PlasmaFAIR/fortitude/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "fortitude";
+    maintainers = with lib.maintainers; [ loicreynier ];
+    platforms = with lib.platforms; windows ++ darwin ++ linux;
+  };
+}


### PR DESCRIPTION
Add Fortitude (Fortran linter written in Rust). Using `0.7.5-unstable-2025-10-14` instead of `0.7.5` to incorporate Nix support in tests (see https://github.com/PlasmaFAIR/fortitude/pull/526).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
