### PR TITLE
nvidia-container-toolkit: wait for all device nodes to be present

### DIFF
--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -188,6 +188,10 @@
         ])
       ];
 
+      services.udev.extraRules = ''
+        KERNEL=="nvidia", RUN+="${pkgs.systemd}/bin/systemctl restart nvidia-container-toolkit-cdi-generator.service'"
+      '';
+
       virtualisation = {
         containers.containersConf.settings = {
           engine = {
@@ -289,11 +293,52 @@
 
       systemd.services.nvidia-container-toolkit-cdi-generator = {
         description = "Container Device Interface (CDI) for Nvidia generator";
+        requiredBy = lib.mkMerge [
+          (lib.mkIf config.virtualisation.docker.enable [ "docker.service" ])
+          (lib.mkIf config.virtualisation.podman.enable [ "podman.service" ])
+        ];
         wantedBy = [ "multi-user.target" ];
-        after = [ "systemd-udev-settle.service" ];
         serviceConfig = {
           RuntimeDirectory = "cdi";
           RemainAfterExit = true;
+          ExecStartPre = pkgs.writeShellScript "wait-for-nvidia-devices" ''
+            set -eu
+
+            gpus_dir="/proc/driver/nvidia/gpus"
+            max_wait_seconds=60
+
+            if [ ! -d "$gpus_dir" ]; then
+              echo "wait-for-nvidia-devices: $gpus_dir does not exist; nothing to wait for."
+              exit 0
+            fi
+
+            gpu_count=$(find "$gpus_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+
+            if [ "$gpu_count" -eq 0 ]; then
+              echo "wait-for-nvidia-devices: no GPU entries found in $gpus_dir; nothing to wait for."
+              exit 0
+            fi
+
+            echo "wait-for-nvidia-devices: expecting $gpu_count /dev/nvidiaN device node(s)."
+
+            elapsed=0
+            while true; do
+              dev_count=$(find /dev -mindepth 1 -maxdepth 1 -type c -regex '.*/nvidia[0-9]+' 2>/dev/null | wc -l | tr -d ' ')
+
+              if [ "$dev_count" -eq "$gpu_count" ]; then
+                echo "wait-for-nvidia-devices: found $dev_count matching device node(s)."
+                exit 0
+              fi
+
+              if [ "$elapsed" -ge "$max_wait_seconds" ]; then
+                echo "wait-for-nvidia-devices: timed out after $max_wait_seconds seconds; expected $gpu_count node(s) but found $dev_count." >&2
+                exit 1
+              fi
+
+              sleep 1
+              elapsed=$((elapsed + 1))
+            done
+          '';
           ExecStart =
             let
               script = pkgs.callPackage ./cdi-generate.nix {

--- a/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
+++ b/nixos/modules/services/hardware/nvidia-container-toolkit/default.nix
@@ -189,7 +189,7 @@
       ];
 
       services.udev.extraRules = ''
-        KERNEL=="nvidia", RUN+="${pkgs.systemd}/bin/systemctl restart nvidia-container-toolkit-cdi-generator.service'"
+        KERNEL=="nvidia", RUN+="${lib.getExe' config.systemd.package "systemctl"} restart nvidia-container-toolkit-cdi-generator.service'"
       '';
 
       virtualisation = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes: #451912

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
