### PR TITLE
uv: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-qT5A3nzYkbzjqv8rk93zAcBlhYsI5SkMUYavsxp5QJg=";
+    hash = "sha256-wnuAUoyq2CQt5F5LiIsfclv+RXESZFMzGF6UbQhmsBI=";
   };
 
-  cargoHash = "sha256-3IMOAYRxyMPSJSWnZJ344jHC7nS6TE2CouCr4eTYeaw=";
+  cargoHash = "sha256-AeqOGZrc0MY+WSR3xrEnSfxf0mgdRvxkpNcQrLsmtiY=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/development/python-modules/django-bootstrap4/default.nix
+++ b/pkgs/development/python-modules/django-bootstrap4/default.nix
@@ -31,10 +31,9 @@ buildPythonPackage rec {
   };
 
   patches = [
-    # https://github.com/zostera/django-bootstrap4/pull/826
     (fetchpatch2 {
       name = "uv-build.patch";
-      url = "https://github.com/Prince213/django-bootstrap4/commit/e3e6b7cc6720568177d37ff0998007c84c294c5a.patch?full_index=1";
+      url = "https://github.com/zostera/django-bootstrap4/commit/09b14bc9b70e7da92200c4bc014e2d3c597f0ea6.patch?full_index=1";
       hash = "sha256-ZW9y8n0ZCOP37EoP32e7ue6h93KgGw1pW8Q1Q8IuNk8=";
     })
   ];

--- a/pkgs/development/python-modules/django-bootstrap5/default.nix
+++ b/pkgs/development/python-modules/django-bootstrap5/default.nix
@@ -25,10 +25,9 @@ buildPythonPackage rec {
   };
 
   patches = [
-    # https://github.com/zostera/django-bootstrap5/pull/769
     (fetchpatch2 {
       name = "uv-build.patch";
-      url = "https://github.com/Prince213/django-bootstrap5/commit/e588b25e0c81d9133ca2b9391c125b41d485aefc.patch?full_index=1";
+      url = "https://github.com/zostera/django-bootstrap5/commit/d1d54f5fc8041d2781189321402b4f3937f77913.patch?full_index=1";
       hash = "sha256-cFOY+pu2TAZXpAipSIQh1nPPC0ipfncvpObcH667+ac=";
     })
   ];


### PR DESCRIPTION
Changelog: https://github.com/astral-sh/uv/blob/0.9.3/CHANGELOG.md#093

Cherry picked the commit to master and built on x86_64-linux:
```
/nix/store/8llzyz2pgdlgs7d8rn9ny2c1p5lnvh1y-uv-0.9.3
/nix/store/wjs8mqymypmdgby4h7a6wy5mja9jmzfg-python3.13-uv-0.9.3
/nix/store/wvv0i5lz5842vx06pw35vi1pp3b5sy5w-python3.13-uv-build-0.9.3
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
