### PR TITLE
nushell: 0.107.0 -> 0.108.0

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -23,7 +23,7 @@ let
   # NOTE: when updating this to a new non-patch version, please also try to
   # update the plugins. Plugins only work if they are compiled for the same
   # major/minor version.
-  version = "0.107.0";
+  version = "0.108.0";
 in
 rustPlatform.buildRustPackage {
   pname = "nushell";
@@ -33,10 +33,10 @@ rustPlatform.buildRustPackage {
     owner = "nushell";
     repo = "nushell";
     tag = version;
-    hash = "sha256-ghBuqkiVHvPxD4zBpvL6NG+qL54SD/aLZNZqWUK4a28=";
+    hash = "sha256-8OMTscMObV+IOSgOoTSzJvZTz6q/l2AjrOb9y3p2tZY=";
   };
 
-  cargoHash = "sha256-HQy6maPKxreYPLni0/XETF/EEJqGGcpAurzf+QTVX18=";
+  cargoHash = "sha256-M2wkhhaS3bVhwaa3O0CUK5hL757qFObr7EDtBFXXwxg=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/shells/nushell/plugins/desktop_notifications.nix
+++ b/pkgs/shells/nushell/plugins/desktop_notifications.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_desktop_notifications";
-  version = "0.106.1";
+  version = "0.108.0";
 
   src = fetchFromGitHub {
     owner = "FMotalleb";
     repo = "nu_plugin_desktop_notifications";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FuiXHl7O6/DN7kENrVxOys8mJAGbpb11w9iJ+mqQ/ds=";
+    hash = "sha256-9NkWPoTdMxFlI/BkP8w0ltC6UVh3/tg9gjwBuS3k/Cg=";
   };
 
-  cargoHash = "sha256-yFkiRGrg8eGGap5vyZVRMpddsoTYNrwSC94uLYufmdc=";
+  cargoHash = "sha256-GK6ytH/SDHh6GlLrSA2oJLza1tvYOUp4cR5CM6bloz8=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_hcl";
-  version = "0.107.0";
+  version = "0.108.0";
 
   src = fetchFromGitHub {
     owner = "Yethal";
     repo = "nu_plugin_hcl";
     tag = finalAttrs.version;
-    hash = "sha256-KtX1i3iAZcEHnDdceV4JyildA//y/pnIxK/U/NbSw5w=";
+    hash = "sha256-WyZ8uSYWNzurqpE+BP0hKsknurP7Iyf5L8Y5DjVQZsA=";
   };
 
-  cargoHash = "sha256-CaPyAQgUpGBZx65j7ih4NOBR34rDpE0HQ425freGEOk=";
+  cargoHash = "sha256-2b/0B9W01gGuGc482DYQSbRR2LLZXQxUG2fYB5TklPQ=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 

--- a/pkgs/shells/nushell/plugins/highlight.nix
+++ b/pkgs/shells/nushell/plugins/highlight.nix
@@ -9,17 +9,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_highlight";
-  version = "1.4.8+0.106.0";
+  version = "1.4.10+0.108.0";
 
   src = fetchFromGitHub {
     owner = "cptpiepmatz";
     repo = "nu-plugin-highlight";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H7bCX13miQECEPCOT2eF+TBkUU3qff+LhOiA008GLdI=";
+    hash = "sha256-ynvLvGMxFiYOYGPDdlv1509lWU5DpfBK9Mwa9gLeHsI=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-Qf6qEY6imcI0rfktGl5ErsbT+HCDgTohl+NKFsrQbzA=";
+  cargoHash = "sha256-Xq7ctnzcrSPzo3M3p3Vxtj0U0U9Miw+2VuyYs6P3GlQ=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
@@ -34,6 +34,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/cptpiepmatz/nu-plugin-highlight";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mgttlinger ];
-    broken = true;
   };
 })

--- a/pkgs/shells/nushell/plugins/semver.nix
+++ b/pkgs/shells/nushell/plugins/semver.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_semver";
-  version = "0.11.7";
+  version = "0.11.8";
 
   src = fetchFromGitHub {
     owner = "abusch";
     repo = "nu_plugin_semver";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RrkOVo5MTLtVAp6d+Y1oP3jwImXeofXRdGXRFlwYA9I=";
+    hash = "sha256-ui9zyE5g4LiU2+Csv4p0D61fmPXaDMhnpQ34ggEg3eA=";
   };
 
-  cargoHash = "sha256-vKrwoPn8MLjzTrR7p3SH7I2LKKieJCm4tuarp4hktKA=";
+  cargoHash = "sha256-5W0GbKz18rQ+3TjNanzV4H4LE/7TLZ+8/FbGHffE2RY=";
 
   passthru.update-script = nix-update-script { };
 

--- a/pkgs/shells/nushell/plugins/skim.nix
+++ b/pkgs/shells/nushell/plugins/skim.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_skim";
-  version = "0.19.0";
+  version = "0.20.1";
 
   src = fetchFromGitHub {
     owner = "idanarye";
     repo = "nu_plugin_skim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7yG1/HdapH/Jf6I/cw/1dCjVSwqMPd7XMAK9tG7IqRg=";
+    hash = "sha256-2CqgtV2DnBd8HqnRdZRiT14aw+meaX4A3ndTGvbsMfo=";
   };
 
-  cargoHash = "sha256-FqB4EaHQYSOyT1Oda1FHSbmL4Wrza/9m3nkI01GowUE=";
+  cargoHash = "sha256-3Kua+gZl4Ff6jfSNyEVDbPVH4YfGXhwtuEjcUADecQE=";
 
   nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 


### PR DESCRIPTION
 Diffs: 
 * https://github.com/nushell/nushell/compare/0.107.0...0.108.0
 * https://github.com/fmotalleb/nu_plugin_desktop_notifications/compare/v0.106.1...v0.108.0
 * https://github.com/cptpiepmatz/nu-plugin-highlight/compare/v1.4.8+0.106.0...v1.4.10+0.108.0
 * https://github.com/idanarye/nu_plugin_skim/compare/v0.19.0...v0.20.1
 * https://github.com/Yethal/nu_plugin_hcl/compare/0.107.0...0.108.0
 * https://github.com/abusch/nu_plugin_semver/compare/v0.11.7...v0.11.8
 
 The rest of the non-native plugins are either not yet updated or marked as broken.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (only supported packages)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
