### PR TITLE
androidenv: fingerprint latest versions

### DIFF
--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -91,7 +91,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -156,7 +156,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -233,7 +233,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -280,7 +280,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -357,7 +357,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -404,7 +404,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -483,7 +483,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -576,7 +576,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -669,7 +669,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -762,7 +762,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -855,7 +855,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -948,7 +948,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -1041,7 +1041,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1134,7 +1134,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -1227,7 +1227,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1320,7 +1320,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1413,7 +1413,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1478,7 +1478,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1543,7 +1543,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1608,7 +1608,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1673,7 +1673,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1738,7 +1738,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1803,7 +1803,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1869,7 +1869,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1900,7 +1900,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1931,7 +1931,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1960,7 +1960,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -2010,7 +2010,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2036,7 +2036,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2072,7 +2072,7 @@
         }
       },
       "displayName": "Google Play services",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2101,7 +2101,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2130,7 +2130,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK (Deprecated)",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2168,7 +2168,7 @@
         }
       },
       "displayName": "Google Repository",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2197,7 +2197,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2226,7 +2226,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2256,7 +2256,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2285,7 +2285,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2314,7 +2314,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20369,
+      "last-available-day": 20377,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2984,7 +2984,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -3030,7 +3030,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -3078,7 +3078,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -3130,7 +3130,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -3179,7 +3179,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -3229,7 +3229,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -3275,7 +3275,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -3323,7 +3323,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -3375,7 +3375,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -3431,7 +3431,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -3470,7 +3470,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -3516,7 +3516,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -3564,7 +3564,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -3616,7 +3616,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -3672,7 +3672,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3711,7 +3711,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3757,7 +3757,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3811,7 +3811,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3863,7 +3863,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3919,7 +3919,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3965,7 +3965,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -4013,7 +4013,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -4065,7 +4065,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -4121,7 +4121,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -4167,7 +4167,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -4215,7 +4215,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -4267,7 +4267,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -4316,7 +4316,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -4353,7 +4353,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -4392,7 +4392,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -4438,7 +4438,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -4484,7 +4484,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -4530,7 +4530,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -4571,7 +4571,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -4623,7 +4623,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -4675,7 +4675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -4727,7 +4727,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4776,7 +4776,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4815,7 +4815,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4861,7 +4861,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4907,7 +4907,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4953,7 +4953,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4994,7 +4994,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -5046,7 +5046,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -5098,7 +5098,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -5150,7 +5150,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -5199,7 +5199,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -5243,7 +5243,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -5282,7 +5282,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -5328,7 +5328,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -5374,7 +5374,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -5420,7 +5420,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -5461,7 +5461,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -5513,7 +5513,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -5565,7 +5565,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -5617,7 +5617,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -5673,7 +5673,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -5712,7 +5712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5758,7 +5758,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5804,7 +5804,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5850,7 +5850,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5898,7 +5898,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5950,7 +5950,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -6002,7 +6002,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -6056,7 +6056,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -6112,7 +6112,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -6158,7 +6158,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -6202,7 +6202,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -6241,7 +6241,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -6287,7 +6287,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -6333,7 +6333,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -6374,7 +6374,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -6426,7 +6426,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -6478,7 +6478,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -6530,7 +6530,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -6584,7 +6584,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -6655,7 +6655,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -6701,7 +6701,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -6752,7 +6752,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6796,7 +6796,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6840,7 +6840,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6891,7 +6891,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6958,7 +6958,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -7025,7 +7025,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -7094,7 +7094,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -7150,7 +7150,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -7201,7 +7201,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -7245,7 +7245,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -7289,7 +7289,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -7340,7 +7340,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -7407,7 +7407,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -7476,7 +7476,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -7537,7 +7537,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -7582,7 +7582,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -7628,7 +7628,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -7679,7 +7679,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -7716,7 +7716,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7753,7 +7753,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7804,7 +7804,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7871,7 +7871,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7938,7 +7938,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7997,7 +7997,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -8064,7 +8064,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -8131,7 +8131,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -8192,7 +8192,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -8252,7 +8252,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -8291,7 +8291,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -8354,7 +8354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -8417,7 +8417,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -8468,7 +8468,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -8525,7 +8525,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -8582,7 +8582,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -8641,7 +8641,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -8722,7 +8722,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -8803,7 +8803,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -8864,7 +8864,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8924,7 +8924,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8970,7 +8970,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear-cn/arm64-v8a",
@@ -9014,7 +9014,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear-cn/x86",
@@ -9053,7 +9053,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -9102,7 +9102,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -9153,7 +9153,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -9220,7 +9220,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -9287,7 +9287,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -9353,7 +9353,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -9434,7 +9434,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -9515,7 +9515,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -9586,7 +9586,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -9645,7 +9645,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -9696,7 +9696,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -9745,7 +9745,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9806,7 +9806,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9873,7 +9873,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9949,7 +9949,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -10016,7 +10016,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -10077,7 +10077,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -10130,7 +10130,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -10185,7 +10185,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -10234,7 +10234,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -10295,7 +10295,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -10362,7 +10362,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -10438,7 +10438,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -10519,7 +10519,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -10580,7 +10580,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -10633,7 +10633,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -10698,7 +10698,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -10757,7 +10757,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10803,7 +10803,7 @@
             }
           },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10847,7 +10847,7 @@
             }
           },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10898,7 +10898,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10947,7 +10947,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -11008,7 +11008,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -11075,7 +11075,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -11144,7 +11144,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -11211,7 +11211,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -11286,7 +11286,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -11335,7 +11335,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -11398,7 +11398,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -11458,7 +11458,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -11498,7 +11498,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -11535,7 +11535,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -11586,7 +11586,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -11635,7 +11635,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -11696,7 +11696,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -11764,7 +11764,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11834,7 +11834,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11903,7 +11903,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11966,7 +11966,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -12019,7 +12019,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -12088,7 +12088,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -12137,7 +12137,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -12178,7 +12178,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -12210,7 +12210,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -12256,7 +12256,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -12301,7 +12301,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -12348,7 +12348,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -12406,7 +12406,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -12466,7 +12466,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -12524,7 +12524,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -12584,7 +12584,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -12646,7 +12646,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -12700,7 +12700,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-arm64-v8a",
           "path": "system-images/android-35-ext15/android-wear/arm64-v8a",
