### PR TITLE
frozen-containers: init at 1.2.0-unstable-2025-07-29; libreoffice: use system frozen 

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -156,6 +156,7 @@
   lp_solve,
   xmlsec,
   libcmis,
+  frozen-containers,
 }:
 
 assert builtins.elem variant [
@@ -471,6 +472,7 @@ stdenv.mkDerivation (finalAttrs: {
       which
       xmlsec
       zlib
+      frozen-containers
     ]
     ++ optionals kdeIntegration [
       qt6.qtbase
@@ -563,10 +565,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-system-orcus"
     "--with-system-postgresql"
     "--with-system-xmlsec"
+    "--with-system-frozen"
 
     # TODO: package these as system libraries
     "--without-system-altlinuxhyph"
-    "--without-system-frozen"
     "--without-system-libeot"
     "--without-system-libfreehand"
     "--without-system-libmspub"

--- a/pkgs/by-name/fr/frozen-containers/package.nix
+++ b/pkgs/by-name/fr/frozen-containers/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+}:
+stdenv.mkDerivation {
+  pname = "frozen-containers";
+  version = "1.2.0-unstable-2025-07-29";
+
+  src = fetchFromGitHub {
+    owner = "serge-sans-paille";
+    repo = "frozen";
+    rev = "61dce5ae18ca59931e27675c468e64118aba8744";
+    hash = "sha256-zIczBSRDWjX9hcmYWYkbWY3NAAQwQtKhMTeHlYp4BKk=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Header-only library that provides 0 cost initialization for immutable containers, fixed-size containers, and various algorithms";
+    homepage = "https://github.com/serge-sans-paille/frozen";
+    maintainers = with lib.maintainers; [
+      marcin-serwin
+      szanko
+    ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/serge-sans-paille/frozen

cc @serge-sans-paille

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
