### PR TITLE
flyctl: 0.3.172 -> 0.3.209

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23249,6 +23249,12 @@
     github = "scd31";
     githubId = 57571338;
   };
+  SchahinRohani = {
+    email = "schahin@rouhanizadeh.de";
+    github = "SchahinRohani";
+    githubId = 24507823;
+    name = "Schahin Rouhanizadeh";
+  };
   schinmai-akamai = {
     email = "schinmai@akamai.com";
     github = "tchinmai7";

--- a/pkgs/by-name/fl/flyctl/package.nix
+++ b/pkgs/by-name/fl/flyctl/package.nix
@@ -78,6 +78,7 @@ buildGoModule rec {
       jsierles
       techknowlogick
       RaghavSood
+      SchahinRohani
     ];
     mainProgram = "flyctl";
   };

--- a/pkgs/by-name/fl/flyctl/package.nix
+++ b/pkgs/by-name/fl/flyctl/package.nix
@@ -6,20 +6,23 @@
   testers,
   flyctl,
   installShellFiles,
+  git,
 }:
 
 buildGoModule rec {
   pname = "flyctl";
-  version = "0.3.172";
+  version = "0.3.209";
 
   src = fetchFromGitHub {
     owner = "superfly";
     repo = "flyctl";
     rev = "v${version}";
-    hash = "sha256-jKzlKOdE+SrCzY81ciI9sKN0iiFZMsKp04A+1TV1+i0=";
+    leaveDotGit = true;
+    hash = "sha256-D1MSlg6oFmdyiEaq10DUwzADzleilFIQ22oQd8LGfRk=";
   };
 
-  vendorHash = "sha256-D6b+dLoE4IdhsmnWILe7Thkggq3p0ur4C3BOz7Cuk98=";
+  proxyVendor = true;
+  vendorHash = "sha256-ezGA1LGwQVFMzV/Ogj26pooD06O7FNTXMrYWkv6AwWM=";
 
   subPackages = [ "." ];
 
@@ -31,11 +34,17 @@ buildGoModule rec {
   ];
   tags = [ "production" ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    git
+  ];
 
   patches = [ ./disable-auto-update.patch ];
 
   preBuild = ''
+    # Embed VCS Infos
+    export GOFLAGS="$GOFLAGS -buildvcs=true"
+
     GOOS= GOARCH= CGO_ENABLED=0 go generate ./...
   '';
 


### PR DESCRIPTION
## flyctl: 0.3.172 -> 0.3.209

Update flyctl to version 0.3.209.

**Fixes #430015** - Missing build information in `flyctl version`

**Changes:**
- Add myself as maintainer
- Enable `proxyVendor` to support code generation during build (required for `go:generate` directives using external tools like `go.uber.org/mock/mockgen` and `github.com/Khan/genqlient`)
- Enable `leaveDotGit` to embed VCS information in the binary - this populates the Commit field
- Add `-buildvcs=true` to explicitly enable VCS info embedding
- Note: Commit shows as "-dirty" due to applied patches, which accurately reflects the patched build state

**Before:**
```
flyctl v0.3.172 darwin/arm64 Commit: <none> BuildDate: 1970-01-01T00:00:00Z
```

**After:**
```
flyctl v0.3.209 darwin/arm64 Commit: 9383e01c8cc7e0482b2bd81d093eb6652d92dc76-dirty BuildDate: 1970-01-01T00:00:00Z
```

**Changelog:** https://github.com/superfly/flyctl/releases/tag/v0.3.195

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc