### PR TITLE
python3Packages.tidalapi: 0.8.6 -> 0.8.8

### DIFF
--- a/pkgs/development/python-modules/tidalapi/default.nix
+++ b/pkgs/development/python-modules/tidalapi/default.nix
@@ -49,6 +49,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/tamland/python-tidal";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
+      drafolin
       drawbu
       ryand56
     ];

--- a/pkgs/development/python-modules/tidalapi/default.nix
+++ b/pkgs/development/python-modules/tidalapi/default.nix
@@ -9,17 +9,18 @@
   ratelimit,
   typing-extensions,
   mpegdash,
+  pyaes,
 }:
 buildPythonPackage rec {
   pname = "tidalapi";
-  version = "0.8.6";
+  version = "0.8.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "EbbLabs";
     repo = "python-tidal";
     tag = "v${version}";
-    hash = "sha256-SsyO0bh2ayHfGzINBW1BTTPS/ICvIymIhQ1HUPRFOwU=";
+    hash = "sha256-+O+U8QZhaOdUgPONv1tb5ctiK8NmD2NJK0hokmNtUZM=";
   };
 
   build-system = [
@@ -33,6 +34,7 @@ buildPythonPackage rec {
     isodate
     ratelimit
     typing-extensions
+    pyaes
   ];
 
   doCheck = false; # tests require internet access


### PR DESCRIPTION
Updated tidalapi to latest version and added pyaes as a dependency for the new version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
