### PR TITLE
witness: 0.9.2 -> 0.10.1

### DIFF
--- a/pkgs/by-name/wi/witness/package.nix
+++ b/pkgs/by-name/wi/witness/package.nix
@@ -4,13 +4,10 @@
   buildGoModule,
   fetchFromGitHub,
 
-  # testing
-  testers,
-  witness,
-
+  buildPackages,
   installShellFiles,
 
-  buildPackages,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -60,11 +57,11 @@ buildGoModule rec {
         --zsh <(${exe} completion zsh)
     '';
 
-  passthru.tests.version = testers.testVersion {
-    package = witness;
-    command = "witness version";
-    version = "v${version}";
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Pluggable framework for software supply chain security. Witness prevents tampering of build materials and verifies the integrity of the build process from source to target";

--- a/pkgs/by-name/wi/witness/package.nix
+++ b/pkgs/by-name/wi/witness/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "in-toto";
     repo = "witness";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-MKiPIZFeCWOT4zTbG7SjwdNUHFuqsL4pGu4VvVwyn3s=";
   };
   vendorHash = "sha256-V3SuhBbhXyA0SFOGfBrV/qH+cROr2obHOBcivkgRO6U=";
@@ -30,7 +30,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/in-toto/witness/cmd.Version=v${finalAttrs.version}"
+    "-X github.com/in-toto/witness/cmd.Version=${finalAttrs.src.tag}"
   ];
 
   # Feed in all tests for testing
@@ -76,7 +76,7 @@ buildGoModule (finalAttrs: {
     '';
     mainProgram = "witness";
     homepage = "https://github.com/testifysec/witness";
-    changelog = "https://github.com/testifysec/witness/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/testifysec/witness/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       fkautz

--- a/pkgs/by-name/wi/witness/package.nix
+++ b/pkgs/by-name/wi/witness/package.nix
@@ -12,15 +12,15 @@
 
 buildGoModule rec {
   pname = "witness";
-  version = "0.9.2";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "in-toto";
     repo = "witness";
     rev = "v${version}";
-    sha256 = "sha256-0Q+6nG5N3Xp5asmRMPZccLxw6dWiZVX6fuIUf1rT+mI=";
+    sha256 = "sha256-MKiPIZFeCWOT4zTbG7SjwdNUHFuqsL4pGu4VvVwyn3s=";
   };
-  vendorHash = "sha256-oH/aWt8Hl/BIN+IYLcuVYWDpQZaYABAOGxXyLssjQg0=";
+  vendorHash = "sha256-V3SuhBbhXyA0SFOGfBrV/qH+cROr2obHOBcivkgRO6U=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -38,6 +38,8 @@ buildGoModule rec {
   # want but also limits the tests
   preCheck = ''
     unset subPackages
+    # tests expect no version set
+    unset ldflags
   '';
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''

--- a/pkgs/by-name/wi/witness/package.nix
+++ b/pkgs/by-name/wi/witness/package.nix
@@ -10,14 +10,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "witness";
   version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "in-toto";
     repo = "witness";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-MKiPIZFeCWOT4zTbG7SjwdNUHFuqsL4pGu4VvVwyn3s=";
   };
   vendorHash = "sha256-V3SuhBbhXyA0SFOGfBrV/qH+cROr2obHOBcivkgRO6U=";
@@ -30,7 +30,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/in-toto/witness/cmd.Version=v${version}"
+    "-X github.com/in-toto/witness/cmd.Version=v${finalAttrs.version}"
   ];
 
   # Feed in all tests for testing
@@ -76,11 +76,11 @@ buildGoModule rec {
     '';
     mainProgram = "witness";
     homepage = "https://github.com/testifysec/witness";
-    changelog = "https://github.com/testifysec/witness/releases/tag/v${version}";
+    changelog = "https://github.com/testifysec/witness/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       fkautz
       jk
     ];
   };
-}
+})


### PR DESCRIPTION
- witness: 0.9.2 -> 0.10.1
  - fixes moderate CVE CVE-2025-62375
  - https://github.com/in-toto/go-witness/security/advisories/GHSA-72c7-4g63-hpw5
- witness: provide completions for cross-compile
- witness: switch to versionCheckHook
- witness: move to finalAttrs pattern
- witness: use tag for src


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