@@ -12733,7 +12733,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-x86_64",
           "path": "system-images/android-35-ext15/android-wear/x86_64",
@@ -12780,7 +12780,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis/arm64-v8a",
@@ -12829,7 +12829,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis-x86_64",
           "path": "system-images/android-35-ext15/google_apis/x86_64",
@@ -12880,7 +12880,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis_playstore/arm64-v8a",
@@ -12929,7 +12929,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext15/google_apis_playstore/x86_64",
@@ -12982,7 +12982,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-arm64-v8a",
           "path": "system-images/android-36/android-tv/arm64-v8a",
@@ -13027,7 +13027,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-x86",
           "path": "system-images/android-36/android-tv/x86",
@@ -13062,7 +13062,7 @@
             }
           ],
           "displayName": "Wear OS 6.0 ARM 64 v8a System Image (signed)",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-arm64-v8a",
           "path": "system-images/android-36/android-wear-signed/arm64-v8a",
@@ -13095,7 +13095,7 @@
             }
           ],
           "displayName": "Wear OS 6.0 Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-x86_64",
           "path": "system-images/android-36/android-wear-signed/x86_64",
@@ -13142,7 +13142,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis-arm64-v8a",
           "path": "system-images/android-36/google_apis/arm64-v8a",
@@ -13191,7 +13191,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis-x86_64",
           "path": "system-images/android-36/google_apis/x86_64",
@@ -13242,7 +13242,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore/arm64-v8a",
@@ -13291,7 +13291,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis_playstore-x86_64",
           "path": "system-images/android-36/google_apis_playstore/x86_64",
@@ -13342,7 +13342,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore_ps16k/arm64-v8a",
@@ -13395,7 +13395,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36-page_size_16kb-x86_64",
           "path": "system-images/android-36/google_apis_playstore_ps16k/x86_64",
