### PR TITLE
maintainers/scripts/check-hydra-by-maintainer: cleanup

### DIFF
--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -30,7 +30,7 @@ let
       ) set
     ));
 
-  packages = packagesWith (
+  packages = builtins.trace "evaluating list of packages for maintainer: ${maintainer}" packagesWith (
     name: pkg:
     (
       if builtins.hasAttr "meta" pkg && builtins.hasAttr "maintainers" pkg.meta then

--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -58,11 +58,14 @@ pkgs.stdenvNoCC.mkDerivation {
     echo "----------------------------------------------------------------"
     exit 1
   '';
-  shellHook = ''
-    unset shellHook # do not contaminate nested shells
-    echo "Please stand by"
-    echo nix-shell -p hydra-check --run "hydra-check ${builtins.concatStringsSep " " packages}"
-    nix-shell -p hydra-check --run "hydra-check ${builtins.concatStringsSep " " packages}"
-    exit $?
-  '';
+  shellHook =
+    let
+      command = "hydra-check ${lib.escapeShellArgs packages}";
+    in
+    ''
+      echo "Please stand by"
+      echo "${command}"
+      ${command}
+      exit $?
+    '';
 }

--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -1,4 +1,8 @@
-{ maintainer }:
+{
+  maintainer, # --argstr
+  short ? false, # use --arg short true
+  extra ? "", # --argstr
+}:
 let
   pkgs = import ./../../default.nix {
     config.allowAliases = false;
@@ -53,14 +57,21 @@ pkgs.stdenvNoCC.mkDerivation {
     echo ""
     echo "----------------------------------------------------------------"
     echo ""
-    echo "nix-shell maintainers/scripts/check-hydra-by-maintainer.nix --argstr maintainer SuperSandro2000"
+    echo "nix-shell maintainers/scripts/check-hydra-by-maintainer.nix --argstr maintainer yourname"
+    echo ""
+    echo "nix-shell maintainers/scripts/check-hydra-by-maintainer.nix --argstr maintainer yourname --arg short true"
+    echo ""
+    echo "nix-shell maintainers/scripts/check-hydra-by-maintainer.nix --argstr maintainer yourname --argstr extra \"--json\""
     echo ""
     echo "----------------------------------------------------------------"
     exit 1
   '';
   shellHook =
     let
-      command = "hydra-check ${lib.escapeShellArgs packages}";
+      # trying to only add spaces as necessary for optional args
+      # with optStr don't need spaces between nix templating
+      optStr = cond: string: lib.optionalString cond "${string} ";
+      command = "hydra-check ${optStr short "--short"}${optStr (extra != "") extra}${lib.escapeShellArgs packages}";
     in
     ''
       # if user presses ctrl-c during run

--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -71,7 +71,13 @@ pkgs.stdenvNoCC.mkDerivation {
       # trying to only add spaces as necessary for optional args
       # with optStr don't need spaces between nix templating
       optStr = cond: string: lib.optionalString cond "${string} ";
-      command = "hydra-check ${optStr short "--short"}${optStr (extra != "") extra}${lib.escapeShellArgs packages}";
+      args = [
+        "hydra-check"
+      ]
+      ++ (lib.optional short "--short")
+      ++ (lib.optional (extra != "") extra)
+      ++ (map lib.escapeShellArg packages);
+      command = lib.concatStringsSep " " args;
     in
     ''
       # if user presses ctrl-c during run

--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -63,6 +63,12 @@ pkgs.stdenvNoCC.mkDerivation {
       command = "hydra-check ${lib.escapeShellArgs packages}";
     in
     ''
+      # if user presses ctrl-c during run
+      # pass on ctrl-c to fully quit rather than exiting to nix-shell
+      function ctrl_c() {
+        exit 130
+      }
+      trap ctrl_c INT
       echo "Please stand by"
       echo "${command}"
       ${command}

--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -47,7 +47,7 @@ let
 
 in
 pkgs.stdenv.mkDerivation {
-  name = "nixpkgs-update-script";
+  name = "check-hydra-by-maintainer";
   buildInputs = [ pkgs.hydra-check ];
   buildCommand = ''
     echo ""

--- a/maintainers/scripts/check-hydra-by-maintainer.nix
+++ b/maintainers/scripts/check-hydra-by-maintainer.nix
@@ -46,7 +46,7 @@ let
   ) (name: name) "" pkgs;
 
 in
-pkgs.stdenv.mkDerivation {
+pkgs.stdenvNoCC.mkDerivation {
   name = "check-hydra-by-maintainer";
   buildInputs = [ pkgs.hydra-check ];
   buildCommand = ''


### PR DESCRIPTION
- maintainers/scripts/check-hydra-by-maintainer: correct drv name
- maintainers/scripts/check-hydra-by-maintainer: use stdenvNoCC
- maintainers/scripts/check-hydra-by-maintainer: use hydra-check already in path
- maintainers/scripts/check-hydra-by-maintainer: inform user eval is taking place
- maintainers/scripts/check-hydra-by-maintainer: ctrl-c fully exit
- maintainers/scripts/check-hydra-by-maintainer: expose short and extra


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Used on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
