### PR TITLE
everest{,-bin}: init at 5806 (work around nixpkgs-update bot)

### DIFF
--- a/pkgs/by-name/ce/celestegame/celeste.nix
+++ b/pkgs/by-name/ce/celestegame/celeste.nix
@@ -8,10 +8,11 @@
   unzip,
   yq,
   dotnet-runtime_8,
+  everest,
 
   executableName ? "Celeste",
   desktopItems ? null,
-  everest ? null,
+  withEverest ? false,
   overrideSrc ? null,
   writableDir ? null,
   launchFlags ? "",
@@ -36,12 +37,12 @@ let
   phome = "$out/lib/Celeste";
 
   launchFlags' =
-    if launchFlags != "" && everest == null then
+    if launchFlags != "" && !withEverest then
       lib.warn "launchFlags is useless without Everest." ""
     else
       launchFlags;
   launchEnv' =
-    if launchEnv != "" && everest == null then
+    if launchEnv != "" && !withEverest then
       lib.warn "launchEnv is useless without Everest." ""
     else
       ''
@@ -91,7 +92,7 @@ stdenvNoCC.mkDerivation {
     mkdir -p ${phome}
     unzip -q $src -d ${phome}
   ''
-  + lib.optionalString (everest != null) ''
+  + lib.optionalString withEverest ''
     cp -r ${everest}/* $out
     chmod -R +w ${phome} # Files copied from other derivations are not writable by default
 
@@ -137,7 +138,7 @@ stdenvNoCC.mkDerivation {
       # https://github.com/EverestAPI/Everest/blob/7bd41c26850bbdfef937e2ed929174e864101c4c/Celeste.Mod.mm/Mod/Everest/BOOT.cs#L188-L201
       # It is hardcoded that it launches Celeste instead of Celeste-unwrapped.
       # Therefore, we need to prevent it from restarting.
-      lib.optionalString (everest != null) "--prefix LD_LIBRARY_PATH : ${phome}/lib64-linux"
+      lib.optionalString withEverest "--prefix LD_LIBRARY_PATH : ${phome}/lib64-linux"
     } --chdir ${phome}
 
     icon=$out/share/icons/hicolor/512x512/apps/Celeste.png
@@ -149,7 +150,7 @@ stdenvNoCC.mkDerivation {
   dontStrip = true;
   dontPatchShebangs = true;
   postFixup =
-    lib.optionalString (everest != null) ''
+    lib.optionalString withEverest ''
       rm -r ${phome}/Mods # Currently it is empty.
       ln -s "${writableDir}"/{Mods,LogHistory,CrashLogs,${everestLogFilename}} -t ${phome}
     ''

--- a/pkgs/by-name/ev/everest-bin/package.nix
+++ b/pkgs/by-name/ev/everest-bin/package.nix
@@ -36,7 +36,7 @@ stdenvNoCC.mkDerivation {
     autoPatchelf ${phome}/MiniInstaller-linux
   '';
   meta = {
-    description = "Celeste mod loader";
+    description = "Celeste mod loader (don't install; use celestegame instead)";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ ulysseszhan ];
     homepage = "https://everestapi.github.io";

--- a/pkgs/by-name/ev/everest/deps.json
+++ b/pkgs/by-name/ev/everest/deps.json
@@ -51,8 +51,8 @@
   },
   {
     "pname": "Microsoft.AspNetCore.App.Ref",
-    "version": "8.0.19",
-    "hash": "sha256-QySX2bih1UvwmLcn9cy1j+RuvZZwbcFKggL5Y/WcTnw="
+    "version": "8.0.20",
+    "hash": "sha256-A6300qL9iP7iuY4wF9QkmOcuvoJFB0H64BAM5oGZF/4="
   },
   {
     "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
@@ -81,8 +81,8 @@
   },
   {
     "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
-    "version": "8.0.19",
-    "hash": "sha256-u50rdLuoADSDCthx2Fg+AnT192TalHhFrzFCfMgmTn4="
+    "version": "8.0.20",
+    "hash": "sha256-rToqTSs66gvIi2I69+0/qjhKAXk5/rRQUh0KetP3ZxE="
   },
   {
     "pname": "Microsoft.Build.Tasks.Git",
@@ -166,8 +166,8 @@
   },
   {
     "pname": "Microsoft.NETCore.App.Host.linux-x64",
-    "version": "8.0.19",
-    "hash": "sha256-a9t/bX+WIKOu9q2R52b/hPGwOpkAgpYuP42SW2QXTak="
+    "version": "8.0.20",
+    "hash": "sha256-NlwDtSJmxP+9oIqWEMKU12o96g9TzQAEt//votxI2PU="
   },
   {
     "pname": "Microsoft.NETCore.App.Ref",
@@ -196,8 +196,8 @@
   },
   {
     "pname": "Microsoft.NETCore.App.Ref",
-    "version": "8.0.19",
-    "hash": "sha256-4ymel0R1c0HrX0plAWubJPzev52y0Fsx1esyQ1R7bXc="
+    "version": "8.0.20",
+    "hash": "sha256-1YXXJaiMZOIbLduuWyFGSWt6hOxKa3URNsPDfiMrnDM="
   },
   {
     "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
@@ -226,8 +226,8 @@
   },
   {
     "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
-    "version": "8.0.19",
-    "hash": "sha256-Ou51zUFTPESAAzP/z0+sLDAAXC54+oDlESBBT12M2lM="
+    "version": "8.0.20",
+    "hash": "sha256-BkV2ZjBpQvLhijWFSwWDpr5m2ffNlCtYJA5TUTro6no="
   },
   {
     "pname": "Microsoft.NETCore.DotNetAppHost",

--- a/pkgs/by-name/ev/everest/update.sh
+++ b/pkgs/by-name/ev/everest/update.sh
@@ -18,6 +18,7 @@ commit=$(echo "$latest" | jq -r .commit)
 version=$(echo "$latest" | jq -r .version)
 url=$(echo "$latest" | jq -r .mainDownload)
 
-update-source-version celestegame.passthru.everest $version --rev=$commit
-"$(nix-build --attr celestegame.passthru.everest.fetch-deps --no-out-link)"
-update-source-version celestegame.passthru.everest-bin $version "" $url
+update-source-version everest $version --rev=$commit
+echo > "$(dirname "$(nix-instantiate --eval --strict -A everest.meta.position | sed -re 's/^"(.*):[0-9]+"$/\1/')")/deps.json"
+"$(nix-build --attr everest.fetch-deps --no-out-link)"
+update-source-version everest-bin $version "" $url


### PR DESCRIPTION
Apparently the automatic updates are ineffective due to the fact that `celestegame.passthru.updateScript` does not actually update the version of `celestegame` itself, but update the verison of `celestegame.override { everest = celestegame.passthru.everest; }`. To work around this problem, I created new packages `everest` and `everest-bin`, and moved the update script to `everest`.

See nixpkgs-update log: https://nixpkgs-update-logs.nix-community.org/celestegame/2025-10-15.log

CC @rhelmot.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
