### PR TITLE
 ethrex-bin: init at 3.0.0 (Ethereum execution client)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13677,6 +13677,11 @@
     github = "kkoniuszy";
     githubId = 120419423;
   };
+  klaus933 = {
+    name = "Klaus Lungwitz";
+    github = "klaus993";
+    githubId = 18153834;
+  };
   klchen0112 = {
     name = "klchen0112";
     email = "klchen0112@gmail.com";
@@ -22906,6 +22911,11 @@
     github = "SamLukeYes";
     githubId = 12882091;
     name = "Sam L. Yes";
+  };
+  samoht9277 = {
+    name = "Tomas Casagrande";
+    github = "samoht9277";
+    githubId = 53660242;
   };
   samrose = {
     email = "samuel.rose@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12915,6 +12915,11 @@
     githubId = 589502;
     name = "James Szalay";
   };
+  juanbono = {
+    name = "Juan Bono";
+    github = "juanbono";
+    githubId = 2772065;
+  };
   juancmuller = {
     email = "nix@juancmuller.com";
     githubId = 208500;
@@ -14585,6 +14590,11 @@
     github = "lf-";
     githubId = 6652840;
     matrix = "@jade_:matrix.org";
+  };
+  lferrigno = {
+    name = "Leando Ferrigno";
+    github = "lferrigno";
+    githubId = 5018415;
   };
   lgbishop = {
     email = "lachlan.bishop@hotmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13677,7 +13677,7 @@
     github = "kkoniuszy";
     githubId = 120419423;
   };
-  klaus933 = {
+  klaus993 = {
     name = "Klaus Lungwitz";
     github = "klaus993";
     githubId = 18153834;

--- a/pkgs/by-name/et/ethrex-bin/package.nix
+++ b/pkgs/by-name/et/ethrex-bin/package.nix
@@ -1,0 +1,60 @@
+{ lib, stdenvNoCC, fetchurl }:
+
+let
+  version = "3.0.0";
+
+  urls = {
+    "x86_64-linux" = {
+      plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_x86_64";
+    };
+    "aarch64-linux" = {
+      plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_aarch64";
+    };
+    "aarch64-darwin" = {
+      plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-macos_aarch64";
+    };
+  };
+
+  hashes = {
+    "x86_64-linux".plain   = "sha256-Vg6jwBj5jrSAsb7nn04G/HEKhQyX8sICjmmPMpkIHTI=";
+    "aarch64-linux".plain  = "sha256-8ML5R6EvvYbnfxCRG5mqgNqY/vkl1iEOdoEHKF4BaX8=";
+    "aarch64-darwin".plain = "sha256-dMoRtiJOCLV2B4coLrSLkYdEkTKsvbJGzmv049UpBhY=";
+  };
+
+  sys = stdenvNoCC.hostPlatform.system;
+
+  _ = if !(lib.hasAttr sys urls) then
+        throw "ethrex-bin ${version}: platform ${sys} not supported (supported: ${builtins.concatStringsSep ", " (builtins.attrNames urls)})"
+      else null;
+
+  srcUrl  = urls.${sys}.plain;
+  srcHash = hashes.${sys}.plain;
+
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "ethrex-bin";
+  inherit version;
+
+  src = fetchurl { url = srcUrl; sha256 = srcHash; };
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm755 "$src" "$out/bin/ethrex"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    "$out/bin/ethrex" --version >/dev/null
+  '';
+
+  meta = with lib; {
+    description = "A lightweight, performant, and modular Ethereum execution client powering next-gen L1 and L2 solutions.";
+    homepage = "https://ethrex.xyz/";
+    license = licenses.asl20;
+    mainProgram = "ethrex";
+    platforms = builtins.attrNames urls;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    changelog = "https://github.com/lambdaclass/ethrex/releases/tag/v${version}";
+    maintainers = with maintainers; [ samoht9277 klaus993 ];
+  };
+}

--- a/pkgs/by-name/et/ethrex-bin/package.nix
+++ b/pkgs/by-name/et/ethrex-bin/package.nix
@@ -57,6 +57,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = builtins.attrNames urls;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     changelog = "https://github.com/lambdaclass/ethrex/releases/tag/v${version}";
-    maintainers = with maintainers; [ samoht9277 klaus993 ];
+    maintainers = with maintainers; [ samoht9277 klaus993 juanbono lferrigno ];
   };
 })

