### PR TITLE
userborn: do not use mkForce to disable activationScripts

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -96,8 +96,8 @@ let
     only one of {option}`hashedPassword`, {option}`password`, or
     {option}`hashedPasswordFile` will be set.
 
-    In a system where [](#opt-systemd.sysusers.enable) is `true`, typically
-    only one of {option}`initialPassword`, {option}`initialHashedPassword`,
+    In a system where [](#opt-systemd.sysusers.enable) or [](#opt-services.userborn.enable) is `true`,
+    typically only one of {option}`initialPassword`, {option}`initialHashedPassword`,
     or {option}`hashedPasswordFile` will be set.
 
     If the option {option}`users.mutableUsers` is true, the password defined
@@ -874,7 +874,7 @@ in
       };
 
       system.activationScripts.users =
-        if !config.systemd.sysusers.enable then
+        if !config.systemd.sysusers.enable && !config.services.userborn.enable then
           {
             supportsDryActivation = true;
             text = ''
@@ -925,7 +925,7 @@ in
       # This does not work when the users and groups are created by
       # systemd-sysusers because the users are created too late then.
       system.activationScripts.hashes =
-        if !config.systemd.sysusers.enable then
+        if !config.systemd.sysusers.enable && !config.services.userborn.enable then
           {
             deps = [ "users" ];
             text = ''

--- a/nixos/modules/services/system/userborn.nix
+++ b/nixos/modules/services/system/userborn.nix
@@ -88,9 +88,6 @@ in
       }
     ];
 
-    system.activationScripts.users = lib.mkForce "";
-    system.activationScripts.hashes = lib.mkForce "";
-
     systemd = {
 
       # Create home directories, do not create /var/empty even if that's a user's


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
