### PR TITLE
httplib: added pkgconfig

### DIFF
--- a/pkgs/by-name/ht/httplib/package.nix
+++ b/pkgs/by-name/ht/httplib/package.nix
@@ -4,8 +4,9 @@
   fetchFromGitHub,
   openssl,
   stdenv,
+  copyPkgconfigItems,
+  makePkgconfigItem,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "httplib";
   version = "0.19.0";
@@ -17,18 +18,36 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OLwD7mpwqG7BUugUca+CJpPMaabJzUMC0zYzJK9PBCg=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    copyPkgconfigItems
+  ];
 
   buildInputs = [ openssl ];
 
   strictDeps = true;
+
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "httplib";
+      inherit (finalAttrs) version;
+      cflags = [ "-I${variables.includedir}" ];
+      variables = rec {
+        prefix = placeholder "out";
+        includedir = "${prefix}/include";
+      };
+      inherit (finalAttrs.meta) description;
+    })
+  ];
 
   meta = {
     homepage = "https://github.com/yhirose/cpp-httplib";
     description = "C++ header-only HTTP/HTTPS server and client library";
     changelog = "https://github.com/yhirose/cpp-httplib/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      fzakaria
+    ];
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
Added support for pkgconfig.

```bash
cat  result/lib/pkgconfig/httplib.pc
includedir=/nix/store/8zn99d7khz7959p0yzv43y090glbdjrw-httplib-0.19.0/include
prefix=/nix/store/8zn99d7khz7959p0yzv43y090glbdjrw-httplib-0.19.0

Cflags: -I/nix/store/8zn99d7khz7959p0yzv43y090glbdjrw-httplib-0.19.0/include
Description: C++ header-only HTTP/HTTPS server and client library
Name: httplib
Version: 0.19.0
```

I added myself as maintainer since it had none.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
