### PR TITLE
davmail: Build from source with `ant`

### DIFF
--- a/pkgs/by-name/da/davmail/package.nix
+++ b/pkgs/by-name/da/davmail/package.nix
@@ -1,12 +1,12 @@
 {
   stdenv,
-  fetchzip,
+  fetchFromGitHub,
   lib,
   makeWrapper,
-  unzip,
   glib,
   gtk2,
   gtk3,
+  ant,
   jdk,
   libXtst,
   coreutils,
@@ -17,34 +17,45 @@
 }:
 
 let
-  rev = 3755;
   jre' = (if preferZulu then zulu else jdk).override { enableJavaFX = true; };
   gtk' = if preferGtk3 then gtk3 else gtk2;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "davmail";
   version = "6.4.0";
 
-  src = fetchzip {
-    url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}-${toString rev}.zip";
-    hash = "sha256-cGuAxSIkhkcpRXlv5f3utH/1zZ1aYbLQN/OLuN80JdM=";
-    stripRoot = false;
+  src = fetchFromGitHub {
+    owner = "mguessan";
+    repo = "davmail";
+    tag = finalAttrs.version;
+    hash = "sha256-dj+7e0b8GcyoDzEWGG1SEMijqRBo1IJUFtgxkt9XNRU=";
   };
 
-  postPatch = ''
+  buildPhase = ''
+    runHook preBuild
+
+    ant compile prepare-dist
+    cp -Rv dist/{lib,davmail{,.jar}} .
     sed -i -e '/^JAVA_OPTS/d' davmail
+
+    runHook postBuild
   '';
 
   nativeBuildInputs = [
     makeWrapper
-    unzip
+    ant
+  ];
+
+  buildInputs = [
+    jre'
   ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share/davmail
-    cp -vR ./* $out/share/davmail
+    cp -vR ./{lib,davmail{,.jar}} $out/share/davmail
+    chmod +x $out/share/davmail/davmail
     makeWrapper $out/share/davmail/davmail $out/bin/davmail \
       --set-default JAVA_OPTS "-Xmx512M -Dsun.net.inetaddr.ttl=60 -Djdk.gtk.version=${lib.versions.major gtk'.version}" \
       --prefix PATH : ${
@@ -73,4 +84,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     mainProgram = "davmail";
   };
-}
+})


### PR DESCRIPTION
Rather than building the derivation from a binary archive, this PR builds from a GitHub-tagged release.

Other changes include:

- Using the new `finalAttrs` methodology instead of `rec`.
- Removing `fetchzip` and replacing with `fetchFromGitHub`.
- Removing `rev` from the let-binding, as we build from GitHub.
- Adding `ant` and `jre'` as a `nativeBuildInput` and `buildInput`, respectively.
- Removing `unzip`.

This is a BREAKING CHANGE for consumers, and should be communicated to downstream users.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
