### PR TITLE
calcpad: init at 7.6.0

### DIFF
--- a/pkgs/by-name/ca/calcpad/01-update-config-settings.patch
+++ b/pkgs/by-name/ca/calcpad/01-update-config-settings.patch
@@ -1,0 +1,67 @@
+diff --git a/Calcpad.Cli/Program.cs b/Calcpad.Cli/Program.cs
+--- a/Calcpad.Cli/Program.cs
++++ b/Calcpad.Cli/Program.cs
+@@ -179,10 +179,33 @@ namespace Calcpad.Cli
+                             }
+                             else
+                             {
+-                                var settingsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) +
+-                                                   $"{_dirSeparator}.config{_dirSeparator}calcpad{_dirSeparator}Settings.xml";
+-                                File.SetUnixFileMode(settingsPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+-                                Execute("/bin/bash", $"-c \"nano {settingsPath}\"");
++                                // Get XDG config home or fallback to ~/.config
++                                string configHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
++                                if (string.IsNullOrEmpty(configHome))
++                                    configHome = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".config");
++
++                                var settingsDir = Path.Combine(configHome, "calcpad");
++                                var settingsPath = Path.Combine(settingsDir, "Settings.xml");
++
++                                if (!Directory.Exists(settingsDir))
++                                    Directory.CreateDirectory(settingsDir);
++
++                                string defaultSettingsPath = AppPath + "Settings.xml";
++
++                                if (!File.Exists(settingsPath))
++                                {
++                                    try
++                                    {
++                                        File.Copy(defaultSettingsPath, settingsPath);
++                                        File.SetUnixFileMode(settingsPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
++                                    }
++                                    catch (Exception ex)
++                                    {
++                                        Console.Error.WriteLine($"Failed to copy default settings: {ex.Message}");
++                                    }
++                                }
++
++                                Execute("nano", settingsPath);
+                                 Console.Write(Messages.Press_Any_Key_When_Ready);
+                                 Console.ReadKey();
+                                 settings = GetSettings();
+@@ -220,11 +243,21 @@ namespace Calcpad.Cli
+                 Settings settings = new(); 
+                 settings.Math.Decimals = 6;
+                 XmlSerializer writer = new(settings.GetType());
+-                var path = OperatingSystem.IsWindows() ?
+-                    AppPath:
+-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + $"{_dirSeparator}.config{_dirSeparator}calcpad{_dirSeparator}";
+ 
+-                var fileName = path + "Settings.xml";
++                string path;
++                if (OperatingSystem.IsWindows())
++                {
++                    path = AppPath;
++                }
++                else
++                {
++                    string configHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
++                    if (string.IsNullOrEmpty(configHome))
++                        configHome = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".config");
++                    path = Path.Combine(configHome, "calcpad");
++                }
++
++                var fileName = Path.Combine(path, "Settings.xml");
+                 FileStream fileStream = null;
+                 try
+                 {

--- a/pkgs/by-name/ca/calcpad/deps.json
+++ b/pkgs/by-name/ca/calcpad/deps.json
@@ -1,0 +1,127 @@
+[
+  {
+    "pname": "coverlet.collector",
+    "version": "6.0.4",
+    "hash": "sha256-ieiUl7G5pVKQ4V6rxhEe0ehep0/u1RBD3EAI63AQTI0="
+  },
+  {
+    "pname": "DocumentFormat.OpenXml",
+    "version": "3.3.0",
+    "hash": "sha256-U6dBZ1UtiG8OMSVA2xLIamEzqDvWmHlfO+biX8CRuec="
+  },
+  {
+    "pname": "DocumentFormat.OpenXml.Framework",
+    "version": "3.3.0",
+    "hash": "sha256-X1OfFgK2QhmOxu0+xWfqw//2Iwn27GXijbJ1GkiOww0="
+  },
+  {
+    "pname": "HtmlAgilityPack",
+    "version": "1.12.4",
+    "hash": "sha256-58ohjvtRXFwfY46Hny9GWL2r6KwZzkJWHFXwIWjkaHU="
+  },
+  {
+    "pname": "Markdig.Signed",
+    "version": "0.43.0",
+    "hash": "sha256-6NeFJ2x5/yrw+wXcjukZx9j+sDr19nqE+zrBEcV1ShY="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "18.0.1",
+    "hash": "sha256-G6y5iyHZ3R2shlLCW/uTusio/UqcnWT79X+UAbxvDQY="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "18.0.1",
+    "hash": "sha256-0c3/rp9di0w7E5UmfRh6Prrm3Aeyi8NOj5bm2i6jAh0="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "18.0.1",
+    "hash": "sha256-oJbS7SZ46RzyOQ+gCysW7qJRy7V8RlQVa5d8uajb91M="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "18.0.1",
+    "hash": "sha256-OXYf5vg4piDr10ve0bZ2ZSb+nb3yOiHayJV3cu5sMV4="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "Packaging.Targets",
+    "version": "0.1.220",
+    "hash": "sha256-IZTVnbPqeKiPSXJDb65T4FzVkCKEPS3c5xucieeUJDI="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "3.119.1",
+    "hash": "sha256-TIVr52NpQ9cab5eJCcH/OYHjNOTKhwCqpClK2c8S4TM="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux",
+    "version": "3.119.1",
+    "hash": "sha256-TTY6bxFPk27JZKefivb+N/k0eTAGTlmDRyhRvZ4Gjmc="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "3.119.1",
+    "hash": "sha256-0QJGcO91MWLSeQpE4ZNn/KUVoHRcrPeDbKklxCVB00o="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "3.119.1",
+    "hash": "sha256-ySPkn8SrShOqhihC33EJ4HJt9desDISC4gAI4FQBi2U="
+  },
+  {
+    "pname": "System.IO.Packaging",
+    "version": "10.0.0",
+    "hash": "sha256-MmCRDTVXbbyr1WqLBfGTjUdZ+RmiteGyLC6Yv+9ms+g="
+  },
+  {
+    "pname": "System.IO.Packaging",
+    "version": "8.0.1",
+    "hash": "sha256-xf0BAfqQvITompBsvfpxiLts/6sRQEzdjNA3f/q/vY4="
+  },
+  {
+    "pname": "xunit",
+    "version": "2.9.3",
+    "hash": "sha256-BPrpSbjlIB7PoH+ocCusqMDrMZgRQZSzeTeJzHK/I9c="
+  },
+  {
+    "pname": "xunit.abstractions",
+    "version": "2.0.3",
+    "hash": "sha256-0D1y/C34iARI96gb3bAOG8tcGPMjx+fMabTPpydGlAM="
+  },
+  {
+    "pname": "xunit.analyzers",
+    "version": "1.18.0",
+    "hash": "sha256-DOgamLnfi9Ua5IDm3JVm9MaOFbSSbmq5l8j2NPO3qd0="
+  },
+  {
+    "pname": "xunit.assert",
+    "version": "2.9.3",
+    "hash": "sha256-vHYOde8bd10pOmr7iTAYNtPlqHzsJl4x3t1DDuYdDCA="
+  },
+  {
+    "pname": "xunit.core",
+    "version": "2.9.3",
+    "hash": "sha256-qkVQ8Jw/LZWmxirkPOwiry7bvZn3IuaRzu/sp2H8anw="
+  },
+  {
+    "pname": "xunit.extensibility.core",
+    "version": "2.9.3",
+    "hash": "sha256-mcpVX+m0R7F0ev9CaBnbai9gtu4GVcqijEuRqe89D0g="
+  },
+  {
+    "pname": "xunit.extensibility.execution",
+    "version": "2.9.3",
+    "hash": "sha256-2rxMs2Dt4cAcmOFMwP5Yd3RpP0BnmiL8cXlKysXY0jw="
+  },
+  {
+    "pname": "xunit.runner.visualstudio",
+    "version": "3.1.5",
+    "hash": "sha256-O5657884QGldszsEWQFCDRTXViFBmZ4GGC+4iU+usSQ="
+  }
+]

--- a/pkgs/by-name/ca/calcpad/package.nix
+++ b/pkgs/by-name/ca/calcpad/package.nix
@@ -1,0 +1,72 @@
+{
+  stdenv,
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  nano,
+  wkhtmltopdf,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "calcpad";
+  version = "7.6.0";
+
+  src = fetchFromGitHub {
+    owner = "proektsoftbg";
+    repo = "calcpad";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2rBaHnr+80Dec1NUrvrqD8VvZthS55+imFDimQtDkyA=";
+  };
+
+  patches = [
+    # The program uses a post-install script to install the configuration file,
+    # but that post-install script is not ran. Also, the program assumes that the
+    # configuration file on Linux will be located at `~/Documents/.config/calcpad`,
+    # which is not common. Patched to use `XDG_CONFIG_HOME` with a fallback to `~/.config`.
+    ./01-update-config-settings.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace Calcpad.Tests/Calcpad.Tests.csproj \
+      --replace-fail '..\Calcpad.core\Calcpad.Core.csproj' '..\Calcpad.Core\Calcpad.Core.csproj'
+
+    substituteInPlace Calcpad.Cli/Calcpad.Cli.csproj \
+      --replace-fail 'Include="doc\*\*"' 'Include="doc\**"' \
+      --replace-fail 'Include="Examples\*\*"' 'Include="Examples\**"' \
+      --replace-fail 'Include="Syntax\*\*"' 'Include="Syntax\**"'
+
+    substituteInPlace Calcpad.Cli/Converter.cs \
+      --replace-fail "/usr/bin/wkhtmltopdf" "${wkhtmltopdf}/bin/wkhtmltopdf"
+
+    substituteInPlace Calcpad.Cli/doc/template.html \
+      --replace-fail "https://calcpad.local/jquery-3.6.3.min.js" "jquery-3.6.3.min.js"
+  '';
+
+  # The CLI tool is packaged as the GUI uses WPF, which is not natively
+  # supported on Linux - see https://github.com/Proektsoftbg/Calcpad/issues/94.
+  projectFile = "Calcpad.Cli/Calcpad.Cli.csproj";
+  testProjectFile = "Calcpad.Tests/Calcpad.Tests.csproj";
+
+  nugetDeps = ./deps.json;
+  runtimeDeps = [
+    nano
+    wkhtmltopdf
+  ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+
+  doCheck = true;
+
+  meta = {
+    broken = stdenv.hostPlatform.isDarwin;
+    description = "CLI tool for mathematical and engineering calculations";
+    homepage = "https://calcpad.eu";
+    changelog = "https://github.com/Proektsoftbg/Calcpad/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ magicquark ];
+    mainProgram = "Cli";
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
### Init `calcpad` at Version 7.6.0

`calcpad` is tool for performing mathematical and engineering calculations,  [project homepage](https://calcpad.eu/), [code repository](https://github.com/Proektsoftbg/Calcpad).

The tool provides an online version and a desktop version. This PR packages the desktop version.

Note that the GUI only works on Microsoft Windows, but the CLI is cross-platform. This PR packages the `calcpad` CLI, which can be used to process calculations and produce formatted `html`, `pdf` and `docx` reports of said calculations.

#### Testing
- The tool provides its own testing suite that has been enabled. It runs and passes when I build the package.
- Basic functionality of the Cli tool has been tested, basic mathematics, alongside the `HELP` and `SETTINGS` commands.
- Exporting of a file to `html`, `pdf` and `docx` has been performed using the example file located here: https://github.com/Proektsoftbg/Calcpad/blob/main/Calcpad.Cli/Examples/Mathematics/Combinatorics.cpd

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
