### PR TITLE
Reserve a top-level "alt" attrset for overlaying onto

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14882,4 +14882,8 @@ with pkgs;
   davis = callPackage ../by-name/da/davis/package.nix {
     php = php83; # https://github.com/tchapi/davis/issues/195
   };
+
+  # Reserved namespace for overlaying onto.
+  # Never used within Nixpkgs.
+  alt = { };
 }


### PR DESCRIPTION
# Summary
[summary]: #summary

Reserve at the top-level of Nixpkgs an `alt` attrset for overlaying additional package sets onto.

# Motivation
[motivation]: #motivation

We believe Nixpkgs to be the solution that solves the widest variety of problems in software deployment. This is a logical conclusion given that a Nixpkgs expression has the widest variety of packages and potential configurations available relative to any other solution.

For developers and admins to solve an increasing variety of problems, the variety internal to Nixpkgs must increase accordingly. Increasing the automony of developers allows them to increase the rate at which they solve problems.

The recommended way of autonomously augmenting Nixpkgs is to apply overlays. As internal conflicts intensify and the ratio of reviewers to committers widens, the variety of Nixpkgs maintainers is decreased and more packages will inevitably be pushed onto overlays.

Overlays however suffer from a few problems:
 - no indication of which packages are original and which are overlayed
 - naming clashes
 - evaluation overhead
 - lack of conventions for composition

An empty attrset at the top-level of Nixpkgs is proposed as a namespace for attaching overlayed package sets to address these issues.

# Detailed design
[design]: #detailed-design

Reserve an empty attrset `alt` at the top-level of Nixpkgs.

Nixpkgs maintainers shall not declare anything within this attrset.
Exceptions may be made in the future for functions with names prefixed by an underscore (`_`).

Overlays that provide specialised package sets are encouraged to declare package sets within the `alt` attrset.

Resolving name clashes within the `alt` attrset is the responsibility of overlay maintainers and end-users.
Nixpkgs maintainers abdicate all authority over the use of `alt`.

# Examples and Interactions
[examples-and-interactions]: #examples-and-interactions

Overlays should declare package in a single set within `alt`:
```nix
let altName = "uniLab321"; in

final: prev:
let  
  callPackage = final.newScope final.alt.${altName};
in {
  prev.alt // {
    ${altName} = {
      foo = callPackage ./foo { };
      bar = callpackage ./bar { };
    };
  };
}
```

Overlays that conform to the `alt` namespace convention can be lazily applied to Nixpkgs using an intermediate overlay.
```nix
{
  overlayComposition = final: prev: {                                        
    alt = prev.alt // final.lib.mapAttrs (name: f: (f final prev).alt.${name}) {
      uniLab321 = import ../lab/overlay.nix
      bakaGe = import (<games> + /overlay.nix);
      guix = import ./guix-adapter.nix;
      localHackspace = import /local/hackspace/overlay.nix;
      autonomousMurderCorp = import ../work/overlay.nix;
    };
  };
}
```

# Drawbacks
[drawbacks]: #drawbacks

- Political decentralisation.
- No reliable mechanism to resolve cross overlay dependencies.
- Probably worse error messages.

# Alternatives
[alternatives]: #alternatives

- Wait for it to get into Nixpkgs
- Fork Nixpkgs
- `--extra-experimental-features flakes`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