@@ -13434,9 +13434,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "818b27a07b6e851ddd305139f967fa11111502a3",
-              "size": 1933295305,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.1_r02.zip"
+              "sha1": "4b3c296dfa125a03944317da5c3b9c852e384a95",
+              "size": 1931618675,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.1_r03.zip"
             }
           ],
           "dependencies": {
@@ -13452,13 +13452,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-google_apis-arm64-v8a",
           "path": "system-images/android-36.1/google_apis/arm64-v8a",
           "revision": "36.1-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "3"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
@@ -13483,9 +13483,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "269ca25dc3511e2a6bdcaf457734b585807af485",
-              "size": 1965091162,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.1_r02.zip"
+              "sha1": "e7c2ee3e0efcdc79e13b8c40d93629c83741c143",
+              "size": 1958060347,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.1_r03.zip"
             }
           ],
           "dependencies": {
@@ -13501,13 +13501,13 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36.1-google_apis-x86_64",
           "path": "system-images/android-36.1/google_apis/x86_64",
           "revision": "36.1-google_apis-x86_64",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "3"
           },
           "type-details": {
             "abi:5": "x86_64",
@@ -13534,9 +13534,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "e829404c284fa09105b89e66e3aceeb1fac9a60c",
-              "size": 1960800700,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.1_r02.zip"
+              "sha1": "240c7164dd250be3c096dd62801e96f7b144bc2f",
+              "size": 1955944487,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.1_r03.zip"
             }
           ],
           "dependencies": {
@@ -13552,13 +13552,13 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36.1/google_apis_playstore/arm64-v8a",
           "revision": "36.1-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "3"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
@@ -13583,9 +13583,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "6c0cacff6e3e3021dedd8f80cd302d09dba354e3",
-              "size": 2008752086,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.1_r02.zip"
+              "sha1": "4931dd84c74db66b29c934b313d407faf3298921",
+              "size": 1998865059,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.1_r03.zip"
             }
           ],
           "dependencies": {
@@ -13601,13 +13601,13 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36.1-google_apis_playstore-x86_64",
           "path": "system-images/android-36.1/google_apis_playstore/x86_64",
           "revision": "36.1-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "2"
+            "major:0": "3"
           },
           "type-details": {
             "abi:5": "x86_64",
@@ -13652,7 +13652,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36.1/google_apis_playstore_ps16k/arm64-v8a",
@@ -13705,7 +13705,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36.1-page_size_16kb-x86_64",
           "path": "system-images/android-36.1/google_apis_playstore_ps16k/x86_64",
@@ -13762,7 +13762,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis/arm64-v8a",
@@ -13811,7 +13811,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis-x86_64",
           "path": "system-images/android-36-ext19/google_apis/x86_64",
@@ -13862,7 +13862,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis_playstore/arm64-v8a",
@@ -13911,7 +13911,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis_playstore-x86_64",
           "path": "system-images/android-36-ext19/google_apis_playstore/x86_64",
@@ -13964,7 +13964,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
           "path": "system-images/android-36.0-Baklava/google_apis/arm64-v8a",
@@ -14014,7 +14014,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
           "path": "system-images/android-36.0-Baklava/google_apis/x86_64",
@@ -14066,7 +14066,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore/arm64-v8a",
@@ -14116,7 +14116,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore/x86_64",
@@ -14168,7 +14168,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/arm64-v8a",
@@ -14222,7 +14222,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/x86_64",
@@ -14280,7 +14280,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-google_apis-arm64-v8a",
           "path": "system-images/android-CANARY/google_apis/arm64-v8a",
@@ -14330,7 +14330,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-google_apis-x86_64",
           "path": "system-images/android-CANARY/google_apis/x86_64",
@@ -14382,7 +14382,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-CANARY/google_apis_playstore/arm64-v8a",
@@ -14432,7 +14432,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-google_apis_playstore-x86_64",
           "path": "system-images/android-CANARY/google_apis_playstore/x86_64",
@@ -14484,7 +14484,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-page_size_16kb-arm64-v8a",
           "path": "system-images/android-CANARY/google_apis_playstore_ps16k/arm64-v8a",
@@ -14538,7 +14538,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20369,
+          "last-available-day": 20377,
           "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-page_size_16kb-x86_64",
           "path": "system-images/android-CANARY/google_apis_playstore_ps16k/x86_64",
@@ -15146,16 +15146,17 @@
   },
   "latest": {
     "build-tools": "36.1.0",
-    "cmake": "4.1.1",
+    "cmake": "4.1.2",
     "cmdline-tools": "19.0",
-    "emulator": "36.2.10",
+    "emulator": "36.2.12",
     "ndk": "29.0.14206865",
     "ndk-bundle": "22.1.7171670",
     "platform-tools": "36.0.0",
     "platforms": "36.1",
     "skiaparser": "8",
     "sources": "36.1",
-    "tools": "26.1.1"
+    "tools": "26.1.1",
+    "fingerprint": "8eb220e182767bf0"
   },
   "licenses": {
     "android-googletv-license": [
@@ -15220,7 +15221,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15269,7 +15270,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15318,7 +15319,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15367,7 +15368,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15416,7 +15417,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15465,7 +15466,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15514,7 +15515,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15563,7 +15564,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15612,7 +15613,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -15660,7 +15661,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -15708,7 +15709,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15757,7 +15758,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15806,7 +15807,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15855,7 +15856,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15904,7 +15905,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15953,7 +15954,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -16001,7 +16002,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16050,7 +16051,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -16098,7 +16099,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16147,7 +16148,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -16195,7 +16196,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -16243,7 +16244,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -16291,7 +16292,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -16339,7 +16340,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -16387,7 +16388,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -16435,7 +16436,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -16483,7 +16484,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -16531,7 +16532,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -16579,7 +16580,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -16627,7 +16628,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -16675,7 +16676,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -16723,7 +16724,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -16771,7 +16772,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -16819,7 +16820,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -16867,7 +16868,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -16915,7 +16916,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -16963,7 +16964,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -17011,7 +17012,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -17059,7 +17060,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -17107,7 +17108,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17157,7 +17158,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17207,7 +17208,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -17255,7 +17256,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -17303,7 +17304,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -17351,7 +17352,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -17399,7 +17400,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17449,7 +17450,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17499,7 +17500,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17549,7 +17550,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -17597,7 +17598,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -17645,7 +17646,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -17693,7 +17694,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -17741,7 +17742,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -17789,7 +17790,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -17837,7 +17838,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -17878,7 +17879,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -17919,7 +17920,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -17960,7 +17961,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -18002,7 +18003,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -18043,7 +18044,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -18084,7 +18085,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -18125,7 +18126,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -18166,7 +18167,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -18207,7 +18208,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -18249,7 +18250,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -18291,7 +18292,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -18333,7 +18334,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -18374,7 +18375,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -18416,7 +18417,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -18458,7 +18459,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -18500,7 +18501,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -18542,7 +18543,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -18583,7 +18584,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0",
@@ -18624,7 +18625,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -18666,7 +18667,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -18708,7 +18709,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -18750,7 +18751,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc5",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc5",
@@ -18792,7 +18793,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.1.0",
@@ -18833,7 +18834,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36.1-rc1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.1.0-rc1",
@@ -18884,7 +18885,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -18925,7 +18926,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -18966,7 +18967,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -19007,7 +19008,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -19048,7 +19049,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -19089,7 +19090,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -19130,7 +19131,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -19171,7 +19172,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -19212,7 +19213,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -19253,7 +19254,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -19294,7 +19295,7 @@
           }
         ],
         "displayName": "CMake 3.31.6",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.6",
