### PR TITLE
lib.customisation: fix error message when running in `nix repl`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -305,9 +305,10 @@ rec {
         arg:
         let
           loc = unsafeGetAttrPos arg fargs;
+          loc' = if loc != null then loc.file + ":" + toString loc.line else "<unknown location>";
         in
         "Function called without required argument \"${arg}\" at "
-        + "${loc.file}:${toString loc.line}${prettySuggestions (getSuggestions arg)}";
+        + "${loc'}${prettySuggestions (getSuggestions arg)}";
 
       # Only show the error for the first missing argument
       error = errorForArg (head (attrNames missingArgs));


### PR DESCRIPTION
This code was more careful before
<https://github.com/NixOS/nixpkgs/commit/dd435697b31467d6b0f4112ed519aafc140bb6de> (it didn't assume that `unsafeGetAttrPos` always returns a non-null location). Unfortunately, `unsafeGetAttrPos` *does* return `null` when dealing with `nix repl`:

```
nix-repl> f = {foo}: foo

nix-repl> builtins.unsafeGetAttrPos "foo" (builtins.functionArgs f)
null
```

Here's how to reproduce the issue.

*Before* this fix:

```
nix-repl> f = {foo}: foo

nix-repl> myCallPackage = lib.callPackageWith {}

nix-repl> myCallPackage f {}
error:
       … while calling the 'abort' builtin
         at /home/jeremy/src/github.com/NixOS/nixpkgs/lib/customisation.nix:323:7:
          322|     else
          323|       abort "lib.customisation.callPackageWith: ${error}";
             |       ^
          324|

       … while selecting an attribute
         at /home/jeremy/src/github.com/NixOS/nixpkgs/lib/customisation.nix:310:14:
          309|         "Function called without required argument \"${arg}\" at "
          310|         + "${loc.file}:${toString loc.line}${prettySuggestions (getSuggestions arg)}";
             |              ^
          311|

       error: expected a set but found null: null

```

*After*:

```
nix-repl> f = {foo}: foo

nix-repl> myCallPackage = lib.callPackageWith {}

nix-repl> myCallPackage f {}
error:
       … while calling the 'abort' builtin
         at /home/jeremy/src/github.com/NixOS/nixpkgs/lib/customisation.nix:332:7:
          331|     # Inputs
          332|
             |       ^
          333|     `autoArgs`

       error: evaluation aborted with the following error message: 'lib.customisation.callPackageWith: Function called without required argument "foo" at <unknown location>'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
