### PR TITLE
poppler: 25.07.0 → 25.10.0

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -99,13 +99,23 @@ stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "fix-build-poppler-25.06.0.patch";
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/97bd8f29a61e691ceea98ca2444b974cf4256ae0.patch";
+      url = "https://gitlab.com/inkscape/inkscape/-/commit/40f5b15b7e29908b79c54e81db6f340936102e08.patch";
       hash = "sha256-bYRd/KUh/7qFb7x0EuUgQYA9P8abcTf5XS67gzaAiXA=";
     })
     (fetchpatch {
       name = "fix-build-poppler-25.07.0.patch";
-      url = "https://gitlab.com/inkscape/inkscape/-/commit/ce52c5f96106ae5747171663a46831f21aa52d95.patch";
-      hash = "sha256-3Yj+neSRSSQPeeZkHJ0P6v3Sis/lg9xiygktI6Z+zDY=";
+      url = "https://gitlab.com/inkscape/inkscape/-/commit/8ae83ca81bbaebcc0ff0abe82300d56d2c94e6f9.patch";
+      hash = "sha256-s7UMnv1pAiQA/HL5CEdBwCn4v/tsphc0MSnBJAoqolY=";
+    })
+    (fetchpatch {
+      name = "fix-build-poppler-25.09.0.patch";
+      url = "https://gitlab.com/inkscape/inkscape/-/commit/f48b429827dca510b41a5671d467e574ef348625.patch";
+      hash = "sha256-9CfmkTGMVHjZiiE3zvi4YOrytcir8a7O2z3PrhjcohI=";
+    })
+    (fetchpatch {
+      name = "fix-build-poppler-25.10.0.patch";
+      url = "https://gitlab.com/inkscape/inkscape/-/commit/4dba481fe898c6317696d50b109f5aed8f269c19.patch";
+      hash = "sha256-FFCkMU+Ec2qobG4ru89NPcM9Gxw8ZyFV+6jpW8ZwgE4=";
     })
   ];
 

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -314,6 +314,19 @@ stdenv.mkDerivation (finalAttrs: {
     # Revert part of https://github.com/LibreOffice/core/commit/6f60670877208612b5ea320b3677480ef6508abb that broke zlib linking
     ./readd-explicit-zlib-link.patch
 
+    # Backport patch to fix build with Poppler 25.09
+    (fetchpatch2 {
+      url = "https://github.com/LibreOffice/core/commit/7848e02819c007026952a3fdc9da0961333dc079.patch";
+      includes = [ "sdext/*" ];
+      hash = "sha256-Nw6GFmkFy13w/ktCxw5s7SHL34auP1BQ9JvQnQ65aVU=";
+    })
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "25.8") [
+    # Fix build with Poppler 25.10
+    (fetchpatch2 {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libreoffice-fresh/-/raw/41e58e117c356af2be83993595caf61f9f30cc89/poppler-25.10.patch";
+      hash = "sha256-KMsjDtRRH8Vy/FXaVwxUo0Ww10PCE0sK8+ZL0Ja2kJQ=";
+    })
   ]
   ++ lib.optionals (variant == "collabora") [
     # Backport patch to fix build with Poppler 25.05

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -335,6 +335,11 @@ stdenv.mkDerivation (finalAttrs: {
       includes = [ "sdext/*" ];
       hash = "sha256-8yipl5ln1yCNfVM8SuWowsw1Iy/SXIwbdT1ZfNw4cJA=";
     })
+    # Fix build with Poppler 25.10
+    (fetchpatch2 {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libreoffice-still/-/raw/f5241554e4a0f6fd95ac4e5cc398a30243407e6a/fix_build_with_poppler_25.10.patch";
+      hash = "sha256-lbPOkc1HeT5Qsp6XfVyVJtmvSL68qTrmbd3q9lvKSu8=";
+    })
   ]
   ++ lib.optionals (variant == "collabora") [
     ./fix-unpack-collabora.patch

--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   useMinimalFeatures ? false,
   useArmadillo ? (!useMinimalFeatures),
@@ -91,6 +92,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-CFQF3vDhhXsAnIfUcn6oTQ4Xm+GH/36dqSGc0HvyEJ0=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-build-poppler-25.10.0.patch";
+      url = "https://github.com/OSGeo/gdal/commit/a716a6cd5ffd779b30950f046fce91878fc97b9d.patch";
+      hash = "sha256-dSotpnTiMjt3Bz63hpNjF5juZ3JsjIpD59/67cR9rNU=";
+    })
+  ];
 
   nativeBuildInputs = [
     bison

--- a/pkgs/by-name/sc/scribus/package.nix
+++ b/pkgs/by-name/sc/scribus/package.nix
@@ -121,6 +121,16 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/scribusproject/scribus/commit/13fc4f874354511e05bf91a48703b57b4c489715.patch";
       hash = "sha256-+pbQ77SaTh04QX55wmS6WeuZf3IGe5nq3pmrhk68tb8=";
     })
