### PR TITLE
wifitui : init at 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9279,6 +9279,12 @@
     githubId = 14135816;
     name = "Geraldo Nascimento";
   };
+  greed = {
+    email = "greedoftheendless@gmail.com";
+    github = "greedoftheendless";
+    githubId = 126356018;
+    name = "Abhijit";
+  };
   gerg-l = {
     email = "gregleyda@proton.me";
     github = "Gerg-L";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9279,12 +9279,6 @@
     githubId = 14135816;
     name = "Geraldo Nascimento";
   };
-  greed = {
-    email = "greedoftheendless@gmail.com";
-    github = "greedoftheendless";
-    githubId = 126356018;
-    name = "Abhijit";
-  };
   gerg-l = {
     email = "gregleyda@proton.me";
     github = "Gerg-L";
@@ -9687,6 +9681,12 @@
     github = "GreatNateDev";
     githubId = 99703235;
     name = "Nate";
+  };
+  greed = {
+    email = "greedoftheendless@gmail.com";
+    github = "greedoftheendless";
+    githubId = 126356018;
+    name = "Abhijit";
   };
   greg = {
     email = "greg.hellings@gmail.com";

--- a/pkgs/by-name/wi/wifitui/package.nix
+++ b/pkgs/by-name/wi/wifitui/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "wifitui";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "shazow";
+    repo = "wifitui";
+    tag = "v${version}";
+    hash = "sha256-MC83hjeCxoP6xp0BfC7gsYZcGzgckWLpxAuXyuhWpn0=";
+  };
+
+  vendorHash = "sha256-SEQPc13cefzT8SyuD3UmNtTDgcrXUGTX54SBrnOHJJw=";
+
+  meta = with lib; {
+    description = "Fast featureful friendly wifi terminal UI";
+    homepage = "https://github.com/shazow/wifitui";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      greed
+      shazow
+    ];
+  };
+}


### PR DESCRIPTION
### 🛰️ TUI Wi-Fi Manager

This is a **TUI-based Wi-Fi manager**. Since there wasn’t an official Nix package available from the developer, I created one to make it easily installable on **NixOS** and other **Nix-based systems**.

There are **no code modifications** to the original project — I only made a nix package for it.

The goal is to make this tool accessible, cleanly packaged, and ready for others to use through the Nix ecosystem.

**Original Repository:** [shazow/wifitui](https://github.com/shazow/wifitui)

---

## ✅ Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests  
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests  
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage  

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md  
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests  
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md  
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests  
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md  
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test  

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/  
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
