### PR TITLE
signal-desktop: 7.73.0 -> 7.75.1

### DIFF
--- a/pkgs/by-name/si/signal-desktop/dont-strip-absolute-paths.patch
+++ b/pkgs/by-name/si/signal-desktop/dont-strip-absolute-paths.patch
@@ -1,14 +1,14 @@
 diff --git a/node/build_node_bridge.py b/node/build_node_bridge.py
-index c983fc3..2ab06dc 100755
---- a/node/build_node_bridge.py
-+++ b/node/build_node_bridge.py
-@@ -138,9 +138,6 @@ def main(args: Optional[List[str]] = None) -> int:
-     cargo_env['CARGO_PROFILE_RELEASE_LTO'] = 'thin'
-     # Enable ARMv8 cryptography acceleration when available
+index a2da3c8b..cb5d475f 100755
+--- i/node/build_node_bridge.py
++++ w/node/build_node_bridge.py
+@@ -154,9 +154,6 @@ def main(args: Optional[List[str]] = None) -> int:
      cargo_env['RUSTFLAGS'] += ' --cfg aes_armv8'
+     # Access tokio's unstable metrics
+     cargo_env['RUSTFLAGS'] += ' --cfg tokio_unstable'
 -    # Strip absolute paths
 -    for path in build_helpers.rust_paths_to_remap():
 -        cargo_env['RUSTFLAGS'] += f' --remap-path-prefix {path}='
- 
+
      # If set (below), will post-process the build library using this instead of just `cp`-ing it.
      objcopy = None

--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -24,23 +24,23 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.81.1";
+  version = "0.83.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uhxfVFsoB+c1R5MUOgpJFm8ZD3vgU8BIn35QSfbEp5w=";
+    hash = "sha256-lSk9C2RIRsAlSUr8folhdHkHkpAfPM+vwJ/rZ6mys3Q=";
   };
 
-  cargoHash = "sha256-Q3GSeaW3YveLxLeJPpPXUVwlJ0QLRkAmRGSJetxKl4Y=";
+  cargoHash = "sha256-0P89+p0WlQaa48wpgsaapIhEzlAnWVPl9qD+jnBw9mM=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-6Mr3SJn4pO0p6PISXvEOhN9uPk1TIEU03ssclNUg2No=";
+    hash = "sha256-4sd8JVQfCC4dAkksICbb3e4JjNcgplOW26TyRkAFWp0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -52,13 +52,13 @@ let
     '';
   });
 
-  version = "7.73.0";
+  version = "7.74.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-5cwGV0WPOS7O/xnQZ38t/hiQppqFFtVQmGuniGsD6H8=";
+    hash = "sha256-ahFc/AOBfgW34S1zcLZYj9pie/2aAK/tdZzC7An4lNU=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -69,7 +69,7 @@ let
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname src version;
       fetcherVersion = 1;
-      hash = "sha256-cT7Ixl/V/mesPHvJUsG63Y/wXwKjbjkjdjP3S7uEOa0=";
+      hash = "sha256-WUwclz7dJl+s5zRjWu/HTJ5eZroAFA6vR8mZzwib6Po=";
     };
 
     strictDeps = true;
@@ -134,15 +134,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-9YvNs925xBUYEpF429rHfMXIGPapVYd8j1jZa/yBuhA="
+        "sha256-h1F9/lKtcT8Gce+EVj8RrPzHtjqp11ycHAkf7xldHeM="
       else
-        "sha256-lcr8EeL+wd6VihKcBgfXNRny8VskX8g7I7WTAkLuBss=";
+        "sha256-tDlQTOSUkCjRXtA7NIUgI+ax+GCPFXK+eZLe0fXVhJY=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1759413120;
+    SOURCE_DATE_EPOCH = 1759960657;
   };
 
   preBuild = ''
@@ -218,12 +218,10 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 $icon $out/share/icons/hicolor/`basename ''${icon%.png}`/apps/signal-desktop.png
     done
 
