### PR TITLE
capstone_4, edb: fix build failure with cmake 4

### DIFF
--- a/pkgs/development/libraries/capstone/4.nix
+++ b/pkgs/development/libraries/capstone/4.nix
@@ -26,6 +26,17 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  # CMake 2.6 is deprecated and is no longer supported by CMake > 4
+  # https://github.com/NixOS/nixpkgs/issues/445447
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 2.6)"  \
+      "cmake_minimum_required(VERSION 3.10)" \
+    --replace-fail \
+      "cmake_policy (SET CMP0048 OLD)" \
+      "cmake_policy (SET CMP0048 NEW)"
+  '';
+
   meta = {
     description = "Advanced disassembly library";
     homepage = "http://www.capstone-engine.org";

--- a/pkgs/development/tools/misc/edb/default.nix
+++ b/pkgs/development/tools/misc/edb/default.nix
@@ -53,6 +53,18 @@ stdenv.mkDerivation (finalAttrs: {
     # submodules were fetched and will throw an error if it's not there.
     # Avoid using leaveDotGit in the fetchFromGitHub options as it is non-deterministic.
     mkdir -p src/qhexview/.git lib/gdtoa-desktop/.git
+
+    # CMake 3.1 is deprecated and is no longer supported by CMake > 4
+    # https://github.com/NixOS/nixpkgs/issues/445447
+    substituteInPlace CMakeLists.txt src/CMakeLists.txt src/test/CMakeLists.txt plugins/CMakeLists.txt plugins/*/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required (VERSION 3.1)" \
+      "cmake_minimum_required(VERSION 3.10)"
+    substituteInPlace lib/CMakeLists.txt lib/libELF/CMakeLists.txt lib/libPE/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 3.1)" \
+      "cmake_minimum_required(VERSION 3.10)"
+    substituteInPlace lib/gdtoa-desktop/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required (VERSION 3.0)" \
+      "cmake_minimum_required (VERSION 3.10)"
   '';
 
   passthru = {


### PR DESCRIPTION
Fix `capstone_4` and `edb` (which depends on it) build failure on newer cmake 4.
- https://github.com/NixOS/nixpkgs/issues/445447

CMake 4 is no longer retro compatible with versions < 3.5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