@@ -19342,7 +19343,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -19383,7 +19384,7 @@
           }
         ],
         "displayName": "CMake 4.0.2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.2",
@@ -19424,7 +19425,7 @@
           }
         ],
         "displayName": "CMake 4.0.3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.3",
@@ -19465,7 +19466,7 @@
           }
         ],
         "displayName": "CMake 4.1.0",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.0",
@@ -19506,7 +19507,7 @@
           }
         ],
         "displayName": "CMake 4.1.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.1",
@@ -19514,6 +19515,47 @@
         "revision-details": {
           "major:0": "4",
           "micro:2": "1",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "4.1.2": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "c8c4f1c19b75c56f28b9dcf1af928d25cf1a1471",
+            "size": 31275750,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.2-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "a0578a0543942c7eb35822c88a516b87e5b9867a",
+            "size": 43690978,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.2-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "06bc3fe29aa49297dcc11a2ffe3a999445df05ae",
+            "size": 21045753,
+            "url": "https://dl.google.com/android/repository/cmake-4.1.2-windows.zip"
+          }
+        ],
+        "displayName": "CMake 4.1.2",
+        "last-available-day": 20377,
+        "license": "android-sdk-license",
+        "name": "cmake",
+        "path": "cmake/4.1.2",
+        "revision": "4.1.2",
+        "revision-details": {
+          "major:0": "4",
+          "micro:2": "2",
           "minor:1": "1"
         },
         "type-details": {
@@ -19549,7 +19591,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -19589,7 +19631,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -19629,7 +19671,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -19707,7 +19749,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -19785,7 +19827,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -19825,7 +19867,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -19866,7 +19908,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -19907,7 +19949,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -19947,7 +19989,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -19988,7 +20030,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -20028,7 +20070,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0",
@@ -20068,7 +20110,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -20109,7 +20151,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -20150,7 +20192,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -20190,7 +20232,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -20230,7 +20272,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -20270,7 +20312,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -20310,7 +20352,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -20350,7 +20392,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -20390,7 +20432,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -20430,7 +20472,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -21521,7 +21563,7 @@
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -21529,6 +21571,54 @@
         "revision-details": {
           "major:0": "36",
           "micro:2": "10",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.2.12": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "b87561b33f5f1df3647519628c3597353dbf534d",
+            "size": 320123396,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14214601.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "5c1b8bcd88285a343b4436d1082e8a544408e592",
+            "size": 395794431,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14214601.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "e53928cb3b24acb942ff8003cd9a9a91eddece04",
+            "size": 313352024,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14214601.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "1140a142d87fa2f6be84f5ebe7ef781a9eba429c",
+            "size": 443355796,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14214601.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20377,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.2.12",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "12",
           "minor:1": "2"
         },
         "type-details": {
@@ -21625,6 +21715,54 @@
         "revision-details": {
           "major:0": "36",
           "micro:2": "3",
+          "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.3.4": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "bc4a8c9f80ad58842fe2286bf03e78e4e1292e19",
+            "size": 325925467,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-14257411.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "b40ab44776ebb18d064554bdc623a1549fc802a3",
+            "size": 468816526,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-14257411.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "205aa614c02fc8f59be6bc1dcf7f3ec4f209f27e",
+            "size": 380621007,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-14257411.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "edd34ac4150107b5f9a5840c1810747745d6611e",
+            "size": 449704089,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-14257411.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20377,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.3.4",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "4",
           "minor:1": "3"
         },
         "type-details": {
@@ -21757,7 +21895,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -21819,7 +21957,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -21881,7 +22019,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -21943,7 +22081,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -22006,7 +22144,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -22068,7 +22206,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -22132,7 +22270,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -22196,7 +22334,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -22258,7 +22396,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -22306,7 +22444,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -22355,7 +22493,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -22403,7 +22541,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -22459,7 +22597,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -22515,7 +22653,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -22570,7 +22708,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -22626,7 +22764,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -22681,7 +22819,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -22736,7 +22874,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -22791,7 +22929,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -22847,7 +22985,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -22902,7 +23040,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -22957,7 +23095,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -23013,7 +23151,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -23069,7 +23207,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -23125,7 +23263,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -23174,7 +23312,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -23223,7 +23361,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -23272,7 +23410,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -23320,7 +23458,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -23368,7 +23506,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -23416,7 +23554,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -23465,7 +23603,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -23514,7 +23652,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -23563,7 +23701,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -23611,7 +23749,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -23660,7 +23798,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -23709,7 +23847,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -23758,7 +23896,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -23807,7 +23945,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -23855,7 +23993,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -23903,7 +24041,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -23951,7 +24089,7 @@
           }
         },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -23993,7 +24131,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -24035,7 +24173,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -24076,7 +24214,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -24117,7 +24255,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -24158,7 +24296,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -24199,7 +24337,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -24241,7 +24379,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -24283,7 +24421,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -24324,7 +24462,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -24365,7 +24503,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -24406,7 +24544,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.3.13750724",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.3.13750724",
@@ -24447,7 +24585,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -24489,7 +24627,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -24531,7 +24669,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -24573,7 +24711,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -24614,7 +24752,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.1.13356709",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.1.13356709",
@@ -24655,7 +24793,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.2.13676358",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.2.13676358",
@@ -24696,7 +24834,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13113456",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13113456",
@@ -24738,7 +24876,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13599879",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13599879",
@@ -24780,7 +24918,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13846066",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13846066",
@@ -24822,7 +24960,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.14033849",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.14033849",
@@ -24864,7 +25002,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.14206865",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/29.0.14206865",
@@ -24928,7 +25066,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24990,7 +25128,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25052,7 +25190,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25114,7 +25252,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -25177,7 +25315,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25239,7 +25377,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -25303,7 +25441,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -25367,7 +25505,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25429,7 +25567,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25477,7 +25615,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25526,7 +25664,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25574,7 +25712,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25630,7 +25768,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25686,7 +25824,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25741,7 +25879,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25797,7 +25935,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25852,7 +25990,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25907,7 +26045,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25962,7 +26100,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26018,7 +26156,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26073,7 +26211,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26128,7 +26266,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26184,7 +26322,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26240,7 +26378,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26296,7 +26434,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26459,7 +26597,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -26515,6 +26653,47 @@
             "xsi:type": "ns5:genericDetailsType"
           }
         }
