### PR TITLE
sentry-cli: fix build on Darwin

### DIFF
--- a/pkgs/by-name/se/sentry-cli/fix-swift-lib-path.patch
+++ b/pkgs/by-name/se/sentry-cli/fix-swift-lib-path.patch
@@ -1,0 +1,13 @@
+diff --git a/apple-catalog-parsing/build.rs b/apple-catalog-parsing/build.rs
+index 2ab4c71b..80301b1a 100644
+--- a/apple-catalog-parsing/build.rs
++++ b/apple-catalog-parsing/build.rs
+@@ -30,7 +30,7 @@ fn main() {
+     // Add necessary libraries to the linker search path. Without this line, compiling fails
+     // on systems without Xcode installed (xcode-select is still required).
+     println!(
+-        "cargo:rustc-link-search=native=/Library/Developer/CommandLineTools/usr/lib/swift/macosx"
++        "cargo:rustc-link-search=native=/usr/lib/swift/macosx"
+     );
+ 
+     let out_dir = env::var("OUT_DIR").expect("OUT_DIR is set for build scripts");

--- a/pkgs/by-name/se/sentry-cli/fix-swift-lib-path.patch
+++ b/pkgs/by-name/se/sentry-cli/fix-swift-lib-path.patch
@@ -1,8 +1,8 @@
 diff --git a/apple-catalog-parsing/build.rs b/apple-catalog-parsing/build.rs
-index 2ab4c71b..80301b1a 100644
+index 2ab4c71b59..6bcf003c0a 100644
 --- a/apple-catalog-parsing/build.rs
 +++ b/apple-catalog-parsing/build.rs
-@@ -30,7 +30,7 @@ fn main() {
+@@ -30,7 +30,7 @@
      // Add necessary libraries to the linker search path. Without this line, compiling fails
      // on systems without Xcode installed (xcode-select is still required).
      println!(
@@ -11,3 +11,30 @@ index 2ab4c71b..80301b1a 100644
      );
  
      let out_dir = env::var("OUT_DIR").expect("OUT_DIR is set for build scripts");
+@@ -87,17 +87,14 @@
+     println!("cargo:rustc-link-search=framework=/System/Library/PrivateFrameworks");
+     println!("cargo:rustc-link-lib=framework=CoreUI");
+ 
+-    // Link to swift macOS support libraries for Swift runtime support on older macOS versions
+-    let developer_dir = Command::new("xcode-select")
+-        .args(["-p"])
+-        .output()
+-        .expect("Failed to get developer directory, please ensure Xcode is installed.");
+-    let developer_dir_path = String::from_utf8(developer_dir.stdout)
+-        .expect("Failed to convert developer directory to UTF-8")
+-        .trim()
+-        .to_owned();
+-
+-    println!(
+-        "cargo:rustc-link-search={developer_dir_path}/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"
++    // Link libobjc to avoid the following error: ld: can't find ordinal for imported symbol '___objc_personality_v0'
++    println!("cargo:rustc-link-lib=objc");
++
++    println!(
++        "cargo:rustc-link-search=/usr/lib/swift"
++    );
++
++    println!(
++        "cargo:rustc-link-search=@swiftLib@/lib/swift/macosx"
+     );
+ }

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -8,7 +8,7 @@
   stdenv,
   swift,
   swiftpm,
-  writeShellScriptBin,
+  replaceVars,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sentry-cli";
@@ -26,7 +26,9 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_NO_VENDOR = 1;
 
   patches = [
-    ./fix-swift-lib-path.patch
+    (replaceVars ./fix-swift-lib-path.patch {
+      swiftLib = lib.getLib swift;
+    })
   ];
 
   buildInputs = [ openssl ];
@@ -36,9 +38,6 @@ rustPlatform.buildRustPackage rec {
   ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
       swift
       swiftpm
-      (writeShellScriptBin "xcode-select" ''
-        echo $DEVELOPER_DIR
-      '')
   ]);
 
   # By default including `swiftpm` in `nativeBuildInputs` will take over `buildPhase`

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -35,9 +35,10 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     installShellFiles
     pkg-config
-  ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
-      swift
-      swiftpm
+  ]
+  ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+    swift
+    swiftpm
   ]);
 
   # By default including `swiftpm` in `nativeBuildInputs` will take over `buildPhase`

--- a/pkgs/by-name/se/sentry-cli/package.nix
+++ b/pkgs/by-name/se/sentry-cli/package.nix
@@ -6,6 +6,9 @@
   openssl,
   pkg-config,
   stdenv,
+  swift,
+  swiftpm,
+  writeShellScriptBin,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "sentry-cli";
@@ -22,11 +25,24 @@ rustPlatform.buildRustPackage rec {
   # Needed to get openssl-sys to use pkgconfig.
   OPENSSL_NO_VENDOR = 1;
 
+  patches = [
+    ./fix-swift-lib-path.patch
+  ];
+
   buildInputs = [ openssl ];
   nativeBuildInputs = [
     installShellFiles
     pkg-config
-  ];
+  ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+      swift
+      swiftpm
+      (writeShellScriptBin "xcode-select" ''
+        echo $DEVELOPER_DIR
+      '')
+  ]);
+
+  # By default including `swiftpm` in `nativeBuildInputs` will take over `buildPhase`
+  dontUseSwiftpmBuild = true;
 
   cargoHash = "sha256-6AM1oGX4q6kHePiS0fsoXPt0b89O9WItIBukPIwapJQ=";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes #448301.
Closes #441427.
Closes #452661.

I have tested that the built binary runs (`sentry-cli --version`), but not that the catalog parsing functionality works. If anyone knows how and is able to test that, that'd be great.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
