### PR TITLE
prometheus-tailscale-exporter: init at 0.2.5

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -144,6 +144,8 @@
 
 - [conman](https://github.com/dun/conman), a serial console management program. Available as [services.conman](#opt-services.conman.enable).
 
+- [Prometheus Tailscale Exporter](https://github.com/adinhodovic/tailscale-exporter), a Prometheus exporter for Tailscale Tailnet metrics.
+
 - [KMinion](https://github.com/redpanda-data/kminion), feature-rich Prometheus exporter for Apache Kafka. Available as [services.prometheus.exporters.kafka](options.html#opt-services.prometheus.exporters.kafka).
 
 - [Spoolman](https://github.com/Donkie/Spoolman), a inventory management system for Filament spools. Available as [services.spoolman](#opt-services.spoolman.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -127,6 +127,7 @@ let
         "storagebox"
         "surfboard"
         "systemd"
+        "tailscale"
         "tibber"
         "unbound"
         "unpoller"

--- a/nixos/modules/services/monitoring/prometheus/exporters/tailscale.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/tailscale.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  inherit (utils) escapeSystemdExecArgs;
+
+  cfg = config.services.prometheus.exporters.tailscale;
+in
+{
+  port = 9250;
+  extraOpts = with types; {
+    package = mkPackageOption pkgs "prometheus-tailscale-exporter" { };
+    environmentFile = mkOption {
+      type = path;
+      description = ''
+        Environment file containg at least the TAILSCALE_TAILNET,
+        TAILSCALE_OAUTH_CLIENT_ID, and TAILSCALE_OAUTH_CLIENT_SECRET
+        environment variables.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      EnvironmentFile = cfg.environmentFile;
+      ExecStart = escapeSystemdExecArgs (
+        [
+          (getExe cfg.package)
+          "--listen-address"
+          "${cfg.listenAddress}:${toString cfg.port}"
+        ]
+        ++ cfg.extraFlags
+      );
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-tailscale-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-tailscale-exporter/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "tailscale-exporter";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "adinhodovic";
+    repo = "tailscale-exporter";
+    tag = version;
+    hash = "sha256-6iQtGfQsXVmwFaSA7B1AG+kbtSyKVWFbEld1lMb0DnE=";
+  };
+
+  vendorHash = "sha256-Nbx6LyGGhdgI4oEtbyqhJ2H1lY6BfSL/ROH/Dh4UOk0=";
+
+  subPackages = [
+    "cmd/tailscale-exporter"
+    "collector"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.tests = {
+    inherit (nixosTests.prometheus-exporters) tailscale;
+  };
+
+  meta = {
+    description = "Tailscale Tailnet metric exporter for Prometheus";
+    homepage = "https://github.com/adinhodovic/tailscale-exporter";
+    changelog = "https://github.com/adinhodovic/tailscale-exporter/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      squat
+    ];
+    mainProgram = "tailscale-exporter";
+  };
+}


### PR DESCRIPTION
This PR introduces a new package and NixOS module for monitoring a Tailscale Tailnet with Prometheus, via https://github.com/adinhodovic/tailscale-exporter.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
