### PR TITLE
nixos/pcscd: etc

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -121,18 +121,40 @@ in
         ) cfg.extendReaderNames;
       };
 
-      # If the cfgFile is empty and not specified (in which case the default
-      # /etc/reader.conf is assumed), pcscd will happily start going through the
-      # entire confdir (/etc in our case) looking for a config file and try to
-      # parse everything it finds. Doesn't take a lot of imagination to see how
-      # well that works. It really shouldn't do that to begin with, but to work
-      # around it, we force the path to the cfgFile.
-      #
-      # https://github.com/NixOS/nixpkgs/issues/121088
-      serviceConfig.ExecStart = [
-        ""
-        "${lib.getExe package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
-      ];
+      serviceConfig = {
+        # If the cfgFile is empty and not specified (in which case the default
+        # /etc/reader.conf is assumed), pcscd will happily start going through the
+        # entire confdir (/etc in our case) looking for a config file and try to
+        # parse everything it finds. Doesn't take a lot of imagination to see how
+        # well that works. It really shouldn't do that to begin with, but to work
+        # around it, we force the path to the cfgFile.
+        #
+        # https://github.com/NixOS/nixpkgs/issues/121088
+        ExecStart = [
+          ""
+          "${lib.getExe package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
+        ];
+
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = "identity";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        UMask = "0077";
+      };
     };
   };
 }

--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -125,7 +125,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://salsa.debian.org/rousseau/PCSC/-/blob/${finalAttrs.version}/ChangeLog";
     license = lib.licenses.bsd3;
     mainProgram = "pcscd";
-    maintainers = [ lib.maintainers.anthonyroussel ];
+    maintainers = [
+      lib.maintainers.anthonyroussel
+      lib.maintainers.parrot7483
+    ];
     pkgConfigModules = [ "libpcsclite" ];
     platforms = lib.platforms.unix;
     broken = !(polkitSupport -> dbusSupport) || !(systemdSupport -> dbusSupport);


### PR DESCRIPTION
Harden the systemd pcscd service. Use the same settings as the upstream definition.

https://salsa.debian.org/rousseau/PCSC/-/blob/master/etc/pcscd.service.in

With this the systemd-analyze security gives a "3.9 OK" rating. I tested both OTP tokens and AusweisApp with a USB card reader. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
