### PR TITLE
commitmsgfmt: add updateScript and update

### DIFF
--- a/pkgs/by-name/co/commitmsgfmt/package.nix
+++ b/pkgs/by-name/co/commitmsgfmt/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   testers,
   commitmsgfmt,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "commitmsgfmt";
@@ -22,6 +23,7 @@ rustPlatform.buildRustPackage rec {
     package = commitmsgfmt;
     command = "commitmsgfmt -V";
   };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://gitlab.com/mkjeldsen/commitmsgfmt";

--- a/pkgs/by-name/co/commitmsgfmt/package.nix
+++ b/pkgs/by-name/co/commitmsgfmt/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "commitmsgfmt";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitLab {
     owner = "mkjeldsen";
     repo = "commitmsgfmt";
     rev = "v${version}";
-    hash = "sha256-HEkPnTO1HeJg8gpHFSUTkEVBPWJ0OdfUhNn9iGfaDD4=";
+    hash = "sha256-6mMjDMWkpaKXqmyE2taV4pDa92Tdt4VEHHLdOpRHung=";
   };
 
-  cargoHash = "sha256-cej+Jpp12QEaru1mecuXtIFDEnSBvTwpx0Vgp8s7jj8=";
+  cargoHash = "sha256-Ewn7NCFtl8phC5cFyLWZcGZy4w+huummzeuXFRn64lQ=";
 
   passthru.tests.version = testers.testVersion {
     package = commitmsgfmt;


### PR DESCRIPTION
## Things done

1. Added updateScript config
2. Updated to latest release: https://gitlab.com/mkjeldsen/commitmsgfmt/-/releases/v1.7.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
