### PR TITLE
libgit2: fix heap buffer overflow in SSH custom credential handling

### DIFF
--- a/pkgs/by-name/li/libgit2/fix-ssh-custom-heap-buffer-overflow.patch
+++ b/pkgs/by-name/li/libgit2/fix-ssh-custom-heap-buffer-overflow.patch
@@ -1,0 +1,31 @@
+commit 4277cc75bc147d0af6ffddc7db96f48492977968
+Author: bakersdozen123 <taunts_bakers_3r@icloud.com>
+Date:   Sat Oct 11 09:56:48 2025 -0700
+
+    ssh: fix custom ssh heap buffer overflow
+    
+    The `ssh_custom_free()` function calls `strlen()` on the `publickey`
+    field, which stores binary data, not a null-terminated string. This
+    causes a heap buffer overflow when the public key data is not
+    null-terminated or contains embedded null bytes.
+    
+    The `publickey` field stores binary data, as required by the underlying
+    `libssh2_userauth_publickey()` function, which accepts a public key
+    parameter of the type `const unsigned char*`.
+    
+    Use the stored `publickey_len` instead of `strlen()` to determine the
+    correct buffer size.
+
+diff --git a/src/libgit2/transports/credential.c b/src/libgit2/transports/credential.c
+index b47bd63a1..7d0eacecf 100644
+--- a/src/libgit2/transports/credential.c
++++ b/src/libgit2/transports/credential.c
+@@ -161,7 +161,7 @@ static void ssh_custom_free(struct git_credential *cred)
+ 
+ 	if (c->publickey) {
+ 		/* Zero the memory which previously held the publickey */
+-		size_t key_len = strlen(c->publickey);
++		size_t key_len = c->publickey_len;
+ 		git__memzero(c->publickey, key_len);
+ 		git__free(c->publickey);
+ 	}

--- a/pkgs/by-name/li/libgit2/package.nix
+++ b/pkgs/by-name/li/libgit2/package.nix
@@ -39,6 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/xI3v7LNhpgfjv/m+sZwYDhhYvS6kQYxiiiG3+EF8Mw=";
   };
 
+  patches = [
+    # https://github.com/libgit2/libgit2/pull/7146
+    ./fix-ssh-custom-heap-buffer-overflow.patch
+  ];
+
   cmakeFlags = [
     "-DREGEX_BACKEND=pcre2"
     "-DUSE_HTTP_PARSER=llhttp"

--- a/pkgs/tools/package-management/nix/dependencies.nix
+++ b/pkgs/tools/package-management/nix/dependencies.nix
@@ -34,5 +34,12 @@ regular@{
       # only a stripped down version is built which takes a lot less resources to build
       requiredSystemFeatures = [ ];
     };
+
+    libgit2 = pkgs.libgit2.overrideAttrs (old: {
+      # Drop the SSH buffer overflow patch to avoid rebuilding Nix
+      patches = lib.filter (p: !lib.hasSuffix "fix-ssh-custom-heap-buffer-overflow.patch" (toString p)) (
+        old.patches or [ ]
+      );
+    });
   };
 }


### PR DESCRIPTION
The ssh_custom_free() function was calling strlen() on binary public key data, causing a heap buffer overflow when the data wasn't null-terminated. It also caused keys with null bytes in them to be not cleared completely. This patch uses the stored publickey_len field instead of strlen() to determine the correct buffer size for zeroing memory.

This fix has been published in unmerged PR https://github.com/libgit2/libgit2/pull/7146

Nix uses libgit2, but not the transports / libssh2 integration. Other applications may be affected, and need this fix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
