### PR TITLE
xv: fix build, add xrandr support

### DIFF
--- a/pkgs/by-name/xv/xv/package.nix
+++ b/pkgs/by-name/xv/xv/package.nix
@@ -7,7 +7,9 @@
   libpng,
   libwebp,
   libtiff,
+  libjpeg,
   jasper,
+  libxrandr,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +30,9 @@ stdenv.mkDerivation rec {
     libpng
     libwebp
     libtiff
+    libjpeg
     jasper
+    libxrandr
   ];
 
   meta = {


### PR DESCRIPTION
As of a few days ago, this package failed to build for me.  Partly this was due to an upstream bug (which I have submitted a fix for: https://github.com/jasper-software/xv/pull/38), but this arose because the build no longer finds the `libjpeg` package which is supposed to be pulled in by `jasper`.  This worked for years and now simply doesn't.  Possibly this is related to #438296.

However, by explicitly adding `libjpeg` to the inputs, I got it to build again (and the upstream bug is not triggered).

In addition, this PR adds `libxrandr` to the inputs, which allows xv to be built with RandR support.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
