### PR TITLE
mrtg: gcc14 broke detection of print format specifiers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27146,6 +27146,11 @@
     githubId = 120451;
     name = "Urban Skudnik";
   };
+  usovalx = {
+    name = "Oleksandr Usov";
+    github = "usovalx";
+    githubId = 1041626;
+  };
   usrfriendly = {
     name = "Arin Lares";
     email = "arinlares@gmail.com";

--- a/pkgs/by-name/mr/mrtg/configure-long-long-format-gcc14.patch
+++ b/pkgs/by-name/mr/mrtg/configure-long-long-format-gcc14.patch
@@ -1,0 +1,10 @@
+--- mrtg-2.17.10/configure.bak	2025-10-17 20:44:24.878718603 +0100
++++ mrtg-2.17-10/configure	2025-10-17 20:44:40.343747835 +0100
+@@ -3664,6 +3664,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
++#include <stdlib.h>
+             int main()
+             {
+                 long long b, a = -0x3AFAFAFAFAFAFAFALL;

--- a/pkgs/by-name/mr/mrtg/package.nix
+++ b/pkgs/by-name/mr/mrtg/package.nix
@@ -53,7 +53,10 @@ stdenv.mkDerivation rec {
     description = "Multi Router Traffic Grapher";
     homepage = "https://oss.oetiker.ch/mrtg/";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ robberer ];
+    maintainers = with maintainers; [
+      robberer
+      usovalx
+    ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/mr/mrtg/package.nix
+++ b/pkgs/by-name/mr/mrtg/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  makeWrapper,
   fetchurl,
   perl,
   gd,
@@ -24,6 +25,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-x/EcteIXpQDYfuO10mxYqGUu28DTKRaIu3krAQ+uQ6w=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [
     # add support for ipv6 snmp:
     # https://github.com/oetiker/mrtg/blob/433ebfa5fc043971b46a5cd975fb642c76e3e49d/src/bin/mrtg#L331-L341
@@ -31,6 +34,20 @@ stdenv.mkDerivation rec {
     gd
     rrdtool
   ];
+
+  patches = [
+    # gcc14 broke detection of printf format specifiers
+    # building from master seems to be fixed upstream, so next release can (likely) drop the patch
+    # just keep the CFLAGS below
+    ./configure-long-long-format-gcc14.patch
+  ];
+  env.NIX_CFLAGS_COMPILE = "-Werror";
+  env.NIX_CFLAGS_LINK = "-lm";
+
+  postInstall = ''
+    # mrtg wants plain C locale
+    wrapProgram $out/bin/mrtg  --set LANG C
+  '';
 
   meta = with lib; {
     description = "Multi Router Traffic Grapher";


### PR DESCRIPTION
Out of the box 2.17.10 MRTG is borken when built with GCC14.
This patches format flags detection, and adds compiler flags to catch it for the future.
See similar bug in gentoo: https://bugs.gentoo.org/936236

Would appreciate if this can be ticked for backport - it's broken in stable as well

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
