### PR TITLE
codesnap: 0.10.9 -> 0.12.10

### DIFF
--- a/pkgs/by-name/co/codesnap/package.nix
+++ b/pkgs/by-name/co/codesnap/package.nix
@@ -4,25 +4,32 @@
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
+  openssl,
+  pkg-config,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codesnap";
-  version = "0.10.9";
+  version = "0.12.10";
 
   src = fetchFromGitHub {
-    owner = "mistricky";
-    repo = "CodeSnap";
-    tag = "v${version}";
-    hash = "sha256-EtMEUtLSgYrb0izPPCh432uX2p/8Ykf2caAR+8ZdxhU=";
+    owner = "codesnap-rs";
+    repo = "codesnap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BIdqSEsQIV5Z2mYMgoW0gtBaMNxhEsAbZbs/KDJEK4E=";
   };
 
-  cargoHash = "sha256-atvSygt1Xi+rPxcJb0zdRBnL6SpSkyCcGxs1z2hWXGA=";
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  cargoHash = "sha256-xenMTuCy3ABEBddH759m0AgMJUlsS0eFj473Y6qjzkY=";
 
   cargoBuildFlags = [
     "-p"
     "codesnap-cli"
   ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  OPENSSL_NO_VENDOR = true;
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -35,9 +42,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command-line tool for generating beautiful code snippets";
     homepage = "https://github.com/mistricky/CodeSnap";
-    changelog = "https://github.com/mistricky/CodeSnap/releases/tag/v${version}";
+    changelog = "https://github.com/mistricky/CodeSnap/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nartsiss ];
     mainProgram = "codesnap";
   };
-}
+})


### PR DESCRIPTION


## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
