### PR TITLE
teamspeak6-client: 6.0.0-beta2 -> 6.0.0-beta3.1

### DIFF
--- a/pkgs/by-name/te/teamspeak6-client/package.nix
+++ b/pkgs/by-name/te/teamspeak6-client/package.nix
@@ -22,6 +22,7 @@
   libxkbcommon,
   libgbm,
   nss,
+  pipewire,
   udev,
   libGL,
   xorg,
@@ -29,11 +30,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "teamspeak6-client";
-  version = "6.0.0-beta2";
+  version = "6.0.0-beta3.1";
 
   src = fetchurl {
     url = "https://files.teamspeak-services.com/pre_releases/client/${finalAttrs.version}/teamspeak-client.tar.gz";
-    hash = "sha256-3jNPv3uQ2RztR1p4XQNLUg5IVrvW/dcdtqXdiGJKVSs=";
+    hash = "sha256-CWKyn49DSWgrkJyYcPwKUz2PBykvFQc1f7G/yvrHbWU=";
   };
 
   sourceRoot = ".";
@@ -55,6 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     libxkbcommon
     libgbm
     nss
+    pipewire
     xorg.libX11
     xorg.libXScrnSaver
     xorg.libXdamage
@@ -102,6 +104,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           udev
           libGL
           libpulseaudio
+          pipewire
         ]
       }"
 


### PR DESCRIPTION
Teamspeak now supports screenshare on Wayland, which requires Pipewire.

Release notes (6.0.0-beta3): https://community.teamspeak.com/t/teamspeak-6-0-0-beta3-foundation-i-update/62417
Release notes (6.0.0-beta3.1): https://community.teamspeak.com/t/hotfix-teamspeak-6-0-0-beta3-1-foundation-i-hotfix/62449


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
