### PR TITLE
[perl-updates] Fix cross compilations of perl and modules required for nixos-container

### DIFF
--- a/pkgs/development/interpreters/perl/cross.patch
+++ b/pkgs/development/interpreters/perl/cross.patch
@@ -27,7 +27,7 @@ index 746abd63bc..c55d7cd2d0 100644
 @@ -650,27 +651,29 @@ sub _dump_string {
      join '', map { "$_\n" } @lines;
  }
- 
+
 -sub _has_internal_string_value {
 +# taken from cpan/JSON-PP/lib/JSON/PP.pm
 +sub _looks_like_number {
@@ -46,7 +46,7 @@ index 746abd63bc..c55d7cd2d0 100644
 +    return 1 if $value * 0 == 0;
 +    return -1; # inf/nan
  }
- 
+
  sub _dump_scalar {
      my $string = $_[1];
      my $is_key = $_[2];
@@ -69,8 +69,8 @@ index 746abd63bc..c55d7cd2d0 100644
          $string =~ s/\\/\\\\/g;
 @@ -800,9 +803,6 @@ sub errstr {
  # Helper functions. Possibly not needed.
- 
- 
+
+
 -# Use to detect nv or iv
 -use B;
 -
@@ -80,7 +80,7 @@ index 746abd63bc..c55d7cd2d0 100644
 @@ -822,35 +822,8 @@ sub _can_flock {
      }
  }
- 
+
 -
 -# XXX-INGY Is this core in 5.8.1? Can we remove this?
 -# XXX-XDG Scalar::Util 1.18 didn't land until 5.8.8, so we need this
@@ -112,7 +112,7 @@ index 746abd63bc..c55d7cd2d0 100644
 -    }
 +    *refaddr = *builtin::refaddr;
  }
- 
+
  delete $CPAN::Meta::YAML::{refaddr};
 diff --git a/cpan/CPAN-Meta/lib/CPAN/Meta/Merge.pm b/cpan/CPAN-Meta/lib/CPAN/Meta/Merge.pm
 index 3604eae402..991f69d275 100644
@@ -122,16 +122,16 @@ index 3604eae402..991f69d275 100644
  use strict;
  use warnings;
 +no warnings 'experimental::builtin';
- 
+
  package CPAN::Meta::Merge;
- 
+
  our $VERSION = '2.150010';
- 
+
  use Carp qw/croak/;
 -use Scalar::Util qw/blessed/;
 +use builtin qw/blessed/;
  use CPAN::Meta::Converter 2.141170;
