### PR TITLE
rar: 7.01 -> 7.12; generate manpage from rar.txt

### DIFF
--- a/pkgs/by-name/ra/rar/package.nix
+++ b/pkgs/by-name/ra/rar/package.nix
@@ -7,25 +7,21 @@
 }:
 
 let
-  version = "7.01";
+  version = "7.12";
   downloadVersion = lib.replaceStrings [ "." ] [ "" ] version;
   # Use `./update.sh` to generate the entries below
   srcs = {
-    i686-linux = {
-      url = "https://www.rarlab.com/rar/rarlinux-x32-${downloadVersion}.tar.gz";
-      hash = "sha256-1CSbxM7arGpn4Yj5fHEFKcDURFPrC2+XptLoaDH8LDs=";
-    };
     x86_64-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-x64-${downloadVersion}.tar.gz";
-      hash = "sha256-34iWajylsSmIOuAT6kV7c2537qWFHc+gT+JT/trWrw8=";
+      hash = "sha256-Yw2andExNnJzZnvuB5rRA/Rp8bfNvJtCpPKDzCmTurI=";
     };
     aarch64-darwin = {
       url = "https://www.rarlab.com/rar/rarmacos-arm-${downloadVersion}.tar.gz";
-      hash = "sha256-BjEJFzKyRpN4XL6KYW7ykQcSxqF4tYr2dCFf50JHH38=";
+      hash = "sha256-lQeOD1n/0F6+ZlpVfp1NHAcxVqJ3fZFn9sQg7kSKg8U=";
     };
     x86_64-darwin = {
       url = "https://www.rarlab.com/rar/rarmacos-x64-${downloadVersion}.tar.gz";
-      hash = "sha256-1ExnVDre49wWwB/BKP/L9xdYOMx8qkeZfmObJ7xm4dY=";
+      hash = "sha256-Wzp5Izpc4usNldBEb3OZCeNyByTTJegoxbDD8HNnCPo=";
     };
   };
   manSrc = fetchurl {

--- a/pkgs/by-name/ra/rar/update.sh
+++ b/pkgs/by-name/ra/rar/update.sh
@@ -42,12 +42,12 @@ updateHash() {
     hash=$(nix store prefetch-file --json "$url" | jq -r .hash)
     currentHash=$(cd "$DIRNAME" && nix "${NIX_FLAGS[@]}" eval --raw "$NIXPKGS_ROOT#legacyPackages.$nix_arch.rar.src.outputHash")
 
-    sed -i "s|$currentHash|$hash|g" "$DIRNAME/default.nix"
+    sed -i "s|$currentHash|$hash|g" "$DIRNAME/package.nix"
 }
 
 updateVersion() {
     local -r version="$1"
-    sed -i "s|version = \"[0-9.]*\";|version = \"$version\";|g" "$DIRNAME/default.nix"
+    sed -i "s|version = \"[0-9.]*\";|version = \"$version\";|g" "$DIRNAME/package.nix"
 }
 
 latestVersion="${1:-}"
@@ -70,7 +70,6 @@ if [[ "$currentVersion" == "$latestVersion" ]]; then
     exit 0
 fi
 
-updateHash "$latestVersion" x32 linux i686-linux
 updateHash "$latestVersion" x64 linux x86_64-linux
 updateHash "$latestVersion" arm macos aarch64-darwin
 updateHash "$latestVersion" x64 macos x86_64-darwin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
From what I found this man page was manually created from the rar.txt file and it hasn't been updated since 2014 (rar v5.x.)
Downloading the file from aur fails a lot of times for me in CI builds. 
I think it would be better to just remove it. Although we can try to generate it from the rar.txt that's included alongside the rar binary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
