### PR TITLE
python313Packages.magika: disable imports on aarch64

### DIFF
--- a/pkgs/development/python-modules/magika/default.nix
+++ b/pkgs/development/python-modules/magika/default.nix
@@ -37,7 +37,9 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  pythonImportsCheck = [ "magika" ];
+  # Imports in the build sandbox on aarch64-linux, but the program still works at
+  # runtime. See https://github.com/microsoft/onnxruntime/issues/10038.
+  pythonImportsCheck = lib.optionals (stdenv.system != "aarch64-linux") [ "magika" ];
 
   passthru.tests.version = testers.testVersion { package = magika; };
 
@@ -48,7 +50,5 @@ buildPythonPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ mihaimaruseac ];
     mainProgram = "magika-python-client";
-    # Currently, disabling on AArch64 as it onnx runtime crashes on ofborg
-    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
   };
 }


### PR DESCRIPTION
Very similar to the following PR: [NixOS/nixpkgs#351917](https://github.com/NixOS/nixpkgs/pull/351917) and [NixOS/nixpkgs#448801](https://github.com/NixOS/nixpkgs/pull/448801)

The python code from [magika](https://github.com/google/magika) is a simple wrapper that loads a model using ONNX Runtime ([see code](https://github.com/google/magika/blob/main/python/src/magika/magika.py#L31))

As mentioned in PR #351917 and #448801, loading ONNX Runtime models fails on aarch64 when running inside the Nix sandbox, because the runtime attempts to read information from `/sys`. However, the build succeeds if `/sys` is made available to the sandbox, so the command:

```
nix build .#python313Packages.magika --system aarch64-linux --option extra-sandbox-paths /sys
```
Succeeds!


Since this package only serves as a lightweight wrapper around a model, we can safely disable the import on aarch64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
