### PR TITLE
uboot: expose some comments as longDescription

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -313,9 +313,6 @@ in
     '';
   };
 
-  # Flashing instructions:
-  # dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=512 skip=1 seek=1
-  # dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=1 count=444
   ubootLibreTechCC =
     let
       firmwareImagePkg = fetchFromGitHub {
@@ -330,6 +327,15 @@ in
       defconfig = "libretech-cc_defconfig";
       extraMeta = {
         broken = stdenv.buildPlatform.system != "x86_64-linux"; # aml_encrypt_gxl is a x86_64 binary
+        longDescription = ''
+          Boot loader for the Libre Computer AML-S905X-CC.
+
+          Flashing instructions:
+          ```sh
+          dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=512 skip=1 seek=1
+          dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=1 count=444
+          ```
+        '';
         platforms = [ "aarch64-linux" ];
       };
       filesToInstall = [ "u-boot.bin" ];
@@ -415,10 +421,6 @@ in
     ];
   };
 
-  # Flashing instructions:
-  # dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=1 count=442
-  # dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=512 skip=1 seek=1
-  # dd if=u-boot.gxbb of=<device> conv=fsync bs=512 seek=97
   ubootOdroidC2 =
     let
       firmwareBlobs = fetchFromGitHub {
@@ -431,7 +433,19 @@ in
     in
     buildUBoot {
       defconfig = "odroid-c2_defconfig";
-      extraMeta.platforms = [ "aarch64-linux" ];
+      extraMeta = {
+        longDescription = ''
+          Boot loader for the Hardkernel ODROID-C2.
+
+          Flashing instructions:
+          ```sh
+          dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=1 count=442
+          dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=512 skip=1 seek=1
+          dd if=u-boot.gxbb of=<device> conv=fsync bs=512 seek=97
+          ```
+        '';
+        platforms = [ "aarch64-linux" ];
+      };
       filesToInstall = [
         "u-boot.bin"
         "u-boot.gxbb"
@@ -774,13 +788,17 @@ in
     ];
   };
 
-  # A special build with much lower memory frequency (666 vs 1600 MT/s) which
-  # makes ROCK64 V2 boards stable. This is necessary because the DDR3 routing
-  # on that revision is marginal and not unconditionally stable at the specified
-  # frequency. If your ROCK64 is unstable you can try this u-boot variant to
-  # see if it works better for you. The only disadvantage is lowered memory
-  # bandwidth.
   ubootRock64v2 = buildUBoot {
+    extraMeta.longDescription = ''
+      Boot loader for the Pine64 Rock64 V2.
+
+      A special build with much lower memory frequency (666 vs 1600 MT/s) which
+      makes ROCK64 V2 boards stable. This is necessary because the DDR3 routing
+      on that revision is marginal and not unconditionally stable at the specified
+      frequency. If your ROCK64 is unstable you can try this u-boot variant to
+      see if it works better for you. The only disadvantage is lowered memory
+      bandwidth.
+    '';
     prePatch = ''
       substituteInPlace arch/arm/dts/rk3328-rock64-u-boot.dtsi \
         --replace rk3328-sdram-lpddr3-1600.dtsi rk3328-sdram-lpddr3-666.dtsi
@@ -864,8 +882,15 @@ in
     extraConfig = ''
       CONFIG_CMD_SETEXPR=y
     '';
-    # sata init; load sata 0 $loadaddr u-boot-with-nand-spl.imx
-    # sf probe; sf update $loadaddr 0 80000
+    extraMeta.longDescription = ''
+      Boot loader for the CompuLab CM-FX6.
+
+      Flashing instructions:
+      ```
+      sata init; load sata 0 $loadaddr u-boot-with-nand-spl.imx
+      sf probe; sf update $loadaddr 0 80000
+      ```
+    '';
   };
 
   ubootVisionFive2 = buildUBoot {


### PR DESCRIPTION
Some comments are useful to users, so let's allow them to read the comments without having to look in the source code.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
