### PR TITLE
python3Packages.paramiko: invoke is a required dependency

### DIFF
--- a/pkgs/by-name/du/duplicity/package.nix
+++ b/pkgs/by-name/du/duplicity/package.nix
@@ -75,20 +75,17 @@ let
       glib
     ];
 
-    pythonPath =
-      with python3.pkgs;
-      [
-        b2sdk
-        boto3
-        idna
-        pygobject3
-        fasteners
-        paramiko
-        pexpect
-        # Currently marked as broken.
-        # pydrive2
-      ]
-      ++ paramiko.optional-dependencies.invoke;
+    pythonPath = with python3.pkgs; [
+      b2sdk
+      boto3
+      idna
+      pygobject3
+      fasteners
+      paramiko
+      pexpect
+      # Currently marked as broken.
+      # pydrive2
+    ];
 
     nativeCheckInputs = [
       gnupg # Add 'gpg' to PATH.

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   dependencies = [
     bcrypt
     cryptography
+    invoke
     pynacl
   ];
 
@@ -39,7 +40,6 @@ buildPythonPackage rec {
       gssapi
     ];
     ed25519 = [ ];
-    invoke = [ invoke ];
   };
 
   nativeCheckInputs = [


### PR DESCRIPTION
See at https://github.com/paramiko/paramiko/blob/4.0.0/pyproject.toml#L14
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
