### PR TITLE
reaper-sws-extension: 2.14.0.3 -> 2.14.0.7

### DIFF
--- a/pkgs/by-name/re/reaper-sws-extension/linux.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/linux.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "reaper-oss";
     repo = "sws";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-37pBbNACQuuEk1HJTiUHdb0mDiR2+ZsEQUOhz7mrPPg=";
+    hash = "sha256-J2igVacDClHgKGZ2WATcd5XW2FkarKtALxVLgqa90Cs=";
     fetchSubmodules = true;
   };
 
@@ -36,4 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ gtk3 ];
 
+  postPatch = ''
+    substituteInPlace vendor/taglib/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)' \
+      'cmake_minimum_required(VERSION ${cmake.version})' \
+  '';
 })

--- a/pkgs/by-name/re/reaper-sws-extension/package.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/package.nix
@@ -9,7 +9,7 @@ in
 callPackage p {
 
   pname = "reaper-sws-extension";
-  version = "2.14.0.3";
+  version = "2.14.0.7";
   meta = {
     description = "Reaper Plugin Extension";
     longDescription = ''


### PR DESCRIPTION
Resolves #452617

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
