### PR TITLE
udpreplay: fix build with cmake4

### DIFF
--- a/pkgs/by-name/ud/udpreplay/package.nix
+++ b/pkgs/by-name/ud/udpreplay/package.nix
@@ -3,6 +3,7 @@
   cmake,
   libpcap,
   fetchFromGitHub,
+  fetchpatch,
   lib,
 }:
 stdenv.mkDerivation rec {
@@ -16,6 +17,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-kF9a3pjQbFKf25NKyK7uSq0AAO6JK7QeChLhm9Z3wEA=";
   };
+
+  patches = [
+    # Increase minimum CMake required to 3.5
+    (fetchpatch {
+      url = "https://github.com/rigtorp/udpreplay/commit/52bd71d6c004cd69899dbe8d529f3ce0a8154e7f.patch?full_index=1";
+      hash = "sha256-nWtC77SNpNDDkEli5loc8eVJ1ll0AdgEKQ4pV84JoSk=";
+    })
+  ];
 
   meta = with lib; {
     description = "Replay UDP packets from a pcap file";


### PR DESCRIPTION
- #445447
- upstream as a fix: https://github.com/rigtorp/udpreplay/commit/52bd71d6c004cd69899dbe8d529f3ce0a8154e7f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
