### PR TITLE
wayland-bongocat: packaging fixes

### DIFF
--- a/pkgs/by-name/wa/wayland-bongocat/package.nix
+++ b/pkgs/by-name/wa/wayland-bongocat/package.nix
@@ -34,6 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
     "release"
   ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'CC = gcc' 'CC ?= gcc'
+  '';
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/wa/wayland-bongocat/package.nix
+++ b/pkgs/by-name/wa/wayland-bongocat/package.nix
@@ -29,13 +29,11 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-protocols
   ];
 
-  # Build phases
-  # Ensure that the Makefile has the correct directory with the Wayland protocols
-  preBuild = ''
-    export WAYLAND_PROTOCOLS_DIR="${wayland-protocols}/share/wayland-protocols"
-  '';
+  makeFlags = [
+    "WAYLAND_PROTOCOLS_DIR=${wayland-protocols}/share/wayland-protocols"
+    "release"
+  ];
 
-  makeFlags = [ "release" ];
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/wa/wayland-bongocat/package.nix
+++ b/pkgs/by-name/wa/wayland-bongocat/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  bash,
   fetchFromGitHub,
   pkg-config,
   wayland,
@@ -25,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-scanner
   ];
   buildInputs = [
+    bash
     wayland
     wayland-protocols
   ];

--- a/pkgs/by-name/wa/wayland-bongocat/package.nix
+++ b/pkgs/by-name/wa/wayland-bongocat/package.nix
@@ -54,6 +54,14 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/bongocat-find-devices --help
+
+    runHook postInstallCheck
+  '';
+
   # Package information
   meta = {
     description = "Delightful Wayland overlay that displays an animated bongo cat reacting to keyboard input";

--- a/pkgs/by-name/wa/wayland-bongocat/package.nix
+++ b/pkgs/by-name/wa/wayland-bongocat/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   bash,
   fetchFromGitHub,
+  gitUpdater,
   pkg-config,
   wayland,
   wayland-protocols,
@@ -62,7 +63,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  # Package information
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
   meta = {
     description = "Delightful Wayland overlay that displays an animated bongo cat reacting to keyboard input";
     homepage = "https://github.com/saatvik333/wayland-bongocat";


### PR DESCRIPTION
- fixes `bongocat-find-devices` error
  > /usr/bin/bash: bad interpreter
- fixes cross compilation (`nix-build -A pkgsCross.aarch64-multiplatform.wayland-bongocat`)
- adds an update script
- reworks `WAYLAND_PROTOCOLS_DIR` handling to be more idiomatic (`makeFlags` instead of ad-hoc `preBuild`)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] ~[Package tests] at `passthru.tests`.~ (none present)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
