### PR TITLE
nixos/gdm: Add accentColor and cursorTheme options

### DIFF
--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -169,6 +169,50 @@ in
         '';
       };
 
+      accentColor = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "blue"
+            "teal"
+            "green"
+            "yellow"
+            "orange"
+            "red"
+            "pink"
+            "purple"
+            "slate"
+          ] # https://github.com/GNOME/gsettings-desktop-schemas/blob/master/schemas/org.gnome.desktop.interface.gschema.xml.in
+        );
+        default = null;
+        description = ''
+          If not null, set the accent color for GDM.
+          This is useful if you use a custom accent color and want to have the same in GDM.
+        '';
+      };
+
+      cursorTheme = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.submodule {
+            options = {
+              name = lib.mkOption {
+                type = lib.types.str;
+                description = "Name of the cursor theme.";
+              };
+              package = lib.mkOption {
+                type = lib.types.nullOr lib.types.package;
+                default = null;
+                description = "If not null, the package providing the cursor theme. If null it is assumed to be in the system profile.";
+              };
+            };
+          }
+        );
+        default = null;
+        description = ''
+          If not null, set the cursor theme for GDM.
+          This is useful if you use a custom cursor theme and want to have the same in GDM.
+        '';
+      };
+
     };
 
   };
@@ -241,6 +285,11 @@ in
     environment.systemPackages = [
       pkgs.adwaita-icon-theme
       pkgs.gdm # For polkit rules
+      lib.optionals
+      (cfg.cursorTheme != null && cfg.cursorTheme.package != null)
+      [
+        cfg.cursorTheme.package
+      ] # For cursor theme
     ];
 
     # We dont use the upstream gdm service
@@ -314,6 +363,20 @@ in
           settings."org/gnome/login-screen" = {
             banner-message-enable = true;
             banner-message-text = cfg.banner;
+          };
+        }
+      ]
+      ++ lib.optionals (cfg.cursorTheme != null) [
+        {
+          settings."org/gnome/desktop/interface" = {
+            cursor-theme = cfg.cursorTheme.name;
+          };
+        }
+      ]
+      ++ lib.optionals (cfg.accentColor != null) [
+        {
+          settings."org/gnome/desktop/interface" = {
+            accent-color = cfg.accentColor;
           };
         }
       ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This pull request adds new customization options for the GDM module in NixOS, allowing users to set the accent color and cursor theme for the login screen. These options help users maintain a consistent look and feel between their desktop environment and GDM.

**New customization options:**

* Added the `accentColor` option to the GDM module, allowing users to specify a custom accent color for the GDM. This supports several predefined colors and helps match to the user's desktop theme.
* Added the `cursorTheme` option, which lets users set a custom cursor theme for GDM, including specifying the theme name and an optional package providing the theme. This helps match to the user's desktop theme.

**Configuration and package management:**

* Updated system packages to include the cursor theme package if specified, ensuring the required files are available for GDM.

**GDM settings integration:**

* Modified the DConf settings for GDM to apply the configured accent color and cursor theme, so these settings take effect in GDM.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
