### PR TITLE
verus-bin: init at version 0.2025.08.23.bb6fd4e

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11501,6 +11501,12 @@
     githubId = 153585330;
     name = "Jacob Levi";
   };
+  jakeginesin = {
+    email = "ginesin@cmu.edu";
+    github = "JakeGinesin";
+    githubId = 39607713;
+    name = "Jake Ginesin";
+  };
   jakehamilton = {
     name = "Jake Hamilton";
     email = "jake.hamilton@hey.com";

--- a/pkgs/by-name/ve/verus-bin/package.nix
+++ b/pkgs/by-name/ve/verus-bin/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  gitUpdater,
+  autoPatchelfHook,
+}:
+
+let
+  version = "0.2025.10.05.bf8e97e";
+  url = "https://github.com/verus-lang/verus/releases/download/release/${version}/verus-${version}";
+  srcs = {
+    "x86_64-linux" = fetchzip {
+      url = "${url}-x86-linux.zip";
+      hash = "sha256-r+JKbmxzT8ywza695mobk7KsXWg8tA+vgpEdOi13r8U=";
+    };
+    "x86_64-darwin" = fetchzip {
+      url = "${url}-x86-macos.zip";
+      hash = "sha256-3VEhlPzs1WvplT33QqgZgX/IBfL8T/nwTlQj0aWx5ug=";
+    };
+    "aarch64-darwin" = fetchzip {
+      url = "${url}-arm64-macos.zip";
+      hash = "sha256-aKpC78p54m5Wa+LRYDJthVU7cAOH2Z046VECxYnbqzg=";
+    };
+    "x86_64-windows" = fetchzip {
+      url = "${url}-x86-win.zip";
+      hash = "sha256-gwLUvkiWeEqmzV3g77Dbm4bxgo6lpSEYsRQMEQjGfvc=";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "verus-bin";
+  inherit version;
+
+  src =
+    srcs.${stdenv.hostPlatform.system}
+      or (throw "verus-bin is not supported on ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    stdenv.cc.cc
+  ];
+
+  # intended to be used with rustup
+  autoPatchelfIgnoreMissingDeps = [ "librustc_driver-*.so" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r $src/* $out/
+
+    mkdir -p $out/bin
+    ln -s $out/verus $out/bin/verus
+    ln -s $out/cargo-verus $out/bin/cargo-verus
+    ln -s $out/rust_verify $out/bin/rust_verify
+    ln -s $out/z3 $out/bin/z3
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "release/";
+    url = "https://github.com/verus-lang/verus";
+  };
+
+  meta = {
+    homepage = "https://github.com/verus-lang/verus";
+    description = "Verified Rust for low-level systems code";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jakeginesin
+      stephen-huan
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "x86_64-windows"
+    ];
+    mainProgram = "verus";
+  };
+}


### PR DESCRIPTION
Adding a binary build of [Verus](https://github.com/verus-lang/verus), a formal verification tool for Rust.

(please be nice, I am a first-time contributor) 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTIgit config pull.rebase falseNG.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
