### PR TITLE
olive-editor: fix build

### DIFF
--- a/pkgs/by-name/ol/olive-editor/olive-editor-kddockwidgets-fix-build-with-qt-6_10.patch
+++ b/pkgs/by-name/ol/olive-editor/olive-editor-kddockwidgets-fix-build-with-qt-6_10.patch
@@ -1,0 +1,21 @@
+diff --git a/ext/KDDockWidgets/CMakeLists.txt b/ext/KDDockWidgets/CMakeLists.txt
+index 608a2491..d0edc399 100644
+--- a/ext/KDDockWidgets/CMakeLists.txt
++++ b/ext/KDDockWidgets/CMakeLists.txt
+@@ -160,8 +160,16 @@
+ include(KDQtInstallPaths) #to set QT_INSTALL_FOO variables
+ 
+ set(${PROJECT_NAME}_DEPS "widgets")
++if(Qt6Core_VERSION VERSION_GREATER_EQUAL "6.10.0")
++    set(QT_NO_PRIVATE_MODULE_WARNING ON)
++    find_package(Qt6 ${QT_MIN_VERSION} NO_MODULE REQUIRED COMPONENTS WidgetsPrivate)
++endif()
+ if(${PROJECT_NAME}_QTQUICK)
+     find_package(Qt${Qt_VERSION_MAJOR} NO_MODULE REQUIRED COMPONENTS Quick QuickControls2)
++    if(Qt6Core_VERSION VERSION_GREATER_EQUAL "6.10.0")
++        set(QT_NO_PRIVATE_MODULE_WARNING ON)
++        find_package(Qt6 ${QT_MIN_VERSION} NO_MODULE REQUIRED COMPONENTS QuickPrivate)
++    endif()
+     add_definitions(-DKDDOCKWIDGETS_QTQUICK)
+     set(${PROJECT_NAME}_DEPS "${${PROJECT_NAME}_DEPS} quick quickcontrols2")
+ else()

--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -14,12 +14,13 @@
   portaudio,
   imath,
   qt6,
+  fmt_10,
 }:
 
 let
   # https://github.com/olive-editor/olive/issues/2284
   # we patch support for 2.3+, but 2.5 fails
-  openimageio' = openimageio.overrideAttrs (old: rec {
+  openimageio' = (openimageio.override { fmt = fmt_10; }).overrideAttrs (old: rec {
     version = "2.4.15.0";
     src = (
       old.src.override {

--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -57,6 +57,11 @@ stdenv.mkDerivation {
       url = "https://github.com/olive-editor/olive/commit/311eeb72944f93f873d1cd1784ee2bf423e1e7c2.patch";
       hash = "sha256-lswWn4DbXGH1qPvPla0jSgUJQXuqU7LQGHIPoXAE8ag=";
     })
+
+    # Fix build of `kddockwidgets` with qt6-6.10, adapted from:
+    # https://github.com/KDAB/KDDockWidgets/pull/615
+    # https://github.com/KDAB/KDDockWidgets/commit/f2b50fff29bd4b49acdfed3ed8fc42eb0a502032
+    ./olive-editor-kddockwidgets-fix-build-with-qt-6_10.patch
   ];
 
   # https://github.com/olive-editor/olive/issues/2200

--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -36,7 +36,7 @@ in
 
 stdenv.mkDerivation {
   pname = "olive-editor";
-  version = "unstable-2023-06-12";
+  version = "0.1.2-unstable-2023-06-12";
 
   src = fetchFromGitHub {
     fetchSubmodules = true;


### PR DESCRIPTION
olive-editor: fix build of pinned openimageio

- add `override` to pinned `openimageio` with `fmt_10`, it does not
build with new default `fmt_11`

Fixes build failure of pinned `openimageio`:
```
CMake Error at src/cmake/modules/Findfmt.cmake:19 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  src/cmake/externalpackages.cmake:325 (find_package)
  src/cmake/externalpackages.cmake:354 (find_or_download_fmt)
  CMakeLists.txt:166 (include)
```

---

olive-editor: fix build with qt6-6.10

- add patch from merged upstream PR of `kddockwidgets` submodule:
https://www.github.com/KDAB/KDDockWidgets/pull/615
https://github.com/KDAB/KDDockWidgets/commit/f2b50fff29bd4b49acdfed3ed8fc42eb0a502032
(does not apply with `fetchpatch`)

Fixes build failure with qt6-6.10:
```
CMake Error at ext/KDDockWidgets/src/CMakeLists.txt:306 (target_link_libraries):
  Target "kddockwidgets" links to:

    Qt6::WidgetsPrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

---

olive-editor: cleanup

- replace `version` with correct format

---

Fixes #452183 - build failure of `olive-editor` since `2025-10-10` (logs of build failure of pinned `openimageio` inside):
https://hydra.nixos.org/build/310067751
https://cache.nixos.org/log/agrjbsihadkngj2w9qnixr8dml0ri96y-openimageio-2.4.15.0.drv
```text
CMake Error at src/cmake/modules/Findfmt.cmake:19 (string):
  string sub-command REGEX, mode MATCHALL needs at least 5 arguments total to
  command.
Call Stack (most recent call first):
  src/cmake/externalpackages.cmake:325 (find_package)
  src/cmake/externalpackages.cmake:354 (find_or_download_fmt)
  CMakeLists.txt:166 (include)
...
-- Configuring incomplete, errors occurred!
```

---


If you try to pass cmake variable quoting error with something like:
```diff
--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -30,6 +30,11 @@

     # robin-map headers require c++17
     cmakeFlags = (old.cmakeFlags or [ ]) ++ [ (lib.cmakeFeature "CMAKE_CXX_STANDARD" "17") ];
+
+    postPatch = ''
+      substituteInPlace src/cmake/modules/Findfmt.cmake \
+        --replace-fail 'REGEX MATCHALL "[0-9]+[.0-9]+" FMT_VERSION ''${TMP}' 'REGEX MATCHALL "[0-9]+[.0-9]+" FMT_VERSION "''${TMP}"'
+    '';
   });
 in
```

build will go further, but then fail with error not being able to find `fmt`:
```text
/build/source/src/libutil/ustring_test.cpp:21:14: fatal error: OpenImageIO/detail/fmt/std.h: No such file or directory
    21 | #    include <OpenImageIO/detail/fmt/std.h>
       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [src/libutil/CMakeFiles/ustring_test.dir/build.make:79: src/libutil/CMakeFiles/ustring_test.dir/ustring_test.cpp.o] Error 1
```
They seem to parse this `FMT_VERSION` from `include/fmt/core.h`:
https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/9984e930004c6334cd33fe9c37a1324665c3ecc3/src/cmake/modules/Findfmt.cmake#L18
https://github.com/fmtlib/fmt/blob/e69e5f977d458f2650bb346dadf2ad30c5320281/include/fmt/core.h#L21
which does not exist in `fmt_11`:
https://github.com/fmtlib/fmt/blob/11.2.0/include/fmt/core.h
it is in `include/fmt/base.h` now:
https://github.com/fmtlib/fmt/blob/40626af88bd7df9a5fb80be7b25ac85b122d6c21/include/fmt/base.h#L24
We can patch new path instead, but that could change in newer `fmt` version and it does not seem like this `openimageio` pin is ever going to change.

Or backport:
https://github.com/AcademySoftwareFoundation/OpenImageIO/commit/65cfc19d06fc69551107bed08ca848928e6669a2
but that has more potential for issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
