### PR TITLE
python313Packages.ovito: init at 3.14.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23527,6 +23527,12 @@
     githubId = 5512096;
     name = "Sébastien Guimmara";
   };
+  sh4k095 = {
+    email = "carlofedep@gmail.com";
+    github = "sh4k095";
+    githubId = 86348751;
+    name = "Carlo Federico Pauletti";
+  };
   shackra = {
     name = "Jorge Javier Araya Navarro";
     email = "jorge@esavara.cr";

--- a/pkgs/development/python-modules/ovito/default.nix
+++ b/pkgs/development/python-modules/ovito/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+  autoPatchelfHook,
+  numpy,
+  traits,
+  pyside6,
+  pythonOlder,
+}:
+
+buildPythonPackage {
+  pname = "ovito";
+  version = "3.14.1";
+  format = "wheel";
+  disabled = pythonOlder "3.13";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/76/6e/d9d636c5d6590f14cee5f9b4865f913a49f53bfc7f44104a33fc7233fa6f/ovito-3.14.1-cp313-cp313-manylinux_2_28_x86_64.whl";
+    hash = "sha256-GF30rBzgm/ChOLuAmkhD81j532SgQay0+NKg2Mdwqbg=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libcuda.so.1"
+    "libnvidia-ml.so.1"
+  ];
+
+  dependencies = [
+    numpy
+    traits
+    pyside6
+  ];
+
+  meta = {
+    description = "OVITO python module enabling OVITO's I/O, analysis and rendering capabilities in standalone python scripts.";
+    homepage = "https://docs.ovito.org/python/index.html";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sh4k095 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11329,6 +11329,8 @@ self: super: with self; {
 
   ovh = callPackage ../development/python-modules/ovh { };
 
+  ovito = callPackage ../development/python-modules/ovito { };
+
   ovmfvartool = callPackage ../development/python-modules/ovmfvartool { };
 
   ovoenergy = callPackage ../development/python-modules/ovoenergy { };


### PR DESCRIPTION
I with to contribute the `ovito` python package to nixpkgs. It enables the use of `pkgs.ovito`'s I/O, analysis and rendering capabilities in standalone python scripts. The derivation has been tested inside a flake, it builds successfully and appears to be functional.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
