### PR TITLE
gappa: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/by-name/ga/gappa/package.nix
+++ b/pkgs/by-name/ga/gappa/package.nix
@@ -5,7 +5,7 @@
   gmp,
   mpfr,
   boost,
-  version ? "1.6.0",
+  version ? "1.6.1",
 }:
 
 stdenv.mkDerivation {
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://gappa.gitlabpages.inria.fr/releases/gappa-${version}.tar.gz";
-    hash = "sha256-aNht0Ttv+gzS9eLzu4PQitRK/zQN9QQ4YOEjQ2d9xIM=";
+    hash = "sha256-1ux5ImKR8edXyvL21w3jY2o4/fATEjO2SMzS8B0o8Ok=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ga/gappa/package.nix
+++ b/pkgs/by-name/ga/gappa/package.nix
@@ -6,6 +6,8 @@
   mpfr,
   boost,
   version ? "1.6.1",
+  versionCheckHook,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
@@ -25,6 +27,11 @@ stdenv.mkDerivation {
 
   buildPhase = "./remake";
   installPhase = "./remake install";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://gappa.gitlabpages.inria.fr/";

--- a/pkgs/by-name/ga/gappa/package.nix
+++ b/pkgs/by-name/ga/gappa/package.nix
@@ -5,19 +5,20 @@
   gmp,
   mpfr,
   boost,
-  version ? "1.6.1",
   versionCheckHook,
   nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gappa";
-  inherit version;
+  version = "1.6.1";
 
   src = fetchurl {
-    url = "https://gappa.gitlabpages.inria.fr/releases/gappa-${version}.tar.gz";
+    url = "https://gappa.gitlabpages.inria.fr/releases/gappa-${finalAttrs.version}.tar.gz";
     hash = "sha256-1ux5ImKR8edXyvL21w3jY2o4/fATEjO2SMzS8B0o8Ok=";
   };
+
+  strictDeps = true;
 
   buildInputs = [
     gmp
@@ -25,8 +26,21 @@ stdenv.mkDerivation {
     boost.dev
   ];
 
-  buildPhase = "./remake";
-  installPhase = "./remake install";
+  buildPhase = ''
+    runHook preBuild
+
+    ./remake
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ./remake install
+
+    runHook postInstall
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -44,4 +58,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ vbgl ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
