### PR TITLE
nvrs: init at 0.1.9

### DIFF
--- a/nixos/modules/programs/nvrs.nix
+++ b/nixos/modules/programs/nvrs.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.nvrs;
+  settingsFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ adamperkowski ];
+
+  options.programs.nvrs = {
+    enable = lib.mkEnableOption "nvrs";
+
+    package = lib.mkPackageOption pkgs "nvrs" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+      };
+
+      default = { };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/nvrs/config.toml`
+
+        See <https://nvrs.adamperkowski.dev/configuration.html> for details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc = {
+      "nvrs/nvrs.toml" = lib.mkIf (cfg.settings != { }) {
+        source = settingsFormat.generate "nvrs-config.toml" cfg.settings;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/nv/nvrs/package.nix
+++ b/pkgs/by-name/nv/nvrs/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  nix-update-script,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nvrs";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "adamperkowski";
+    repo = "nvrs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6ATkebFYuOOvhzSO+gClPbtaz9/Zph4m8/cqkufRYFw=";
+  };
+
+  cargoHash = "sha256-h3egaj4RQImxIf0MB8ZM9V92Xlml5BK++s7RJQwAk+E=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  buildFeatures = [ "cli" ];
+  cargoBuildFlags = [
+    "--bin"
+    "nvrs"
+  ];
+
+  # Skip tests that rely on network access.
+  # We're also not running cli tokio tests because they don't implement skipping functionality.
+  cargoTestFlags = [
+    "--lib"
+    "--"
+    "--skip=api::aur::request_test"
+    "--skip=api::crates_io::request_test"
+    "--skip=api::gitea::request_test"
+    "--skip=api::github::request_test"
+    "--skip=api::gitlab::request_test"
+    "--skip=api::regex::request_test"
+  ];
+
+  passthru.update-script = nix-update-script { };
+
+  meta = {
+    description = "Fast new version checker for software releases";
+    homepage = "https://nvrs.adamperkowski.dev";
+    changelog = "https://github.com/adamperkowski/nvrs/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ adamperkowski ];
+    mainProgram = "nvrs";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
nvrs is an alternative to [nvchecker](https://github.com/lilydjwg/nvchecker). It's a CLI toolthat fetches newest software releases.
[GitHub Repo](https://github.com/adamperkowski/nvrs?tab=readme-ov-file)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
