### PR TITLE
hashcards: init at 0-unstable-2025-10-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22162,6 +22162,12 @@
     githubId = 641278;
     name = "Robert T. McGibbon";
   };
+  rmgaray = {
+    email = "ramiro.sgaray@gmail.com";
+    github = "rmgaray";
+    githubId = 29001707;
+    name = "Ramiro Sergio Garay";
+  };
   rmgpinto = {
     email = "hessian_loom_0u@icloud.com";
     github = "rmgpinto";

--- a/pkgs/by-name/ha/hashcards/package.nix
+++ b/pkgs/by-name/ha/hashcards/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hashcards";
+  version = "0-unstable-2025-10-11";
+
+  src = fetchFromGitHub {
+    owner = "eudoxia0";
+    repo = "hashcards";
+    rev = "ef6d4e70c7108a07edb88b34170d4ecb6d115dc7";
+    hash = "sha256-h3MQxcHdvkL3FQArvoYj+YACnyBNzFF//lZZl6dokUU=";
+  };
+
+  cargoHash = "sha256-2Rzc30QVDTsSEk3DLxqvPFN/Bu++1WVXFDMmvFCUAdU=";
+
+  nativeBuildInputs = [
+    openssl
+    pkg-config
+  ];
+
+  # For some reason, the pkg-config hook does not work for openssl
+  PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
+
+  meta = {
+    description = "Text-based spaced repetition system";
+    mainProgram = "hashcards";
+    homepage = "https://github.com/eudoxia0/hashcards";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rmgaray ];
+  };
+}


### PR DESCRIPTION
[hashcards](https://github.com/eudoxia0/hashcards) is a Spaced Repetition System (like Anki or Mnemosyne) with a focus on being text-based, simple and efficient. In particular, it allows for writing cards using just Markdown, and therefore to keep decks under version control.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
