### PR TITLE
nixos/tsidp: pass dir flag to avoid state being created in $HOME/.config

### DIFF
--- a/nixos/modules/services/security/tsidp.nix
+++ b/nixos/modules/services/security/tsidp.nix
@@ -23,6 +23,8 @@ let
     nullOr
     ;
 
+  stateDir = "/var/lib/tsidp";
+
   cfg = config.services.tsidp;
 in
 {
@@ -154,7 +156,7 @@ in
         ];
 
         environment = {
-          HOME = "/var/lib/tsidp";
+          HOME = stateDir;
           TAILSCALE_USE_WIP_CODE = "1"; # Needed while tsidp is in development (< v1.0.0).
         };
 
@@ -163,6 +165,7 @@ in
           ExecStart =
             let
               args = lib.cli.toGNUCommandLineShell { mkOptionName = k: "-${k}"; } {
+                dir = stateDir;
                 hostname = cfg.settings.hostName;
                 port = cfg.settings.port;
                 local-port = cfg.settings.localPort;
@@ -179,8 +182,8 @@ in
           RestartSec = "15";
 
           DynamicUser = true;
-          StateDirectory = "tsidp";
-          WorkingDirectory = "/var/lib/tsidp";
+          StateDirectory = baseNameOf stateDir;
+          WorkingDirectory = stateDir;
           ReadWritePaths = mkIf (cfg.settings.useLocalTailscaled) [
             "/var/run/tailscale" # needed due to `ProtectSystem = "strict";`
             "/var/lib/tailscale"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Avoids state being created in /var/lib/tsidp/.config/tsnet-tsidp as opposed to just /var/lib/tsidp.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
