### PR TITLE
linkwarden: 2.13.0 -> 2.13.1

### DIFF
--- a/pkgs/by-name/li/linkwarden/package.nix
+++ b/pkgs/by-name/li/linkwarden/package.nix
@@ -51,13 +51,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "linkwarden";
-  version = "2.13.0";
+  version = "2.13.1";
 
   src = fetchFromGitHub {
     owner = "linkwarden";
     repo = "linkwarden";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zoJ5y2J+lkmfAFdI/7FvFAC6D308IPxaLzpGtj42IrU=";
+    hash = "sha256-ARy7UNG1Rnq3E8UaM1zgmbtr9uLvsfIHLdvVeTKjM+I=";
   };
 
   patches = [
@@ -71,21 +71,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
        pkgs/by-name/ne/nextjs-ollama-llm-ui/0002-use-local-google-fonts.patch
     */
     ./01-localfont.patch
-
-    /*
-      https://github.com/linkwarden/linkwarden/pull/1290
-
-      Fixes an issue where linkwarden cannot save a plain HTTP (no TLS) website.
-    */
-    (fetchpatch {
-      url = "https://github.com/linkwarden/linkwarden/commit/327826d760e5b1870c58a25f85501a7c9a468818.patch";
-      hash = "sha256-kq1GIEW0chnPmzvg4eDSS/5WtRyWlrHlk41h4pSCMzg=";
-    })
   ];
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-Z1EwecQGWHr6RZCDHAy7BA6BEoixj1dbKH3XE8sfeKQ=";
+    hash = "sha256-FpJJwei7T8emcFtkIOOWyf92w3zp5n1b1MnSRA5dnyI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/linkwarden/linkwarden/releases/tag/v2.13.1

My PR was merged finally, so the patch is no longer necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