-    # TODO: Remove --ozone-platform=wayland after next electron update,
-    # see https://github.com/electron/electron/pull/48309
     makeWrapper '${lib.getExe electron}' "$out/bin/signal-desktop" \
       --add-flags "$out/share/signal-desktop/app.asar" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -52,13 +52,13 @@ let
     '';
   });
 
-  version = "7.74.0";
+  version = "7.75.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-ahFc/AOBfgW34S1zcLZYj9pie/2aAK/tdZzC7An4lNU=";
+    hash = "sha256-Abt0Rh+6hDLIfHtiTZZCZuKf4SCBLu917wopV6H7n+I=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -134,15 +134,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 1;
     hash =
       if withAppleEmojis then
-        "sha256-h1F9/lKtcT8Gce+EVj8RrPzHtjqp11ycHAkf7xldHeM="
+        "sha256-b13di3TdaS6CT8gAZfBqlu4WheIHL+X8LvAo148H8kI="
       else
-        "sha256-tDlQTOSUkCjRXtA7NIUgI+ax+GCPFXK+eZLe0fXVhJY=";
+        "sha256-/Yy9R+MRN5e5vGU0XgwJa7oFpHn8bi8B0y89aaT2LQI=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1759960657;
+    SOURCE_DATE_EPOCH = 1760562217;
   };
 
   preBuild = ''

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -52,13 +52,13 @@ let
     '';
   });
 
-  version = "7.75.0";
+  version = "7.75.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-Abt0Rh+6hDLIfHtiTZZCZuKf4SCBLu917wopV6H7n+I=";
+    hash = "sha256-l5fMVXwuXHaGcBuemkwzUcEuktTseGL2k13oxoo81+0=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1760562217;
+    SOURCE_DATE_EPOCH = 1760633959;
   };
 
   preBuild = ''

--- a/pkgs/by-name/si/signal-desktop/replace-apple-emoji-with-noto-emoji.patch
+++ b/pkgs/by-name/si/signal-desktop/replace-apple-emoji-with-noto-emoji.patch
@@ -49,11 +49,11 @@ diff --git a/package.json b/package.json
 index 5755fec..86125ba 100644
 --- a/package.json
 +++ b/package.json
-@@ -137,7 +137,6 @@
+@@ -154,7 +154,6 @@
      "dashdash": "2.0.0",
      "direction": "1.0.4",
-     "emoji-datasource": "15.1.2",
--    "emoji-datasource-apple": "15.1.2",
+     "emoji-datasource": "16.0.0",
+-    "emoji-datasource-apple": "16.0.0",
      "emoji-regex": "10.4.0",
      "encoding": "0.1.13",
      "fabric": "4.6.0",
@@ -64,46 +64,46 @@ index 5755fec..86125ba 100644
 -}
 +}
 \ No newline at end of file
-diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index f04b2b1..070fa0f 100644
---- a/pnpm-lock.yaml
-+++ b/pnpm-lock.yaml
-@@ -184,9 +184,6 @@ importers:
+diff --git i/pnpm-lock.yaml w/pnpm-lock.yaml
+index b162101a8..82ee9d67e 100644
+--- i/pnpm-lock.yaml
++++ w/pnpm-lock.yaml
+@@ -197,9 +197,6 @@ importers:
        emoji-datasource:
-         specifier: 15.1.2
-         version: 15.1.2
+         specifier: 16.0.0
+         version: 16.0.0
 -      emoji-datasource-apple:
--        specifier: 15.1.2
--        version: 15.1.2
+-        specifier: 16.0.0
+-        version: 16.0.0
        emoji-regex:
          specifier: 10.4.0
          version: 10.4.0
-@@ -4817,9 +4814,6 @@ packages:
+@@ -5814,9 +5811,6 @@ packages:
      resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
      engines: {node: '>=12'}
