### PR TITLE
[25.05] sdl3: 3.2.20 -> 3.2.24, cleanup deps

### DIFF
--- a/pkgs/by-name/ib/ibusMinimal/package.nix
+++ b/pkgs/by-name/ib/ibusMinimal/package.nix
@@ -1,0 +1,1 @@
+{ ibus }: ibus.override { libOnly = true; }

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -17,7 +17,11 @@
   libX11,
   libGL,
 }:
-
+let
+  # tray support on sdl3 pulls in gtk3, which is quite an expensive dependency.
+  # sdl2 does not support the tray, so we can just disable that requirement.
+  sdl3' = sdl3.override { traySupport = false; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl2-compat";
   version = "2.32.56";
@@ -35,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    sdl3
+    sdl3'
     libX11
   ];
 
@@ -53,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "SDL2COMPAT_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ sdl3 ]))
+    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ sdl3' ]))
   ];
 
   # skip timing-based tests as those are flaky

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -57,7 +57,7 @@ assert lib.assertMsg (ibusSupport -> dbusSupport) "SDL3 requires dbus support to
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
-  version = "3.2.22";
+  version = "3.2.24";
 
   outputs = [
     "lib"
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libsdl-org";
     repo = "SDL";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-4jGfw2hNZTGuae2DMLz8xJBtfNu5abIN5GlNIKDOUpw=";
+    hash = "sha256-LUkj9Rrf+zOW0IdV7aGccb/5bKh3TWf1IGtQkCDHd4k=";
   };
 
   postPatch =

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -57,7 +57,7 @@ assert lib.assertMsg (ibusSupport -> dbusSupport) "SDL3 requires dbus support to
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
-  version = "3.2.20";
+  version = "3.2.22";
 
   outputs = [
     "lib"
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libsdl-org";
     repo = "SDL";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-ESYjTN2prkAeHcTYurZaWeM3RgEKtwCZrt9gSMcOAe0=";
+    hash = "sha256-4jGfw2hNZTGuae2DMLz8xJBtfNu5abIN5GlNIKDOUpw=";
   };
 
   postPatch =

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -58,11 +58,15 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
   version = "3.2.20";
 
