### PR TITLE
fna3d: fix CMake 4.0 incompatibility by upgrading to 25.10

### DIFF
--- a/pkgs/by-name/fn/fna3d/package.nix
+++ b/pkgs/by-name/fn/fna3d/package.nix
@@ -4,20 +4,26 @@
   fetchFromGitHub,
   cmake,
   SDL2,
+  sdl3,
+  useSDL3 ? false,
 }:
+
 stdenv.mkDerivation rec {
   pname = "fna3d";
-  version = "25.02";
+  version = "25.10";
 
   src = fetchFromGitHub {
     owner = "FNA-XNA";
     repo = "FNA3D";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-0rRwIbOciPepo+ApvJiK5IyhMdq/4jsMlCSv0UeDETs=";
+    hash = "sha256-Hbj1GGKSFaP2C7V0II6x6euxRDc/BYSK00cVsFMKGEw=";
   };
 
-  buildInputs = [ SDL2 ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SDL3" useSDL3)
+  ];
+  buildInputs = if useSDL3 then [ sdl3 ] else [ SDL2 ];
   nativeBuildInputs = [ cmake ];
 
   installPhase = ''

--- a/pkgs/by-name/fn/fna3d/package.nix
+++ b/pkgs/by-name/fn/fna3d/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     homepage = "https://fna-xna.github.io/";
     license = lib.licenses.mspl;
     platforms = lib.platforms.linux;
-    mainProgram = "fna3d";
     maintainers = with lib.maintainers; [ mrtnvgr ];
   };
 }

--- a/pkgs/by-name/fn/fna3d/package.nix
+++ b/pkgs/by-name/fn/fna3d/package.nix
@@ -26,14 +26,6 @@ stdenv.mkDerivation rec {
   buildInputs = if useSDL3 then [ sdl3 ] else [ SDL2 ];
   nativeBuildInputs = [ cmake ];
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 libFNA3D.so $out/lib/libFNA3D.so
-    ln -s libFNA3D.so $out/lib/libFNA3D.so.0
-    ln -s libFNA3D.so $out/lib/libFNA3D.so.0.${version}
-    runHook postInstall
-  '';
-
   meta = {
     description = "Accuracy-focused XNA4 reimplementation for open platforms";
     homepage = "https://fna-xna.github.io/";

--- a/pkgs/by-name/fn/fna3d/package.nix
+++ b/pkgs/by-name/fn/fna3d/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Accuracy-focused XNA4 reimplementation for open platforms";
     homepage = "https://fna-xna.github.io/";
-    license = lib.licenses.mspl;
+    license = lib.licenses.zlib;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ mrtnvgr ];
   };


### PR DESCRIPTION
Building some steam related FHSEnv I noticed that fna3d was broken due to the CMake 4.0 upgrade (see #445447). I've updated it to a version that includes a fix making it compatible again. The fix was introduced in 25.05. It switched to building against SDL3 by default in version 25.03. I've opted to still build it against SDL2 by default in nixpkgs, to avoid a breaking? change for now.

I have not yet had the chance to test its functionality, but the release notes indicate no further breaking changes to my understanding.
See https://github.com/FNA-XNA/FNA3D/releases.

In the process of this I've also attempted to clean up the package nix file a bit, fixing the `license` and `mainProgram` meta attributes, and removing the unnecessarily? specialised install phase (just using the `cmakeInstallPhase`).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
