### PR TITLE
sundials: cleanup

### DIFF
--- a/pkgs/by-name/su/sundials/package.nix
+++ b/pkgs/by-name/su/sundials/package.nix
@@ -1,18 +1,19 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
   cmake,
-  fetchurl,
+  gfortran,
   python3,
   blas,
   lapack,
-  gfortran,
   suitesparse,
+  nix-update-script,
   lapackSupport ? true,
   kluSupport ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sundials";
   version = "7.5.0";
 
@@ -21,9 +22,11 @@ stdenv.mkDerivation rec {
     "examples"
   ];
 
-  src = fetchurl {
-    url = "https://github.com/LLNL/sundials/releases/download/v${version}/sundials-${version}.tar.gz";
-    hash = "sha256-CJrGWVB973OLemW1dP/jqQDThWnjMj2XCevtPkRa3sw=";
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo = "sundials";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZyUTFaMEbfNtR9oGIy0fQ+qQwb3hQ7CxTv9IevkeidE=";
   };
 
   nativeBuildInputs = [
@@ -51,34 +54,36 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DEXAMPLES_INSTALL_PATH=${placeholder "examples"}/share/examples"
+    (lib.cmakeFeature "EXAMPLES_INSTALL_PATH" "${placeholder "examples"}/share/examples")
   ]
   ++ lib.optionals lapackSupport [
-    "-DENABLE_LAPACK=ON"
-    "-DLAPACK_LIBRARIES=${lapack}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}"
+    (lib.cmakeBool "ENABLE_LAPACK" true)
+    (lib.cmakeFeature "LAPACK_LIBRARIES" "${lapack}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}")
   ]
   ++ lib.optionals kluSupport [
-    "-DENABLE_KLU=ON"
-    "-DKLU_INCLUDE_DIR=${suitesparse.dev}/include"
-    "-DKLU_LIBRARY_DIR=${suitesparse}/lib"
+    (lib.cmakeBool "ENABLE_KLU" true)
+    (lib.cmakeFeature "KLU_INCLUDE_DIR" "${lib.getDev suitesparse}/include")
+    (lib.cmakeFeature "KLU_LIBRARY_DIR" "${suitesparse}/lib")
   ]
   ++ [
-    (
-      # Use the correct index type according to lapack and blas used. They are
-      # already supposed to be compatible but we check both for extra safety. 64
-      # should be the default but we prefer to be explicit, for extra safety.
-      if blas.isILP64 then "-DSUNDIALS_INDEX_SIZE=64" else "-DSUNDIALS_INDEX_SIZE=32"
-    )
+    # Use the correct index type according to lapack and blas used. They are
+    # already supposed to be compatible but we check both for extra safety. 64
+    # should be the default but we prefer to be explicit, for extra safety.
+    (lib.cmakeFeature "SUNDIALS_INDEX_SIZE" (toString (if blas.isILP64 then 64 else 32)))
   ];
 
   doCheck = true;
   checkTarget = "test";
 
-  meta = with lib; {
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     description = "Suite of nonlinear differential/algebraic equation solvers";
     homepage = "https://computing.llnl.gov/projects/sundials";
-    platforms = platforms.all;
-    maintainers = with maintainers; [ idontgetoutmuch ];
-    license = licenses.bsd3;
+    downloadPage = "https://github.com/LLNL/sundials";
+    changelog = "https://github.com/LLNL/sundials/releases/tag/v${finalAttrs.version}";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ idontgetoutmuch ];
+    license = lib.licenses.bsd3;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @idontgetoutmuch

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
