### PR TITLE
python3Packages.scalene: 1.5.52 -> 1.5.55

### DIFF
--- a/pkgs/development/python-modules/scalene/default.nix
+++ b/pkgs/development/python-modules/scalene/default.nix
@@ -38,7 +38,7 @@ in
 
 buildPythonPackage rec {
   pname = "scalene";
-  version = "1.5.52";
+  version = "1.5.55";
   pyproject = true;
   disabled = pythonOlder "3.9";
 
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     owner = "plasma-umass";
     repo = "scalene";
     tag = "v${version}";
-    hash = "sha256-8WE/tR0tGwdNSPtieS90QAOFlS66h/JxaV2LvpZjx2E=";
+    hash = "sha256-aO7l/paYqbneDArAbXxptIlMGfvc1dAaFLucEj/7xbk=";
   };
 
   patches = [
@@ -95,6 +95,8 @@ buildPythonPackage rec {
   disabledTests = [
     # Flaky -- socket collision
     "test_show_browser"
+    # File not found
+    "test_nested_package_relative_import"
   ];
 
   # remove scalene directory to prevent pytest import confusion


### PR DESCRIPTION
Version bump via update script

https://github.com/plasma-umass/scalene/releases/tag/v1.5.53
https://github.com/plasma-umass/scalene/releases/tag/v1.5.54
https://github.com/plasma-umass/scalene/releases/tag/v1.5.55

https://github.com/plasma-umass/scalene/compare/v1.5.52...v1.5.55


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
