### PR TITLE
 leatherman, cpp-hocon, libwhereami: fix build failure with cmake 4

### DIFF
--- a/pkgs/by-name/cp/cpp-hocon/package.nix
+++ b/pkgs/by-name/cp/cpp-hocon/package.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -i -e '/add_subdirectory(tests)/d' lib/CMakeLists.txt
+
+    # CMake 3.2.2 is deprecated and no longer supported by CMake > 4
+    # https://github.com/NixOS/nixpkgs/issues/445447
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 3.2.2)" \
+      "cmake_minimum_required(VERSION 3.10)"
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/by-name/le/leatherman/package.nix
+++ b/pkgs/by-name/le/leatherman/package.nix
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DLEATHERMAN_ENABLE_TESTING=OFF" ];
 
+  # CMake4 3.2.2 is deprecated and no longer supported by CMake > 4
+  # https://github.com/NixOS/nixpkgs/issues/445447
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 3.2.2)" \
+      "cmake_minimum_required(VERSION 3.10)"
+  '';
+
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/li/libwhereami/package.nix
+++ b/pkgs/by-name/li/libwhereami/package.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
     owner = "puppetlabs";
   };
 
+  # CMake 2.2.2 is deprecated and no longer supported by CMake > 4
+  # https://github.com/NixOS/nixpkgs/issues/445447
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 3.2.2)" \
+      "cmake_minimum_required(VERSION 3.10)"
+  '';
+
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix `leatherman` and its dependant pacakges, `cpp-hocon` & `libwhereami`, build failure on newer cmake 4.

- https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
