### PR TITLE
music-assistant: 2.5.8 -> 2.6.0

### DIFF
--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.15.1";
+  version = "2.15.3";
   pyproject = true;
 
   src = fetchPypi {
     pname = "music_assistant_frontend";
     inherit version;
-    hash = "sha256-l6SKBMqP2FrjVUmywDXf0I4Te0qbzufUVR7frWAzrks=";
+    hash = "sha256-atwFGd6KplVPw4e6rHrNlXmMCsozL56lCVYVWCg9RPs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/mu/music-assistant/librespot.patch
+++ b/pkgs/by-name/mu/music-assistant/librespot.patch
@@ -1,25 +1,26 @@
 diff --git a/music_assistant/providers/spotify/helpers.py b/music_assistant/providers/spotify/helpers.py
-index 8b6c4e78f5f3f64c9dc6206028177c99ed0542ed..25ed6e468b393d2da74167e3c2ac4bdcd2e2699e 100644
+index 6f87b44f46b64805ef6799a54d596fd1684017f1..23de7fc2145619dd4f02551e81cb383f2b79fa15 100644
 --- a/music_assistant/providers/spotify/helpers.py
 +++ b/music_assistant/providers/spotify/helpers.py
 @@ -4,6 +4,7 @@ from __future__ import annotations
-
+ 
  import os
  import platform
 +from shutil import which
-
+ 
  from music_assistant.helpers.process import check_output
-
+ 
 @@ -20,12 +21,8 @@ async def get_librespot_binary() -> str:
          except OSError:
              return None
-
+ 
 -    base_path = os.path.join(os.path.dirname(__file__), "bin")
 -    system = platform.system().lower().replace("darwin", "macos")
 -    architecture = platform.machine().lower()
 -
-     if bridge_binary := await check_librespot(
+     if librespot_binary := await check_librespot(
 -        os.path.join(base_path, f"librespot-{system}-{architecture}")
 +        which("librespot")
      ):
-         return bridge_binary
+         return librespot_binary
+ 

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -15,13 +15,13 @@ let
       music-assistant-frontend = self.callPackage ./frontend.nix { };
 
       music-assistant-models = super.music-assistant-models.overridePythonAttrs (oldAttrs: rec {
-        version = "1.1.45";
+        version = "1.1.47";
 
         src = fetchFromGitHub {
           owner = "music-assistant";
           repo = "models";
           tag = version;
-          hash = "sha256-R1KkMe9dVl5J1DjDsFhSYVebpiqBkXZSqkLrd7T8gFg=";
+          hash = "sha256-NNKF61CRBe+N9kY+JUa77ClHSJ9RhpsiheMg7Ytyq2M=";
         };
 
         postPatch = ''
@@ -47,14 +47,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.5.8";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-7Q+BYw7wnT7QdqrDjagaxupzD0iKTc26z4TfxNtugdA=";
+    hash = "sha256-e596gvj+ZZDQzyBVfI50nO0a0eZifrkQVhUNNP2Jj8A=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,10 +1,14 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.5.8";
+  version = "2.6.0";
   providers = {
     airplay = ps: [
     ];
+    alexa =
+      ps: with ps; [
+        alexapy
+      ];
     apple_music = ps: [
     ]; # missing pywidevine
     audible =
@@ -68,7 +72,16 @@
       ];
     listenbrainz_scrobble = ps: [
     ]; # missing liblistenbrainz
+    lrclib = ps: [
+    ];
     musicbrainz = ps: [
+    ];
+    musiccast =
+      ps: with ps; [
+        aiomusiccast
+        setuptools
+      ];
+    nugs = ps: [
     ];
     opensubsonic =
       ps: with ps; [
@@ -117,6 +130,8 @@
       ps: with ps; [
         aioslimproto
       ];
+    subsonic_scrobble = ps: [
+    ];
     template_player_provider = ps: [
     ];
     test = ps: [


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.6.0

Tested playback from Spotify and YouTube Music via the [built-in Web Player](https://www.music-assistant.io/player-support/builtin/) and the built-in Snapcast server without any issues.

I **did not** test any of the new providers, notably [Alexa (experimental)](https://www.music-assistant.io/player-support/alexa/), [MusicCast](https://www.music-assistant.io/player-support/musiccast/) and [Nugs](https://www.music-assistant.io/music-providers/nugs/).

diff: https://github.com/music-assistant/server/compare/2.5.8...2.6.0
diff: https://github.com/music-assistant/frontend/compare/2.15.1...2.15.3
diff: https://github.com/music-assistant/models/compare/1.1.45...1.1.47

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test