### PR TITLE
python3Packages.hawkmoth: fix broken state with llvm 21 by using 20

### DIFF
--- a/pkgs/development/python-modules/hawkmoth/default.nix
+++ b/pkgs/development/python-modules/hawkmoth/default.nix
@@ -3,13 +3,18 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  llvmPackages_20,
   libclang,
   sphinx,
-  clang,
   pytestCheckHook,
   strictyaml,
 }:
+let
+  libclang_20 = libclang.override {
+    llvmPackages = llvmPackages_20;
+  };
 
+in
 buildPythonPackage rec {
   pname = "hawkmoth";
   version = "0.21.0";
@@ -25,13 +30,13 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   dependencies = [
-    libclang
+    libclang_20
     sphinx
   ];
-  propagatedBuildInputs = [ clang ];
+  propagatedBuildInputs = [ llvmPackages_20.clang ];
 
   nativeCheckInputs = [
-    clang
+    llvmPackages_20.clang
     pytestCheckHook
     strictyaml
   ];


### PR DESCRIPTION
Hawkmoth is broken with LLVM 21 release. This is already reported, but there is no stable fix on the Hawkmoth's size, yet. Thus this changes the used LLVM version in Hawkmoth to 20.

https://github.com/jnikula/hawkmoth/pull/291

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
