### PR TITLE
[Backport release-25.05] dprint-plugins.dprint-plugin-markdown: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-markdown.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-markdown.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "Markdown code formatter.";
-  hash = "sha256-2lpgVMExOjMVRTvX6hGRWuufwh2AIkiXaOzkN8LhZgw=";
+  description = "Markdown code formatter";
+  hash = "sha256-XrTiMkgjHOD8a2N5Ips79+D2SbM36s9Hdk7o/iwGIlc=";
   initConfig = {
     configExcludes = [ ];
     configKey = "markdown";
@@ -9,6 +9,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-markdown";
   updateUrl = "https://plugins.dprint.dev/dprint/markdown/latest.json";
-  url = "https://plugins.dprint.dev/markdown-0.19.0.wasm";
-  version = "0.19.0";
+  url = "https://plugins.dprint.dev/markdown-0.20.0.wasm";
+  version = "0.20.0";
 }


### PR DESCRIPTION
manual backport to `release-25.05`, for #452576

* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-10-06T02%3A12%3A03Z#changes-acceptable-for-releases). 
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.