- 
+
  sub _is_identical {
 diff --git a/cpan/CPAN-Meta/lib/CPAN/Meta/Prereqs.pm b/cpan/CPAN-Meta/lib/CPAN/Meta/Prereqs.pm
 index d4e93fd8a5..809da68d02 100644
@@ -143,40 +143,27 @@ index d4e93fd8a5..809da68d02 100644
  use warnings;
 +no warnings 'experimental::builtin';
  package CPAN::Meta::Prereqs;
- 
+
  our $VERSION = '2.150010';
-@@ -14,7 +15,6 @@ our $VERSION = '2.150010';
+@@ -14,7 +14,7 @@ our $VERSION = '2.150010';
  #pod =cut
- 
+
  use Carp qw(confess);
 -use Scalar::Util qw(blessed);
++use builtin qw(blessed);
  use CPAN::Meta::Requirements 2.121;
- 
+
  #pod =method new
-@@ -168,7 +168,12 @@ sub types_in {
- sub with_merged_prereqs {
-   my ($self, $other) = @_;
- 
--  my @other = blessed($other) ? $other : @$other;
-+  eval 'require Scalar::Util';
-+  my @other = unless($@){
-+    Scalar::Util::blessed($other) ? $other : @$other;
-+  }else{
-+    builtin::blessed($other) ? $other : @$other;
-+  }
- 
-   my @prereq_objs = ($self, @other);
- 
 diff --git a/cpan/JSON-PP/lib/JSON/PP.pm b/cpan/JSON-PP/lib/JSON/PP.pm
 index fc8fcbc8f0..cda7b90c65 100644
 --- a/cpan/JSON-PP/lib/JSON/PP.pm
 +++ b/cpan/JSON-PP/lib/JSON/PP.pm
 @@ -4,6 +4,7 @@ package JSON::PP;
- 
+
  use 5.008;
  use strict;
 +no warnings 'experimental::builtin';
- 
+
  use Exporter ();
  BEGIN { our @ISA = ('Exporter') }
 diff --git a/dist/Data-Dumper/Dumper.pm b/dist/Data-Dumper/Dumper.pm
@@ -184,34 +171,34 @@ index bb6d3caedb..0c2fde4743 100644
 --- a/dist/Data-Dumper/Dumper.pm
 +++ b/dist/Data-Dumper/Dumper.pm
 @@ -11,6 +11,7 @@ package Data::Dumper;
- 
+
  use strict;
  use warnings;
 +no warnings 'experimental::builtin';
- 
+
  #$| = 1;
- 
+
 @@ -125,8 +126,7 @@ sub new {
  # Packed numeric addresses take less memory. Plus pack is faster than sprintf
- 
+
  sub format_refaddr {
 -    require Scalar::Util;
 -    pack "J", Scalar::Util::refaddr(shift);
 +    pack "J", builtin::refaddr(shift);
  };
- 
+
  #
 @@ -282,9 +282,8 @@ sub _dump {
        warn "WARNING(Freezer method call failed): $@" if $@;
      }
- 
+
 -    require Scalar::Util;
 -    my $realpack = Scalar::Util::blessed($val);
 -    my $realtype = $realpack ? Scalar::Util::reftype($val) : ref $val;
 +    my $realpack = builtin::blessed($val);
 +    my $realtype = $realpack ? builtin::reftype($val) : ref $val;
      $id = format_refaddr($val);
- 
+
      # Note: By this point $name is always defined and of non-zero length.
 @@ -576,7 +575,7 @@ sub _dump {
      # here generates a different result. So there are actually "three" different
@@ -222,3 +209,15 @@ index bb6d3caedb..0c2fde4743 100644
        $out .= sprintf "v%vd", $val;
      }
      # \d here would treat "1\x{660}" as a safe decimal number
+diff --git a/cpan/JSON-PP/lib/JSON/PP.pm b/cpan/JSON-PP/lib/JSON/PP.pm
+index fc8fcbc8f0..cda7b90c65 100644
+--- a/cpan/JSON-PP/lib/JSON/PP.pm
++++ b/cpan/JSON-PP/lib/JSON/PP.pm
+@@ -12,6 +12,6 @@ package JSON::PP;
+
+ use Carp ();
+-use Scalar::Util qw(blessed reftype refaddr);
++use builtin qw(blessed reftype refaddr);
+ #use Devel::Peek;
+
+

--- a/pkgs/development/interpreters/perl/cross.patch
+++ b/pkgs/development/interpreters/perl/cross.patch
@@ -11,7 +11,62 @@ Updated for perl v5.40.0 by marcus@means.no
 
 ---
 
- # safe if given an unblessed reference
+diff --git a/cpan/CPAN-Meta-Requirements/lib/CPAN/Meta/Requirements/Range.pm b/cpan/CPAN-Meta-Requirements/lib/CPAN/Meta/Requirements/Range.pm
+index b0e83b0d2d..dab4907704 100644
+--- a/cpan/CPAN-Meta-Requirements/lib/CPAN/Meta/Requirements/Range.pm
++++ b/cpan/CPAN-Meta-Requirements/lib/CPAN/Meta/Requirements/Range.pm
+@@ -52,21 +52,38 @@
+ # from version::vpp
+ sub _find_magic_vstring {
+   my $value = shift;
+-  my $tvalue = '';
+-  require B;
+-  my $sv = B::svref_2object(\$value);
+-  my $magic = ref($sv) eq 'B::PVMG' ? $sv->MAGIC : undef;
+-  while ( $magic ) {
+-    if ( $magic->TYPE eq 'V' ) {
+-      $tvalue = $magic->PTR;
+-      $tvalue =~ s/^v?(.+)$/v$1/;
+-      last;
+-    }
+-    else {
+-      $magic = $magic->MOREMAGIC;
++
++  # B is not available in miniperl (it depends on XS), so try to load it safely
++  my $has_B = eval { require B; 1 };
++
++  if ($has_B) {
++     my $sv = B::svref_2object(\$value);
++     my $magic = ref($sv) eq 'B::PVMG' ? $sv->MAGIC : undef;
++     while ($magic) {
++       if ($magic->TYPE eq 'V') {
++         my $tvalue = $magic->PTR;
++         $tvalue =~ s/^v?(.+)$/v$1/;
++         return $tvalue;
++       }
++       $magic = $magic->MOREMAGIC;
+     }
+   }
+-  return $tvalue;
++
++  # --- Fallback for miniperl ---
++  # Perl represents vstrings internally as sequences of bytes like "\x01\x02\x03"
++  # and only shows them as "v1.2.3" when printed.
++  # Try to detect that pattern heuristically.
++  use builtin qw/reftype/;
++  if (!ref($value) && reftype(\$value) eq 'VSTRING') {
++    return sprintf("v%vd", $value);
++  }
++
++  # If it's already a "v1.2.3" string, just return it as is
++  if ($value =~ /^v\d+(?:\.\d+)*$/) {
++    return $value;
++  }
++
++  return '';
+ }
+
+ # Perl 5.10.0 didn't have "is_qv" in version.pm
 diff --git a/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm b/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm
 index 746abd63bc..c55d7cd2d0 100644
 --- a/cpan/CPAN-Meta-YAML/lib/CPAN/Meta/YAML.pm
@@ -21,7 +76,7 @@ index 746abd63bc..c55d7cd2d0 100644
  use strict;
  use warnings;
 +no warnings 'experimental::builtin';
- package CPAN::Meta::YAML; # git description: v1.68-2-gcc5324e
+ package CPAN::Meta::YAML; # git description: v1.75-3-g85169f1
  # XXX-INGY is 5.8.1 too old/broken for utf8?
  # XXX-XDG Lancaster consensus was that it was sufficient until
 @@ -650,27 +651,29 @@ sub _dump_string {
@@ -221,3 +276,24 @@ index fc8fcbc8f0..cda7b90c65 100644
  #use Devel::Peek;
 
 
+diff --git a/cpan/CPAN-Meta/lib/Parse/CPAN/Meta.pm b/cpan/CPAN-Meta/lib/Parse/CPAN/Meta.pm
+--- a/cpan/CPAN-Meta/lib/Parse/CPAN/Meta.pm
++++ b/cpan/CPAN-Meta/lib/Parse/CPAN/Meta.pm
+@@ -53,7 +53,8 @@ sub load_json_string {
+   my ($class, $string) = @_;
+   require Encode;
+   # load_json_string takes characters, decode_json expects bytes
+-  my $encoded = Encode::encode('UTF-8', $string, Encode::PERLQQ());
++  my $encoded = $string;
++  utf8::encode($encoded); # Miniperl workaround
+   my $data = eval { $class->json_decoder()->can('decode_json')->($encoded) };
+   croak $@ if $@;
+   return $data || {};
+@@ -122,7 +122,7 @@ sub _slurp {
+   open my $fh, "<:raw", "$_[0]" ## no critic
+     or die "can't open $_[0] for reading: $!";
+   my $content = do { local $/; <$fh> };
+-  $content = Encode::decode('UTF-8', $content, Encode::PERLQQ());
++  utf8::decode($content); # Workaround for miniperl
+   return $content;
+ }

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -166,10 +166,14 @@ stdenv.mkDerivation (
     configureScript = lib.optionalString (!crossCompiling) "${stdenv.shell} ./Configure";
 
     # !canExecute cross uses miniperl which doesn't have this
-    postConfigure = lib.optionalString (!crossCompiling && stdenv.cc.targetPrefix != "") ''
-      substituteInPlace Makefile \
-        --replace-fail "AR = ar" "AR = ${stdenv.cc.targetPrefix}ar"
-    '';
+    postConfigure =
+      lib.optionalString (!crossCompiling && stdenv.cc.targetPrefix != "") ''
+        substituteInPlace Makefile \
+          --replace-fail "AR = ar" "AR = ${stdenv.cc.targetPrefix}ar"
+      ''
+      + lib.optionalString crossCompiling ''
+        substituteInPlace miniperl_top --replace-fail '-I$top/lib' '-I$top/cpan/JSON-PP/lib -I$top/cpan/CPAN-Meta-YAML/lib -I$top/lib'
+      '';
 
     dontAddStaticConfigureFlags = true;
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -65,19 +65,22 @@ with self;
     args:
     buildPerlPackage (
       {
+        # In case of cross-compilation, generated ./Build have host perl shebang, not build one
+        # so run it with build perl explicitly
         buildPhase = ''
           runHook preBuild
-          perl Build.PL --prefix=$out; ./Build build
+          perl Build.PL --prefix=$out;
+          perl ./Build build
           runHook postBuild
         '';
         installPhase = ''
           runHook preInstall
-          ./Build install
+          perl ./Build install
           runHook postInstall
         '';
         checkPhase = ''
           runHook preCheck
-          ./Build test
+          perl ./Build test
           runHook postCheck
         '';
       }


### PR DESCRIPTION
### Summary

This patch improves compatibility of Perl’s bundled modules when running under **miniperl** — both during bootstrap and as a build environment for Perl-based tooling used in cross-compilation.

---

### Motivation

The primary goal is to enable **cross-compilation of the `nixos-container` package and its dependencies**.

During cross builds, `miniperl` is not just a bootstrap tool — it also serves as the execution environment for pure-Perl build systems such as `Module::Build` and `Module::Build::Tiny`.  
These build systems are used by many of Perl’s bundled modules (including `CPAN::Meta` and `CPAN::Meta::YAML`) and in turn depend on functionality from `Encode` and `B`, which are not available in `miniperl`.

This patch ensures that `miniperl` can execute these build scripts successfully, enabling the full cross-build chain for `nixos-container`.

---

### Changes

- **`Parse::CPAN::Meta::_slurp`**  
  Replaced `Encode::decode` (unavailable under `miniperl`) with a pure-Perl fallback using `utf8::decode`.  
  This ensures reliable UTF-8 decoding without relying on XS modules.

- **`Parse::CPAN::Meta::_find_magic_vstring`**  
  Reimplemented to avoid dependency on the XS-based `B` module.  
  The new version:
  - uses `B` when available (native builds),
  - falls back to a pure-Perl heuristic for vstring detection under `miniperl`.

---

### Context

When cross-compiling Perl (e.g. in `pkgsCross`), `miniperl` is used to run `Module::Build`-style setup scripts for core and bundled CPAN modules.  
Because `miniperl` lacks compiled extensions (`Encode.so`, `B.so`), these scripts would previously fail during parsing of `META.json` and related metadata.

---

### Open question: rebuild impact

The related change that adds an explicit `perl ./Build` invocation in the build logic currently triggers a large number of rebuilds across dependent packages.  
Avoiding this would require introducing conditional logic that makes the code significantly less readable and maintainable.

Possible options:

1. **Keep as is** – cleaner code, but causes more rebuilds initially.  
2. **Add conditional logic** – less readable but minimizes rebuild impact.  
3. **Do (2) temporarily**, then follow up with a clean refactor in a separate PR targeting `staging`.

Feedback from maintainers on the preferred trade-off would be appreciated.

---

### Result

- `Module::Build` and `Module::Build::Tiny` now work correctly under `miniperl`.  
- `CPAN::Meta` and its dependent modules build successfully in cross environments.  
- Cross-builds for `nixos-container` and related Perl tooling now complete without error.  
- No behavior changes for normal build


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