- 
--  emoji-datasource-apple@15.1.2:
--    resolution: {integrity: sha512-32UZTK36x4DlvgD1smkmBlKmmJH7qUr5Qut4U/on2uQLGqNXGbZiheq6/LEA8xRQEUrmNrGEy25wpEI6wvYmTg==}
+
+-  emoji-datasource-apple@16.0.0:
+-    resolution: {integrity: sha512-dVYjsK0FnCry9F+PBtnivhG2K0xdwlmqYaSgiUtztUdAGPYiHYhZcVKvNBqC791g2qyEcFNTBO6utg4eQ3uLTw==}
 -
-   emoji-datasource@15.1.2:
-     resolution: {integrity: sha512-tXAqGsrDVhgCRpFePtaD9P4Z8Ro2SUQSL/4MIJBG0SxqQJaMslEbin8J53OaFwEBu6e7JxFaIF6s4mw9+8acAQ==}
- 
-@@ -14990,8 +14984,6 @@ snapshots:
- 
+   emoji-datasource@16.0.0:
+     resolution: {integrity: sha512-/qHKqK5Nr3+8zhgO6kHmF43Fm5C8HNn0AaFRIpgw8HF3+uF0Vfc8jgLI1ZQS5ba1vBzksS8NBCjHejwLb2D/Sg==}
+
+@@ -17037,8 +17031,6 @@ snapshots:
+
    emittery@0.13.1: {}
- 
--  emoji-datasource-apple@15.1.2: {}
+
+-  emoji-datasource-apple@16.0.0: {}
 -
-   emoji-datasource@15.1.2: {}
- 
+   emoji-datasource@16.0.0: {}
+
    emoji-regex@10.4.0: {}
 diff --git a/stylesheets/components/fun/FunEmoji.scss b/stylesheets/components/fun/FunEmoji.scss
-index 78c7563..83d196c 100644
---- a/stylesheets/components/fun/FunEmoji.scss
-+++ b/stylesheets/components/fun/FunEmoji.scss
+index ea029fd5b..0e3563b4f 100644
+--- i/stylesheets/components/fun/FunEmoji.scss
++++ w/stylesheets/components/fun/FunEmoji.scss
 @@ -5,19 +5,9 @@
  $emoji-sprite-sheet-grid-item-count: 62;
- 
+
  @mixin emoji-sprite($sheet, $margin, $scale) {
 -  $size: calc($sheet * 1px * $scale);
 -  $margin-start: calc($margin * $scale);
@@ -123,16 +123,22 @@ index 78c7563..83d196c 100644
 +  background-position: center;
    background-repeat: no-repeat;
  }
- 
+
 diff --git a/ts/components/fun/FunEmoji.tsx b/ts/components/fun/FunEmoji.tsx
-index 08785e8..d25b868 100644
+index ddb30bf6d..5fc39339b 100644
 --- a/ts/components/fun/FunEmoji.tsx
 +++ b/ts/components/fun/FunEmoji.tsx
-@@ -10,7 +10,14 @@ export const FUN_STATIC_EMOJI_CLASS = 'FunStaticEmoji';
- export const FUN_INLINE_EMOJI_CLASS = 'FunInlineEmoji';
- 
- function getEmojiJumboUrl(emoji: EmojiVariantData): string {
--  return `emoji://jumbo?emoji=${encodeURIComponent(emoji.value)}`;
+@@ -20,13 +20,14 @@ function getEmojiJumboBackground(
+   emoji: EmojiVariantData,
+   size: number | undefined
+ ): string | null {
+-  if (size != null && size < MIN_JUMBOMOJI_SIZE) {
+-    return null;
+-  }
+-  if (KNOWN_JUMBOMOJI.has(emoji.value)) {
+-    return `url(emoji://jumbo?emoji=${encodeURIComponent(emoji.value)})`;
+-  }
+-  return null;
 +  const emojiToNotoName = (emoji: string): string =>
 +    `emoji_u${
 +      [...emoji]
@@ -140,7 +146,7 @@ index 08785e8..d25b868 100644
 +        .map(c => c.codePointAt(0)?.toString(16).padStart(4, "0"))
 +        .join("_")
 +    }.png`;
-+  return `file://@noto-emoji-pngs@/${emojiToNotoName(emoji.value)}`;
++  return `url(file://@noto-emoji-pngs@/${emojiToNotoName(emoji.value)})`;
  }
  
  export type FunStaticEmojiSize =

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -19,16 +19,21 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.58.1";
+  version = "2.59.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HI+HVDv+nuJp2BPIAVY+PI6Pof1pnB8L6CIAgBT+tJA=";
+    hash = "sha256-zgDXkkKJrcD357DxbPq/sL/c4AG8xyMPY5IpcBtvATY=";
   };
 
