### PR TITLE
treewide: fix composer hashes that were broken by composer update

### DIFF
--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -216,7 +216,7 @@ In Nix, there are multiple approaches to building a Composer-based project.
 
 ::: {.warning}
 `buildComposerProject2` has a [known bug](https://github.com/NixOS/nixpkgs/issues/451395)
-where the `vendorHash` changes every a Composer release happens that changes the
+where the `vendorHash` changes every time a Composer release happens that changes the
 `autoload.php` or vendored composer code.
 :::
 

--- a/doc/languages-frameworks/php.section.md
+++ b/doc/languages-frameworks/php.section.md
@@ -214,6 +214,12 @@ code, while others choose not to.
 
 In Nix, there are multiple approaches to building a Composer-based project.
 
+::: {.warning}
+`buildComposerProject2` has a [known bug](https://github.com/NixOS/nixpkgs/issues/451395)
+where the `vendorHash` changes every a Composer release happens that changes the
+`autoload.php` or vendored composer code.
+:::
+
 One such method is the `php.buildComposerProject2` helper function, which serves
 as a wrapper around `mkDerivation`.
 

--- a/pkgs/by-name/ag/agorakit/package.nix
+++ b/pkgs/by-name/ag/agorakit/package.nix
@@ -27,7 +27,7 @@ php82.buildComposerProject2 (finalAttrs: {
     runHook postInstall
   '';
 
-  vendorHash = "sha256-tBB3Zl/N1XqPTD84at5WoGrD0G5rJbobk4E8BFOSm+M=";
+  vendorHash = "sha256-cg9OIBvWX69yU6U6Ag/T3jScG2OUdpTqc+KwP6VyUHo=";
   composerStrictValidation = false;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ba/baikal/package.nix
+++ b/pkgs/by-name/ba/baikal/package.nix
@@ -21,5 +21,7 @@ php.buildComposerProject2 (finalAttrs: {
     homepage = "https://sabre.io/baikal/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ wrvsrx ];
+    # vendorHash non-reproducible
+    broken = true;
   };
 })

--- a/pkgs/by-name/co/composer-require-checker/package.nix
+++ b/pkgs/by-name/co/composer-require-checker/package.nix
@@ -16,7 +16,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-UAofdc8mqSnJXhCTABSf9JZERqur86lzNDI66EHgEQE=";
   };
 
-  vendorHash = "sha256-bNeQEfwXly3LFuEKeSK6J6pRfQF6TNwUqu3SdTswmFI=";
+  vendorHash = "sha256-TlBrL4KyMVHaxqlfvnTkj3TkmU8h5/0BRC5e8yWrhCI=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/de/deployer/package.nix
+++ b/pkgs/by-name/de/deployer/package.nix
@@ -15,7 +15,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-wtkixHexsJNKsLnnlHssh0IzxwWYMPKDcaf/D0zUNKk=";
   };
 
-  vendorHash = "sha256-0uBI30n31W0eDVA9/W366O0Qo2jWZBqEL+YbJx4J7P0=";
+  vendorHash = "sha256-/bf1rvoG1N6GNqisBwMqY05qhTsy7gMeWXarXgElU/M=";
 
   meta = {
     changelog = "https://github.com/deployphp/deployer/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/en/engelsystem/package.nix
+++ b/pkgs/by-name/en/engelsystem/package.nix
@@ -23,7 +23,7 @@ php.buildComposerProject2 (finalAttrs: {
 
   inherit php;
 
-  vendorHash = "sha256-0Mv48mB/pTQtYd2do6wTdhD/c2zwbU1gTYsdU7rELPY=";
+  vendorHash = "sha256-ODJgsvECw+q3sAA6pWNw4X2Png7f4G2Jty9AQSj/SgE=";
   composoerNoDev = true;
   composerStrictValidation = false;
 

--- a/pkgs/by-name/fl/flarum/package.nix
+++ b/pkgs/by-name/fl/flarum/package.nix
@@ -17,7 +17,7 @@ php.buildComposerProject2 (finalAttrs: {
 
   composerLock = ./composer.lock;
   composerStrictValidation = false;
-  vendorHash = "sha256-pup+ZfPEnqoA3wEXQNn4pWTYXri6d4XzMfuc8k1SeQk=";
+  vendorHash = "sha256-4wB8MRnqnruo9VXupMmAqiRSZx8F2i+8zcOphTeDp1g=";
 
   meta = with lib; {
     changelog = "https://github.com/flarum/framework/blob/main/CHANGELOG.md";

--- a/pkgs/by-name/gr/grocy/package.nix
+++ b/pkgs/by-name/gr/grocy/package.nix
@@ -19,7 +19,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-MnN6TIkNZWT+pAQf0+z5l3hj/7K/d3BfI7VAaUEKG8s=";
   };
 
-  vendorHash = "sha256-n+6yNXqarWRZt6VEuHrFe3nrTiGeHnkURmO2UuB/BVc=";
+  vendorHash = "sha256-6vWV8+4tETUFBLeEoG7d8lHKILXvM7ezWbDiG11GA/s=";
 
   offlineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";

--- a/pkgs/by-name/mo/movim/package.nix
+++ b/pkgs/by-name/mo/movim/package.nix
@@ -88,7 +88,7 @@ php.buildComposerProject2 (finalAttrs: {
     ++ lib.optional minify.style.enable lightningcss
     ++ lib.optional minify.svg.enable scour;
 
-  vendorHash = "sha256-xkFyjs3jW7j+8WosRaxBEYQU2dwQlDr4/nrdtW03xvA=";
+  vendorHash = "sha256-Ke+bh/mvKUk5qxjlBZo4jJhLneyFRq0HYXTwK/KZMBs=";
 
   postPatch = ''
     # Our modules are already wrapped, removes missing *.so warnings;

--- a/pkgs/by-name/pd/pdepend/package.nix
+++ b/pkgs/by-name/pd/pdepend/package.nix
@@ -17,7 +17,7 @@ php.buildComposerProject2 (finalAttrs: {
   };
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-szKVZhWcd8p4307irNqgSAK2+hl8AW+gCPyf0EEco8A=";
+  vendorHash = "sha256-uK+nJFXDVPYFbosAUxqu+mmNsD7AnZ18NnIN9FYAaPQ=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;

--- a/pkgs/by-name/pe/pest/package.nix
+++ b/pkgs/by-name/pe/pest/package.nix
@@ -16,7 +16,7 @@ php.buildComposerProject2 (finalAttrs: {
   };
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-rOJ6PFp4Xfe89usoH455EAT30d2Tu3zd3+C/6K/kGBw=";
+  vendorHash = "sha256-4CpyerXmfXbwsNsK16V+GY3Rzo4BfavGpOVITD14p8w=";
 
   meta = {
     changelog = "https://github.com/pestphp/pest/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/ph/phpactor/package.nix
+++ b/pkgs/by-name/ph/phpactor/package.nix
@@ -16,7 +16,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-9XWlWwq+xvqPgKIc7IGoMVTxajjYsrPo/ra/0JIE168=";
   };
 
-  vendorHash = "sha256-3xkt0QjytW4BOCgZdevat7zkSuZTPPvwz3yptiq5zoo=";
+  vendorHash = "sha256-91Yz78nh4r+Gr7gKSwelTdO436ehENVTPUWcnDaU7zg=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ph/phpdocumentor/package.nix
+++ b/pkgs/by-name/ph/phpdocumentor/package.nix
@@ -17,7 +17,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-iQA19FrXvVLzg+LaY1BcNmG8amMfKPVFwYbZ7dr+H9Q=";
   };
 
-  vendorHash = "sha256-sFRy9Hy9CVNjjYqbPbKH0XhoUdu4HlkiuHDDovTGono=";
+  vendorHash = "sha256-iXkj0Pa4ln8GX/ARCpnijaWdFM4VYZuj42RP0GS2LW8=";
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 

--- a/pkgs/by-name/pr/pretty-php/package.nix
+++ b/pkgs/by-name/pr/pretty-php/package.nix
@@ -15,7 +15,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-zBhxuEViLxeQ9m3u1L0wYqeL+YEWWwvJS7PtsFPO5QU=";
   };
 
-  vendorHash = "sha256-vnmp/HLzaOzHu22lzugRXIHL43YQ/hm223gcUbIiLT4=";
+  vendorHash = "sha256-Y1/wNFPXza2aO07ZFybpwI3XbTVBhEvFHs9ygHQbcSo=";
 
   passthru = {
     tests.version = testers.testVersion {

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -58,6 +58,7 @@ php.buildComposerProject2 (finalAttrs: {
     mainProgram = "psysh";
     license = lib.licenses.mit;
     homepage = "https://psysh.org/";
-    teams = [ lib.teams.php ];
+    # `composerVendor` doesn't build
+    broken = true;
   };
 })

--- a/pkgs/by-name/ro/roave-backward-compatibility-check/package.nix
+++ b/pkgs/by-name/ro/roave-backward-compatibility-check/package.nix
@@ -16,7 +16,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-4rhIaPdyyLiIhVYC4KNKbPAbVsHKnK6BOsebFjmmDeI=";
   };
 
-  vendorHash = "sha256-k+zFpBHE+r0a67gqUry+luMIhJZ5wo1RpEaF4c7vAmI=";
+  vendorHash = "sha256-uZqstfVp5uY7Sec32XLK7RvuUtP8Hj21W7tayhhuf2g=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/ro/robo/package.nix
+++ b/pkgs/by-name/ro/robo/package.nix
@@ -16,7 +16,7 @@ php82.buildComposerProject2 (finalAttrs: {
     hash = "sha256-bAT4jHvqWeYcACeyGtBwVBA2Rz+AvkZcUGLDwSf+fLg=";
   };
 
-  vendorHash = "sha256-vketnTu5VEgt3HBbtnTppWl3+sSSIsCB2MpvL27bxv4=";
+  vendorHash = "sha256-Rg8WTZUnWA4bemNmE7hxFwfnlMtYyPkeltAQEWJ2VDU=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/development/php-packages/box/default.nix
+++ b/pkgs/development/php-packages/box/default.nix
@@ -16,7 +16,7 @@ php82.buildComposerProject2 (finalAttrs: {
     hash = "sha256-giJAcH2R9hAlUTbwRi7rbmUP+WV8Nfb9XmoHHs4RcbI=";
   };
 
-  vendorHash = "sha256-7oZtuQ7PhB7q9vNO2TLI46kg2q9BgdLjGUduGXAHc0E=";
+  vendorHash = "sha256-A/hAw0J4Q3kun6soxI6h7kpyGef9q0EFg8HAQHHZUro=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -14,6 +14,13 @@
   versionCheckHook,
 }:
 
+/*
+    XXX IMPORTANT
+
+    Make sure to check if the `vendorHash` of `buildComposerProject2` changes when updating!
+    See https://github.com/NixOS/nixpkgs/issues/451395
+*/
+
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "composer";
   version = "2.8.12";

--- a/pkgs/development/php-packages/phing/default.nix
+++ b/pkgs/development/php-packages/phing/default.nix
@@ -17,7 +17,7 @@
       hash = "sha256-gY6ocmkd7eJIMaBrewfxYL7gTr+1qNHTkuAp+w9ApUU=";
     };
 
-    vendorHash = "sha256-3frpoQzHtJA2/jJpZT+yIRatEwiY6LIUGzEZBa8hXbM=";
+    vendorHash = "sha256-zrHOw7Uyq8H7AyxrfCo5VthX1EeoSB44ynrRt38u3Sk=";
 
     nativeInstallCheckInputs = [
       versionCheckHook

--- a/pkgs/development/php-packages/phive/default.nix
+++ b/pkgs/development/php-packages/phive/default.nix
@@ -15,7 +15,7 @@ php.buildComposerProject2 (finalAttrs: {
     hash = "sha256-dv9v1KCLNheFmrRQ7cID5WFvoiH0OWVPWSrN023dEqA=";
   };
 
-  vendorHash = "sha256-H1QJ+ML0tbZzEBKknP0GHhUhw+ujiIH/QNmEgA2zSmM=";
+  vendorHash = "sha256-U6BHAd4tWQKm6uCJ5sM51PltXhF3J4ieTnbC060+8Jg=";
 
   meta = {
     changelog = "https://github.com/phar-io/phive/releases/tag/${finalAttrs.version}";

--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -17,7 +17,7 @@ php.buildComposerProject2 (finalAttrs: {
   };
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-ySdLlqlGKZ6LgmAOBMkBNoCAqWrgMwE/Cj6ZEPEsCko=";
+  vendorHash = "sha256-AQAASj5vrSE1xkJ/SZHU4GwOWNobe9ES0Yo+YrLH354=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;

--- a/pkgs/development/php-packages/phpinsights/default.nix
+++ b/pkgs/development/php-packages/phpinsights/default.nix
@@ -17,7 +17,7 @@ php.buildComposerProject2 (finalAttrs: {
   };
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-CwIfRmwJREz24Qj6J2PKQp+ix+/ZXo1oamcHc1fPUoc=";
+  vendorHash = "sha256-uy8/bkgjDXnt544S70IOwX9I8U0lMLAkbiBDYXyJBcY=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/development/php-packages/phpmd/default.nix
+++ b/pkgs/development/php-packages/phpmd/default.nix
@@ -19,7 +19,7 @@ php.buildComposerProject2 (finalAttrs: {
   # Missing `composer.lock` from the repository.
   # Issue open at https://github.com/phpmd/phpmd/issues/1056
   composerLock = ./composer.lock;
-  vendorHash = "sha256-AahAs3Gq1OQ+CW3+rU8NnWcR3hKzVNq7s3llsO4mQ38=";
+  vendorHash = "sha256-tiL8PL6Muc/i4Il1rCeEKenCmIEVn3rHFZInbUGQW9o=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";


### PR DESCRIPTION
Immediate solution for #451395.
Not a proper solution, this fixes the symptom, but it will happen again.

Approach to fix all hashes:

* Identify all build failures (i.e. packages that weren't updated since Aug 22) by:

 ```
$ nix build -L -f. $(rg buildComposerProject2 pkgs/development/php-packages | xargs -I {} dirname {} | xargs -I {} basename {} | xargs -I {} echo phpPackages.{}.composerVendor) --rebuild --keep-going
$ nix build -L -f. $(rg buildComposerProject2 pkgs/by-name/ | xargs -I {} dirname {} | xargs -I {} basename {} | xargs -I {} echo {}.composerVendor) --keep-going --rebuild
```

  and manually confirm that those are all affected pkgs.

* Manually update hashes
* Manually check diffs with diffoscope (I decided to mark `psysh` and `baikal` as broken, see commits)
* Rebuild again with the above commands to check that nothing went wrong

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
