### PR TITLE
python3Packages.setproctitle: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/setproctitle/default.nix
+++ b/pkgs/development/python-modules/setproctitle/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   ];
 
   # Setting the process title fails on macOS in the Nix builder environment (regardless of sandboxing)
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [ "test_setproctitle_darwin" ];
+  disabledTests = if stdenv.hostPlatform.isDarwin then [ "test_setproctitle_darwin" ] else null;
 
   pythonImportsCheck = [ "setproctitle" ];
 

--- a/pkgs/development/python-modules/setproctitle/default.nix
+++ b/pkgs/development/python-modules/setproctitle/default.nix
@@ -5,6 +5,7 @@
   setuptools,
   pytestCheckHook,
   procps,
+  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,9 @@ buildPythonPackage rec {
     pytestCheckHook
     procps
   ];
+
+  # Setting the process title fails on macOS in the Nix builder environment (regardless of sandboxing)
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [ "test_setproctitle_darwin" ];
 
   pythonImportsCheck = [ "setproctitle" ];
 


### PR DESCRIPTION
Ref: https://github.com/NixOS/nixpkgs/pull/449539

Some tests got re-enabled in https://github.com/NixOS/nixpkgs/pull/444696, but one of them fails on Darwin: https://github.com/dvarrazzo/py-setproctitle/blob/master/tests/setproctitle_test.py#L73C5-L73C29

I couldn't figure out the root cause, maybe it has to do with the Nix builder environment or the nixbld user running the tests? I verified that the library works when invoked from a Nix shell by a regular user.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
