### PR TITLE
patreon-dl: init at 3.3.1

### DIFF
--- a/pkgs/by-name/pa/patreon-dl/package.nix
+++ b/pkgs/by-name/pa/patreon-dl/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+
+  useFFmpeg ? true,
+  ffmpeg,
+
+  chromium,
+  firefox,
+  browser ?
+    if lib.meta.availableOn stdenv.hostPlatform chromium && stdenv.hostPlatform.isLinux then
+      "chromium"
+    else if lib.meta.availableOn stdenv.hostPlatform firefox && stdenv.hostPlatform.isLinux then
+      "firefox"
+    else
+      null, # can be null, chromium, or firefox
+
+  useYtDlp ? false,
+  yt-dlp,
+
+  testers,
+  patreon-dl,
+}:
+
+assert browser == null || browser == "chromium" || browser == "firefox";
+
+let
+  browserConfig =
+    if browser == "chromium" then
+      "--set PUPPETEER_BROWSER chrome --set PUPPETEER_EXECUTABLE_PATH \"${chromium}/bin/chromium-browser\""
+    else if browser == "firefox" then
+      "--set PUPPETEER_BROWSER firefox --set PUPPETEER_EXECUTABLE_PATH \"${firefox}/bin/firefox\""
+    else
+      "";
+  path = lib.makeBinPath (lib.optional useFFmpeg ffmpeg ++ lib.optional useYtDlp yt-dlp);
+  wrapperArgs = "--set PATH \"${path}\" ${browserConfig}";
+in
+
+buildNpmPackage rec {
+  pname = "patreon-dl";
+  version = "3.3.1";
+  src = fetchFromGitHub {
+    owner = "patrickkfkan";
+    repo = "patreon-dl";
+    rev = "v${version}";
+    hash = "sha256-9mBaQX51T41UW+RM3KXaof6AtnNmszBsOLcbLyvFtI0=";
+  };
+  PUPPETEER_SKIP_DOWNLOAD = "true";
+  npmDepsHash = "sha256-o4H6B8JqmB8J3JJ3Rjg0wNxWoCkmwxyC+Ork+DtBxXQ=";
+  postFixup = ''
+    for f in $out/bin/*
+    do
+      wrapProgram $out/bin/patreon-dl ${wrapperArgs}
+    done
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = patreon-dl;
+    command = "patreon-dl -h";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "Tool for downloading content from Patreon feeds";
+    homepage = "https://github.com/patrickkfkan/patreon-dl";
+    license = licenses.mit;
+    maintainers = with maintainers; [ piperswe ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This inits the patreon-dl package at 3.3.1, with support for the optional FFmpeg, Puppeteer, and yt-dlp integrations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
