### PR TITLE
beets: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -112,6 +112,8 @@ python3Packages.buildPythonApplication {
     gobject-introspection
     sphinxHook
     python3Packages.pydata-sphinx-theme
+    python3Packages.sphinx-design
+    python3Packages.sphinx-copybutton
   ]
   ++ extraNativeBuildInputs;
 
@@ -132,6 +134,12 @@ python3Packages.buildPythonApplication {
     "html"
     "man"
   ];
+  # Causes an installManPage error. Not clear why this directory gets generated
+  # with the manpages. The same directory is observed correctly in
+  # $doc/share/doc/beets-${version}/html
+  preInstallSphinx = ''
+    rm -r .sphinx/man/man/_sphinx_design_static
+  '';
 
   postInstall = ''
     mkdir -p $out/share/zsh/site-functions

--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -103,6 +103,10 @@ python3Packages.buildPythonApplication {
       platformdirs
       pyyaml
       unidecode
+      # Can be built without it, but is useful on btrfs systems, and doesn't
+      # add too much to the closure. See:
+      # https://github.com/NixOS/nixpkgs/issues/437308
+      reflink
       typing-extensions
       lap
     ]
@@ -202,6 +206,9 @@ python3Packages.buildPythonApplication {
     "test_reject_different_art"
     # touches network
     "test_merge_duplicate_album"
+    # The existence of the dependency reflink (see comment above), causes this
+    # test to be run, and it fails in the sandbox.
+    "test_successful_reflink"
   ];
 
   # Perform extra "sanity checks", before running pytest tests.

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -31,12 +31,12 @@ lib.makeExtensible (
 
     beets-stable = callPackage ./common.nix rec {
       inherit python3Packages extraPatches;
-      version = "2.5.0";
+      version = "2.5.1";
       src = fetchFromGitHub {
         owner = "beetbox";
         repo = "beets";
         tag = "v${version}";
-        hash = "sha256-YZvS9oB+v+48i1avQcs6ClnYz4aMqJQ2e6cBiZ4ULb0=";
+        hash = "sha256-H3jcEHyK13+RHVlV4zp+8M3LZ0Jc2FdmAbLpekGozLA=";
       };
     };
 


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
