### PR TITLE
bambu-studio: 02.02.02.56 -> 02.03.00.70; fix CMake 4.0 build faliure

### DIFF
--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -119,6 +119,27 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/no-osmesa.patch
   ];
 
+  # Please remove CMake patches after the upstream issue gets resolved.
+  # https://github.com/bambulab/BambuStudio/issues/8415
+  postPatch = ''
+    substituteInPlace src/{admesh,boost,clipper,miniz,glu-libtess,Shiny,semver,imgui,imguizmo}/CMakeLists.txt \
+      --replace-fail \
+      'cmake_minimum_required(VERSION 2.8.12)' \
+      'cmake_minimum_required(VERSION 3.5)'
+
+    substituteInPlace src/{minilzo,qhull}/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 2.6)' \
+      'cmake_minimum_required(VERSION 3.5)'
+
+    substituteInPlace cmake/modules/FindOpenVDB.cmake --replace-fail \
+      'cmake_minimum_required(VERSION 3.3)' \
+      'cmake_minimum_required(VERSION 3.5)'
+
+    substituteInPlace src/libigl/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.0)' \
+      'cmake_minimum_required(VERSION 3.5)'
+  '';
+
   doCheck = true;
   checkInputs = [ gtest ];
 

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -56,13 +56,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bambu-studio";
-  version = "02.02.02.56";
+  version = "02.03.00.70";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vg+sEIztFBfzROl2surRd4l/afZ+tGMtG65m3kDIPAY=";
+    hash = "sha256-2duNeSBi2WvsAUxkzTbKH+SiliNovc7LVICTzgQkrN8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Resolves #451897

Upstream issue: https://github.com/bambulab/BambuStudio/issues/8415

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
