### PR TITLE
linphonePackages.bctoolbox: swap `openssl` for `bc-mbedtls`

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/bc-mbedtls/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/bc-mbedtls/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+
+  cmake,
+  ninja,
+  perl, # Project uses Perl for scripting and testing
+  python3,
+}:
+let
+  rev = "1d452d3852321cb55c07307cb506b25759134b76";
+in
+stdenv.mkDerivation {
+  pname = "mbedtls";
+  # taken from `ChangeLog`
+  version = "3.6.1-unstable-2025-08-11";
+
+  src = fetchFromGitLab {
+    inherit rev;
+
+    domain = "gitlab.linphone.org";
+    group = "BC";
+    owner = "public/external";
+    repo = "mbedtls";
+    sha256 = "sha256-jQpRn2F21sPKKAiaqsUvaKyuR80AnedG/hAyiNamKjc=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    perl
+    python3
+  ];
+
+  strictDeps = true;
+
+  # trivialautovarinit on clang causes test failures
+  hardeningDisable = lib.optional stdenv.cc.isClang "trivialautovarinit";
+
+  cmakeFlags = [
+    # tests don't compile, due to how BC sets up threading
+    "-DENABLE_TESTING=OFF"
+    "-DENABLE_PROGRAMS=OFF"
+
+    "-DUSE_SHARED_MBEDTLS_LIBRARY=${if stdenv.hostPlatform.isStatic then "off" else "on"}"
+
+    # Avoid a dependency on jsonschema and jinja2 by not generating source code
+    # using python. In releases, these generated files are already present in
+    # the repository and do not need to be regenerated. See:
+    # https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.3.0 below "Requirement changes".
+    "-DGEN_FILES=off"
+  ];
+
+  # Parallel checking causes test failures
+  # https://github.com/Mbed-TLS/mbedtls/issues/4980
+  enableParallelChecking = false;
+
+  meta = {
+    homepage = "https://gitlab.linphone.org/BC/public/external/mbedtls";
+    changelog = "https://gitlab.linphone.org/BC/public/external/mbedtls/-/blob/${rev}/ChangeLog";
+    description = "Portable cryptographic and TLS library, formerly known as PolarSSL (Linphone fork)";
+    license = with lib.licenses; [
+      asl20 # or
+      gpl2Plus
+    ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ naxdy ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/linphone/bctoolbox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/bctoolbox/default.nix
@@ -2,7 +2,7 @@
   bcunit,
   bc-decaf,
   mkLinphoneDerivation,
-  openssl,
+  bc-mbedtls,
   lib,
 
   # tests
@@ -14,15 +14,14 @@ mkLinphoneDerivation (finalAttrs: {
   propagatedBuildInputs = [
     bcunit
     bc-decaf
-    openssl
+    bc-mbedtls
   ];
 
   cmakeFlags = [
     "-DENABLE_STRICT=NO"
 
-    # mbedtils does not build
-    "-DENABLE_MBEDTLS=NO"
-    "-DENABLE_OPENSSL=YES"
+    "-DENABLE_MBEDTLS=YES"
+    "-DENABLE_OPENSSL=NO"
   ];
 
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Apparently bctoolbox doesn't play nice with (our?) openssl. The alternative is to use their fork of mbedtls, which afaict is the first choice anyway.

Closes #452331

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