-  cargoHash = "sha256-n+1pe202U2lljisSRBWeVvuBLyp7jhXG+ovDDi5WV8Q=";
+  cargoHash = "sha256-uwMNJ+PQa/Q7XZ9QONo+vm2wMqGwOEB97Kl/RFQkdhU=";
+
+  preConfigure = ''
+    # Check for matching webrtc version
+    grep 'webrtc.version=${webrtc.version}' config/version.properties
+  '';
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/si/signal-desktop/webrtc-sources.json
+++ b/pkgs/by-name/si/signal-desktop/webrtc-sources.json
@@ -1,33 +1,25 @@
 {
     "src": {
         "args": {
-            "hash": "sha256-Qj0UFRWfZrBG9WUX4zkyiatIekNSYXsneP5aLvufNh4=",
+            "hash": "sha256-mNj4Sw7EROc2Cn4nPSm789h1je7EOjNAg2s6fQ19Dcc=",
             "owner": "signalapp",
             "repo": "webrtc",
-            "tag": "7204c"
+            "tag": "7339c"
         },
         "fetcher": "fetchFromGitHub"
     },
-    "src/base": {
-        "args": {
-            "hash": "sha256-wKFvb28LeB7/YVGmWKhcvXCEeNB6HaxMgZJLpC5a1Zk=",
-            "rev": "4ba67f727a84a10e32a417dc7e194f4fc6a23390",
-            "url": "https://chromium.googlesource.com/chromium/src/base"
-        },
-        "fetcher": "fetchFromGitiles"
-    },
     "src/build": {
         "args": {
-            "hash": "sha256-Bfd3paXVGon4p85V2UO6vEHG/t1g8EAxvYQ+DdPcuI8=",
-            "rev": "7adbc7e3263f3ab427ba7c5ac7839a69082ff7fb",
+            "hash": "sha256-BFKseH/tEQcQ1UF2YPBcfMLY54qBmM7OboC15NFO9e0=",
+            "rev": "66d076c7ab192991f67891b062b35404f3cb0739",
             "url": "https://chromium.googlesource.com/chromium/src/build"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/buildtools": {
         "args": {
-            "hash": "sha256-adtGyo+wm8+keR0um1fOdChABdBYboGBawD0LfcY00w=",
-            "rev": "1fc7350e65e9d7848c083b83aaf67611e74a5654",
+            "hash": "sha256-c1I0yBRDb9JUkywmJJy0IZp802qJRsoQV72ydinzxVs=",
+            "rev": "0c4bbb0f8a874de0a2a15d196031c7303d04fbb3",
             "url": "https://chromium.googlesource.com/chromium/src/buildtools"
         },
         "fetcher": "fetchFromGitiles"
@@ -43,40 +35,40 @@
     },
     "src/testing": {
         "args": {
-            "hash": "sha256-CQg6fxDz0dk4fD+X53stTwJJ25feYoU9KdsgjTAzbp8=",
-            "rev": "44b0a8d794b28dbd74614e5f5e7da2b407030647",
+            "hash": "sha256-PkTTET3CB1pQLipi0e6m+fVhf7S3MSEqiYeLFg9Pbjs=",
+            "rev": "305de9533d3ee2840af0b3f2c8ed0b32802b0a5d",
             "url": "https://chromium.googlesource.com/chromium/src/testing"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party": {
         "args": {
-            "hash": "sha256-KfIQS+FrzFDAS0B3yfzPj4PqD16H0dBE6z1JgFag/20=",
-            "rev": "8a150db896356cd9b47f8c1a6d916347393f90f2",
+            "hash": "sha256-P0fhs0vabiD7+C2ILX6gE62RKXfXbLmHRjbWLpqY48g=",
+            "rev": "e30091e8987ee0bb0cd30bc467250a96a7614762",
             "url": "https://chromium.googlesource.com/chromium/src/third_party"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/boringssl/src": {
         "args": {
-            "hash": "sha256-+Gs+efB1ZizjMYRSRTQrMDPZsDC+dgNJ9+yHXkzm/ZM=",
-            "rev": "9295969e1dad2c31d0d99481734c1c68dcbc6403",
+            "hash": "sha256-bpsZTEQ2/TE7xxhOtDz5PKzkOClImHtCTgOaINzg8Vk=",
+            "rev": "ddb2ca4b48fca9a1c468d83dc513b837331843ac",
             "url": "https://boringssl.googlesource.com/boringssl.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/breakpad/breakpad": {
         "args": {
-            "hash": "sha256-+Z7KphmQYCeN0aJkqyMrJ4tIi3BhqN16KoPNLb/bMGo=",
-            "rev": "2625edb085169e92cf036c236ac79ab594a7b1cc",
+            "hash": "sha256-8OfbSe+ly/5FFYk8NubAV39ACMr5S4wbLBVdiQHWeok=",
+            "rev": "ff252ff6faf5e3a52dc4955aab0d84831697dc94",
             "url": "https://chromium.googlesource.com/breakpad/breakpad.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/catapult": {
         "args": {
-            "hash": "sha256-xHe9WoAq1FElMSnu5mlEzrH+EzKiwWXeXMCH69KL5a0=",
-            "rev": "5477c6dfde1132b685c73edc16e1bc71449a691d",
+            "hash": "sha256-khxdFV6fxbTazz195MlxktLlihXytpNYCykLrI8nftM=",
+            "rev": "0fd1415f0cf3219ba097d37336141897fab7c5e9",
             "url": "https://chromium.googlesource.com/catapult.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -107,8 +99,8 @@
     },
     "src/third_party/compiler-rt/src": {
         "args": {
-            "hash": "sha256-FVdcKGwRuno3AzS6FUvI8OTj3mBMRfFR2A8GzYcwIU4=",
-            "rev": "57196dd146582915c955f6d388e31aea93220c51",
+            "hash": "sha256-TANkUmIqP+MirWFmegENuJEFK+Ve/o0A0azuxTzeAo8=",
+            "rev": "dc425afb37a69b60c8c02fef815af29e91b61773",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -123,24 +115,24 @@
     },
     "src/third_party/dav1d/libdav1d": {
         "args": {
-            "hash": "sha256-+DY4p41VuAlx7NvOfXjWzgEhvtpebjkjbFwSYOzSjv4=",
-            "rev": "8d956180934f16244bdb58b39175824775125e55",
+            "hash": "sha256-2J4M6EkfVtPLUpRWwzXdLkvJio4gskC0ihZnM5H3qYc=",
+            "rev": "716164239ad6e6b11c5dcdaa3fb540309d499833",
             "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/depot_tools": {
         "args": {
-            "hash": "sha256-1avxBlK0WLHTru5wUecbiGpSEYv8Epobsl4EfCaWX9A=",
-            "rev": "a8900cc0f023d6a662eb66b317e8ddceeb113490",
+            "hash": "sha256-+jbfCtruv6MR+A/uzw5WaSj2u92W6bB/vmLBCzL39mM=",
+            "rev": "d85491b0a1dcb82dd8e124a876ecd7e3d50dc5e8",
             "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/ffmpeg": {
         "args": {
-            "hash": "sha256-noc3iZ1yCEgkwWyznx48rXC8JuKxla9QgC/CIjRL/y8=",
-            "rev": "dcdd0fa51b65a0b1688ff6b8f0cc81908f09ded2",
+            "hash": "sha256-c5w8CuyE1J0g79lrNq1stdqc1JaAkMbtscdcywmAEMY=",
+            "rev": "d2d06b12c22d27af58114e779270521074ff1f85",
             "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -155,24 +147,24 @@
     },
     "src/third_party/fontconfig/src": {
         "args": {
-            "hash": "sha256-Kz7KY+evfOciKFHIBLG1JxIRgHRTzuBLgxXHv3m/Y1Y=",
-            "rev": "8cf0ce700a8abe0d97ace4bf7efc7f9534b729ba",
+            "hash": "sha256-6HLV0U/MA1XprKJ70TKvwUBdkGQPwgqP4Oj5dINsKp0=",
+            "rev": "86b48ec01ece451d5270d0c5181a43151e45a042",
             "url": "https://chromium.googlesource.com/external/fontconfig.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/freetype/src": {
         "args": {
-            "hash": "sha256-Mt6uJGGHiGYNNLx2xrooYirynL9DW0s05G1GJiqzhi8=",
-            "rev": "e07e56c7f106b600262ab653d696b7b57f320127",
+            "hash": "sha256-oiezGGrPlHVGi24IpLr6UfUs7gT+Epzw37TtAkEixek=",
+            "rev": "08805be530d6820d2bf8a1b7685826de40f06812",
             "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/fuzztest/src": {
         "args": {
-            "hash": "sha256-MHli8sadgC3OMesBGhkjPM/yW49KFOtdFuBII1bcFas=",
-            "rev": "f03aafb7516050ea73f617bf969f03eac641aefc",
+            "hash": "sha256-uWPhInzuidI4smFRjRF95aaVNTsehKd/1y4uRzr12mk=",
+            "rev": "7bab06ff5fbbf8b8cce05a8661369dc2e11cde66",
             "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -187,24 +179,24 @@
     },
     "src/third_party/googletest/src": {
         "args": {
-            "hash": "sha256-md/jPkFrs/0p0BYGyquh57Zxh+1dKaK26PDtUN1+Ce0=",
-            "rev": "09ffd0015395354774c059a17d9f5bee36177ff9",
+            "hash": "sha256-07pEo2gj3n/IOipqz7UpZkBOywZt7FkfZFCnVyp3xYw=",
+            "rev": "373af2e3df71599b87a40ce0e37164523849166b",
             "url": "https://chromium.googlesource.com/external/github.com/google/googletest.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/grpc/src": {
         "args": {
-            "hash": "sha256-z96goSSgBUvTjNse/LO88zNIzg+SWEYgVDaoA/elkLU=",
-            "rev": "cadf3c8329377e93b1f5e2d6a43d91f7a4becc28",
+            "hash": "sha256-5vv8V/hEKalfHa2Qo8QIxLvXoamcLxNQ/bcqY8vCvjk=",
+            "rev": "806e186735cc3bf4375f43d2d6a9483c607e4278",
             "url": "https://chromium.googlesource.com/external/github.com/grpc/grpc.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/gtest-parallel": {
         "args": {
-            "hash": "sha256-VUuk5tBTh+aU2dxVWUF1FePWlKUJaWSiGSXk/J5zgHw=",
-            "rev": "96f4f904922f9bf66689e749c40f314845baaac8",
+            "hash": "sha256-uVq+oDrue4sf1JPoeymIIDe79Fv7rcJAVOjxUF42Xo0=",
+            "rev": "cd488bdedc1d2cffb98201a17afc1b298b0b90f1",
             "url": "https://chromium.googlesource.com/external/github.com/google/gtest-parallel"
         },
         "fetcher": "fetchFromGitiles"
@@ -219,8 +211,8 @@
     },
     "src/third_party/icu": {
         "args": {
-            "hash": "sha256-/T7uyzwTCDaamLwSvutvbn6BJuoG1RqeR+xhXI5jmJw=",
-            "rev": "b929596baebf0ab4ac7ec07f38365db4c50a559d",
+            "hash": "sha256-k3z31DhDPoqjcZdUL4vjyUMVpUiNk44+7rCMTDVPH8Q=",
+            "rev": "1b2e3e8a421efae36141a7b932b41e315b089af8",
             "url": "https://chromium.googlesource.com/chromium/deps/icu.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -243,32 +235,32 @@
     },
     "src/third_party/libFuzzer/src": {
         "args": {
-            "hash": "sha256-Lb+HczYax0T7qvC0/Nwhc5l2szQTUYDouWRMD/Qz7sA=",
-            "rev": "e31b99917861f891308269c36a32363b120126bb",
+            "hash": "sha256-TDi1OvYClJKmEDikanKVTmy8uxUXJ95nuVKo5u+uFPM=",
+            "rev": "bea408a6e01f0f7e6c82a43121fe3af4506c932e",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libaom/source/libaom": {
         "args": {
-            "hash": "sha256-pyLKjLG83Jlx6I+0M8Ah94ku4NIFcrHNYswfVHMvdrc=",
-            "rev": "2cca4aba034f99842c2e6cdc173f83801d289764",
+            "hash": "sha256-cER77Q9cM5rh+oeh1LDyKDZyQK5VbtE/ANNTN2cYzMo=",
+            "rev": "e91b7aa26d6d0979bba2bee5e1c27a7a695e0226",
             "url": "https://aomedia.googlesource.com/aom.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libc++/src": {
         "args": {
-            "hash": "sha256-36ulJk/YTfP5k1sDeA/WQyIO8xaplRKK4cQhfTZdpko=",
-            "rev": "a01c02c9d4acbdae3b7e8a2f3ee58579a9c29f96",
+            "hash": "sha256-34+xTZqWpm+1aks2b4nPD3WRJTkTxNj6ZjTuMveiQ+M=",
+            "rev": "adbb4a5210ae2a8a4e27fa6199221156c02a9b1a",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libc++abi/src": {
         "args": {
-            "hash": "sha256-DkCvfFjMztFTzKf081XyiefW6tMBSZ1AdzcPzXAVPnk=",
-            "rev": "9810fb23f6ba666f017c2b67c67de2bcac2b44bd",
+            "hash": "sha256-wO64dyP1O3mCBh/iiRkSzaWMkiDkb7B98Avd4SpnY70=",
+            "rev": "a6c815c69d55ec59d020abde636754d120b402ad",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -291,32 +283,32 @@
     },
     "src/third_party/libunwind/src": {
         "args": {
-            "hash": "sha256-O1S3ijnoVrTHmZDGmgQQe0MVGsSZL7usXAPflGFmMXY=",
-            "rev": "8575f4ae4fcf8892938bd9766cf1a5c90a0ed04e",
+            "hash": "sha256-GmLreEtoyHMXr6mZgZ7NS1ZaS9leB9eMbISeN7qmfqw=",
+            "rev": "84c5262b57147e9934c0a8f2302d989b44ec7093",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libvpx/source/libvpx": {
         "args": {
-            "hash": "sha256-SFdYF8vnwNHQbZ1N/ZHr4kxfi9o+BAtuqbak80m9uP4=",
-            "rev": "b84ca9b63730e7d4563573a56a66317eb0087ebf",
+            "hash": "sha256-BbXiBbnGwdsbZCZIpurfTzYvDUCysdt+ocRh6xvuUI8=",
+            "rev": "a985e5e847a2fe69bef3e547cf25088132194e39",
             "url": "https://chromium.googlesource.com/webm/libvpx.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/libyuv": {
         "args": {
-            "hash": "sha256-J9Wi3aCc6OjtQCP8JnrY7PYrY587dKLaa1KGAMWmE0c=",
-            "rev": "61bdaee13a701d2b52c6dc943ccc5c888077a591",
+            "hash": "sha256-ievGlutmOuuEEhWS82vMqxwqXCq8PF3508N0MCMPQus=",
+            "rev": "cdd3bae84818e78466fec1ce954eead8f403d10c",
             "url": "https://chromium.googlesource.com/libyuv/libyuv.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/third_party/llvm-libc/src": {
         "args": {
-            "hash": "sha256-BsoHIvdqgYzBUkd23++enEHIhq5GeVWrWdVdhXrHh9A=",
-            "rev": "9c3ae3120fe83b998d0498dcc9ad3a56c29fad0c",
+            "hash": "sha256-MgOyCveySgpUoIj6jJGbDjzMVpPDbeKtvpFUC+ocdsY=",
+            "rev": "8ec6b26421b5fa7aa876fdab486fa1decc558326",
             "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -331,8 +323,8 @@
     },
     "src/third_party/nasm": {
         "args": {
-            "hash": "sha256-neYrS4kQ76ihUh22Q3uPR67Ld8+yerA922YSZU1KxJs=",
-            "rev": "9f916e90e6fc34ec302573f6ce147e43e33d68ca",
+            "hash": "sha256-TxzAcp+CoKnnM0lCGjm+L3h6M30vYHjM07vW6zUe/vY=",
+            "rev": "e2c93c34982b286b27ce8b56dd7159e0b90869a2",
             "url": "https://chromium.googlesource.com/chromium/deps/nasm.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -347,8 +339,8 @@
     },
     "src/third_party/perfetto": {
         "args": {
-            "hash": "sha256-kzVsti2tygOMgT61TmCz26AByMd3gIXA6xz8RE0iCz4=",
-            "rev": "dd35b295cd359ba094404218414955f961a0d6ae",
+            "hash": "sha256-JwoqF2VWrkwcokaGY6bo73YJWtO7lDnvOqFCBmIEBXY=",
+            "rev": "0c893ed6bf6b42e3fee58daf3380d301c72550ed",
             "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git"
         },
         "fetcher": "fetchFromGitiles"
@@ -363,16 +355,16 @@
     },
     "src/third_party/re2/src": {
         "args": {
-            "hash": "sha256-f/k2rloV2Nwb0KuJGUX4SijFxAx69EXcsXOG4vo+Kis=",
-            "rev": "c84a140c93352cdabbfb547c531be34515b12228",
+            "hash": "sha256-vjh4HI4JKCMAf5SZeqstb0M01w8ssaTwwrLAUsrFkkQ=",
+            "rev": "8451125897dd7816a5c118925e8e42309d598ecc",
             "url": "https://chromium.googlesource.com/external/github.com/google/re2.git"
         },
         "fetcher": "fetchFromGitiles"
     },
     "src/tools": {
         "args": {
-            "hash": "sha256-j95oiK5+hhKC+NNQ27EVZugZI/n2QZJNRyz2QE4pVXc=",
-            "rev": "901b847deda65d44f1bba16a9f47e2ea68a805be",
+            "hash": "sha256-9CYGP9LI/fSHUAjqvXxyNZZVwxkr5TdEZME4l/7fizM=",
+            "rev": "ec8f1c6113753a31c55b6d6bddfbe198046029a8",
             "url": "https://chromium.googlesource.com/chromium/src/tools"
         },
         "fetcher": "fetchFromGitiles"

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -34,7 +34,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "signal-webrtc";
-  version = finalAttrs.gclientDeps."src".path.rev;
+  version = finalAttrs.gclientDeps."src".path.tag;
 
   gclientDeps = gclient2nix.importGclientDeps ./webrtc-sources.json;
   sourceRoot = "src";
@@ -87,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     "is_clang=false"
     "treat_warnings_as_errors=false"
     "use_llvm_libatomic=false"
+    "use_custom_libcxx=false"
 
     # https://github.com/signalapp/ringrtc/blob/main/bin/build-desktop
     "rtc_build_examples=false"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Please check emoji features when testing this change.

I had to fix the emoji patch because upstream updated the `emoji-datasource` version in https://github.com/signalapp/Signal-Desktop/commit/5350ead9e41c1ab4ba959278eb4843605ae489ab.

https://github.com/signalapp/Signal-Desktop/releases/tag/v7.74.0
https://github.com/signalapp/Signal-Desktop/releases/tag/v7.75.0
https://github.com/signalapp/Signal-Desktop/releases/tag/v7.75.1
https://github.com/signalapp/Signal-Desktop/compare/v7.73.0...v7.75.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
