### PR TITLE
openboardview: fix build with cmake 4

### DIFF
--- a/pkgs/by-name/op/openboardview/fix-darwin-build.patch
+++ b/pkgs/by-name/op/openboardview/fix-darwin-build.patch
@@ -1,0 +1,24 @@
+From 7a7ca124d10b1a3230a8e65da6d0113226b46d89 Mon Sep 17 00:00:00 2001
+From: Mario Hros <966992+k3a@users.noreply.github.com>
+Date: Fri, 17 Oct 2025 17:48:21 +0200
+Subject: [PATCH] Bump MacOS deplyment target to fix compilation error.
+
+This fixes filesystem:path errors on recent MacOS:
+platform.h:26:19: error: 'path' is unavailable: introduced in macOS 10.15
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 147bd4af..563514cc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.11)
+ 
+ # Set OSX target version, before calling project() (inside version.cmake). FORCE is needed when project() is called within an included file
+-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version" FORCE)
++set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version" FORCE)
+ 
+ # Set a default build type like suggested in official blog https://www.kitware.com/cmake-and-the-default-build-type/
+ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/OpenBoardView/OpenBoardView/commit/b03d0f69ec1611f5eb93f81291b4ba8c58cd29eb.patch";
       hash = "sha256-Hp7KgzulPC2bPtRsd6HJrTLu0oVoQEoBHl0p2DcOLQw=";
     })
+    (fetchpatch {
+      name = "fix-compatibility-with-cmake4.patch";
+      url = "https://github.com/OpenBoardView/OpenBoardView/commit/55ba0afca413189e8611b2861fe6653499028e47.patch?full_index=1";
+      hash = "sha256-InzfX2aU20oyyImDdmjCS+FGm0aQOMbN//Vwty1VCpI=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/OpenBoardView/OpenBoardView/commit/55ba0afca413189e8611b2861fe6653499028e47.patch?full_index=1";
       hash = "sha256-InzfX2aU20oyyImDdmjCS+FGm0aQOMbN//Vwty1VCpI=";
     })
+    # https://github.com/OpenBoardView/OpenBoardView/pull/339
+    ./fix-darwin-build.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
- #445447
- upstream has a fix: https://github.com/OpenBoardView/OpenBoardView/commit/55ba0afca413189e8611b2861fe6653499028e47
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
