### PR TITLE
cvise: fix `unifdef.patch` (crashes otherwise)

### DIFF
--- a/pkgs/development/tools/misc/cvise/default.nix
+++ b/pkgs/development/tools/misc/cvise/default.nix
@@ -13,6 +13,8 @@
   pebble,
   psutil,
   pytestCheckHook,
+  testers,
+  cvise,
 }:
 
 buildPythonApplication rec {
@@ -77,6 +79,16 @@ buildPythonApplication rec {
     # Needs gcc, fails when run noninteractively (without tty).
     "test_simple_reduction"
   ];
+
+  passthru = {
+    tests = {
+      # basic syntax check
+      help-output = testers.testVersion {
+        package = cvise;
+        command = "cvise --version";
+      };
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/marxin/cvise";

--- a/pkgs/development/tools/misc/cvise/unifdef.patch
+++ b/pkgs/development/tools/misc/cvise/unifdef.patch
@@ -1,6 +1,7 @@
---- a/cvise.py
-+++ b/cvise.py
-@@ -93,4 +93,5 @@ def find_external_programs():
+--- a/cvise/utils/externalprograms.py
++++ b/cvise/utils/externalprograms.py
+@@ -43,5 +43,6 @@ def find_external_programs():
+ 
      # Special case for clang-format
      programs['clang-format'] = '@CLANG_FORMAT_PATH@'
 +    programs['unifdef'] = '@UNIFDEF@'


### PR DESCRIPTION
Without the change `cvise` does not even parse:

    $ cvise --help |& unnix
      File "/<<NIX>>/cvise-2.12.0/bin/.cvise-wrapped", line 96
        programs['unifdef'] = '/<<NIX>>/unifdef-2.12/bin/unifdef'
        ^^^^^^^^
    SyntaxError: expected 'except' or 'finally' block

Happens because the patch applies to the unrelated bit of the source.

While at it added minimal `cvise --version` test.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
