### PR TITLE
python3Packages.holistic-trace-analysis: fix tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/holistic-trace-analysis/default.nix
+++ b/pkgs/development/python-modules/holistic-trace-analysis/default.nix
@@ -17,6 +17,7 @@
 
   # tests
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -42,7 +43,15 @@ buildPythonPackage rec {
     torch
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Permission denied: '/tmp/my_saved_cp_graph/trace_data.csv'
+    "test_critical_path_breakdown_and_save_restore"
+  ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # Makes assumptions about the filesystem layout

--- a/pkgs/development/python-modules/holistic-trace-analysis/default.nix
+++ b/pkgs/development/python-modules/holistic-trace-analysis/default.nix
@@ -1,8 +1,9 @@
 {
+  lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   jupyterlab,
-  lib,
   numpy,
   pandas,
   plotly,
@@ -36,6 +37,11 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Makes assumptions about the filesystem layout
+    "tests/test_config.py"
+  ];
 
   pythonImportsCheck = [ "hta" ];
 

--- a/pkgs/development/python-modules/holistic-trace-analysis/default.nix
+++ b/pkgs/development/python-modules/holistic-trace-analysis/default.nix
@@ -3,14 +3,20 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build system
+  setuptools,
+
+  # dependencies
   jupyterlab,
   numpy,
   pandas,
   plotly,
   pydot,
-  pytestCheckHook,
-  setuptools,
   torch,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/holistic-trace-analysis/default.nix
+++ b/pkgs/development/python-modules/holistic-trace-analysis/default.nix
@@ -51,11 +51,17 @@ buildPythonPackage rec {
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # Permission denied: '/tmp/my_saved_cp_graph/trace_data.csv'
     "test_critical_path_breakdown_and_save_restore"
+    # Fails under Python 3.12 on Darwin with I/O errors
+    # Permission denied: '/tmp/path_does_not_exist/...'
+    "test_critical_path_overlaid_trace"
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # Makes assumptions about the filesystem layout
     "tests/test_config.py"
+    # EOFError -- makes assumptions about file I/O under Python 3.12
+    # https://github.com/facebookresearch/HolisticTraceAnalysis/issues/300
+    "tests/test_symbol_table.py"
   ];
 
   pythonImportsCheck = [ "hta" ];


### PR DESCRIPTION
The program makes assumptions about the filesystem layout that fail on nix darwin. Disabled as appropriate. Added `writableTmpDirAsHomeHook` to handle the remaining tmpdir issues on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
