### PR TITLE
dcm2niix: 1.0.20241211 -> 1.0.20250506

### DIFF
--- a/pkgs/by-name/dc/dcm2niix/package.nix
+++ b/pkgs/by-name/dc/dcm2niix/package.nix
@@ -19,21 +19,21 @@ let
   cloudflareZlib = fetchFromGitHub {
     owner = "ningfei";
     repo = "zlib";
-    # HEAD revision of the gcc.amd64 branch on 2025-01-05. Reminder to update
+    # HEAD revision of the gcc.amd64 branch on 2025-10-15. Reminder to update
     # whenever bumping package version.
-    rev = "1cb075520d254005cde193982f1856b877fd39d8";
-    hash = "sha256-1+V7XwYOYqSzcFK86V+gDILGwAqKGQ+HSlXphWtqSvk=";
+    rev = "7d9d0b20249fd459c69e4b98bc569b7157f3018c";
+    hash = "sha256-WnD9pOnM6J3nCLBKYb28+JaIy0z/9csbn+AsyWZQnLs=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.0.20241211";
+  version = "1.0.20250506";
   pname = "dcm2niix";
 
   src = fetchFromGitHub {
     owner = "rordenlab";
     repo = "dcm2niix";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NpvtMCcyVfYlnvXjyvTDsa71IxUhi8FepX82qRSG7TA=";
+    hash = "sha256-KtUWrm3Nq3khDxpaQ4W57y+h/gPeEMwfzBv4XYkAhoA=";
   };
 
   patches = lib.optionals withCloudflareZlib [


### PR DESCRIPTION
Diff: https://github.com/rordenlab/dcm2niix/compare/v1.0.20241211...v1.0.20250506

Changelog: https://github.com/rordenlab/dcm2niix/releases/tag/v1.0.20250506

related: #445447 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
