### PR TITLE
Revert "workflows/eval: run Lix in the merge queue"

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -284,10 +284,6 @@ jobs:
                           diff.removed,
                           diff.changed,
                           diff.rebuilds
-                        ).filter(attr =>
-                          // Exceptions related to dev shells, which changed at some time between 2.18 and 2.24.
-                          !attr.startsWith('tests.devShellTools.nixos.') &&
-                          !attr.startsWith('tests.devShellTools.unstructuredDerivationInputEnv.')
                         )
                         if (attrs.length > 0) {
                           core.setFailed(

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -11,9 +11,6 @@ on:
       systems:
         required: true
         type: string
-      defaultVersion:
-        required: true
-        type: string
       testVersions:
         required: false
         default: false
@@ -108,7 +105,7 @@ jobs:
       - name: Evaluate the ${{ matrix.system }} output paths at the merge commit
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
-          MATRIX_VERSION: ${{ matrix.version || inputs.defaultVersion }}
+          MATRIX_VERSION: ${{ matrix.version || 'nixVersions.latest' }}
         run: |
           nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned  -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
@@ -122,14 +119,12 @@ jobs:
         if: inputs.targetSha
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
-          # This must match the default version set in the Merge Queue.
-          VERSION: lixPackageSets.latest.lix
         # This is very quick, because it pulls the eval results from Cachix.
         run: |
           nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/trusted-pinned -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
             --arg chunkSize 8000 \
-            --argstr nixPath "$VERSION" \
+            --argstr nixPath "nixVersions.latest" \
             --out-link target
 
       - name: Compare outpaths against the target branch

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -55,8 +55,6 @@ jobs:
     with:
       mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
       systems: ${{ needs.prepare.outputs.systems }}
-      # This must match the version in Eval's target step.
-      defaultVersion: lixPackageSets.latest.lix
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block the Merge Queue.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,7 +86,6 @@ jobs:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
       systems: ${{ needs.prepare.outputs.systems }}
-      defaultVersion: nixVersions.latest
       testVersions: ${{ contains(fromJSON(needs.prepare.outputs.touched), 'pinned') && !contains(fromJSON(needs.prepare.outputs.headBranch).type, 'development') }}
 
   labels:


### PR DESCRIPTION
This reverts commit https://github.com/NixOS/nixpkgs/commit/7ed2c7e297db3cd90e7e3e952e5068eb24ec6aef from #451926.

This [breaks the performance report](https://github.com/NixOS/nixpkgs/pull/421125#issuecomment-3411547609), because it compares Lix vs Nix and needs more thought before re-application.

Also added a small fix to make sure that the recent #451929 doesn't regress, at least checked by the updates to the pin.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
