### PR TITLE
python3Packages.meta-memcache: init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/meta-memcache-socket/default.nix
+++ b/pkgs/development/python-modules/meta-memcache-socket/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cargo,
+  rustPlatform,
+  rustc,
+}:
+
+buildPythonPackage rec {
+  pname = "meta-memcache-socket";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "RevenueCat";
+    repo = "meta-memcache-socket-py";
+    tag = version;
+    hash = "sha256-uPcuzi3fCC8XNJP43ObcSCn5vSgG0V0fx7cDSfQZIQg=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-CjzpZGwHbCmIxtVIvpYxzXiRwd2Nr66lXbn2vEI1BgI=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    rustc
+  ];
+
+  pythonImportsCheck = [
+    "meta_memcache_socket"
+  ];
+
+  meta = {
+    description = "Helpers for meta-memcache-py, implemented in rust for improved performance";
+    homepage = "https://github.com/RevenueCat/meta-memcache-socket-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ typedrat ];
+  };
+}

--- a/pkgs/development/python-modules/meta-memcache/default.nix
+++ b/pkgs/development/python-modules/meta-memcache/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  pytestCheckHook,
+  fetchFromGitHub,
+  setuptools,
+  marisa-trie,
+  meta-memcache-socket,
+  prometheus-client,
+  pytest-mock,
+  uhashring,
+  zstandard,
+}:
+buildPythonPackage rec {
+  pname = "meta-memcache";
+  version = "2.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "RevenueCat";
+    repo = "meta-memcache-py";
+    tag = "v2.0.2";
+    hash = "sha256-cgtifhEHm3XJ0teEmHk26MXhttOiydRApAAu2cMxffI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    marisa-trie
+    meta-memcache-socket
+    uhashring
+    zstandard
+  ];
+
+  optional-dependencies = {
+    metrics = [
+      prometheus-client
+    ];
+  };
+
+  pythonImportsCheck = [
+    "meta_memcache"
+  ];
+
+  nativeCheckInputs = [
+    prometheus-client
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  meta = {
+    description = "Modern, pure python, memcache client with support for new meta commands";
+    homepage = "https://github.com/RevenueCat/meta-memcache-py";
+    changelog = "https://github.com/RevenueCat/meta-memcache-py/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ typedrat ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9278,6 +9278,8 @@ self: super: with self; {
 
   messagebird = callPackage ../development/python-modules/messagebird { };
 
+  meta-memcache = callPackage ../development/python-modules/meta-memcache { };
+
   meta-memcache-socket = callPackage ../development/python-modules/meta-memcache-socket { };
 
   metaflow = callPackage ../development/python-modules/metaflow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9278,6 +9278,8 @@ self: super: with self; {
 
   messagebird = callPackage ../development/python-modules/messagebird { };
 
+  meta-memcache-socket = callPackage ../development/python-modules/meta-memcache-socket { };
+
   metaflow = callPackage ../development/python-modules/metaflow { };
 
   metakernel = callPackage ../development/python-modules/metakernel { };


### PR DESCRIPTION
This is a Python library used by the dragonflydb test suite. I'm moving this to a separate PR because I'm removing the attempt to get the test suite working from #452792, but I don't want to just let this hit the bitbucket.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
