### PR TITLE
python3Packages.torch-geometric: 2.6.1 -> 2.7.0

### DIFF
--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -17,26 +17,27 @@
   requests,
   torch,
   tqdm,
+  xxhash,
 
   # optional-dependencies
+  # benchmark
   matplotlib,
   networkx,
   pandas,
   protobuf,
   wandb,
+  # dev
   ipython,
   matplotlib-inline,
   pre-commit,
   torch-geometric,
+  # full
   ase,
-  # captum,
   graphviz,
   h5py,
   numba,
   opt-einsum,
-  pgmpy,
   pynndescent,
-  # pytorch-memlab,
   rdflib,
   rdkit,
   scikit-image,
@@ -47,9 +48,18 @@
   tabulate,
   torchmetrics,
   trimesh,
+  # graphgym
   pytorch-lightning,
   yacs,
+  # modelhub
   huggingface-hub,
+  # rag
+  # pcst-fast,
+  datasets,
+  transformers,
+  sentencepiece,
+  accelerate,
+  # test
   onnx,
   onnxruntime,
   pytest,
@@ -63,14 +73,14 @@
 
 buildPythonPackage rec {
   pname = "torch-geometric";
-  version = "2.6.1";
+  version = "2.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyg-team";
     repo = "pytorch_geometric";
     tag = version;
-    hash = "sha256-Zw9YqPQw2N0ZKn5i5Kl4Cjk9JDTmvZmyO/VvIVr6fTU=";
+    hash = "sha256-xlOzpoYRoEfIRWSQoZbEPvUW43AMr3rCgIYnxwG/z3A=";
   };
 
   build-system = [
@@ -87,6 +97,7 @@ buildPythonPackage rec {
     requests
     torch
     tqdm
+    xxhash
   ];
 
   optional-dependencies = {
@@ -113,7 +124,7 @@ buildPythonPackage rec {
       numba
       opt-einsum
       pandas
-      pgmpy
+      # pgmpy
       pynndescent
       # pytorch-memlab
       rdflib
@@ -136,9 +147,19 @@ buildPythonPackage rec {
     modelhub = [
       huggingface-hub
     ];
+    rag = [
+      # pcst-fast (unpackaged)
+      datasets
+      transformers
+      pandas
+      sentencepiece
+      accelerate
+      torchmetrics
+    ];
     test = [
       onnx
       onnxruntime
+      # onnxscript (unpackaged)
       pytest
       pytest-cov-stub
     ];
@@ -151,6 +172,14 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     writableTmpDirAsHomeHook
+  ];
+
+  pytestFlags = [
+    # DeprecationWarning: Failing to pass a value to the 'type_params' parameter of
+    # 'typing._eval_type' is deprecated, as it leads to incorrect behaviour when calling
+    # typing._eval_type on a stringified annotation that references a PEP 695 type parameter.
+    # It will be disallowed in Python 3.15.
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pyg-team/pytorch_geometric/compare/2.6.1...2.7.0
Changelog: https://github.com/pyg-team/pytorch_geometric/blob/refs/tags/2.7.0/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc