### PR TITLE
configarr: add package

### DIFF
--- a/pkgs/by-name/co/configarr/package.nix
+++ b/pkgs/by-name/co/configarr/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+let
+  version = "1.17.1";
+  systemMap = {
+    "x86_64-linux" = {
+      url = "https://github.com/raydak-labs/configarr/releases/download/v${version}/configarr-linux-x64.tar.xz";
+      hash = "sha256:786d8c4c3921cbc4fc2df21ecdd3945046c178776db952bf3e038138f1ac8110";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/raydak-labs/configarr/releases/download/v${version}/configarr-linux-arm64.tar.xz";
+      hash = "sha256:9f2754176b54d44308b46dd2efb8a40d73aa5491c4d7f4b1325b0ed0c536577f";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/raydak-labs/configarr/releases/download/v${version}/configarr-darwin-x64.tar.xz";
+      hash = "sha256:4016be5500b47c029d6c3a396d2624846ebc0dc0bfa1aeeb8fe5ad11d42f4a4f";
+    };
+    "aarch64-darwin" = {
+      url = "https://github.com/raydak-labs/configarr/releases/download/v${version}/configarr-darwin-arm64.tar.xz";
+      hash = "sha256:744239eba8566e91fbbcc64a685e25e434de55aae036af0e0256f297ce73f119";
+    };
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "configarr";
+  inherit version;
+
+  src = fetchurl (systemMap.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}"));
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 configarr $out/bin/configarr
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Sync TRaSH Guides + custom configs with *arr applications";
+    homepage = "https://configarr.de";
+    changelog = "https://github.com/raydak-labs/configarr/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ BlackDark ];
+    mainProgram = "configarr";
+    platforms = with lib.platforms; [ x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin ];
+  };
+}

--- a/pkgs/by-name/co/configarr/package.nix
+++ b/pkgs/by-name/co/configarr/package.nix
@@ -29,11 +29,17 @@ stdenvNoCC.mkDerivation {
   pname = "configarr";
   inherit version;
 
-  src = fetchurl (systemMap.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}"));
+  src = fetchurl (systemMap.${stdenvNoCC.hostPlatform.system} or
+    (throw "Configarr does not support system: ${stdenvNoCC.hostPlatform.system}"));
+
+  dontConfigure = true;
+  dontBuild = true;
+  sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall
 
+    mkdir -p $out/bin
     install -Dm755 configarr $out/bin/configarr
 
     runHook postInstall
@@ -46,6 +52,7 @@ stdenvNoCC.mkDerivation {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ BlackDark ];
     mainProgram = "configarr";
-    platforms = with lib.platforms; [ x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds configarr to nixpkgs. Had a couple of requests and now finally released some binaries for testing which have been created with bun to avoid installing node + deps for getting configarr running.

Ref: https://github.com/raydak-labs/configarr/releases/tag/v1.17.1

Binaries are compressed with xz.

Never used nixos before so not sure how to test. 
If anyone could give it try and say if the executable is working then great :) 

Related: 
- https://github.com/NixOS/nixpkgs/pull/402381
- https://github.com/NixOS/nixpkgs/issues/400393
- https://github.com/raydak-labs/configarr/issues/272

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
