### PR TITLE
parallel-launcher: 8.3.0 -> 9.0.2

### DIFF
--- a/pkgs/by-name/pa/parallel-launcher/fix-paths.patch
+++ b/pkgs/by-name/pa/parallel-launcher/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/core/retroarch.cpp b/src/core/retroarch.cpp
-index c2a2c47..97fa782 100644
+index 7502922..c6a572b 100644
 --- a/src/core/retroarch.cpp
 +++ b/src/core/retroarch.cpp
-@@ -102,7 +102,7 @@ static void loadConfig( std::map<string, string> &configs ) {
+@@ -103,7 +103,7 @@ static void loadConfig( std::map<string, string> &configs ) {
  
  	const fs::path basePath = RetroArch::getBasePath();
  	configs["system_directory"] = (basePath / _NFS("system")).u8string();
@@ -11,7 +11,7 @@ index c2a2c47..97fa782 100644
  	configs["savefile_directory"] = (basePath / _NFS("saves")).u8string();
  	configs["savestate_directory"] = (basePath / _NFS("states")).u8string();
  	configs["libretro_info_path"] = (basePath / _NFS("info")).u8string();
-@@ -110,7 +110,7 @@ static void loadConfig( std::map<string, string> &configs ) {
+@@ -111,7 +111,7 @@ static void loadConfig( std::map<string, string> &configs ) {
  #if defined(FLATPAK_VERSION)
  	configs["assets_directory"] = "/app/share/libretro/assets/";
  #elif defined(__linux__)
@@ -20,7 +20,7 @@ index c2a2c47..97fa782 100644
  	configs["osk_overlay_directory"] = (BaseDir::data() / "retro-data" / "overlays" / "keyboards").u8string();
  	configs["overlay_directory"] = (BaseDir::data() / "retro-data" / "overlays").u8string();
  	configs["audio_filter_dir"] = (BaseDir::data() / "retro-data" / "filters" / "audio").u8string();
-@@ -845,13 +845,7 @@ fs::path RetroArch::getBasePath() {
+@@ -866,13 +866,7 @@ fs::path RetroArch::getBasePath() {
  }
  
  fs::path RetroArch::getCorePath() {
@@ -35,7 +35,7 @@ index c2a2c47..97fa782 100644
  }
  
  fs::path RetroArch::getConfigPath() {
-@@ -866,7 +860,7 @@ fs::path RetroArch::getExePath() {
+@@ -887,7 +881,7 @@ fs::path RetroArch::getExePath() {
  #elif defined(FLATPAK_VERSION)
  	return BaseDir::program() / "retroarch";
  #else
@@ -45,27 +45,41 @@ index c2a2c47..97fa782 100644
  }
  
 diff --git a/src/main.cpp b/src/main.cpp
-index 3ca39b2..f3c14ba 100644
+index fbd4c92..91ef84e 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
-@@ -200,6 +200,7 @@ int main( int argc, char **argv ) {
+@@ -209,7 +209,7 @@ int main( int argc, char **argv ) {
  		fs::path( "/usr/local/share/parallel-launcher/translations/" ),
  		fs::path( "/usr/share/parallel-launcher/translations/" )
  #else
-+		fs::read_symlink( "/proc/self/exe" ).parent_path().parent_path() / "share/parallel-launcher/translations/",
- 		fs::path( "/usr/share/parallel-launcher/translations/" ),
+-		fs::path( "/usr/share/parallel-launcher/translations/" ),
++		fs::path( "@sharePath@/translations/" ),
  		fs::path( "/usr/local/share/parallel-launcher/translations/" ),
  		BaseDir::program() / "lang"
+ #endif
+diff --git a/src/plugins/discord-plugin.cpp b/src/plugins/discord-plugin.cpp
+index 055c0ee..7ce44fb 100644
+--- a/src/plugins/discord-plugin.cpp
++++ b/src/plugins/discord-plugin.cpp
+@@ -38,7 +38,7 @@ const DiscordPlugin &DiscordPlugin::tryLoad( bool *success ) noexcept {
+ 		return s_abi;
+ 	}
+ 
+-	void *handle = dlopen( (BaseDir::data() / "plugins" / "libdiscord-rpc.so").u8string().c_str(), RTLD_NOW );
++	void *handle = dlopen( "libdiscord-rpc.so", RTLD_NOW );
+ 	if( !handle ) {
+ 		if( success != nullptr ) *success = false;
+ 		return s_stub;
 diff --git a/src/polyfill/base-directory.cpp b/src/polyfill/base-directory.cpp
-index 720a754..db607ca 100644
+index 2dcc704..45970a4 100644
 --- a/src/polyfill/base-directory.cpp
 +++ b/src/polyfill/base-directory.cpp
-@@ -134,7 +134,7 @@ static Locations getLocations() {
+@@ -146,7 +146,7 @@ static Locations getLocations() {
  #if defined(FLATPAK_VERSION)
  		fs::path( "/app/share/parallel-launcher" )
  #elif defined(__linux__)
 -		fs::path( "/usr/share/parallel-launcher" )
-+		fs::read_symlink( "/proc/self/exe" ).parent_path().parent_path() / "share/parallel-launcher"
++		fs::path( "@sharePath@" )
  #endif
  	};
  }

--- a/pkgs/by-name/pa/parallel-launcher/fix-version-checks.patch
+++ b/pkgs/by-name/pa/parallel-launcher/fix-version-checks.patch
@@ -1,8 +1,8 @@
 diff --git a/src/core/updates.cpp b/src/core/updates.cpp
-index 403290b..f7d6547 100644
+index cb9ca39..4dc5dfb 100644
 --- a/src/core/updates.cpp
 +++ b/src/core/updates.cpp
-@@ -30,8 +30,8 @@
+@@ -24,8 +24,8 @@
  #endif
  
  const InstalledVersionsInfo InstalledVersionsInfo::Default {
@@ -13,7 +13,7 @@ index 403290b..f7d6547 100644
  	/* lastUpdateCheck */ 0
  };
  
-@@ -47,15 +47,7 @@ template<> void JsonSerializer::serialize<RetroArchVersion>( JsonWriter &jw, con
+@@ -41,15 +41,7 @@ template<> void JsonSerializer::serialize<RetroArchVersion>( JsonWriter &jw, con
  }
  
  template<> RetroArchVersion JsonSerializer::parse<RetroArchVersion>( const Json &json ) {
@@ -30,7 +30,7 @@ index 403290b..f7d6547 100644
  }
  
  static constexpr char P_RETROARCH[] = "retroarch";
-@@ -73,47 +65,14 @@ template<> void JsonSerializer::serialize<InstalledVersionsInfo>( JsonWriter &jw
+@@ -67,44 +59,15 @@ template<> void JsonSerializer::serialize<InstalledVersionsInfo>( JsonWriter &jw
  }
  
  template<> InstalledVersionsInfo JsonSerializer::parse<InstalledVersionsInfo>( const Json &json ) {
@@ -60,11 +60,7 @@ index 403290b..f7d6547 100644
 -#if defined(__linux__)
 -	const Json &vjson = json["linux_x64"];
 -#elif defined(_WIN32)
--	#ifdef _WIN64
--		const Json &vjson = json["windows_x64"];
--	#else
--		const Json &vjson = json["windows_x86"];
--	#endif
+-	const Json &vjson = json["windows_x64"];
 -#elif defined(__APPLE__)
 -	const Json &vjson = AppleUtil::shouldUseArmCore() ? json["macos_arm64"] : json["macos_x64"];
 -#else
@@ -75,14 +71,16 @@ index 403290b..f7d6547 100644
  	return ParallelCoreVersion{
 -		JsonSerializer::parse<Version>( vjson["version"] ),
 -		vjson["sha1"].get<string>(),
+-		vjson["zipSignature"].get<string>(),
 -		vjson["url"].get<string>()
 +		InstalledVersionsInfo::Default.parallelVersion,
++		"",
 +		"",
 +		""
  	};
  }
  
-@@ -178,6 +137,7 @@ void RetroUpdater::checkForUpdates(
+@@ -169,6 +132,7 @@ void RetroUpdater::checkForUpdates(
  	bool waitForCoreUpdates,
  	bool forceUpdate
  ) {

--- a/pkgs/by-name/pa/parallel-launcher/parallel-n64-next.nix
+++ b/pkgs/by-name/pa/parallel-launcher/parallel-n64-next.nix
@@ -15,13 +15,13 @@ in
 # Based on the libretro parallel-n64 derivation with slight tweaks
 libretro.mkLibretroCore (finalAttrs: {
   core = "parallel-n64-next";
-  version = "2.24.1";
+  version = "2.27.1";
 
   src = fetchFromGitLab {
     owner = "parallel-launcher";
     repo = "parallel-n64";
     tag = reformatVersion finalAttrs.version;
-    hash = "sha256-BeeKX78zozxx72cmJ3HI0nH/STvkltMBZs2+mb4ukM0=";
+    hash = "sha256-u4F6CbC1NEU3OWtcqMIi/teX+SS4Jq9v5M2qc9z5bXg=";
   };
 
   extraNativeBuildInputs = [

--- a/pkgs/by-name/pa/parallel-launcher/update.sh
+++ b/pkgs/by-name/pa/parallel-launcher/update.sh
@@ -8,7 +8,7 @@ packageDir="$nixpkgs/pkgs/by-name/pa/parallel-launcher"
 
 getLatestVersion() {
   curl -s "https://gitlab.com/api/v4/projects/parallel-launcher%2F$1/repository/tags" \
-  | jq -r '.[0] | select(.) | .name' \
+  | jq -r '.[0].name' \
   | sed 's|v||' \
   | sed 's|-|.|'
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

parallel-launcher release notes:
https://gitlab.com/parallel-launcher/parallel-launcher/-/releases/v9.0-0
https://gitlab.com/parallel-launcher/parallel-launcher/-/releases/v9.0-1
https://gitlab.com/parallel-launcher/parallel-launcher/-/releases/v9.0-2

parallel-launcher.parallel-n64-core release notes:
https://gitlab.com/parallel-launcher/parallel-n64/-/releases/v2.25-0
https://gitlab.com/parallel-launcher/parallel-n64/-/releases/v2.26-0
https://gitlab.com/parallel-launcher/parallel-n64/-/releases/v2.26-1
https://gitlab.com/parallel-launcher/parallel-n64/-/releases/v2.26-2
https://gitlab.com/parallel-launcher/parallel-n64/-/releases/v2.27-0
https://gitlab.com/parallel-launcher/parallel-n64/-/releases/v2.27-1

The big packaging change for the PL application is an upgrade from Qt 5 to Qt 6 plus some other new build dependencies that 9.0.0+ expects.

The state of the `discord-rpc` dependency in the nixpkgs PL package as of 8.3.0 is a little strange because:
1. The `discord-rpc` dependency is not actually needed at compile time at all because PL lazy loads it with `dlopen` and provides the headers in its source.
2.  If you enable Discord integration in PL, it downloads a version of `libdiscord-rpc.so` at runtime to a PL config directory somewhere in `$HOME/...`. The nixpkgs `discord-rpc` dependency is not needed to build the current 8.3.0 version of the package at all.
3. Due to #&#8203;2, Discord integration will work even if you have `withDiscordRpc` set to `false`.

Following up from my comment [here](https://github.com/NixOS/nixpkgs/pull/449212#issuecomment-3373471808), this PR changes how we handle the `discord-rpc` dependency to force it to use the version in nixpkgs. With my PR here, if you build the package with `withDiscordRpc` set to `false` and enable Discord integration in PL, it will still prompt you to download the PL-hosted one, but it won't be able to load it because we patched it to no longer look for it in the path in the user's `$HOME/...` directory. I don't want to do more invasive patching to prevent the download and/or not lazy load it.

This is a breaking change because the behavior described by #&#8203;3 is no longer true. To restore Discord integration, this will now force people to override the package. Should I change the default of `withDiscordRpc` to `true` to make sure the old behavior is retained (I would prefer this)? Should people just have to deal with it? Am I overthinking this? Probably.

That all being said... it does feel dumb to purposely cripple the package this way. Especially because it works fine if things are set up as described in #&#8203;2. Part of me just wants to remove the `discord-rpc` dependency stuff entirely, but letting a program download dependencies at runtime like this when they're available in nixpkgs isn't very Nix-y. This is probably fine for now and I can restore the downloading behavior if nixpkgs ever fully drops `discord-rpc`.

If anyone has opinions on how to handle this `discord-rpc` thing, please let me know.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
