### PR TITLE
standard-clojure-style: init at 0.25.0

### DIFF
--- a/pkgs/by-name/st/standard-clojure-style/package.nix
+++ b/pkgs/by-name/st/standard-clojure-style/package.nix
@@ -1,0 +1,99 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  bash,
+  bun,
+  makeBinaryWrapper,
+  nodejs,
+}:
+let
+  pname = "standard-clojure-style";
+  version = "0.25.0";
+  src = fetchFromGitHub {
+    owner = "oakmac";
+    repo = "standard-clojure-style-js";
+    tag = "v${version}";
+    hash = "sha256-wZ/5rJYngnAE1NVLGxQ4GS15dCjvuQBnBNxTCm3lyJM=";
+  };
+  node_modules = stdenv.mkDerivation {
+    pname = "${pname}-node_modules";
+    inherit src version;
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+    nativeBuildInputs = [ bun ];
+    dontConfigure = true;
+    dontPatchShebangs = true;
+    buildPhase = ''
+      bun install --frozen-lockfile --no-progress --no-save
+      rm -rf node_modules/.bin node_modules/.cache
+    '';
+    installPhase = ''
+      mkdir -p $out/node_modules
+
+      cp -R ./node_modules $out
+    '';
+    outputHash =
+      {
+        aarch64-darwin = "sha256-eE5ozYjXwEATM6gMlGfd7b0QdXcf9ocwRYrVZrVx83k=";
+        aarch64-linux = "sha256-2rhfJrpz3yzV79KpLeGzxphsc9zd0CJQ+xLqMaKW01Q=";
+        x86_64-darwin = "sha256-eE5ozYjXwEATM6gMlGfd7b0QdXcf9ocwRYrVZrVx83k=";
+        x86_64-linux = "sha256-2rhfJrpz3yzV79KpLeGzxphsc9zd0CJQ+xLqMaKW01Q=";
+      }
+      .${stdenv.hostPlatform.system};
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname src version;
+  nativeBuildInputs = [
+    bash
+    makeBinaryWrapper
+    nodejs
+  ];
+  strictDeps = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s ${node_modules}/node_modules $out
+    cp -R ./lib ./scripts ./cli.mjs ./package.json $out
+
+    cd $out
+    node ./scripts/build-release.js
+
+    # bun is referenced naked in the package.json generated script
+    makeBinaryWrapper ${bun}/bin/bun $out/bin/standard-clj \
+      --prefix PATH : ${lib.makeBinPath [ bun ]} \
+      --add-flags "run --prefer-offline --no-install $out/cli.mjs"
+
+    rm -rf scripts package.json
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/oakmac/standard-clojure-style-js";
+    changelog = "https://github.com/oakmac/standard-clojure-style-js/releases/tag/v${version}";
+    description = "Format Clojure code according to Standard Clojure Style";
+    mainProgram = "standard-clj";
+    maintainers = with lib.maintainers; [ john-shaffer ];
+    license = [ lib.licenses.isc ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
Adds standard-clojure-style, a config-free Clojure code formatter.

Homepage: https://github.com/oakmac/standard-clojure-style-js

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
