### PR TITLE
safeeyes: 2.2.3 -> 3.2.0

### DIFF
--- a/pkgs/by-name/sa/safeeyes/package.nix
+++ b/pkgs/by-name/sa/safeeyes/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
   alsa-utils,
   gobject-introspection,
@@ -17,7 +17,7 @@
   nix-update-script,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "safeeyes";
   version = "3.2.0";
   pyproject = true;
@@ -38,9 +38,9 @@ python3.pkgs.buildPythonApplication rec {
     libnotify
   ];
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     babel
     psutil
     xlib
@@ -49,7 +49,7 @@ python3.pkgs.buildPythonApplication rec {
     packaging
   ];
 
-  optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python3Packages; {
     healthstats = [ croniter ];
     wayland = [ pywayland ];
   };
@@ -85,8 +85,13 @@ python3.pkgs.buildPythonApplication rec {
 
   meta = {
     homepage = "http://slgobinath.github.io/SafeEyes";
-    description = "Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder. A Free and Open Source Linux alternative to EyeLeo";
-    license = lib.licenses.gpl3;
+    description = "Break reminder to prevent eye strain";
+    longDescription = ''
+      Protect your eyes from eye strain using this simple and
+      beautiful, yet extensible break reminder.  Free GNU/Linux
+      alternative to EyeLeo.
+    '';
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     mainProgram = "safeeyes";
   };


### PR DESCRIPTION
Resolves #452698

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
