### PR TITLE
yaak: 2025.1.2 -> 2025.6.1

### DIFF
--- a/pkgs/by-name/ya/yaak/package.nix
+++ b/pkgs/by-name/ya/yaak/package.nix
@@ -20,25 +20,28 @@
   makeWrapper,
   nix-update-script,
   stdenv,
+  lld,
+  wasm-pack,
+  wasm-bindgen-cli_0_2_100,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yaak";
-  version = "2025.1.2";
+  version = "2025.6.1";
 
   src = fetchFromGitHub {
     owner = "mountain-loop";
     repo = "yaak";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gD6gp7Qtf162zpRY0b3+g98GSH2aY07s2Auv4+lmbXQ=";
+    hash = "sha256-3sEq7VpzaIMbkvHQTQLf3NRbAJjtpOJpirdcA7y2FIE=";
   };
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-4D7ETUOLixpFB4luqQlwkGR/C6Ke6+ZmPg3dKKkrw7c=";
+    hash = "sha256-zz9wlJ3yQ3oTyCFrAV7vD1xENLW+vmf2Pzly4yYas/g=";
   };
 
-  cargoHash = "sha256-YxOSfSyn+gUsw0HeKrkXZg568X9CAY1UWKnGHHWCC78=";
+  cargoHash = "sha256-CMx7vTSGeQMXpXeH4LIOKEb29CfKXQV+r8tSYdmW5U4=";
 
   cargoRoot = "src-tauri";
 
@@ -51,6 +54,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     protobuf
     perl
     makeWrapper
+    lld
+    wasm-pack
+    wasm-bindgen-cli_0_2_100
   ];
 
   buildInputs = [
@@ -66,11 +72,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  # This must be set so that `npm rebuild` doesn't download wasm-pack
+  env.NPM_CONFIG_IGNORE_SCRIPTS = "true";
 
   postPatch = ''
     substituteInPlace src-tauri/tauri.conf.json \
-      --replace-fail '"createUpdaterArtifacts": "v1Compatible"' '"createUpdaterArtifacts": false' \
       --replace-fail '"0.0.0"' '"${finalAttrs.version}"'
+    substituteInPlace src-tauri/tauri.commercial.conf.json \
+      --replace-fail '"createUpdaterArtifacts": "v1Compatible"' '"createUpdaterArtifacts": false' \
+      --replace-fail '"https://update.yaak.app/check/{{target}}/{{arch}}/{{current_version}}"' '"https://non.existent.domain"'
     substituteInPlace package.json \
       --replace-fail '"bootstrap:vendor-node": "node scripts/vendor-node.cjs",' "" \
       --replace-fail '"bootstrap:vendor-protoc": "node scripts/vendor-protoc.cjs",' ""
@@ -94,6 +104,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ln -s ${protobuf}/bin/protoc src-tauri/vendored/protoc/yaakprotoc-${archPlatforms}
       ln -s ${protobuf}/include src-tauri/vendored/protoc/include
     '';
+
+  tauriBuildFlags = [
+    "--config"
+    "./src-tauri/tauri.commercial.conf.json"
+  ];
 
   # Permission denied (os error 13)
   # write to src-tauri/vendored/protoc/include

--- a/pkgs/by-name/ya/yaak/package.nix
+++ b/pkgs/by-name/ya/yaak/package.nix
@@ -116,7 +116,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   preInstall = "pushd src-tauri";
 
-  postInstall = "popd";
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir $out/bin
+      makeWrapper $out/Applications/Yaak.app/Contents/MacOS/yaak-app $out/bin/yaak-app
+    ''
+    + ''
+      popd
+    '';
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/yaak-app \
@@ -132,7 +139,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/mountain-loop/yaak/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ redyf ];
-    mainProgram = "yaak";
+    mainProgram = "yaak-app";
     platforms = [
       "x86_64-linux"
       "aarch64-linux"


### PR DESCRIPTION
Updates yaak to the latest release.
Closes #420347

Some inspiration has been taken from #424876.
Seems to also solve the display issues currently on master.
<img width="1611" height="1095" alt="image" src="https://github.com/user-attachments/assets/cfcd7a1f-12b8-4faf-8f9a-7b9fe7d44a14" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
