### PR TITLE
yaziPlugins.dupes: init at 0-unstable-2025-10-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17586,6 +17586,12 @@
     name = "Sean Gilligan";
     keys = [ { fingerprint = "3B66 ACFA D10F 02AA B1D5  2CB1 8DD0 D81D 7D1F C61A"; } ];
   };
+  mshnwq = {
+    email = "mshnwq.com@gmail.com";
+    github = "mshnwq";
+    githubId = 68467027;
+    name = "Hayan Al-Machnouk";
+  };
   msiedlarek = {
     email = "mikolaj@siedlarek.pl";
     github = "msiedlarek";

--- a/pkgs/by-name/ya/yazi/plugins/dupes/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/dupes/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+  jdupes,
+  bash,
+}:
+mkYaziPlugin {
+  pname = "dupes.yazi";
+  version = "0-unstable-2025-10-16";
+
+  src = fetchFromGitHub {
+    owner = "mshnwq";
+    repo = "dupes.yazi";
+    rev = "012a21e1864296503f7bb1e7297b71fe57af8994";
+    hash = "sha256-VUF7vmtnXuEsbyS0/pPTgwrDDrnMqt77eIkeQZFxoZk=";
+  };
+
+  postPatch = ''
+    substituteInPlace main.lua --replace-fail \
+      'set_state("cmdline", "jdupes")' \
+      'set_state("cmdline", "${lib.getExe jdupes}")'
+    substituteInPlace main.lua --replace-fail \
+      'set_state("shell", "bash")' \
+      'set_state("shell", "${lib.getExe bash}")'
+  '';
+
+  meta = {
+    description = "Duplicate files plugin for Yazi";
+    homepage = "https://github.com/Mshnwq/dupes.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mshnwq ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
