### PR TITLE
ocamlPackages.ppx_js_style: 0.17.0 → 0.17.1

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1438,16 +1438,28 @@ with self;
     meta.broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
-  ppx_js_style = janePackage {
-    pname = "ppx_js_style";
-    hash = "sha256-7jRzxe4bLyZ2vnHeqWiLlCUvOlNUAk0dwCfBFhrykUU=";
-    meta.description = "Code style checker for Jane Street Packages";
-    propagatedBuildInputs = [
-      octavius
-      ppxlib
-    ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  ppx_js_style = janePackage (
+    {
+      pname = "ppx_js_style";
+      meta.description = "Code style checker for Jane Street Packages";
+      propagatedBuildInputs = [
+        octavius
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-YGGG468WVZbT5JfCB32FfTV7kdRz14ProDQxkdZuE44=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-7jRzxe4bLyZ2vnHeqWiLlCUvOlNUAk0dwCfBFhrykUU=";
+        }
+    )
+  );
 
   ppx_let = janePackage (
     {

--- a/pkgs/development/ocaml-modules/ppx_yojson_conv/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_yojson_conv/default.nix
@@ -5,18 +5,22 @@
   ppx_js_style,
   ppx_yojson_conv_lib,
   ppxlib,
+  version ? if lib.versionAtLeast ppxlib.version "0.36.0" then "0.17.1" else "0.15.1",
 }:
-buildDunePackage rec {
+buildDunePackage {
   pname = "ppx_yojson_conv";
-  version = "0.15.1";
-  duneVersion = "3";
-  minimalOCamlVersion = "4.08.0";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "janestreet";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-lSOUSMVgsRiArEhFTKpAj2yFBPbtaIc/SxdPA+24xXs=";
+    repo = "ppx_yojson_conv";
+    tag = "v${version}";
+    hash =
+      {
+        "0.15.1" = "sha256-lSOUSMVgsRiArEhFTKpAj2yFBPbtaIc/SxdPA+24xXs=";
+        "0.17.1" = "sha256-QI2uN1/KeyDxdk6oxPt48lDir55Kkgx2BX6wKCY59LI=";
+      }
+      ."${version}";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
ocamlPackages.ppx_yojson_conv: 0.15.1 → 0.17.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