--- a/pkgs/by-name/et/ethrex-bin/package.nix
+++ b/pkgs/by-name/et/ethrex-bin/package.nix
@@ -4,15 +4,9 @@ let
   version = "3.0.0";
 
   urls = {
-    "x86_64-linux" = {
-      plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_x86_64";
-    };
-    "aarch64-linux" = {
-      plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_aarch64";
-    };
-    "aarch64-darwin" = {
-      plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-macos_aarch64";
-    };
+    "x86_64-linux".plain   = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_x86_64";
+    "aarch64-linux".plain  = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_aarch64";
+    "aarch64-darwin".plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-macos_aarch64";
   };
 
   hashes = {
@@ -31,7 +25,7 @@ let
   srcHash = hashes.${sys}.plain;
 
 in
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ethrex-bin";
   inherit version;
 
@@ -47,8 +41,16 @@ stdenvNoCC.mkDerivation rec {
     "$out/bin/ethrex" --version >/dev/null
   '';
 
+  passthru.tests.version = stdenvNoCC.mkDerivation {
+    name = "ethrex-version-test";
+    buildCommand = ''
+      export PATH=${finalAttrs.finalPackage}/bin:$PATH
+      ethrex --version | tee $out
+    '';
+  };
+
   meta = with lib; {
-    description = "A lightweight, performant, and modular Ethereum execution client powering next-gen L1 and L2 solutions.";
+    description = "Ethereum execution client (official prebuilt binary)";
     homepage = "https://ethrex.xyz/";
     license = licenses.asl20;
     mainProgram = "ethrex";
@@ -57,4 +59,4 @@ stdenvNoCC.mkDerivation rec {
     changelog = "https://github.com/lambdaclass/ethrex/releases/tag/v${version}";
     maintainers = with maintainers; [ samoht9277 klaus993 ];
   };
-}
+})

--- a/pkgs/by-name/et/ethrex-bin/package.nix
+++ b/pkgs/by-name/et/ethrex-bin/package.nix
@@ -1,27 +1,36 @@
-{ lib, stdenvNoCC, fetchurl }:
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
 
 let
   version = "3.0.0";
 
   urls = {
-    "x86_64-linux".plain   = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_x86_64";
-    "aarch64-linux".plain  = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_aarch64";
-    "aarch64-darwin".plain = "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-macos_aarch64";
+    "x86_64-linux".plain =
+      "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_x86_64";
+    "aarch64-linux".plain =
+      "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-linux_aarch64";
+    "aarch64-darwin".plain =
+      "https://github.com/lambdaclass/ethrex/releases/download/v${version}/ethrex-macos_aarch64";
   };
 
   hashes = {
-    "x86_64-linux".plain   = "sha256-Vg6jwBj5jrSAsb7nn04G/HEKhQyX8sICjmmPMpkIHTI=";
-    "aarch64-linux".plain  = "sha256-8ML5R6EvvYbnfxCRG5mqgNqY/vkl1iEOdoEHKF4BaX8=";
+    "x86_64-linux".plain = "sha256-Vg6jwBj5jrSAsb7nn04G/HEKhQyX8sICjmmPMpkIHTI=";
+    "aarch64-linux".plain = "sha256-8ML5R6EvvYbnfxCRG5mqgNqY/vkl1iEOdoEHKF4BaX8=";
     "aarch64-darwin".plain = "sha256-dMoRtiJOCLV2B4coLrSLkYdEkTKsvbJGzmv049UpBhY=";
   };
 
   sys = stdenvNoCC.hostPlatform.system;
 
-  _ = if !(lib.hasAttr sys urls) then
-        throw "ethrex-bin ${version}: platform ${sys} not supported (supported: ${builtins.concatStringsSep ", " (builtins.attrNames urls)})"
-      else null;
+  _ =
+    if !(lib.hasAttr sys urls) then
+      throw "ethrex-bin ${version}: platform ${sys} not supported (supported: ${builtins.concatStringsSep ", " (builtins.attrNames urls)})"
+    else
+      null;
 
-  srcUrl  = urls.${sys}.plain;
+  srcUrl = urls.${sys}.plain;
   srcHash = hashes.${sys}.plain;
 
 in
@@ -29,7 +38,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ethrex-bin";
   inherit version;
 
-  src = fetchurl { url = srcUrl; sha256 = srcHash; };
+  src = fetchurl {
+    url = srcUrl;
+    sha256 = srcHash;
+  };
   dontUnpack = true;
 
   installPhase = ''
@@ -57,6 +69,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = builtins.attrNames urls;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     changelog = "https://github.com/lambdaclass/ethrex/releases/tag/v${version}";
-    maintainers = with maintainers; [ samoht9277 klaus993 juanbono lferrigno ];
+    maintainers = with maintainers; [
+      samoht9277
+      klaus993
+      juanbono
+      lferrigno
+    ];
   };
 })


### PR DESCRIPTION
Adds [lambdaclass/ethrex](https://github.com/lambdaclass/ethrex), an Ethereum execution client built on rust, developed by @LambdaClass
* https://lambdaclass.com/
* https://ethrex.xyz/

This PR packages the **official prebuilt binaries** for macOS and Linux.

Also added myself (@samoht9277) and co-worker's (@klaus993, @lferrigno and @juanbono) as maintainers.

This PR adds `*-bin` variants first. A **from-source** package (`ethrex`) is planned next.
We had some issues (and some questions) regarding building it from source, since each platform currently enables different Rust feature sets and dependencies, depending on the platform and OS.  
For now, GPU-related builds and platform-specific features were removed to keep this initial contribution simple and stable.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin 
    - (not supported by ethrex)
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
