### PR TITLE
signal-desktop-bin: 7.71.0 -> 7.77.1

### DIFF
--- a/pkgs/by-name/si/signal-desktop-bin/copy-noto-emoji.py
+++ b/pkgs/by-name/si/signal-desktop-bin/copy-noto-emoji.py
@@ -18,24 +18,6 @@ import sys
 from pathlib import Path
 
 
-def signal_name_to_emoji(signal_emoji_name: str) -> str:
-    r"""Return the emoji corresponding to a Signal emoji name.
-
-    Signal emoji names are concatenations of UTF‐16 code units,
-    represented in lowercase big‐endian hex padded to four digits.
-
-    >>> signal_name_to_emoji("d83dde36200dd83cdf2bfe0f")
-    '😶‍🌫️'
-    >>> b"\xd8\x3d\xde\x36\x20\x0d\xd8\x3c\xdf\x2b\xfe\x0f".decode("utf-16-be")
-    '😶‍🌫️'
-    """
-    hex_bytes = zip(signal_emoji_name[::2], signal_emoji_name[1::2])
-    emoji_utf_16_be = bytes(
-        int("".join(hex_pair), 16) for hex_pair in hex_bytes
-    )
-    return emoji_utf_16_be.decode("utf-16-be")
-
-
 def emoji_to_noto_name(emoji: str) -> str:
     r"""Return the Noto emoji name of an emoji.
 
@@ -68,16 +50,15 @@ def _main() -> None:
 
     for signal_emoji_names in jumbomoji_packs.values():
         for signal_emoji_name in signal_emoji_names:
-            emoji = signal_name_to_emoji(signal_emoji_name)
 
             try:
                 shutil.copy(
-                    noto_png_path / f"emoji_u{emoji_to_noto_name(emoji)}.png",
-                    out_path / emoji,
+                    noto_png_path / f"emoji_u{emoji_to_noto_name(signal_emoji_name)}.png",
+                    out_path / signal_emoji_name,
                 )
             except FileNotFoundError:
                 print(
-                    f"Missing Noto emoji: {emoji} {signal_emoji_name}",
+                    f"Missing Noto emoji: {signal_emoji_name}",
                     file=sys.stderr,
                 )
                 continue

--- a/pkgs/by-name/si/signal-desktop-bin/generic.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/generic.nix
@@ -92,12 +92,12 @@ let
   });
 
   noto-emoji-sheet-32 = fetchurl {
-    url = "https://raw.githubusercontent.com/iamcal/emoji-data/refs/tags/v15.1.2/sheet_google_32.png";
-    hash = "sha256-S03NCTbvB5yeQl62WpLNjNGhjNErtgaOB6tAj/X8vPc=";
+    url = "https://raw.githubusercontent.com/iamcal/emoji-data/refs/tags/v16.0.0/sheet_google_32.png";
+    hash = "sha256-tBfp9s1LvBBla7/V4TtumiVFtV5qTPcxLXW+H6qjSVI=";
   };
   noto-emoji-sheet-64 = fetchurl {
-    url = "https://raw.githubusercontent.com/iamcal/emoji-data/refs/tags/v15.1.2/sheet_google_64.png";
-    hash = "sha256-kZYStR5xAuausSpOD6wJZRJZ1K6nPpweE3aYSgWntS4=";
+    url = "https://raw.githubusercontent.com/iamcal/emoji-data/refs/tags/v16.0.0/sheet_google_64.png";
+    hash = "sha256-eVoMWY0WLJpKriPyGIxge4ybwZEst9hDgkWfjekaOuE=";
   };
 in
 stdenv.mkDerivation rec {
@@ -263,8 +263,7 @@ stdenv.mkDerivation rec {
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/signal-desktop.desktop \
-      --replace-fail "/${bindir}/signal-desktop" ${meta.mainProgram} \
-      --replace-fail "StartupWMClass=Signal" "StartupWMClass=signal"
+      --replace-fail "/${bindir}/signal-desktop" ${meta.mainProgram}
 
     mv $out/share/applications/signal{-desktop,}.desktop
 

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
@@ -1,7 +1,7 @@
 { callPackage, commandLineArgs }:
 callPackage ./generic.nix { inherit commandLineArgs; } {
   pname = "signal-desktop-bin";
-  version = "7.71.0";
+  version = "7.77.1";
 
   libdir = "usr/lib64/signal-desktop";
   bindir = "usr/bin";
@@ -10,6 +10,6 @@ callPackage ./generic.nix { inherit commandLineArgs; } {
     bsdtar -xf $downloadedFile -C "$out"
   '';
 
-  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/09571107-signal-desktop/signal-desktop-7.71.0-1.fc42.aarch64.rpm";
-  hash = "sha256-sNGIkO2HAXl0ykFyZNNV75iVUQ+oRGv6NZW8tVUxfJA=";
+  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/09751999-signal-desktop/signal-desktop-7.77.1-1.fc42.aarch64.rpm";
+  hash = "sha256-IkAJxq3JK3kKdtLy1lkVUfJNuEStMjn7iQEwsFurwOs=";
 }

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-darwin.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-darwin.nix
@@ -6,11 +6,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "signal-desktop-bin";
-  version = "7.71.0";
+  version = "7.77.1";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/signal-desktop-mac-universal-${finalAttrs.version}.dmg";
-    hash = "sha256-G4wCIzKnWwBYSTuXhZ6681Z2+0Rn2bpvb3vhKMAXFc4=";
+    hash = "sha256-vnNR5KTdeTKUMlHnjfB+WkBtpcLP+KEmIPoTfk7Q1+w=";
   };
   sourceRoot = ".";
 

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
@@ -1,12 +1,12 @@
 { callPackage, commandLineArgs }:
 callPackage ./generic.nix { inherit commandLineArgs; } rec {
   pname = "signal-desktop-bin";
-  version = "7.71.0";
+  version = "7.77.1";
 
   libdir = "opt/Signal";
   bindir = libdir;
   extractPkg = "dpkg-deb -x $downloadedFile $out";
 
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-y7ONN6VBVFH8zyXJNM3+cY4JegSolXfhH3T85WiM2Dk=";
+  hash = "sha256-57sm6wmtp0eXWCv7LviCiBEi5/IysubiuBYSP7eVkkU=";
 }


### PR DESCRIPTION
Diff: https://github.com/signalapp/Signal-Desktop/compare/v7.71.0...v7.76.0

- Adapted `copy-noto-emoji.py` for upstream changes
- Updated the emoji sheets for `emoji-datasource` `v16.0.0` (which is now used by `signal-desktop`)
- Dropped `--replace-fail "StartupWMClass=Signal" "StartupWMClass=signal"` since the correct name is now used upstream

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
