### PR TITLE
fireminipro: init at v0.0.7

### DIFF
--- a/pkgs/by-name/fi/fireminipro/package.nix
+++ b/pkgs/by-name/fi/fireminipro/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  qt6,
+  minipro,
+  libxkbcommon,
+  mesa,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fireminipro";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "Jartza";
+    repo = "fireminipro";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+flVdPInMBnQgQyqXkbvrMcth0/4yII36xdjSnfe+wE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    minipro
+    libxkbcommon
+    mesa
+  ];
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    if [ "$system" = "x86_64-darwin" ] || [ "$system" = "aarch64-darwin" ]; then
+      install -D fireminipro.app/Contents/MacOS/fireminipro --target-directory=$out/bin
+    else
+      install -D fireminipro --target-directory=$out/bin
+    fi
+
+    runHook postInstall
+  '';
+
+  patches = [ ./darwin-finder.patch ];
+
+
+  meta = {
+    description = "Modern, cross-platform graphical front-end for the Minipro programmer software";
+    homepage = "https://github.com/Jartza/fireminipro";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nulleric ];
+    mainProgram = "fireminipro";
+  };
+})


### PR DESCRIPTION
Useful minipro gui - https://github.com/Jartza/fireminipro

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
