### PR TITLE
nixos/libvirtd: add dbus support

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -394,6 +394,11 @@ in
         The backend used to setup virtual network firewall rules.
       '';
     };
+
+    dbus = {
+      enable = mkEnableOption "exposing libvirtd APIs over D-Bus";
+      package = mkPackageOption pkgs "libvirt-dbus" { };
+    };
   };
 
   ###### implementation
@@ -426,15 +431,28 @@ in
 
     boot.kernelModules = [ "tun" ];
 
-    users.groups.libvirtd.gid = config.ids.gids.libvirtd;
-
-    # libvirtd runs qemu as this user and group by default
-    users.extraGroups.qemu-libvirtd.gid = config.ids.gids.qemu-libvirtd;
-    users.extraUsers.qemu-libvirtd = {
-      uid = config.ids.uids.qemu-libvirtd;
-      isNormalUser = false;
-      group = "qemu-libvirtd";
-    };
+    users = lib.mkMerge [
+      {
+        # libvirtd runs qemu as this user and group by default
+        users.qemu-libvirtd = {
+          uid = config.ids.uids.qemu-libvirtd;
+          isNormalUser = false;
+          group = "qemu-libvirtd";
+        };
+        groups = {
+          libvirtd.gid = config.ids.gids.libvirtd;
+          qemu-libvirtd.gid = config.ids.gids.qemu-libvirtd;
+        };
+      }
+      (lib.mkIf cfg.dbus.enable {
+        users.libvirtdbus = {
+          isSystemUser = true;
+          group = "libvirtdbus";
+          description = "Libvirt D-Bus bridge";
+        };
+        groups.libvirtdbus = { };
+      })
+    ];
 
     security.wrappers.qemu-bridge-helper = {
       setuid = true;
@@ -449,7 +467,7 @@ in
 
     services.firewalld.packages = [ cfg.package ];
 
-    systemd.packages = [ cfg.package ];
+    systemd.packages = [ cfg.package ] ++ lib.optional cfg.dbus.enable cfg.dbus.package;
 
     systemd.services.libvirtd-config = {
       description = "Libvirt Virtual Machine Management Daemon - configuration";
@@ -629,5 +647,7 @@ in
       (mkIf cfg.nss.enable (mkOrder 430 [ "libvirt" ]))
       (mkIf cfg.nss.enableGuest (mkOrder 432 [ "libvirt_guest" ]))
     ];
+
+    services.dbus.packages = lib.optional cfg.dbus.enable cfg.dbus.package;
   };
 }

--- a/nixos/tests/libvirtd.nix
+++ b/nixos/tests/libvirtd.nix
@@ -16,6 +16,7 @@
             touch /tmp/qemu_hook_is_working
           ''}";
           libvirtd.nss.enable = true;
+          libvirtd.dbus.enable = true;
         };
         boot.supportedFilesystems = [ "zfs" ];
         networking.hostId = "deadbeef"; # needed for zfs
@@ -72,5 +73,15 @@
       with subtest("test if hooks are linked and run"):
         virthost.succeed("ls /var/lib/libvirt/hooks/qemu.d/is_working")
         virthost.succeed("ls /tmp/qemu_hook_is_working")
+
+      with subtest("check libvirt over dbus"):
+        # The service is activated on-demand and shouldn't be active yet
+        virthost.fail("systemctl is-active libvirt-dbus.service")
+
+        # Get the hostname property of the Test connection (this will activate the service)
+        virthost.succeed("busctl get-property org.libvirt /org/libvirt/Test org.libvirt.Connect Hostname")
+
+        # Now the service should be active
+        virthost.succeed("systemctl is-active libvirt-dbus.service")
     '';
 }

--- a/pkgs/by-name/li/libvirt-dbus/package.nix
+++ b/pkgs/by-name/li/libvirt-dbus/package.nix
@@ -11,6 +11,7 @@
   systemd,
   gitUpdater,
   lib,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -60,8 +61,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = false; # needs running D-Bus and libvirt
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
+  passthru = {
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+    tests = {
+      inherit (nixosTests) libvirtd;
+    };
   };
 
   meta = {


### PR DESCRIPTION
Adds a simple module and NixOS tests for libvirt-dbus.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
