### PR TITLE
python3Packages.ibis-framework: 10.8.0 -> 11.0.0; python3Packages.narwhals, python3Packages.pandera: fixes

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -98,14 +98,14 @@ in
 
 buildPythonPackage rec {
   pname = "ibis-framework";
-  version = "10.8.0";
+  version = "11.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ibis-project";
     repo = "ibis";
     tag = version;
-    hash = "sha256-Uuqm9Exu/oK3BGBL4ViUOGArMWhVutUn1gFRj1I4vt4=";
+    hash = "sha256-hf5guWeX9WQbKaNrs7ALwwDxV1Rgeb5Z0PedTQ4P7S0=";
   };
 
   build-system = [
@@ -175,6 +175,9 @@ buildPythonPackage rec {
 
     # duckdb ParserError: syntax error at or near "AT"
     "test_90"
+
+    # assert 0 == 3 (tests edge case behavior of databases)
+    "test_self_join_with_generated_keys"
   ];
 
   # patch out tests that check formatting with black

--- a/pkgs/development/python-modules/narwhals/default.nix
+++ b/pkgs/development/python-modules/narwhals/default.nix
@@ -73,6 +73,8 @@ buildPythonPackage rec {
     "test_convert_time_zone_to_connection_tz_pyspark"
     "test_replace_time_zone_to_connection_tz_pyspark"
     "test_lazy"
+    # Incompatible with ibis 11
+    "test_unique_3069"
   ];
 
   pytestFlags = [

--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -133,6 +133,10 @@ buildPythonPackage rec {
     # KeyError: 'dask'
     "tests/dask/test_dask.py::test_series_schema"
     "tests/dask/test_dask_accessor.py::test_dataframe_series_add_schema"
+
+    # TypeError: memtable() got an unexpected keyword argument 'name'
+    # https://github.com/unionai-oss/pandera/issues/2154
+    "tests/ibis/test_ibis_container.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
Ibis: https://github.com/ibis-project/ibis/releases/tag/11.0.0
narwhals, pandera: disable tests that are incompatible with ibis 11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
