### PR TITLE
git-lfs: 3.7.0 -> 3.7.1

### DIFF
--- a/pkgs/by-name/gi/git-lfs/package.nix
+++ b/pkgs/by-name/gi/git-lfs/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "git-lfs";
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
     tag = "v${version}";
-    hash = "sha256-EFuuyD83aYe6XMKbRfAykVMfGFOQ4I6ORvMRm0Q8vfM=";
+    hash = "sha256-N5ckTnyA3mueZre+rMhFZBiAFgEu4pmtzkiUidXnan8=";
   };
 
   vendorHash = "sha256-6H0KpLin+DqwEg5bdzaxj2CoNSneZ/ET43MTrrdF3h8=";


### PR DESCRIPTION
Fixes CVE-2025-26625.

Changes:
https://github.com/git-lfs/git-lfs/releases/tag/v3.7.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 452865`
Commit: `e839548206c904d0b2ea2d0a1dab4068bb24ce4d`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>pulsar</li>
  </ul>
</details>
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>makehuman</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 58 packages built:</summary>
  <ul>
    <li>bundix</li>
    <li>cabal2nix</li>
    <li>chirpstack-concentratord</li>
    <li>crate2nix</li>
    <li>crush</li>
    <li>crystal2nix</li>
    <li>dub-to-nix</li>
    <li>envision</li>
    <li>gcalcli</li>
    <li>gcalcli.dist</li>
    <li>git-lfs</li>
    <li>git-unroll</li>
    <li>github-backup</li>
    <li>github-backup.dist</li>
    <li>haskellPackages.cli-nix</li>
    <li>haskellPackages.cli-nix.doc</li>
    <li>haskellPackages.nix-thunk</li>
    <li>haskellPackages.nix-thunk.doc</li>
    <li>haskellPackages.nvfetcher</li>
    <li>haskellPackages.nvfetcher.doc</li>
    <li>haskellPackages.update-nix-fetchgit</li>
    <li>haskellPackages.update-nix-fetchgit.doc</li>
    <li>kcl</li>
    <li>lixPackageSets.git.nix-update</li>
    <li>lixPackageSets.git.nix-update.dist</li>
    <li>lixPackageSets.latest.nix-update (lixPackageSets.lix_2_93.nix-update, lixPackageSets.stable.nix-update)</li>
    <li>lixPackageSets.latest.nix-update.dist (lixPackageSets.lix_2_93.nix-update.dist, lixPackageSets.stable.nix-update.dist)</li>
    <li>lon</li>
    <li>luarocks-packages-updater</li>
    <li>luarocks-packages-updater.dist</li>
    <li>mdwatch</li>
    <li>mlv-app</li>
    <li>nim_lk</li>
    <li>nix-prefetch-git</li>
    <li>nix-prefetch-scripts</li>
    <li>nix-update</li>
    <li>nix-update-source</li>
    <li>nix-update-source.dist</li>
    <li>nix-update.dist</li>
    <li>npins</li>
    <li>nvfetcher</li>
    <li>outline</li>
    <li>prefetch-yarn-deps</li>
    <li>prowlarr</li>
    <li>python313Packages.nixpkgs-updaters-library</li>
    <li>python313Packages.nixpkgs-updaters-library.dist</li>
    <li>radarr</li>
    <li>sonarr</li>
    <li>sus-compiler</li>
    <li>tests.fetchgit.cached-prefetch-avoids-fetch</li>
    <li>tests.fetchgit.prefetch-git-no-add-path</li>
    <li>tests.pkgs-lib</li>
    <li>typescript-language-server</li>
    <li>update-nix-fetchgit</li>
    <li>update-python-libraries</li>
    <li>vimPluginsUpdater</li>
    <li>xosd-xft</li>
    <li>yarn2nix</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>makehuman</summary>
<pre>unpacking source archive /nix/store/6jsac8yxp5i1z0m9qafr9cczfkfvl7kd-makehuman-assets-source
source root is .
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
/build/makehuman-final/makehuman /build/makehuman-final
/build/makehuman-final/makehuman/lib/getpath.py:152: SyntaxWarning: invalid escape sequence '\D'
  value, type_ = "%USERPROFILE%\Documents", winreg.REG_EXPAND_SZ
Traceback (most recent call last):
  File "/build/makehuman-final/makehuman/./compile_targets.py", line 74, in <module>
    np.save(lpath, makehuman.getAssetLicense().toNumpyString())
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/build/makehuman-final/makehuman/makehuman.py", line 408, in toNumpyString
    return _packStringDict(self.asDict())
  File "/build/makehuman-final/makehuman/makehuman.py", line 404, in _packStringDict
    text = np.fromstring(text, dtype='S1')
ValueError: The binary mode of fromstring is removed, use frombuffer instead</pre>
</details>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
