### PR TITLE
nixos/tinyproxy: support multiple listen addresses

### DIFF
--- a/nixos/modules/services/networking/tinyproxy.nix
+++ b/nixos/modules/services/networking/tinyproxy.nix
@@ -60,7 +60,12 @@ in
             freeformType = settingsFormat.type;
             options = {
               Listen = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
+                type =
+                  with lib.types;
+                  nullOr (oneOf [
+                    str
+                    (listOf str)
+                  ]);
                 default = "127.0.0.1";
                 description = ''
                   Specify which address to listen to.

--- a/nixos/tests/tinyproxy.nix
+++ b/nixos/tests/tinyproxy.nix
@@ -2,22 +2,40 @@
 {
   name = "tinyproxy";
 
-  nodes.machine =
-    { config, pkgs, ... }:
-    {
-      services.tinyproxy = {
-        enable = true;
-        settings = {
-          Listen = "127.0.0.1";
-          Port = 8080;
+  nodes = {
+    machine =
+      { config, pkgs, ... }:
+      {
+        services.tinyproxy = {
+          enable = true;
+          settings = {
+            Listen = [
+              "127.0.0.1"
+              "::1"
+            ];
+            Port = 8080;
+          };
         };
+
+        # Disable firewall so we can be sure curl fails because of the
+        # listening address and not the firewall.
+        networking.firewall.enable = false;
       };
-    };
+
+    other = { ... }: { };
+  };
 
   testScript = ''
+    start_all()
+
     machine.wait_for_unit("tinyproxy.service")
     machine.wait_for_open_port(8080)
 
     machine.succeed('curl -s http://localhost:8080 |grep -i tinyproxy')
+    machine.succeed('curl -s http://127.0.0.1:8080 |grep -i tinyproxy')
+    machine.succeed('curl -s "http://[::1]:8080" |grep -i tinyproxy')
+
+    other.wait_for_unit("multi-user.target")
+    other.fail('curl -s http://machine:8080')
   '';
 }


### PR DESCRIPTION
tinyproxy supports multiple listen addresses, add support in the NixOS module.

See <https://github.com/tinyproxy/tinyproxy/issues/214> and <https://github.com/tinyproxy/tinyproxy/pull/216>.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