-  outputs = [
-    "lib"
-    "dev"
-    "out"
-  ];
+  outputs =
+    [
+      "lib"
+      "dev"
+      "out"
+    ]
+    ++ lib.optionals testSupport [
+      "installedTests"
+    ];
 
   src = fetchFromGitHub {
     owner = "libsdl-org";
@@ -73,9 +77,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     # Tests timeout on Darwin
+    # `testtray` loads assets from a relative path, which we are patching to be absolute
     lib.optionalString testSupport ''
       substituteInPlace test/CMakeLists.txt \
         --replace-fail 'set(noninteractive_timeout 10)' 'set(noninteractive_timeout 30)'
+
+      substituteInPlace test/testtray.c \
+        --replace-warn '../test/' '${placeholder "installedTests"}/share/assets/'
     ''
     + lib.optionalString waylandSupport ''
       substituteInPlace src/video/wayland/SDL_waylandmessagebox.c \
@@ -165,6 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_X11" x11Support)
 
     (lib.cmakeBool "SDL_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "SDL_INSTALL_TESTS" testSupport)
   ];
 
   doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -179,6 +188,12 @@ stdenv.mkDerivation (finalAttrs: {
       stdenv.hostPlatform.hasSharedLibraries && stdenv.hostPlatform.extensions.sharedLibrary == ".so"
     ) "-rpath ${lib.makeLibraryPath (finalAttrs.dlopenBuildInputs)}";
   };
+
+  postInstall = lib.optionalString testSupport ''
+    moveToOutput "share/installed-tests" "$installedTests"
+    moveToOutput "libexec/installed-tests" "$installedTests"
+    install -Dm 444 -t $installedTests/share/assets test/*.bmp
+  '';
 
   passthru = {
     # Building this in its own derivation to make sure the rpath hack above propagate to users

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -46,6 +46,7 @@
   libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   sndioSupport ? false,
   testSupport ? true,
+  traySupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   x11Support ? !stdenv.hostPlatform.isAndroid && !stdenv.hostPlatform.isWindows,
 }:
@@ -121,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
       libusb1
     ]
     ++ lib.optional (
-      stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin
+      stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin && traySupport
     ) libayatana-appindicator
     ++ lib.optional alsaSupport alsa-lib
     ++ lib.optional dbusSupport dbus
@@ -168,6 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_PULSEAUDIO" pulseaudioSupport)
     (lib.cmakeBool "SDL_SNDIO" sndioSupport)
     (lib.cmakeBool "SDL_TEST_LIBRARY" testSupport)
+    (lib.cmakeBool "SDL_TRAY_DUMMY" (!traySupport))
     (lib.cmakeBool "SDL_WAYLAND" waylandSupport)
     (lib.cmakeBool "SDL_WAYLAND_LIBDECOR" libdecorSupport)
     (lib.cmakeBool "SDL_X11" x11Support)

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -150,8 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
       # thus, it also does not have to care about gtk integration,
       # so using ibusMinimal avoids an unnecessarily large closure here.
       ibusMinimal
-    ]
-    ++ lib.optional waylandSupport zenity;
+    ];
 
   cmakeFlags = [
     (lib.cmakeBool "SDL_ALSA" alsaSupport)

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -8,7 +8,7 @@
   darwinMinVersionHook,
   dbus,
   fetchFromGitHub,
-  ibus,
+  ibusMinimal,
   installShellFiles,
   libGL,
   libayatana-appindicator,
@@ -100,7 +100,11 @@ stdenv.mkDerivation (finalAttrs: {
       apple-sdk_11
     ]
     ++ lib.optionals ibusSupport [
-      ibus
+      # sdl3 only uses some constants of the ibus headers
+      # it never actually loads the library
+      # thus, it also does not have to care about gtk integration,
+      # so using ibusMinimal avoids an unnecessarily large closure here.
+      ibusMinimal
     ]
     ++ lib.optional waylandSupport zenity;
 

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString waylandSupport ''
       substituteInPlace src/video/wayland/SDL_waylandmessagebox.c \
         --replace-fail '"zenity"' '"${lib.getExe zenity}"'
+      substituteInPlace src/dialog/unix/SDL_zenitydialog.c \
+        --replace-fail '"zenity"' '"${lib.getExe zenity}"'
     '';
 
   strictDeps = true;

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -54,6 +54,7 @@
 assert lib.assertMsg (
   waylandSupport -> openglSupport
 ) "SDL3 requires OpenGL support to enable Wayland";
+assert lib.assertMsg (ibusSupport -> dbusSupport) "SDL3 requires dbus support to enable ibus";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -178,6 +178,7 @@ stdenv.mkDerivation (finalAttrs: {
     isocodes
     json-glib
     libX11
+    vala # for share/vala/Makefile.vapigen (PKG_CONFIG_VAPIGEN_VAPIGEN)
   ]
   ++ lib.optionals (!libOnly) [
     gtk3
@@ -185,7 +186,6 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     libdbusmenu-gtk3
     libnotify
-    vala # for share/vala/Makefile.vapigen (PKG_CONFIG_VAPIGEN_VAPIGEN)
   ]
   ++ lib.optionals withWayland [
     libxkbcommon

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -27,8 +27,8 @@
   python3,
   json-glib,
   libnotify ? null,
-  enableUI ? true,
-  withWayland ? true,
+  enableUI ? !libOnly,
+  withWayland ? !libOnly,
   libxkbcommon,
   wayland,
   buildPackages,
@@ -36,6 +36,8 @@
   nixosTests,
   versionCheckHook,
   nix-update-script,
+  libX11,
+  libOnly ? false,
 }:
 
 let
@@ -89,6 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+  ]
+  ++ lib.optionals (!libOnly) [
     "installedTests"
   ];
 
@@ -116,20 +120,28 @@ stdenv.mkDerivation (finalAttrs: {
     "GLIB_COMPILE_RESOURCES=${lib.getDev buildPackages.glib}/bin/glib-compile-resources"
     "PKG_CONFIG_VAPIGEN_VAPIGEN=${lib.getBin buildPackages.vala}/bin/vapigen"
     "--disable-memconf"
-    (lib.enableFeature (dconf != null) "dconf")
-    (lib.enableFeature (libnotify != null) "libnotify")
+    "--disable-gtk2"
+    "--with-python=${python3BuildEnv.interpreter}"
+    (lib.enableFeature (!libOnly && dconf != null) "dconf")
+    (lib.enableFeature (!libOnly && libnotify != null) "libnotify")
     (lib.enableFeature withWayland "wayland")
     (lib.enableFeature enableUI "ui")
-    "--disable-gtk2"
-    "--enable-gtk4"
-    "--enable-install-tests"
+    (lib.enableFeature (!libOnly) "gtk3")
+    (lib.enableFeature (!libOnly) "gtk4")
+    (lib.enableFeature (!libOnly) "xim")
+    (lib.enableFeature (!libOnly) "appindicator")
+    (lib.enableFeature (!libOnly) "tests")
+    (lib.enableFeature (!libOnly) "install-tests")
+    (lib.enableFeature (!libOnly) "emoji-dict")
+    (lib.enableFeature (!libOnly) "unicode-dict")
+  ]
+  ++ lib.optionals (!libOnly) [
     "--with-unicode-emoji-dir=${unicode-emoji}/share/unicode/emoji"
     "--with-emoji-annotation-dir=${cldr-annotations}/share/unicode/cldr/common/annotations"
-    "--with-python=${python3BuildEnv.interpreter}"
     "--with-ucd-dir=${unicode-character-database}/share/unicode"
   ];
 
-  makeFlags = [
+  makeFlags = lib.optionals (!libOnly) [
     "test_execsdir=${placeholder "installedTests"}/libexec/installed-tests/ibus"
     "test_sourcesdir=${placeholder "installedTests"}/share/installed-tests/ibus"
   ];
@@ -145,10 +157,13 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     pkg-config
     python3BuildEnv
+    glib # required to satisfy AM_PATH_GLIB_2_0
     vala
-    wrapGAppsHook3
     dbus-launch
     gobject-introspection
+  ]
+  ++ lib.optionals (!libOnly) [
+    wrapGAppsHook3
   ];
 
   propagatedBuildInputs = [
@@ -159,14 +174,17 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     systemd
     dconf
-    gdk-pixbuf
     python3.pkgs.pygobject3 # for pygobject overrides
-    gtk3
-    gtk4
     isocodes
     json-glib
-    libnotify
+    libX11
+  ]
+  ++ lib.optionals (!libOnly) [
+    gtk3
+    gtk4
+    gdk-pixbuf
     libdbusmenu-gtk3
+    libnotify
     vala # for share/vala/Makefile.vapigen (PKG_CONFIG_VAPIGEN_VAPIGEN)
   ]
   ++ lib.optionals withWayland [
@@ -184,13 +202,13 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "version";
   versionCheckProgram = "${placeholder "out"}/bin/ibus";
 
-  postInstall = ''
+  postInstall = lib.optionalString (!libOnly) ''
     # It has some hardcoded FHS paths and also we do not use it
     # since we set up the environment in NixOS tests anyway.
     moveToOutput "bin/ibus-desktop-testing-runner" "$installedTests"
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString (!libOnly) ''
     # set necessary environment also for tests
     for f in $installedTests/libexec/installed-tests/ibus/*; do
         wrapGApp $f
@@ -198,7 +216,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests = {
+    tests = lib.optionalAttrs (!libOnly) {
       installed-tests = nixosTests.installed-tests.ibus;
     };
     updateScript = nix-update-script { };


### PR DESCRIPTION
This is a big backport of all the improvements we've seen to SDL3 in unstable recently. AFAICT, none have been breaking, but bring pretty big benefits in maintenance, cross compilation, and of course bringing us up to the latest version in stable!

Here's the obligatory list of all PRs backported - and thanks to the original authors of each :)

- https://github.com/NixOS/nixpkgs/pull/413222
- https://github.com/NixOS/nixpkgs/pull/418644
- https://github.com/NixOS/nixpkgs/pull/414472
- https://github.com/NixOS/nixpkgs/pull/418646
- https://github.com/NixOS/nixpkgs/pull/439652
- https://github.com/NixOS/nixpkgs/pull/448146

Also supersedes https://github.com/NixOS/nixpkgs/pull/425265

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
