### PR TITLE
semgrep: 1.104.0 -> 1.140.0

### DIFF
--- a/pkgs/development/python-modules/semgrep/common.nix
+++ b/pkgs/development/python-modules/semgrep/common.nix
@@ -1,9 +1,9 @@
 { lib }:
 
 rec {
-  version = "1.104.0";
+  version = "1.140.0";
 
-  srcHash = "sha256-rVBnjG+g7OaOQ8LYCurqNC2dYY/Dm4hdocgotc4lADg=";
+  srcHash = "sha256-RLcES0kamYMlLo1L4Y+mSJDB91SP84h75oLQxX9eCjQ=";
 
   # submodule dependencies
   # these are fetched so we:
@@ -13,8 +13,8 @@ rec {
     "cli/src/semgrep/semgrep_interfaces" = {
       owner = "semgrep";
       repo = "semgrep-interfaces";
-      rev = "5e0c767ec323f3f2356d3bf8dbdf7c7836497d8a";
-      hash = "sha256-RvkUbS+q/UqkKLDBCvDWkuRYDzWXp+JonFE7qVkEsY8=";
+      rev = "8baadf6b8604b59c9a660dbb371726c12a3666b8";
+      hash = "sha256-37sEprdR8I45tRYsXNNFz0okoTH32MJU9EvMogEMtMw=";
     };
   };
 
@@ -25,19 +25,19 @@ rec {
   core = {
     x86_64-linux = {
       platform = "musllinux_1_0_x86_64.manylinux2014_x86_64";
-      hash = "sha256-Qn97ZJI1//n47z/qX87AuIWRvvXurwH26C/vBrZ12gc=";
+      hash = "sha256-/aZnv5a7ifSk1l98Qf+HKQhnrHKi88SKTuJZwQ7Ons4=";
     };
     aarch64-linux = {
       platform = "musllinux_1_0_aarch64.manylinux2014_aarch64";
-      hash = "sha256-vuLuxsqnaPSbcVuwyhRRTTTwDVCZvOkRJURZUKnh/9I=";
+      hash = "sha256-f0k/sNME/0JGrvV7/H47jWLY3OadslzljfA7Kpp0STo=";
     };
     x86_64-darwin = {
       platform = "macosx_10_14_x86_64";
-      hash = "sha256-QWESQQyBzyupzC1V5zs1GgZBtHEUgayvcKwDn+5pXUc=";
+      hash = "sha256-HldS8Rcx+OkFYfBr/5+rMXVg8prrAuBCDTbkgb8DVsQ=";
     };
     aarch64-darwin = {
       platform = "macosx_11_0_arm64";
-      hash = "sha256-gkX82X79L+v5A1Mby6sCqXcx79fgJGIfmRdARtULmUc=";
+      hash = "sha256-LiIO4Smomx6tHTtg8ewwXaKXdJDpcmE+auJ5FjWi990=";
     };
   };
 

--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -22,6 +22,7 @@
   opentelemetry-exporter-otlp-proto-http,
   opentelemetry-instrumentation-requests,
   opentelemetry-sdk,
+  mcp,
   packaging,
   peewee,
   pytest-freezegun,
@@ -97,6 +98,7 @@ buildPythonPackage rec {
     packaging
     jsonschema
     wcmatch
+    mcp
     peewee
     defusedxml
     urllib3
@@ -125,6 +127,7 @@ buildPythonPackage rec {
     "tests/default/e2e"
     "tests/default/e2e-pysemgrep"
     "tests/default/e2e-other"
+    "tests/default/mcp"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/semgrep/semgrep-core.nix
+++ b/pkgs/development/python-modules/semgrep/semgrep-core.nix
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation rec {
       inherit version;
       format = "wheel";
       dist = python;
-      python = "cp39.cp310.cp311.py39.py310.py311";
+      python = "cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314";
       inherit (data) platform hash;
     };
 


### PR DESCRIPTION
Why
===
New version

Changes
===
* fix update script
* Update wheel package format compatible versions
* add missing mcp python package dependency

Test plan
===
```
[ryantm:~/p/nixpkgs]$ ./result/bin/semgrep  --version
[00.05][WARNING](ca-certs): Ignored 176 trust anchors.
1.140.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
