### PR TITLE
keymap-drawer: init tests

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -421,6 +421,11 @@ Check that two paths have the same contents.
 
 : A message that is printed last if the file system object contents at the two paths don't match exactly.
 
+`checkMetadata` (boolean)
+
+: Whether to fail on metadata differences, such as permissions or ownership.
+  Defaults to `true`.
+
 :::{.example #ex-testEqualContents-toyexample}
 
 # Check that two paths have the same contents

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -57,6 +57,7 @@
       actual,
       expected,
       postFailureMessage ? null,
+      checkMetadata ? true,
     }:
     runCommand "equal-contents-${lib.strings.toLower assertion}"
       {
@@ -66,12 +67,13 @@
           expected
           postFailureMessage
           ;
+        excludeMetadata = if checkMetadata then "no" else "yes";
         nativeBuildInputs = [ diffoscopeMinimal ];
       }
       ''
         echo "Checking:"
         printf '%s\n' "$assertion"
-        if ! diffoscope --no-progress --text-color=always --exclude-directory-metadata=no -- "$actual" "$expected"
+        if ! diffoscope --no-progress --text-color=always --exclude-directory-metadata="$excludeMetadata" -- "$actual" "$expected"
         then
           echo
           echo 'Contents must be equal, but were not!'

--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -2,9 +2,11 @@
   lib,
 
   buildPythonPackage,
+  callPackages,
   fetchFromGitHub,
   pythonOlder,
 
+  keymap-drawer,
   nix-update-script,
   pcpp,
   platformdirs,
@@ -59,6 +61,12 @@ buildPythonPackage {
   versionCheckProgram = "${placeholder "out"}/bin/keymap";
   versionCheckProgramArg = "--version";
 
+  passthru.tests = callPackages ./tests {
+    # Explicitly pass the correctly scoped package.
+    # The top-level package will still resolve to itself, because the way
+    # `toPythonApplication` interacts with scopes is weird.
+    inherit keymap-drawer;
+  };
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/development/python-modules/keymap-drawer/tests/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/tests/default.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  fetchFromGitHub,
+  runCommand,
+  stdenv,
+  testers,
+
+  keymap-drawer,
+  yamllint,
+}:
+let
+  runKeymapDrawer =
+    name:
+    runCommand "keymap-drawer-${name}" {
+      nativeBuildInputs = [ keymap-drawer ];
+    };
+
+  MattSturgeon-example = fetchFromGitHub {
+    owner = "MattSturgeon";
+    repo = "glove80-config";
+    rev = "d55267dd26593037256b35a5d6ebba0f75541da5";
+    hash = "sha256-MV6cNpgHBuaGvpu2aR1aBNMpwPnDqOSbGf+2ykxocP4=";
+    nonConeMode = true;
+    sparseCheckout = [
+      "config"
+      "img"
+    ];
+  };
+
+  # MattSturgeon's example requires MDI icons
+  mdi = fetchFromGitHub {
+    owner = "Templarian";
+    repo = "MaterialDesign-SVG";
+    tag = "v7.4.47";
+    hash = "sha256-NoSSRT1ID38MT70IZ+7h/gMVCNsjNs3A2RX6ePGwuQ0=";
+  };
+in
+{
+  dump-config = runKeymapDrawer "dump-config" ''
+    keymap dump-config --output "$out"
+
+    if [ ! -s "$out" ]; then
+      >&2 echo 'Expected `dump-config` to have content.'
+      exit 1
+    fi
+
+    ${lib.getExe yamllint} --strict --config-data relaxed "$out"
+  '';
+
+  parse-zmk = testers.testEqualContents {
+    assertion = "keymap parse --zmk-keymap produces expected YAML";
+    expected = "${MattSturgeon-example}/img/glove80.yaml";
+    actual = runKeymapDrawer "parse" ''
+      keymap \
+        --config ${MattSturgeon-example}/config/keymap_drawer.yaml \
+        parse --zmk-keymap ${MattSturgeon-example}/config/glove80.keymap \
+        --output "$out"
+    '';
+    checkMetadata = stdenv.buildPlatform.isLinux;
+  };
+
+  draw = testers.testEqualContents {
+    assertion = "keymap draw produces expected SVG";
+    expected = "${MattSturgeon-example}/img/glove80.svg";
+    actual = runKeymapDrawer "draw" ''
+      ${lib.optionalString stdenv.buildPlatform.isLinux ''
+        export XDG_CACHE_HOME="$PWD/cache"
+        glyphs="$XDG_CACHE_HOME/keymap-drawer/glyphs"
+      ''}
+      ${lib.optionalString stdenv.buildPlatform.isDarwin ''
+        export HOME="$PWD/home"
+        glyphs="$HOME/Library/Caches/keymap-drawer/glyphs"
+      ''}
+      mkdir -p "$glyphs"
+
+      # Unpack MDI icons into the cache
+      for file in ${mdi}/svg/*
+      do
+        ln -s "$file" "$glyphs/mdi:$(basename "$file")"
+      done
+
+      keymap \
+        --config ${MattSturgeon-example}/config/keymap_drawer.yaml \
+        draw ${MattSturgeon-example}/img/glove80.yaml \
+        --output "$out"
+    '';
+    checkMetadata = stdenv.buildPlatform.isLinux;
+  };
+}


### PR DESCRIPTION
- **testers.testEqualContents: add checkMetadata option**  
  Adds a `checkMetadata` option to `testers.testEqualContents`, allowing metadata differences (permissions, ownership) to be ignored.  
  This is used later in the PR to prevent false negatives on Darwin, where Nix store files often differ by group ownership:
  ```diff
  -Device: 1,23 Access: (0444/-r--r--r--) Uid: ( 0/ root) Gid: ( 0/ wheel)
  +Device: 1,23 Access: (0444/-r--r--r--) Uid: ( 0/ root) Gid: ( 350/ nixbld)
  ```

- **keymap-drawer: init tests**  
  Adds functional tests that ensure the package’s executable can parse and draw keymaps correctly.  
  Uses `testers.testEqualContents` (with the new `checkMetadata` flag) to validate expected outputs.  
  My personal globe80 config is used as the test example to avoid committing test fixtures directly to nixpkgs.  
  Although there are other public examples, the ones I looked at didn’t have _exact_ “expected” outputs suitable for deterministic comparison.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
