### PR TITLE
nix-bash-completions: fix for non-NixOS use

### DIFF
--- a/pkgs/by-name/ni/nix-bash-completions/0001-Fix-completion-with-Nix-2.4-on-non-NixOS.patch
+++ b/pkgs/by-name/ni/nix-bash-completions/0001-Fix-completion-with-Nix-2.4-on-non-NixOS.patch
@@ -1,0 +1,49 @@
+From 135798f6dff7cf5167906cecc0e9c86860c70f36 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B8rn=20Forsman?= <bjorn.forsman@gmail.com>
+Date: Mon, 4 Sep 2023 14:10:01 +0200
+Subject: [PATCH] Fix completion with Nix 2.4+ on non-NixOS
+
+Nix 2.4+ stopped setting NIX_PATH in the environment and instead uses a
+built-in default in the C++ code (not exposed to shell processes). That
+means this completion codes sees $override as empty and runs `NIX_PATH=
+nix-instantiate ...`. Setting NIX_PATH to an empty string means Nix
+won't use its default built-in value and completion breaks (assuming
+the completion depends on '<nixpkgs>' or similar search path entries).
+
+NixOS isn't affected because there NIX_PATH is still set (by the OS, not
+by code from the Nix repo).
+
+The fix is to not pass NIX_PATH unless we have a value for it. That
+works for both old and new Nix, on NixOS and non-NixOS.
+
+(I initially tried with a single `$maybe_nix_path nix-instantiate ...`,
+but apparently bash treats the value in $maybe_nix_path as a command
+instead of setting environment variables for the process.)
+---
+ _nix | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/_nix b/_nix
+index 6b9c281..61052f1 100755
+--- a/_nix
++++ b/_nix
+@@ -101,7 +101,15 @@ function _nix_eval_stdin () {
+     # Shortcut: since the output of this function is only used in the -W argument of compgen,
+     # which expects a shell-quoted list of words, we leave the double quotes from the Nix
+     # output intact to approximate shell quoting.
+-    NIX_PATH=$override nix-instantiate --eval - 2> /dev/null | tr '[]' ' '
++    if [[ -n "$override" ]]; then
++        NIX_PATH=$override nix-instantiate --eval - 2> /dev/null | tr '[]' ' '
++    else
++        # Don't set NIX_PATH to empty string, as that'll overwrite/clear Nix'
++        # built-in default (since version 2.4+). Nix 2.3 and older sets
++        # NIX_PATH in shell initialization files, which means for those
++        # versions we already have it in $override (code path above).
++        nix-instantiate --eval - 2> /dev/null | tr '[]' ' '
++    fi
+ }
+ 
+ # Resolve any urls ourselves, as nix will start downloading and block
+-- 
+2.50.1
+

--- a/pkgs/by-name/ni/nix-bash-completions/package.nix
+++ b/pkgs/by-name/ni/nix-bash-completions/package.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation rec {
       url = "https://github.com/hedning/nix-bash-completions/pull/28/commits/ef2055aa28754fa9e009bbfebc1491972e4f4e67.patch";
       hash = "sha256-TRkHrk7bX7DX0COzzYR+1pgTqLy7J55BcejNjRwthII=";
     })
+    # Fix completion with Nix 2.4+ on non-NixOS: https://github.com/hedning/nix-bash-completions/pull/26
+    # Rebased locally due to conflict with the above patch (https://github.com/hedning/nix-bash-completions/pull/28).
+    ./0001-Fix-completion-with-Nix-2.4-on-non-NixOS.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Apply https://github.com/hedning/nix-bash-completions/pull/26 to
nixpkgs, since upstream seems dead. (PR has been sitting there for 2
years.)

Due to a conflict with
https://github.com/hedning/nix-bash-completions/pull/28, which is
already applied here in nixpkgs, pull 26 cannot be applied as is. I
rebased it and added it locally to nixpkgs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
