### PR TITLE
luabind, eigen2, soi: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/ei/eigen2/cmake-4-build.patch
+++ b/pkgs/by-name/ei/eigen2/cmake-4-build.patch
@@ -1,0 +1,47 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index bb12a7cf5..932187427 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ project(Eigen)
+-cmake_minimum_required(VERSION 2.6.2)
++cmake_minimum_required(VERSION 3.10)
+ 
+ set(INCLUDE_INSTALL_DIR
+     "${CMAKE_INSTALL_PREFIX}/include/eigen2"
+diff --git i/doc/examples/CMakeLists.txt w/doc/examples/CMakeLists.txt
+index 9db5b1f58..b535ae80e 100644
+--- i/doc/examples/CMakeLists.txt
++++ w/doc/examples/CMakeLists.txt
+@@ -8,12 +8,10 @@ ADD_EXECUTABLE(${example} ${example_src})
+ if(EIGEN_STANDARD_LIBRARIES_TO_LINK_TO)
+   target_link_libraries(${example} ${EIGEN_STANDARD_LIBRARIES_TO_LINK_TO})
+ endif()
+-GET_TARGET_PROPERTY(example_executable
+-                    ${example} LOCATION)
+ ADD_CUSTOM_COMMAND(
+   TARGET ${example}
+   POST_BUILD
+-  COMMAND ${example_executable}
++  COMMAND ${example}
+   ARGS >${CMAKE_CURRENT_BINARY_DIR}/${example}.out
+ )
+ ADD_DEPENDENCIES(all_examples ${example})
+diff --git i/doc/snippets/CMakeLists.txt w/doc/snippets/CMakeLists.txt
+index 7458830b0..153dbfc68 100644
+--- i/doc/snippets/CMakeLists.txt
++++ w/doc/snippets/CMakeLists.txt
+@@ -14,12 +14,10 @@ ADD_EXECUTABLE(${compile_snippet_target}
+ if(EIGEN_STANDARD_LIBRARIES_TO_LINK_TO)
+   target_link_libraries(${compile_snippet_target} ${EIGEN_STANDARD_LIBRARIES_TO_LINK_TO})
+ endif()
+-GET_TARGET_PROPERTY(compile_snippet_executable
+-                    ${compile_snippet_target} LOCATION)
+ ADD_CUSTOM_COMMAND(
+   TARGET ${compile_snippet_target}
+   POST_BUILD
+-  COMMAND ${compile_snippet_executable}
++  COMMAND ${compile_snippet_target}
+   ARGS >${CMAKE_CURRENT_BINARY_DIR}/${snippet}.out
+ )
+ ADD_DEPENDENCIES(all_snippets ${compile_snippet_target})

--- a/pkgs/by-name/ei/eigen2/package.nix
+++ b/pkgs/by-name/ei/eigen2/package.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # CMake 2.6.2 is deprecated and is no longer supported by CMake > 4
+  # https://github.com/NixOS/nixpkgs/issues/445447
+  patches = [ ./cmake-4-build.patch ];
+
   meta = with lib; {
     homepage = "https://eigen.tuxfamily.org";
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";

--- a/pkgs/development/libraries/luabind/default.nix
+++ b/pkgs/development/libraries/luabind/default.nix
@@ -28,6 +28,14 @@ stdenv.mkDerivation {
     inherit lua;
   };
 
+  # CMake 2.8.3 is deprecated and is no longer supported by CMake > 4
+  # https://github.com/NixOS/nixpkgs/issues/445447
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 2.8.3)" \
+      "cmake_minimum_required(VERSION 3.10)"
+  '';
+
   patches = [ ./0.9.1-discover-luajit.patch ];
 
   meta = {

--- a/pkgs/games/soi/cmake-4-build.patch
+++ b/pkgs/games/soi/cmake-4-build.patch
@@ -1,0 +1,60 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index 1298088..73a5c2d 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ #CMake script for Spheres of Influence
+ #Run 'cmake <source_directory>' to generate a makefile
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.10)
+ 
+ #definitions
+ set(PROJECT_NAME "Spheres\ of\ Influence")
+ set(APP_NAME soi)
+-set(PROJECT_VERSION 0 1 2)
++set(PROJECT_VERSION "0.1.2")
+ set(DESCRIPTION "A physics-based 3D puzzle game")
+ set(README README.txt)
+ set(LICENSE ${README})
+@@ -52,7 +52,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+     "${CMAKE_SOURCE_DIR}/${EXTRA_MODULES_IN}")
+ 
+ #declare the project
+-project(${PROJECT_NAME})
++project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
+ 
+ #grab source files
+ file(GLOB_RECURSE HEADERS ${CMAKE_SOURCE_DIR}/src/*.h)
+@@ -105,18 +105,13 @@ endif()
+ #declare the target program
+ add_executable(${APP_NAME} ${SOURCES} ${EXTRA_SOURCES} ${HEADERS})
+ 
+-#extract the proper versioning breakdown
+-list(GET PROJECT_VERSION 0 VERSION_MAJOR )
+-list(GET PROJECT_VERSION 1 VERSION_MINOR )
+-list(GET PROJECT_VERSION 2 VERSION_PATCH )
+-
+ #add some useful preprocessor defines
+ set_property(
+     TARGET ${APP_NAME} PROPERTY COMPILE_DEFINITIONS
+     ${COMPILEDEFS}
+ #     PROJECT_NAME="${PROJECT_NAME}"
+ #     AUTHOR_NAMES="${AUTHORS}"
+-#     PROJECT_VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
++#     PROJECT_VERSION="${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+ )
+ 
+ #pass on the flags
+@@ -168,9 +163,9 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY ${PROJECT_NAME})
+ set(CPACK_PACKAGE_DESCRIPTION_FILE ${README})
+ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${DESCRIPTION})
+ set(CPACK_PACKAGE_DESCRIPTION ${DESCRIPTION})
+-set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
+-set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
+-set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH})
++set(CPACK_PACKAGE_PROJECT_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
++set(CPACK_PACKAGE_PROJECT_VERSION_MINOR ${PROJECT_VERSION_MINOR})
++set(CPACK_PACKAGE_PROJECT_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+ #set(CPACK_PACKAGE_EXECUTABLES "${APP_NAME}";${PROJECT_NAME})
+ set(CPACK_RESOURCE_FILE_README ${README})
+ set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/${LICENSE})

--- a/pkgs/games/soi/default.nix
+++ b/pkgs/games/soi/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
     "-DLUABIND_LIBRARY=${luabind}/lib/libluabind09.a"
   ];
 
+  # CMake 2.6 is deprecated and is no longer supported by CMake > 4
+  # https://github.com/NixOS/nixpkgs/issues/445447
+  patches = [ ./cmake-4-build.patch ];
+
   meta = with lib; {
     description = "Physics-based puzzle game";
     mainProgram = "soi";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix `luabind`, `eigen2` and `soi` build failure and its dependencies on newer cmake 4.

This should fix build for:
- `luabind`
- `luabind_luajit`
- `osrm-backend`
- `osmscout-server`
- `eigen2`
- `soi`

Should help for:
- #445447

Also, `icesl` which depends on `luabind` fails to build, but it is unrelated to the CMake failure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
