### PR TITLE
orange{3,-{canvas-core,widget-base}}: remove lucasew as maintainer

### DIFF
--- a/pkgs/development/python-modules/orange-canvas-core/default.nix
+++ b/pkgs/development/python-modules/orange-canvas-core/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/biolab/orange-canvas-core";
     changelog = "https://github.com/biolab/orange-canvas-core/releases/tag/${src.tag}";
     license = [ lib.licenses.gpl3 ];
-    maintainers = [ lib.maintainers.lucasew ];
+    maintainers = [ ];
     # Segmentation fault during tests
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/development/python-modules/orange-widget-base/default.nix
+++ b/pkgs/development/python-modules/orange-widget-base/default.nix
@@ -66,6 +66,6 @@ buildPythonPackage rec {
     description = "Implementation of the base OWBaseWidget class and utilities for use in Orange Canvas workflows";
     homepage = "https://github.com/biolab/orange-widget-base";
     license = [ lib.licenses.gpl3Plus ];
-    maintainers = [ lib.maintainers.lucasew ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/orange3/default.nix
+++ b/pkgs/development/python-modules/orange3/default.nix
@@ -222,7 +222,7 @@ let
       homepage = "https://orangedatamining.com/";
       changelog = "https://github.com/biolab/orange3/blob/${src.tag}/CHANGELOG.md";
       license = [ lib.licenses.gpl3Plus ];
-      maintainers = [ lib.maintainers.lucasew ];
+      maintainers = [ ];
       mainProgram = "orange-canvas";
     };
   };


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
