### PR TITLE
Add dinixMinimal

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14712,6 +14712,13 @@
     githubId = 67327023;
     keys = [ { fingerprint = "8185 29F9 BB4C 33F0 69BB  9782 D1AC CDCF 2B9B 9799"; } ];
   };
+  lillecarl = {
+    name = "Carl Andersson";
+    github = "lillecarl";
+    githubId = 207073;
+    email = "nixos@lillecarl.com";
+    matrix = "@lillecarl:matrix.org";
+  };
   lillycham = {
     email = "lillycat332@gmail.com";
     github = "lillycham";

--- a/pkgs/by-name/di/dinit/package.nix
+++ b/pkgs/by-name/di/dinit/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   m4,
   installShellFiles,
-  util-linux,
+  util-linuxMinimal,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/shutdown.cc \
-      --replace-fail '"/bin/umount"' '"${util-linux}/bin/umount"' \
-      --replace-fail '"/sbin/swapoff"' '"${util-linux}/bin/swapoff"'
+      --replace-fail '"/bin/umount"' '"${util-linuxMinimal}/bin/umount"' \
+      --replace-fail '"/sbin/swapoff"' '"${util-linuxMinimal}/bin/swapoff"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/di/dinit/package.nix
+++ b/pkgs/by-name/di/dinit/package.nix
@@ -49,7 +49,10 @@ stdenv.mkDerivation rec {
     description = "Service manager / supervision system, which can (on Linux) also function as a system manager and init";
     homepage = "https://davmac.org/projects/dinit";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ aanderse ];
+    maintainers = with lib.maintainers; [
+      aanderse
+      lillecarl
+    ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Add dinixMinimal, util-linux brings in way too many dependencies for using dinit as container init or userspace process supervisor.

I think it fits the contribution guide, this is one of my first nixpkgs contributions.
@aanderse 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
