### PR TITLE
cups-zj-58: 2018-02-2 -> 0-unstable-2019-04-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6156,6 +6156,12 @@
     github = "deifactor";
     githubId = 30192992;
   };
+  deimelias = {
+    name = "Deim Elias";
+    github = "DeimElias";
+    email = "deimelias@gmail.com";
+    githubId = 100871962;
+  };
   deinferno = {
     name = "deinferno";
     github = "deinferno";

--- a/pkgs/by-name/cu/cups-zj-58/package.nix
+++ b/pkgs/by-name/cu/cups-zj-58/package.nix
@@ -3,31 +3,42 @@
   stdenv,
   fetchFromGitHub,
   cups,
+  cmake,
+  pkg-config,
 }:
 
 stdenv.mkDerivation {
   pname = "cups-zj-58";
-  version = "2018-02-22";
+  version = "2019-04-28";
 
   src = fetchFromGitHub {
     owner = "klirichek";
     repo = "zj-58";
-    rev = "e4212cd702113a4bd4d7013744291c9f60bc5273";
-    sha256 = "1w2qkspm4qqg5h8n6gmakzhiww7gag64chvy9kf89xsl3wsyp6pi";
+    rev = "64743565df4379098b68a197d074c86617a8fc0a";
+    sha256 = "sha256-4l9NRfp0hiPDC6dtFsq7jLf0Gn9tktGy6oZ4GHxSfbw=";
   };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
   buildInputs = [ cups ];
 
   installPhase = ''
+    install -D ppd/zj80.ppd $out/share/cups/model/zjiang/zj80.ppd
+    install -D ppd/zj58.ppd $out/share/cups/model/zjiang/zj58.ppd
     install -D rastertozj $out/lib/cups/filter/rastertozj
-    install -D ZJ-58.ppd $out/share/cups/model/zjiang/ZJ-58.ppd
   '';
 
   meta = with lib; {
     description = "CUPS filter for thermal printer Zjiang ZJ-58";
     homepage = "https://github.com/klirichek/zj-58";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ makefu ];
+    maintainers = with maintainers; [
+      makefu
+      deimelias
+    ];
     license = licenses.bsd2;
   };
 }

--- a/pkgs/by-name/cu/cups-zj-58/package.nix
+++ b/pkgs/by-name/cu/cups-zj-58/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "cups-zj-58";
-  version = "2019-04-28";
+  version = "0-unstable-2019-04-28";
 
   src = fetchFromGitHub {
     owner = "klirichek";
     repo = "zj-58";
     rev = "64743565df4379098b68a197d074c86617a8fc0a";
-    sha256 = "sha256-4l9NRfp0hiPDC6dtFsq7jLf0Gn9tktGy6oZ4GHxSfbw=";
+    hash = "sha256-4l9NRfp0hiPDC6dtFsq7jLf0Gn9tktGy6oZ4GHxSfbw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cu/cups-zj-58/package.nix
+++ b/pkgs/by-name/cu/cups-zj-58/package.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation {
 
   buildInputs = [ cups ];
 
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail "cmake_minimum_required ( VERSION 3.0 )" "cmake_minimum_required ( VERSION 3.10 )"
+  '';
+
   installPhase = ''
     install -D ppd/zj80.ppd $out/share/cups/model/zjiang/zj80.ppd
     install -D ppd/zj58.ppd $out/share/cups/model/zjiang/zj58.ppd


### PR DESCRIPTION
- Update source to the latest commit
- Add me as maintainer
- Change installPhase to match the build process

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
