### PR TITLE
Use default python3 for kluctl

### DIFF
--- a/pkgs/by-name/kl/kluctl/package.nix
+++ b/pkgs/by-name/kl/kluctl/package.nix
@@ -7,7 +7,7 @@
   installShellFiles,
   testers,
   makeWrapper,
-  python310,
+  python3,
 }:
 
 buildGoModule (finalAttrs: {
@@ -52,7 +52,7 @@ buildGoModule (finalAttrs: {
       mv $out/bin/{cmd,kluctl}
       wrapProgram $out/bin/kluctl \
         --set KLUCTL_USE_SYSTEM_PYTHON 1 \
-        --prefix PATH : '${lib.makeBinPath [ python310 ]}'
+        --prefix PATH : '${lib.makeBinPath [ python3 ]}'
       installShellCompletion --cmd kluctl \
         --bash <(${emulator} $out/bin/kluctl completion bash) \
         --fish <(${emulator} $out/bin/kluctl completion fish) \


### PR DESCRIPTION
Note from kluctl author (codablock @ github):
Well, the version you see in Nix is tested properly…that’s basically all about it :)
In theory, it should work with more recent versions. It’s not demanding much of Python, it must basically only be compatible to the Jinja2 version used.
- - - -
Considering the culture we(Nix) has of holding things slightly wrong I believe it makes sense to use the default Python until it becomes a problem 😄 

@sikmir @netthier 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
