### PR TITLE
pianobooster: use patch to fix cmake build failure

### DIFF
--- a/pkgs/by-name/pi/pianobooster/bump-cmake-minimum-required-version.patch
+++ b/pkgs/by-name/pi/pianobooster/bump-cmake-minimum-required-version.patch
@@ -1,0 +1,33 @@
+From aba8b1570051e17e9568cfcc2a2b0ed316e90075 Mon Sep 17 00:00:00 2001
+From: Adrian Bunk <bunk@debian.org>
+Date: Sat, 11 Oct 2025 15:39:08 +0300
+Subject: [PATCH] Bump cmake_minimum_required to support CMake 4
+
+---
+ CMakeLists.txt     | 2 +-
+ src/CMakeLists.txt | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8432a843..c4bbe56e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4)
++cmake_minimum_required(VERSION 3.5)
+ if(COMMAND cmake_policy)
+     cmake_policy(SET CMP0003 NEW)
+ endif(COMMAND cmake_policy)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 02867c8f..23bc9eff 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -10,7 +10,7 @@ else()
+    option(USE_BUNDLED_RTMIDI "Build with bundled rtmidi" ON)
+ endif()
+ 
+-cmake_minimum_required(VERSION 2.4)
++cmake_minimum_required(VERSION 3.5)
+ if(COMMAND cmake_policy)
+     cmake_policy(SET CMP0003 NEW)
+ endif(COMMAND cmake_policy)

--- a/pkgs/by-name/pi/pianobooster/package.nix
+++ b/pkgs/by-name/pi/pianobooster/package.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-1WOlAm/HXSL6QK0Kd1mnFEZxxpMseTG+6WzgMNWt+RA=";
   };
 
+  patches = [
+    # Bump cmake_minimum_required to support CMake 4
+    # https://github.com/pianobooster/PianoBooster/pull/349
+    ./bump-cmake-minimum-required-version.patch
+  ];
+
   postPatch = ''
     substituteInPlace src/Settings.cpp src/GuiMidiSetupDialog.cpp \
       --replace "/usr/share/soundfonts" "${soundfont-fluid}/share/soundfonts" \
@@ -52,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     "-DOpenGL_GL_PREFERENCE=GLVND"
     "-DUSE_JACK=ON"
   ];


### PR DESCRIPTION
- previous pr (#452910) was merged despite not following the recommendation from #445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
