### PR TITLE
nixos/tests/dictd: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -449,6 +449,7 @@ in
   devpi-server = runTest ./devpi-server.nix;
   dex-oidc = runTest ./dex-oidc.nix;
   dhparams = runTest ./dhparams.nix;
+  dictd = runTest ./dictd.nix;
   disable-installer-tools = runTest ./disable-installer-tools.nix;
   discourse = runTest {
     imports = [ ./discourse.nix ];

--- a/nixos/tests/dictd.nix
+++ b/nixos/tests/dictd.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, ... }:
+{
+  name = "dictd";
+  meta.maintainers = with lib.maintainers; [
+    h7x4
+  ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.dictd = {
+        enable = true;
+        DBs = with pkgs.dictdDBs; [
+          jpn2eng
+          eng2jpn
+        ];
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("dictd.service")
+    machine.wait_for_open_port(2628)
+
+    machine.succeed("dict --serverinfo | grep 'On machine: up'")
+    machine.succeed("dict --dbs | grep '${pkgs.dictdDBs.jpn2eng.name}'")
+    machine.succeed("dict -d '${pkgs.dictdDBs.jpn2eng.name}' 例え | grep example")
+    machine.succeed("dict -d '${pkgs.dictdDBs.eng2jpn.name}' example | grep 例え")
+  '';
+}

--- a/pkgs/servers/dict/default.nix
+++ b/pkgs/servers/dict/default.nix
@@ -8,6 +8,7 @@
   libmaa,
   zlib,
   libtool,
+  nixosTests,
 }:
 
 stdenv.mkDerivation rec {
@@ -46,6 +47,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     install -Dm444 -t $out/share/doc/${pname} NEWS README
   '';
+
+  passthru.tests.nixos = nixosTests.dictd;
 
   meta = {
     description = "Dict protocol server and client";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
