### PR TITLE
gnome-themes-extra: drop gtk2, clean up derivation

### DIFF
--- a/pkgs/by-name/gn/gnome-themes-extra/package.nix
+++ b/pkgs/by-name/gn/gnome-themes-extra/package.nix
@@ -14,18 +14,18 @@
   hicolor-icon-theme,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-themes-extra";
   version = "3.28";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-themes-extra/${lib.versions.majorMinor version}/gnome-themes-extra-${version}.tar.xz";
+    url = "mirror://gnome/sources/gnome-themes-extra/${lib.versions.majorMinor finalAttrs.version}/gnome-themes-extra-${finalAttrs.version}.tar.xz";
     hash = "sha256-fEugv/AB8G2Jg8/BBa2qxC3x0SZ6JZF5ingLrFV6WBk=";
   };
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gnome-themes-extra";
     };
   };
 
@@ -58,8 +58,8 @@ stdenv.mkDerivation rec {
     gtk-update-icon-cache "$out"/share/icons/HighContrast
   '';
 
-  meta = with lib; {
-    platforms = platforms.unix;
-    teams = [ teams.gnome ];
+  meta = {
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.gnome ];
   };
-}
+})

--- a/pkgs/by-name/gn/gnome-themes-extra/package.nix
+++ b/pkgs/by-name/gn/gnome-themes-extra/package.nix
@@ -10,7 +10,6 @@
   pkg-config,
   pango,
   atk,
-  gtk2,
   gdk-pixbuf,
   hicolor-icon-theme,
 }:
@@ -35,17 +34,22 @@ stdenv.mkDerivation rec {
     intltool
     gtk3
   ];
+
   buildInputs = [
     gtk3
     librsvg
     pango
     atk
-    gtk2
     gdk-pixbuf
   ];
+
   propagatedBuildInputs = [
     adwaita-icon-theme
     hicolor-icon-theme
+  ];
+
+  configureFlags = [
+    (lib.enableFeature false "gtk2-engine")
   ];
 
   dontDropIconThemeCache = true;


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/410814

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
