### PR TITLE
equilux-theme: drop gnome-themes-extra dependency, modernize derivation

### DIFF
--- a/pkgs/by-name/eq/equilux-theme/package.nix
+++ b/pkgs/by-name/eq/equilux-theme/package.nix
@@ -11,15 +11,15 @@
   bc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "equilux-theme";
   version = "20181029";
 
   src = fetchFromGitHub {
     owner = "ddnexus";
     repo = "equilux-theme";
-    rev = "equilux-v${version}";
-    sha256 = "0lv2yyxhnmnkwxp576wnb01id4fp734b5z5n0l67sg5z7vc2h8fc";
+    tag = "equilux-v${finalAttrs.version}";
+    hash = "sha256-zCEo2D6/PH0MBbb8ssg415EWA1iWm1Nu59NWC7v3YlM=";
   };
 
   nativeBuildInputs = [
@@ -47,11 +47,11 @@ stdenv.mkDerivation rec {
     rm $out/share/themes/*/COPYING
   '';
 
-  meta = with lib; {
-    inherit (src.meta) homepage;
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
     description = "Material Design theme for GNOME/GTK based desktop environments";
-    license = licenses.gpl2;
-    platforms = platforms.all;
-    maintainers = [ maintainers.fpletz ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.fpletz ];
   };
-}
+})

--- a/pkgs/by-name/eq/equilux-theme/package.nix
+++ b/pkgs/by-name/eq/equilux-theme/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   gnome-shell,
-  gnome-themes-extra,
   glib,
   libxml2,
   gtk-engine-murrine,
@@ -30,7 +29,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gnome-themes-extra
     gdk-pixbuf
     librsvg
   ];


### PR DESCRIPTION
This does not change the output of the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
