### PR TITLE
vapoursynth: require macOS 13.3

### DIFF
--- a/pkgs/by-name/va/vapoursynth/package.nix
+++ b/pkgs/by-name/va/vapoursynth/package.nix
@@ -13,6 +13,7 @@
   libass,
   python3,
   testers,
+  darwinMinVersionHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,6 +41,9 @@ stdenv.mkDerivation rec {
         cython
       ]
     ))
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (darwinMinVersionHook "13.3")
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Otherwise the build fails with:

    src/vspipe/vspipe.cpp:285:21: error: 'to_chars' is unavailable: introduced in macOS 13.3
      285 |     auto res = std::to_chars(buffer, buffer + sizeof(buffer), v, std::chars_format::fixed);
          |                     ^
    /nix/store/zzn2cvbh4gs4zvyv9p52kclqqvqrfb5x-libcxx-19.1.2+apple-sdk-15.5/include/c++/v1/__charconv/to_chars_floating_point.h:38:1: note: 'to_chars' has been explicitly marked unavailable here
       38 | to_chars(char* __first, char* __last, double __value, chars_format __fmt);
          | ^
    1 error generated.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
