### PR TITLE
 lenovo-legion: use unstable update script; build with qt6

### DIFF
--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -5,12 +5,13 @@
   wrapQtAppsHook,
   python3,
   nix-update-script,
+  qtbase,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lenovo-legion-app";
   version = "0.0.20-unstable-2025-07-11";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "johnfanv2";
@@ -21,10 +22,14 @@ python3.pkgs.buildPythonApplication rec {
 
   sourceRoot = "${src.name}/python/legion_linux";
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  build-system = with python3.pkgs; [
+    setuptools
+    wrapQtAppsHook
+  ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     pyqt6
+    qtbase
     argcomplete
     pillow
     pyyaml

--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -64,7 +64,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Utility to control Lenovo Legion laptop";
     homepage = "https://github.com/johnfanv2/LenovoLegionLinux";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [
       ulrikstrid
       logger

--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -4,11 +4,12 @@
   xorg,
   wrapQtAppsHook,
   python3,
+  nix-update-script,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lenovo-legion-app";
-  version = "0.0.21-unstable-2025-07-11";
+  version = "0.0.20-unstable-2025-07-11";
   format = "setuptools";
 
   src = fetchFromGitHub {
@@ -51,6 +52,8 @@ python3.pkgs.buildPythonApplication rec {
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Utility to control Lenovo Legion laptop";

--- a/pkgs/os-specific/linux/lenovo-legion/default.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     description = "Linux kernel module for controlling fan and power in Lenovo Legion laptops";
     homepage = "https://github.com/johnfanv2/LenovoLegionLinux";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = [ lib.maintainers.ulrikstrid ];
     broken = kernel.kernelOlder "5.15";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11719,7 +11719,7 @@ with pkgs;
 
   lemonbar-xft = callPackage ../applications/window-managers/lemonbar/xft.nix { };
 
-  lenovo-legion = libsForQt5.callPackage ../os-specific/linux/lenovo-legion/app.nix { };
+  lenovo-legion = qt6Packages.callPackage ../os-specific/linux/lenovo-legion/app.nix { };
 
   libkiwix = callPackage ../applications/misc/kiwix/lib.nix { };
 


### PR DESCRIPTION
I have a legion laptop, but I don't usually use this app much. Seems to be working fine, though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
