### PR TITLE
lastpass-cli: fix build failure with cmake 4

### DIFF
--- a/pkgs/by-name/la/lastpass-cli/716-bump-cmake-minimum-version.patch
+++ b/pkgs/by-name/la/lastpass-cli/716-bump-cmake-minimum-version.patch
@@ -1,0 +1,27 @@
+From 31a4ad5f735933ff8e96403103d5b4f61faee945 Mon Sep 17 00:00:00 2001
+From: Yaksh Bariya <yakshbari4@gmail.com>
+Date: Wed, 11 Jun 2025 06:37:27 +0530
+Subject: [PATCH] fix builds with cmake 4.x
+
+---
+ CMakeLists.txt | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index efc6ba0..cd693f4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,8 +1,10 @@
+-if(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_LESS 3.1)
++if(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 4.0)
++  cmake_minimum_required(VERSION 4.0)
++elseif(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 3.1)
++  cmake_minimum_required(VERSION 3.1)
++else()
+   set(CMAKE_LEGACY_CYGWIN_WIN32 0) # Remove when CMake > 2.8.4 is required
+   cmake_minimum_required(VERSION 2.8)
+-else()
+-  cmake_minimum_required(VERSION 3.1)
+ endif()
+ 
+ project(lpass)

--- a/pkgs/by-name/la/lastpass-cli/package.nix
+++ b/pkgs/by-name/la/lastpass-cli/package.nix
@@ -11,6 +11,7 @@
   curl,
   libxml2,
   libxslt,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -42,6 +43,14 @@ stdenv.mkDerivation rec {
   installTargets = [
     "install"
     "install-doc"
+  ];
+
+  patches = [
+    # CMake 3.1 is deprecated and no longer supported by CMake > 4
+    # https://github.com/NixOS/nixpkgs/issues/445447
+    # The patch comes from https://github.com/lastpass/lastpass-cli/pull/716 while
+    # it is not merged and integrated in a new release.
+    ./716-bump-cmake-minimum-version.patch
   ];
 
   postInstall = ''


### PR DESCRIPTION
Fix `lastpass-cli` build failure on newer cmake 4.
- https://github.com/NixOS/nixpkgs/issues/445447

Applied patch from PR upstream.
```sh
curl -L https://patch-diff.githubusercontent.com/raw/lastpass/lastpass-cli/pull/716.patch > pkgs/by-name/la/lastpass-cli/716-bump-cmake-minimum-version.patch
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
