### PR TITLE
hdrmerge: 0.5.0-unstable-2024-08-02 -> 0.5.0-unstable-2025-04-26

### DIFF
--- a/pkgs/by-name/hd/hdrmerge/package.nix
+++ b/pkgs/by-name/hd/hdrmerge/package.nix
@@ -15,13 +15,19 @@
 
 stdenv.mkDerivation rec {
   pname = "hdrmerge";
-  version = "0.5.0-unstable-2024-08-02";
+  version = "0.5.0-unstable-2025-04-26";
   src = fetchFromGitHub {
     owner = "jcelaya";
     repo = "hdrmerge";
-    rev = "e2a46f97498b321b232cc7f145461212677200f1";
-    hash = "sha256-471gJtF9M36pAId9POG8ZIpNk9H/157EdHqXSAPlhN0=";
+    rev = "3bbe43771ba15b899151721bc14aa57e86b60f2f";
+    hash = "sha256-4FIGchwROXe8qLRBaYih2k9zDll2YoYGDj06SrIqK9Q=";
   };
+
+  # Disable find_package(ALGLIB REQUIRED) in the CMake file by providing a empty
+  # FindALGLIB.cmake, and provide ALGLIB_INCLUDES and ALGLIB_LIBRARIES ourselves
+  preConfigure = ''
+    touch cmake/FindALGLIB.cmake
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -39,12 +45,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DALGLIB_DIR:PATH=${alglib}"
-  ];
-
-  CXXFLAGS = [
-    # GCC 13: error: 'uint32_t' does not name a type
-    "-include cstdint"
+    (lib.cmakeFeature "ALGLIB_INCLUDES" "${alglib}/include/alglib")
+    (lib.cmakeFeature "ALGLIB_LIBRARIES" "alglib3")
   ];
 
   desktopItems = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Bump and unbreak HDRMerge. Currently the build failed because cmake minimum version is lower than 3.15, see [build log on hydra](https://hydra.nixos.org/build/310062072/nixlog/1). 

Note that due to upstream has removed `FindAlglib.cmake` in commit https://github.com/jcelaya/hdrmerge/commit/d25141de784fd5e09c1b7b12b15482dff260f9c7, we will have to provide `ALGLIB_LIBRARIES` and `ALGLIB_INCLUDES` by ourselves and disable `find_package()` in CMakelist.txt.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
