### PR TITLE
nixos/tests/munge: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -954,6 +954,7 @@ in
   mtp = runTest ./mtp.nix;
   multipass = runTest ./multipass.nix;
   mumble = runTest ./mumble.nix;
+  munge = runTest ./munge.nix;
   munin = runTest ./munin.nix;
   # Fails on aarch64-linux at the PDF creation step - need to debug this on an
   # aarch64 machine..

--- a/nixos/tests/munge.nix
+++ b/nixos/tests/munge.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+{
+  name = "munge";
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ./common/user-account.nix ];
+
+      services.munge.enable = true;
+    };
+
+  testScript =
+    { nodes }:
+    let
+      aliceUid = toString nodes.machine.users.users.alice.uid;
+    in
+    ''
+      machine.succeed("mkdir -p /etc/munge && echo '${lib.strings.replicate 5 "hunter2"}' > /etc/munge/munge.key && chown munge: /etc/munge/munge.key")
+      machine.systemctl("restart munged.service")
+      machine.wait_for_unit("munged.service")
+
+      machine.succeed("sudo -u bob -- munge -u ${aliceUid} -s 'top secret' -o ./secret.txt")
+      machine.succeed("grep -v 'top secret' ./secret.txt")
+      machine.succeed("sudo -u alice unmunge -i ./secret.txt | grep 'top secret'")
+    '';
+}

--- a/pkgs/by-name/mu/munge/package.nix
+++ b/pkgs/by-name/mu/munge/package.nix
@@ -6,6 +6,7 @@
   libgcrypt,
   zlib,
   bzip2,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     # rmdir will notify us if anything new is installed to the directories.
     rmdir "$out"/{var{/{lib,log}{/munge,},},etc/munge}
   '';
+
+  passthru.tests.nixos = nixosTests.munge;
 
   meta = with lib; {
     description = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
