### PR TITLE
svg-term: init at 2.1.1

### DIFF
--- a/pkgs/by-name/sv/svg-term/package.nix
+++ b/pkgs/by-name/sv/svg-term/package.nix
@@ -1,0 +1,54 @@
+{
+  asciinema,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  lib,
+  makeWrapper,
+  nodejs,
+  stdenv,
+  versionCheckHook,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "svg-term";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "marionebl";
+    repo = "svg-term-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sB4/SM48UmqaYKj6kzfjzITroL0l/QL4Gg5GSrQ+pdk=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-4Q1NP3VhnACcrZ1XUFPtgSlk1Eh8Kp02rOgijoRJFcI=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    yarnBuildHook
+    yarnConfigHook
+    yarnInstallHook
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  # Some things work without asciinema on the PATH, but --command does not.
+  postInstall = ''
+    wrapProgram $out/bin/svg-term --prefix PATH : ${lib.makeBinPath [ asciinema ]}
+  '';
+
+  meta = {
+    description = "Share terminal sessions as razor-sharp animated SVG everywhere";
+    homepage = "https://github.com/marionebl/svg-term-cli";
+    license = lib.licenses.mit;
+    mainProgram = "svg-term";
+    maintainers = with lib.maintainers; [ samestep ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds https://github.com/marionebl/svg-term-cli/tree/v2.1.1 as a package.

Note that this build does give slightly different outputs from just running the same program via `npx svg-term-cli`; I suspect that's due to npm using different versions of the dependencies from what is specified in `yarn.lock`, which in particular specifies [v1.1.3 of the underlying svg-term library](https://github.com/marionebl/svg-term-cli/blob/v2.1.1/yarn.lock#L3126-L3127) in contrast to the later [v1.3.1 that also exists](https://github.com/marionebl/svg-term/tree/v1.3.1) which is I assume what `npx` chooses. Either way, though, the outputs do seem to work fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
