### PR TITLE
haskell.packages.{ghc94,ghc96,ghc98}.haskell-language-server: disallow inconsistent dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -134,7 +134,6 @@ self: super: {
   relude = dontCheck super.relude;
 
   haddock-library = doJailbreak super.haddock-library;
-  apply-refact = addBuildDepend self.data-default-class super.apply-refact;
   path = self.path_0_9_5;
   inherit
     (
@@ -146,23 +145,26 @@ self: super: {
         };
       in
       lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
-        haskell-language-server = allowInconsistentDependencies (
-          addBuildDepends [ self.retrie self.floskell ] super.haskell-language-server
-        );
-        fourmolu = doJailbreak (dontCheck self.fourmolu_0_14_0_0); # ansi-terminal, Diff
-        ormolu = doJailbreak self.ormolu_0_7_2_0; # ansi-terminal
-        hlint = self.hlint_3_6_1;
-        stylish-haskell = self.stylish-haskell_0_14_5_0;
-        retrie = doJailbreak (unmarkBroken super.retrie);
+        apply-refact = addBuildDepend self.data-default-class super.apply-refact;
         floskell = doJailbreak super.floskell;
+        fourmolu = doJailbreak (dontCheck self.fourmolu_0_14_0_0); # ansi-terminal, Diff
+        haskell-language-server = addBuildDepends [
+          self.retrie
+          self.floskell
+        ] super.haskell-language-server;
+        hlint = self.hlint_3_6_1;
+        ormolu = doJailbreak self.ormolu_0_7_2_0; # ansi-terminal
+        retrie = doJailbreak (unmarkBroken super.retrie);
+        stylish-haskell = self.stylish-haskell_0_14_5_0;
       }
     )
-    retrie
+    apply-refact
     floskell
-    haskell-language-server
     fourmolu
-    ormolu
+    haskell-language-server
     hlint
+    ormolu
+    retrie
     stylish-haskell
     ;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -203,7 +203,6 @@ in
   ghc-lib-parser = doDistribute self.ghc-lib-parser_9_8_5_20250214;
   ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_8_0_2;
   haddock-library = doJailbreak super.haddock-library;
-  apply-refact = addBuildDepend self.data-default-class super.apply-refact;
   inherit
     (
       let
@@ -214,23 +213,26 @@ in
         };
       in
       lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
-        haskell-language-server = allowInconsistentDependencies (
-          addBuildDepends [ self.retrie self.floskell ] super.haskell-language-server
-        );
-        ormolu = doDistribute self.ormolu_0_7_4_0;
-        fourmolu = doDistribute (dontCheck (doJailbreak self.fourmolu_0_15_0_0));
-        hlint = doDistribute self.hlint_3_8;
-        stylish-haskell = self.stylish-haskell_0_14_6_0;
-        retrie = doJailbreak (unmarkBroken super.retrie);
+        apply-refact = addBuildDepend self.data-default-class super.apply-refact;
         floskell = doJailbreak super.floskell;
+        fourmolu = dontCheck (doJailbreak self.fourmolu_0_15_0_0);
+        haskell-language-server = addBuildDepends [
+          self.retrie
+          self.floskell
+        ] super.haskell-language-server;
+        hlint = self.hlint_3_8;
+        ormolu = self.ormolu_0_7_4_0;
+        retrie = doJailbreak (unmarkBroken super.retrie);
+        stylish-haskell = self.stylish-haskell_0_14_6_0;
       }
     )
-    retrie
+    apply-refact
     floskell
-    haskell-language-server
     fourmolu
-    ormolu
+    haskell-language-server
     hlint
+    ormolu
+    retrie
     stylish-haskell
     ;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -105,7 +105,6 @@ in
   ghc-exactprint = doDistribute super.ghc-exactprint_1_8_0_0;
 
   haddock-library = doJailbreak super.haddock-library;
-  apply-refact = addBuildDepend self.data-default-class super.apply-refact;
   ghc-lib-parser = doDistribute self.ghc-lib-parser_9_8_5_20250214;
   ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_8_0_2;
   inherit
@@ -114,27 +113,30 @@ in
         hls_overlay = lself: lsuper: {
           Cabal-syntax = lself.Cabal-syntax_3_10_3_0;
           Cabal = lself.Cabal_3_10_3_0;
-          extensions = dontCheck (doJailbreak super.extensions_0_1_0_1);
+          extensions = dontCheck (doJailbreak lself.extensions_0_1_0_1);
         };
       in
       lib.mapAttrs (_: pkg: doDistribute (pkg.overrideScope hls_overlay)) {
-        haskell-language-server = allowInconsistentDependencies (
-          addBuildDepends [ self.retrie self.floskell ] super.haskell-language-server
-        );
-        ormolu = doDistribute self.ormolu_0_7_4_0;
-        fourmolu = doDistribute (dontCheck (doJailbreak self.fourmolu_0_15_0_0));
-        hlint = doDistribute self.hlint_3_8;
-        stylish-haskell = self.stylish-haskell_0_14_6_0;
-        retrie = doJailbreak (unmarkBroken super.retrie);
+        apply-refact = addBuildDepend self.data-default-class super.apply-refact;
         floskell = doJailbreak super.floskell;
+        fourmolu = dontCheck (doJailbreak self.fourmolu_0_15_0_0);
+        haskell-language-server = addBuildDepends [
+          self.retrie
+          self.floskell
+        ] super.haskell-language-server;
+        hlint = self.hlint_3_8;
+        ormolu = self.ormolu_0_7_4_0;
+        retrie = doJailbreak (unmarkBroken super.retrie);
+        stylish-haskell = self.stylish-haskell_0_14_6_0;
       }
     )
-    retrie
+    apply-refact
     floskell
-    haskell-language-server
     fourmolu
-    ormolu
+    haskell-language-server
     hlint
+    ormolu
+    retrie
     stylish-haskell
     ;
 }


### PR DESCRIPTION
The diff is bigger than it needs to be, because I felt the urge to sort things as well.

Key changes:
- For GHC 9.8, fix `super` -> `lself` for `extensions`.
- Add the `hls_overlay` to `apply-refact` as well.
- Remove `allowInconsistentDependencies`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
