### PR TITLE
buildRustCrate: Move extraRustcOpts so its contents take precedence

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -42,7 +42,6 @@ let
     "-Z"
     "unstable-options"
   ]
-  ++ extraRustcOpts
   # since rustc 1.42 the "proc_macro" crate is part of the default crate prelude
   # https://github.com/rust-lang/cargo/commit/4d64eb99a4#diff-7f98585dbf9d30aa100c8318e2c77e79R1021-R1022
   ++ lib.optional (lib.elem "proc-macro" crateType) "--extern proc_macro"
@@ -51,7 +50,10 @@ let
       "-C linker=${rustc.llvmPackages.lld}/bin/lld"
   ++ lib.optional (
     stdenv.hasCC && stdenv.hostPlatform.linker != "lld"
-  ) "-C linker=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
+  ) "-C linker=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+
+  # Leave extra options at the bottom
+  ++ extraRustcOpts;
   rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
 
   # build the final rustc arguments that can be different between different


### PR DESCRIPTION
I would like to use a custom linker which is passed through via `extraRustcOpts`. But currently the linker can be hard coded if you fall into one of these two cases:
- `(stdenv.hostPlatform.linker == "lld" && rustc ? llvmPackages.lld)`
- `(stdenv.hasCC && stdenv.hostPlatform.linker != "lld")`

Since rustc just uses the last linker provided to it, this is fixed by moving `extraRustcOpts` after the hard coded options. I don't believe there's any reason for it not to remain at the end where it's contents will take precedence.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test