### PR TITLE
maintainers: drop savannidgerinel

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23039,12 +23039,6 @@
     githubId = 73446695;
     name = "Savinien Petitjean";
   };
-  savannidgerinel = {
-    email = "savanni@luminescent-dreams.com";
-    github = "savannidgerinel";
-    githubId = 8534888;
-    name = "Savanni D'Gerinel";
-  };
   savedra1 = {
     email = "michaelsavedra@gmail.com";
     github = "savedra1";

--- a/pkgs/by-name/_1/_1password-gui/package.nix
+++ b/pkgs/by-name/_1/_1password-gui/package.nix
@@ -33,7 +33,6 @@ let
     maintainers = with lib.maintainers; [
       khaneliman
       timstott
-      savannidgerinel
       sebtm
       bdd
     ];

--- a/pkgs/by-name/cg/cgoban/package.nix
+++ b/pkgs/by-name/cg/cgoban/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     homepage = "https://www.gokgs.com/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.free;
-    maintainers = with maintainers; [ savannidgerinel ];
+    maintainers = [ ];
     platforms = temurin-jre-bin-17.meta.platforms;
   };
 }

--- a/pkgs/by-name/ze/zenstates/package.nix
+++ b/pkgs/by-name/ze/zenstates/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     mainProgram = "zenstates";
     homepage = "https://github.com/r4m0n/ZenStates-Linux";
     license = licenses.mit;
-    maintainers = with maintainers; [ savannidgerinel ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Doesn't seem to be in the GitHub org anymore and therefore  is unable to receive pings from CI.
Hasn't commented since [Oct of 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Asavannidgerinel), hasn't opened any tickets themselves since [Mar, 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Asavannidgerinel), both of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/6d40c7d426c102023aae52888215699bc024cfd3/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

@savannidgerinel, you have a week to object this. Even if you don't make it, you're still welcome back.
```
rg "savannidgerinel"
maintainers/maintainer-list.nix
23042:  savannidgerinel = {
23044:    github = "savannidgerinel";

pkgs/by-name/cg/cgoban/package.nix
40:    maintainers = with maintainers; [ savannidgerinel ];

pkgs/by-name/_1/_1password-gui/package.nix
36:      savannidgerinel

pkgs/by-name/ze/zenstates/package.nix
55:    maintainers = with maintainers; [ savannidgerinel ];
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