+    (fetchpatch {
+      name = "fix-build-poppler-25.09.0.patch";
+      url = "https://github.com/scribusproject/scribus/commit/f0cfe30019a514bdaf38b78590451e2c5b9b5420.patch";
+      hash = "sha256-ONQ3BzGhouO+0zqYUObuJC3NUCFi1PWq6qoRvuSZJws=";
+    })
+    (fetchpatch {
+      name = "fix-build-poppler-25.10.0.patch";
+      url = "https://github.com/scribusproject/scribus/commit/3c1fc34fae1aa26fceb65b6bdf631a7f00b03c3c.patch";
+      hash = "sha256-xTwzbT3h4+5hb6Y/sNmzkfDN2LJGOLP1v/WBVsmZXkk=";
+    })
   ];
 
   meta = {

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -55,13 +55,13 @@ let
     domain = "gitlab.freedesktop.org";
     owner = "poppler";
     repo = "test";
-    rev = "c79c6839e859dbee6b73ac260788fa2de8618ba4";
-    hash = "sha256-j66AsBUnFpO5athVgQmf4vcyXxYcJ/plJtHg+3vXG4Y=";
+    rev = "9d5011815a14c157ba25bb160187842fb81579a5";
+    hash = "sha256-sA5f235IJpzzzHqpwHM3zCZC2Yh0ztA6PZa84j/6tfY=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "poppler-${suffix}";
-  version = "25.07.0"; # beware: updates often break cups-filters build, check scribus too!
+  version = "25.10.0"; # beware: updates often break cups-filters build, check scribus too!
 
   outputs = [
     "out"
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://poppler.freedesktop.org/poppler-${finalAttrs.version}.tar.xz";
-    hash = "sha256-xQSpBm29/r43etU87GQf2XHulsTh6Mp05snAPUbYF64=";
+    hash = "sha256-a16btk2rsVeHoU2xZ1KRx6+vk4dDjMk6T7f2rsTub+A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-25.10.0/NEWS
https://gitlab.freedesktop.org/poppler/poppler/-/compare/poppler-25.07.0...poppler-25.10.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Successfully built the following reverse dependencies:
	- [x] `poppler.tests.cups-filters`
	- [x] `poppler.tests.inkscape`
	- [x] `poppler.tests.scribus`
	- [x] `poppler.tests.gegl`
	- [x] ~~`poppler.tests.pdfslicer`~~ failed due to unrelated CMake issue
	- [x] `poppler.tests.vips`
	- [x] `poppler.tests.gdal`
	- [x] `poppler.tests.python-poppler-qt5`
	- [x] `libreoffice-fresh`
	- [x] `libreoffice-still`
	- [x] `gimp`
	- [x]  `miktex`
	- [x] `poppler-qt6`
	- [x] `zathuraPkgs.zathura_pdf_poppler`
	- [x] `diffpdf`
	- [x] `xournalpp`
	- [x] `mate.atril`
	- [x] `qpdfview`
	- [x] `xfce.tumbler`
	- [x] `enlightenment.efl`
	- [x] `python3.pkgs.python-poppler`
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
