### PR TITLE
forgejo: fix `checkPhase` regression

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -105,11 +105,12 @@ buildGoModule rec {
     export ldflags+=" -X main.ForgejoVersion=$(GITEA_VERSION=${version} make show-version-api)"
   '';
 
+  # expose and use the GO_TEST_PACKAGES var from the Makefile
+  # instead of manually copying over the entire list:
+  # https://codeberg.org/forgejo/forgejo/src/tag/v11.0.6/Makefile#L128
+  # https://codeberg.org/forgejo/forgejo/src/tag/v13.0.0/Makefile#L290
   preCheck = ''
-    # expose and use the GO_TEST_PACKAGES var from the Makefile
-    # instead of manually copying over the entire list:
-    # https://codeberg.org/forgejo/forgejo/src/tag/v7.0.4/Makefile#L124
-    echo -e 'show-backend-tests:\n\t@echo ''${GO_TEST_PACKAGES}' >> Makefile
+    echo -e 'show-backend-tests:${lib.optionalString (lib.versionAtLeast version "13") " | compute-go-test-packages"}\n\t@echo ''${GO_TEST_PACKAGES}' >> Makefile
     getGoDirs() {
       make show-backend-tests
     }

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -26,6 +26,7 @@
   stdenv,
   fetchFromGitea,
   buildNpmPackage,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -77,6 +78,7 @@ buildGoModule rec {
   nativeCheckInputs = [
     git
     openssh
+    writableTmpDirAsHomeHook
   ];
 
   patches = [
@@ -104,9 +106,6 @@ buildGoModule rec {
   '';
 
   preCheck = ''
-    # $HOME is required for ~/.ssh/authorized_keys and such
-    export HOME="$TMPDIR/home"
-
     # expose and use the GO_TEST_PACKAGES var from the Makefile
     # instead of manually copying over the entire list:
     # https://codeberg.org/forgejo/forgejo/src/tag/v7.0.4/Makefile#L124


### PR DESCRIPTION
This fixes a regression introduced in #452623 (5de92a8b79f3e0c3fcf75de3c7b6e5e38890732f).

Forgejo v13 made the `GO_TEST_PACKAGES` variable lazy in [1], which causes our custom `show-backend-tests` `make` target to return an empty string, which in turn causes our `checkPhase` to not run a single `go` test.

To fix this, we need to slightly modify our custom make target to reference the newly introduced `compute-go-test-packages` target as a dependency.

[1]: https://codeberg.org/forgejo/forgejo/pulls/9208

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
