### PR TITLE
cargo-hakari: 0.9.35 -> 0.9.36

### DIFF
--- a/pkgs/by-name/ca/cargo-hakari/package.nix
+++ b/pkgs/by-name/ca/cargo-hakari/package.nix
@@ -6,46 +6,40 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-hakari";
-  version = "0.9.35";
+  version = "0.9.36";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
-    tag = "cargo-hakari-${version}";
-    hash = "sha256-+IjtK4kSm2vThgIxDsBLpoh0j9cDhhEqI6Hr2BmC7hc=";
+    tag = "cargo-hakari-${finalAttrs.version}";
+    hash = "sha256-qEYdJhLt4f3+RZz3/T6/vlQgrQYK6S5dNEmu8QH/wj0=";
   };
 
-  cargoHash = "sha256-yAk0hMB3OEaaIuNqiJtl1K5P19pOGtiyt4cvU+Nb814=";
+  cargoHash = "sha256-NrPfdVAi0QblJKFsHTL0BGQWUnqQEpIJwW3HBVHFZpE=";
 
   cargoBuildFlags = [
     "-p"
     "cargo-hakari"
   ];
-  cargoTestFlags = [
-    "-p"
-    "cargo-hakari"
-  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
   versionCheckProgramArg = "--version";
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Manage workspace-hack packages to speed up builds in large workspaces";
-    mainProgram = "cargo-hakari";
     longDescription = ''
       cargo hakari is a command-line application to manage workspace-hack crates.
       Use it to speed up local cargo build and cargo check commands by 15-95%,
       and cumulatively by 20-25% or more.
     '';
     homepage = "https://crates.io/crates/cargo-hakari";
-    changelog = "https://github.com/guppy-rs/guppy/blob/cargo-hakari-${version}/tools/cargo-hakari/CHANGELOG.md";
+    changelog = "https://github.com/guppy-rs/guppy/blob/cargo-hakari-${finalAttrs.version}/tools/cargo-hakari/CHANGELOG.md";
     license = with lib.licenses; [
       mit
       asl20
@@ -55,5 +49,6 @@ rustPlatform.buildRustPackage rec {
       macalinao
       nartsiss
     ];
+    mainProgram = "cargo-hakari";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/guppy-rs/guppy/blob/main/tools/cargo-hakari/CHANGELOG.md


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
