### PR TITLE
kitcat: init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/kitcat/default.nix
+++ b/pkgs/development/python-modules/kitcat/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  matplotlib,
+  fetchFromGitHub,
+  uv-build,
+}:
+
+buildPythonPackage rec {
+  pname = "kitcat";
+  version = "2.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mil-ad";
+    repo = "kitcat";
+    tag = "v${version}";
+    hash = "sha256-r3AIsHQKGVrRzxXszupp8ZjgbjGHv4QJ75IEhgiOUm4=";
+  };
+
+  buildInputs = [ matplotlib ];
+  build-system = [ uv-build ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.11.13,<0.12.0" "uv_build"
+  '';
+
+  meta = {
+    description = "Matplotlib backend for direct plotting in the terminal using Kitty graphics protocol";
+    homepage = "https://github.com/mil-ad/kitcat";
+    changelog = "https://github.com/mil-ad/kitcat/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.lavafroth ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7871,6 +7871,8 @@ self: super: with self; {
 
   kiss-headers = callPackage ../development/python-modules/kiss-headers { };
 
+  kitcat = callPackage ../development/python-modules/kitcat { };
+
   kitchen = callPackage ../development/python-modules/kitchen { };
 
   kivy = callPackage ../development/python-modules/kivy { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Kitcat is a matplotlib backend for direct plotting in the terminal using Kitty graphics protocol.

Homepage: https://github.com/mil-ad/kitcat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
