### PR TITLE
{libubox,ustream-ssl,ubus,uci,uclient,ucode,uqmi,udebug}: upgrade, fix build with cmake 4

### DIFF
--- a/pkgs/by-name/ub/ubus/package.nix
+++ b/pkgs/by-name/ub/ubus/package.nix
@@ -9,12 +9,12 @@
 
 stdenv.mkDerivation {
   pname = "ubus";
-  version = "unstable-2023-12-18";
+  version = "unstable-202-10-17";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ubus.git";
-    rev = "65bb027054def3b94a977229fd6ad62ddd32345b";
-    hash = "sha256-n82Ub0IiuvWbnlDCoN+0hjo/1PbplEbc56kuOYMrHxQ=";
+    rev = "60e04048a0e2f3e33651c19e62861b41be4c290f";
+    hash = "sha256-fjxO77z+do5gZ7nLwHbC14UnP9cmZ5eANNn4X6Sudn0=";
   };
 
   cmakeFlags = [ "-DBUILD_LUA=OFF" ];

--- a/pkgs/by-name/uc/uci/package.nix
+++ b/pkgs/by-name/uc/uci/package.nix
@@ -9,12 +9,12 @@
 
 stdenv.mkDerivation {
   pname = "uci";
-  version = "unstable-2023-08-10";
+  version = "unstable-2025-10-12";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uci.git";
-    rev = "5781664d5087ccc4b5ab58505883231212dbedbc";
-    hash = "sha256-8MyFaZdAMh5oMPO/5QyNT+Or57eBL3mamJLblGGoF9g=";
+    rev = "57c1e8cd2c051d755ca861a9ab38a8049d2e3f95";
+    hash = "sha256-/Ian7WoBvm9nmniHdVTEIyRW1BPTmOe3O0v59aDaXc0=";
   };
 
   hardeningDisable = [ "all" ];

--- a/pkgs/by-name/uc/uclient/package.nix
+++ b/pkgs/by-name/uc/uclient/package.nix
@@ -5,23 +5,29 @@
   cmake,
   pkg-config,
   libubox,
+  ucode,
+  json_c,
 }:
 
 stdenv.mkDerivation {
   pname = "uclient";
-  version = "unstable-2023-04-13";
+  version = "unstable-2025-10-03";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uclient.git";
-    rev = "007d945467499f43656b141171d31f5643b83a6c";
-    hash = "sha256-A47dyVc2MtOL6aImZ0b3SMWH2vzjfAXzRAOF4nfH6S0=";
+    rev = "dc909ca71bc884c0e5362e1d7cc7808696cb2add";
+    hash = "sha256-jrhLBB3Mb7FvxMtKxG7e7D/hcyygTjx868POGtF+Dcc=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
-  buidInputs = [ libubox ];
+  buildInputs = [
+    libubox
+    ucode
+    json_c
+  ];
 
   preConfigure = ''
     sed -e 's|ubox_include_dir libubox/ustream-ssl.h|ubox_include_dir libubox/ustream-ssl.h HINTS ${libubox}/include|g' \

--- a/pkgs/by-name/uc/uclient/package.nix
+++ b/pkgs/by-name/uc/uclient/package.nix
@@ -42,6 +42,5 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ mkg20001 ];
     mainProgram = "uclient-fetch";
     platforms = platforms.all;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/uc/ucode/package.nix
+++ b/pkgs/by-name/uc/ucode/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "JavaScript-like language with optional templating";
     homepage = "https://github.com/jow-/ucode";
     license = licenses.isc;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ mkg20001 ];
   };
 }

--- a/pkgs/by-name/ud/udebug/package.nix
+++ b/pkgs/by-name/ud/udebug/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     mainProgram = "udebugd";
     homepage = "https://git.openwrt.org/?p=project/udebug.git;a=summary";
     license = licenses.free;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ mkg20001 ];
   };
 }

--- a/pkgs/by-name/ud/udebug/package.nix
+++ b/pkgs/by-name/ud/udebug/package.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation {
   pname = "udebug";
-  version = "unstable-2023-12-06";
+  version = "unstable-2025-09-28";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/udebug.git";
-    rev = "6d3f51f9fda706f0cf4732c762e4dbe8c21e12cf";
-    hash = "sha256-5dowoFZn9I2IXMQ3Pz+2Eo3rKfihLzjca84MytQIXcU=";
+    rev = "5327524e715332daaebf6b04c155d2880d230979";
+    hash = "sha256-Zcbbo7Jo7JxNSjUlbB2m2Id8crdxzKc/QFeduPGvows=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/uq/uqmi/package.nix
+++ b/pkgs/by-name/uq/uqmi/package.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation {
   pname = "uqmi";
-  version = "unstable-2024-01-16";
+  version = "unstable-2025-07-30";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uqmi.git";
-    rev = "c3488b831ce6285c8107704156b9b8ed7d59deb3";
-    hash = "sha256-O5CeLk0WYuBs3l5xBUk9kXDRMzFvYSRoqP28KJ5Ztos=";
+    rev = "7914da43cddaaf6cfba116260c81e6e9adffd5ab";
+    hash = "sha256-Ny5Jd/6N1nTcv2GGP1YLFe+ljn15sUQJVAEVPvYtz3M=";
   };
 
   postPatch = ''
@@ -33,13 +33,9 @@ stdenv.mkDerivation {
   ];
 
   env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12") [
-      # Needed with GCC 12 but breaks on darwin (with clang) or older gcc
-      "-Wno-error=dangling-pointer"
-      "-Wno-error=maybe-uninitialized"
-    ]
-    ++ lib.optionals stdenv.cc.isClang [
-      "-Wno-error=sometimes-uninitialized"
+    lib.optionals stdenv.cc.isClang [
+      # error: unknown warning option '-Wno-dangling-pointer' [-Werror,-Wunknown-warning-option]
+      "-Wno-error=unknown-warning-option"
     ]
   );
 

--- a/pkgs/development/libraries/libubox/default.nix
+++ b/pkgs/development/libraries/libubox/default.nix
@@ -13,12 +13,12 @@
 
 stdenv.mkDerivation {
   pname = "libubox";
-  version = "0-unstable-2025-07-23";
+  version = "0-unstable-2025-10-14";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/libubox.git";
-    rev = "49056d178f42da98048a5d4c23f83a6f6bc6dd80";
-    hash = "sha256-sk5r18M0hJ+8CrC2G/rb+XqUmUGer2VBrVbuReHj1dM=";
+    rev = "7d6b9d98d0bdd4e14aedeb7908c28e4b318c8191";
+    hash = "sha256-SBw83zT/tMvmndo4bZ19sLWc493G2jefMhrvqjQ6WJc=";
   };
 
   cmakeFlags = [

--- a/pkgs/development/libraries/ustream-ssl/default.nix
+++ b/pkgs/development/libraries/ustream-ssl/default.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation {
   pname = "ustream-ssl";
-  version = "0-unstable-2024-03-26";
+  version = "0-unstable-2025-10-03";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ustream-ssl.git";
-    rev = "7621339d7694abef5da5e5353ac440f2d39dcecb";
-    hash = "sha256-No0Pk8KbkT7W4Rav7W3rMKEJISbp7RRoRx7t6LPMxlk=";
+    rev = "5a81c108d20e24724ed847cc4be033f2a74e6635";
+    hash = "sha256-IC5740+1YT3TDayath3Md3hdjuml1S1A/OWYd0GxbDc=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
Tracking issue: https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
