### PR TITLE
yelp: 32.3 -> 49.0

### DIFF
--- a/pkgs/by-name/ye/yelp/package.nix
+++ b/pkgs/by-name/ye/yelp/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  desktop-file-utils,
   gettext,
   itstool,
   meson,
@@ -11,11 +12,12 @@
   bzip2,
   glib,
   gtk3,
+  libadwaita,
   libhandy,
   libxml2,
   libxslt,
   sqlite,
-  webkitgtk_4_1,
+  webkitgtk_6_0,
   xz,
   yelp-xsl,
   gnome,
@@ -23,14 +25,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "yelp";
-  version = "42.3";
+  version = "49.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp/${lib.versions.major finalAttrs.version}/yelp-${finalAttrs.version}.tar.xz";
-    hash = "sha256-JszEImeanmp6OqCD2Q/Ns0f18jAL4+AUMaMNDN0qiaM=";
+    hash = "sha256-5mFOCx9Lpf57jRSb3UJnPwMGVvvc1zaumGBxkZfGNFc=";
   };
 
   nativeBuildInputs = [
+    desktop-file-utils # update-desktop-database
     gettext
     itstool
     meson
@@ -43,11 +46,12 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     glib
     gtk3
+    libadwaita
     libhandy
     libxml2
     libxslt
     sqlite
-    webkitgtk_4_1
+    webkitgtk_6_0
     xz
     yelp-xsl
   ];


### PR DESCRIPTION
## Things done

Built but not tested

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