+      },
+      "36.0.2": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "3c5c54a14f51a2da59d7c4874372619a42deb94d",
+            "size": 8785200,
+            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.2-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "5998b371cd55fbd3807632ac36f1b3a62558d46d",
+            "size": 15711207,
+            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.2-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "970632ccb7a364767d64d9eec3d143f5d2adcc3c",
+            "size": 7708640,
+            "url": "https://dl.google.com/android/repository/platform-tools_r36.0.2-win.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform-Tools",
+        "last-available-day": 20377,
+        "license": "android-sdk-preview-license",
+        "name": "platform-tools",
+        "path": "platform-tools",
+        "revision": "36.0.2",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "platforms": {
@@ -26529,7 +26708,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -26568,7 +26747,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -26607,7 +26786,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -26646,7 +26825,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -26685,7 +26864,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -26724,7 +26903,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -26763,7 +26942,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -26802,7 +26981,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -26841,7 +27020,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -26880,7 +27059,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -26933,7 +27112,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26973,7 +27152,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -27012,7 +27191,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -27051,7 +27230,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -27090,7 +27269,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -27129,7 +27308,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -27168,7 +27347,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -27207,7 +27386,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -27246,7 +27425,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -27285,7 +27464,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -27324,7 +27503,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -27377,7 +27556,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27417,7 +27596,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -27456,7 +27635,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -27495,7 +27674,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -27534,7 +27713,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -27574,7 +27753,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -27609,7 +27788,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27655,7 +27834,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -27688,7 +27867,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -27726,7 +27905,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext15",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext15",
@@ -27759,7 +27938,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36",
@@ -27792,7 +27971,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36.1",
@@ -27825,7 +28004,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36-ext19",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36-ext19",
@@ -27872,7 +28051,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27926,7 +28105,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27980,7 +28159,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28020,7 +28199,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -28059,7 +28238,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -28098,7 +28277,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -28137,7 +28316,7 @@
           }
         ],
         "displayName": "Android SDK Platform Baklava-ext19",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-Baklava-ext19",
