### PR TITLE
google-cloud-sdk: ensure determinism by not writing python bytecode

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -161,6 +161,8 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     # Avoid trying to write logs to homeless-shelter
     export HOME=$(mktemp -d)
+    # Prevent Python from writing bytecode to ensure build determinism
+    export PYTHONDONTWRITEBYTECODE=1
     $out/bin/gcloud version --format json | jq '."Google Cloud SDK"' | grep "${version}"
     $out/bin/gsutil version | grep -w "$(cat platform/gsutil/VERSION)"
   '';

--- a/pkgs/by-name/go/google-cloud-sdk/withExtraComponents.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/withExtraComponents.nix
@@ -81,6 +81,8 @@ symlinkJoin {
   postBuild = ''
     sed -i ';' $out/google-cloud-sdk/bin/.gcloud-wrapped
     sed -i -e "s#${google-cloud-sdk}#$out#" "$out/google-cloud-sdk/bin/gcloud"
+    # Prevent Python from writing bytecode to ensure build determinism
+    export PYTHONDONTWRITEBYTECODE=1
     ${installCheck}
   '';
 }


### PR DESCRIPTION
The google-cloud-sdk package is producing different content on different machines, despite having the same hash. The same store path has different numbers of Python bytecode (`.pyc`) files and `__pycache__` directories depending on which machine builds it.

### Root Cause

During build phases, running `gcloud` commands (in `installCheckPhase` and `withExtraComponents.nix` postBuild) causes Python to write bytecode files with timestamps, creating non-deterministic builds.

### Solution

Adding `export PYTHONDONTWRITEBYTECODE=1` before running `gcloud`. This prevents Python from writing `.pyc` files during builds, ensuring deterministic output.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
