### PR TITLE
emacsPackages: don't set `preBuild` or `patches` to null

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -116,7 +116,7 @@ in
             })
           ]
         else
-          previousAttrs.patches or null;
+          previousAttrs.patches or [ ];
       preBuild =
         if applyOrgRoamMissingPatch then
           previousAttrs.preBuild or ""
@@ -129,7 +129,7 @@ in
             popd
           ''
         else
-          previousAttrs.preBuild or null;
+          previousAttrs.preBuild or "";
     }
   );
 

--- a/pkgs/applications/editors/emacs/elisp-packages/lib-override-helper.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/lib-override-helper.nix
@@ -18,7 +18,7 @@ rec {
           if predicate finalAttrs previousAttrs then
             previousAttrs.packageRequires or [ ] ++ packageRequires
           else
-            previousAttrs.packageRequires or null;
+            previousAttrs.packageRequires or [ ];
       }
     );
 
@@ -89,7 +89,7 @@ rec {
           if predicate finalAttrs previousAttrs then
             previousAttrs.nativeBuildInputs or [ ] ++ [ pkgs.writableTmpDirAsHomeHook ]
           else
-            previousAttrs.nativeBuildInputs or null;
+            previousAttrs.nativeBuildInputs or [ ];
       }
     );
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -830,7 +830,7 @@ let
                     rm --recursive --verbose etc/elisp/screenshot
                   ''
                 else
-                  previousAttrs.preBuild or null;
+                  previousAttrs.preBuild or "";
             }
           );
 
@@ -991,7 +991,7 @@ let
                       })
                     ]
                   else
-                    previousAttrs.patches or null;
+                    previousAttrs.patches or [ ];
               }
             )
           );
@@ -1055,7 +1055,7 @@ let
                   ''
                   + previousAttrs.preBuild or ""
                 else
-                  previousAttrs.preBuild or null;
+                  previousAttrs.preBuild or "";
             }
           );
 
@@ -1221,7 +1221,7 @@ let
                     rm --verbose packages/javascript/test-suppport.el
                   ''
                 else
-                  previousAttrs.preBuild or null;
+                  previousAttrs.preBuild or "";
             }
           );
 
@@ -1392,7 +1392,7 @@ let
                     })
                   ]
                 else
-                  previousAttrs.patches or null;
+                  previousAttrs.patches or [ ];
             }
           );
 
@@ -1543,7 +1543,7 @@ let
                     })
                   ]
                 else
-                  previousAttrs.patches or null;
+                  previousAttrs.patches or [ ];
             }
           );
 
@@ -1561,7 +1561,7 @@ let
                   ''
                   + previousAttrs.preBuild or ""
                 else
-                  previousAttrs.preBuild or null;
+                  previousAttrs.preBuild or "";
             }
           );
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -897,7 +897,7 @@ let
                     rm --verbose --force test-bpr.el
                   ''
                 else
-                  previousAttrs;
+                  previousAttrs.preBuild or "";
             }
           );
 


### PR DESCRIPTION
Under some circumstances, some MELPA packages had their `preBuild` or `patches` attributes set to `null`. This does not seem to break their build, but it makes using `overrideAttrs` less convenient: the usual pattern of appending to `previousAttrs.preBuild or ""` does not work if `preBuild` is set but null.

This is the minimal fix: default these to `""` or `[]` instead. While I'm there, fix what looks like a copy/paste error in `bpr` (which will set `patches` to the `previousAttrs` attrset under some circumstances).

Instead of `if`/`else`, I think we could probably use `optionalAttrs`, along the lines of:

```nix
  dap-mode = super.dap-mode.overrideAttrs (
    finalAttrs: previousAttrs:
      lib.optionalAttrs (lib.versionOlder finalAttrs.version "20250131.1624") {
        preBuild = ''
          rm --verbose dapui.el
        ''
        + previousAttrs.preBuild or "";
    }
  );
```

I haven't tried that approach: please let me know if that looks better and I'll confirm it works and add a commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Built the modified packages using

```
nix-repl> :b legacyPackages.x86_64-linux.emacs.pkgs.withPackages (epkgs: [epkgs.alectryon epkgs.codesearch epkgs.dap-mode epkgs.frontside-javascript epkgs.kanagawa-themes epkgs.org-noter epkgs.org-projectile epkgs.bpr ])
```

and confirmed the resulting Emacs started, but I don't know how to meaningfully test the Emacs packages themselves, sorry...

I *think* I applied everything in CONTRIBUTING.md that is relevant but might've missed something, I'm new here :)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