@@ -28171,7 +28350,7 @@
           }
         ],
         "displayName": "Android SDK Platform CANARY",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-preview-license",
         "name": "platforms",
         "path": "platforms/android-CANARY",
@@ -28236,7 +28415,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28354,7 +28533,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -28475,7 +28654,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -28567,7 +28746,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
@@ -28594,7 +28773,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -28624,7 +28803,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -28653,7 +28832,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -28682,7 +28861,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -28711,7 +28890,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -28740,7 +28919,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -28769,7 +28948,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -28798,7 +28977,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -28827,7 +29006,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -28856,7 +29035,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -28885,7 +29064,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -28914,7 +29093,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -28943,7 +29122,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -28972,7 +29151,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -29001,7 +29180,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -29030,7 +29209,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -29059,7 +29238,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -29088,7 +29267,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -29117,7 +29296,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -29146,7 +29325,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -29176,7 +29355,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -29206,7 +29385,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -29236,7 +29415,7 @@
           }
         ],
         "displayName": "Sources for Android 36",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36",
@@ -29264,7 +29443,7 @@
           }
         ],
         "displayName": "Sources for Android 36.1",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36.1",
@@ -29331,7 +29510,7 @@
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20369,
+        "last-available-day": 20377,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",

--- a/pkgs/development/mobile/androidenv/test-suite.nix
+++ b/pkgs/development/mobile/androidenv/test-suite.nix
@@ -18,7 +18,7 @@ let
 in
 stdenv.mkDerivation {
   name = "androidenv-test-suite";
-  version = lib.substring 0 8 (builtins.hashFile "sha256" ./repo.json);
+  version = (lib.importJSON ./repo.json).latest.fingerprint or "0000000000000000";
   buildInputs = lib.attrValues all-tests;
 
   buildCommand = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The update script needs the old version present in the version file, so give it something to use.

This results in things like https://nixpkgs-update-logs.nix-community.org/androidenv.test-suite/2025-08-25.log ("Old version 04991d25" not present in master derivation file with contents:")

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
