### PR TITLE
python3Packages: transition from pytestFlagsArray (2nd round)

### DIFF
--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -214,10 +214,13 @@ buildPythonPackage (finalAttrs: {
     "test_muster_specific_targets_with_dependencies"
   ];
 
-  # in order to use pytest marker, we need to use ppytestFlagsArray
-  # using pytestFlags causes `ERROR: file or directory not found: slow`
-  pytestFlagsArray = [
-    "-m='not slow and not not_in_ci and not regression'"
+  disabledTestMarks = [
+    "slow"
+    "not_in_ci"
+    "regression"
+  ];
+
+  pytestFlags = [
     "--timeout=10" # any test taking long, timouts with more than 60s
     "--benchmark-disable"
     "--tb=line"

--- a/pkgs/development/python-modules/dbt-snowflake/default.nix
+++ b/pkgs/development/python-modules/dbt-snowflake/default.nix
@@ -36,9 +36,9 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "tests/unit" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # pyproject.toml specifies -n auto which only pytest-xdist understands
-    "--override-ini addopts=''"
+    "--override-ini=addopts="
   ];
 
   pythonImportsCheck = [ "dbt.adapters.snowflake" ];

--- a/pkgs/development/python-modules/hydra-joblib-launcher/default.nix
+++ b/pkgs/development/python-modules/hydra-joblib-launcher/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   # tries to write to source directory otherwise:
-  pytestFlagsArray = [ "-p no:cacheprovider" ];
+  pytestFlags = [ "-pno:cacheprovider" ];
 
   meta = {
     inherit (hydra-core.meta) changelog license;

--- a/pkgs/development/python-modules/langchain-experimental/default.nix
+++ b/pkgs/development/python-modules/langchain-experimental/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  enabledTestPaths = [ "tests/unit_tests" ];
 
   pythonImportsCheck = [ "langchain_experimental" ];
 

--- a/pkgs/development/python-modules/mpl-typst/default.nix
+++ b/pkgs/development/python-modules/mpl-typst/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  pytestFlagsArray = [ "-v" ];
+  pytestFlags = [ "-v" ];
 
   pythonImportsCheck = [
     "mpl_typst"

--- a/pkgs/development/python-modules/outlines/default.nix
+++ b/pkgs/development/python-modules/outlines/default.nix
@@ -120,7 +120,7 @@ buildPythonPackage (finalAttrs: {
     tensorflow
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # FutureWarning: functools.partial will be a method descriptor in future Python versions; wrap it in enum.member() if you want to preserve the old behavior
     "-Wignore::FutureWarning"
   ];

--- a/pkgs/development/python-modules/pgspecial/default.nix
+++ b/pkgs/development/python-modules/pgspecial/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     postgresql
   ];
 
-  pytestFlagsArray = [ "-vvv" ];
+  pytestFlags = [ "-vvv" ];
 
   env = {
     PGDATABASE = "_test_db";

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -52,11 +52,11 @@ buildPythonPackage rec {
     })
   ];
 
-  pytestFlagsArray = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+  disabledTestPaths = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # AssertionError: Arrays are not almost equal to 6 decimals
-    "--deselect=tests/distributions/test_normal_full.py::test_fit"
-    "--deselect=tests/distributions/test_normal_full.py::test_from_summaries"
-    "--deselect=tests/distributions/test_normal_full.py::test_serialization"
+    "tests/distributions/test_normal_full.py::test_fit"
+    "tests/distributions/test_normal_full.py::test_from_summaries"
+    "tests/distributions/test_normal_full.py::test_serialization"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/pyoprf/default.nix
+++ b/pkgs/development/python-modules/pyoprf/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "tests/test.py" ];
+  enabledTestPaths = [ "tests/test.py" ];
 
   meta = {
     homepage = "https://github.com/stef/liboprf/tree/master/python";

--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -105,10 +105,13 @@ let
       rm -r skimage
     '';
 
-    pytestFlagsArray = [
-      "${installedPackageRoot}"
+    pytestFlags = [
       "--pyargs"
       "skimage"
+    ];
+
+    enabledTestPaths = [
+      installedPackageRoot
     ];
 
     disabledTestPaths = [

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -290,7 +290,7 @@ buildPythonPackage {
   ++ optional-dependencies.api
   ++ optional-dependencies.similarity;
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "test/python/*"
   ];
 


### PR DESCRIPTION
The remaining use of `pytestFlagsArray` is in `python3Packages.pyarrow`, which is being addressed by
- #426611

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
