### PR TITLE
stasis: init at 0.5.0

### DIFF
--- a/pkgs/by-name/st/stasis/package.nix
+++ b/pkgs/by-name/st/stasis/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  wayland-scanner,
+  wayland,
+  wayland-protocols,
+  dbus,
+  pkg-config,
+  libinput,
+  udev,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stasis";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "saltnpepper97";
+    repo = "stasis";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gJB/y6jSBJZjBTQB9sxbVpllSfF6jwKOEeLqlgIStMA=";
+  };
+
+  cargoHash = "sha256-JX0imd+FuuBq8d3FAYEQ+LLZQV39f8Iu9ftLASs00Fc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    dbus
+    libinput
+    udev
+  ];
+
+  #There are no tests
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern idle manager for Wayland";
+    longDescription = ''
+      Stasis is a smart idle manager for Wayland that understands context.
+      It automatically prevents idle when watching videos, reading documents,
+      or playing music, while allowing idle when appropriate. Features include
+      media-aware idle handling, application-specific inhibitors, Wayland idle
+      inhibitor protocol support, and flexible configuration using the RUNE
+      configuration language.
+    '';
+    homepage = "https://github.com/saltnpepper97/stasis";
+    changelog = "https://github.com/saltnpepper97/stasis/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    platforms = lib.platforms.linux;
+    mainProgram = "stasis";
+  };
+})


### PR DESCRIPTION
[Stasis](https://github.com/saltnpepper97/stasis) - modern idle manager for Wayland.

<details><summary>about</summary>
<p>

Stasis is a smart idle manager for Wayland that understands context. It automatically prevents idle when watching videos, reading documents, or playing music, while allowing idle when appropriate. Features include media-aware idle handling, application-specific inhibitors, Wayland idle inhibitor protocol support, and flexible configuration using the RUNE configuration language.

</p>
</details> 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
