### PR TITLE
limbo: rename to turso, 0.0.14 -> 0.3.2

### DIFF
--- a/pkgs/by-name/tu/turso/package.nix
+++ b/pkgs/by-name/tu/turso/package.nix
@@ -5,26 +5,27 @@
   versionCheckHook,
   nix-update-script,
 }:
-rustPlatform.buildRustPackage rec {
-  pname = "tursodb";
-  version = "0.0.14";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "turso";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
     repo = "turso";
-    tag = "v${version}";
-    hash = "sha256-t3bIW+HuuZzj3NOw2lnTZw9qxj7lGWtR8RbZF0rVbQ4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-biElXD4d6h28Nq7LIjuL+at/y69TxnsJzvnEX8cOM9E=";
   };
 
-  cargoHash = "sha256-DDUl/jojhDmSQY7iI/Dn+Lg4eNuNhj8jyakPtgg4d2k=";
+  cargoHash = "sha256-G2VowcxnCRulQ4pJcpfJbH73vkG+KIteeUF1Hq8TEZg=";
 
   cargoBuildFlags = [
     "-p"
     "turso_cli"
   ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+
   doInstallCheck = true;
   versionCheckProgramArg = "--version";
 
@@ -33,9 +34,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Interactive SQL shell for Turso";
     homepage = "https://github.com/tursodatabase/turso";
-    changelog = "https://github.com/tursodatabase/turso/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/tursodatabase/turso/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nartsiss ];
     mainProgram = "tursodb";
   };
-}
+})

--- a/pkgs/by-name/tu/tursodb/package.nix
+++ b/pkgs/by-name/tu/tursodb/package.nix
@@ -6,12 +6,12 @@
   nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
-  pname = "limbo";
+  pname = "tursodb";
   version = "0.0.14";
 
   src = fetchFromGitHub {
     owner = "tursodatabase";
-    repo = "limbo";
+    repo = "turso";
     tag = "v${version}";
     hash = "sha256-t3bIW+HuuZzj3NOw2lnTZw9qxj7lGWtR8RbZF0rVbQ4=";
   };
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [
     "-p"
-    "limbo"
+    "turso_cli"
   ];
   cargoTestFlags = cargoBuildFlags;
 
@@ -31,11 +31,11 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Interactive SQL shell for Limbo";
-    homepage = "https://github.com/tursodatabase/limbo";
-    changelog = "https://github.com/tursodatabase/limbo/blob/v${version}/CHANGELOG.md";
+    description = "Interactive SQL shell for Turso";
+    homepage = "https://github.com/tursodatabase/turso";
+    changelog = "https://github.com/tursodatabase/turso/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nartsiss ];
-    mainProgram = "limbo";
+    mainProgram = "tursodb";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -839,6 +839,7 @@ mapAliases {
   lightly-qt = throw "'lightly-qt' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   ligo = throw "ligo has been removed from nixpkgs for lack of maintainance"; # Added 2025-06-03
   lima-bin = warnAlias "lima-bin has been replaced by lima" lima; # Added 2025-05-13
+  limbo = warnAlias "limbo has been renamed to turso" turso; # Added 2025-11-07
   lincity_ng = warnAlias "lincity_ng has been renamed to lincity-ng" lincity-ng; # Added 2025-10-09
   linphone = linphonePackages.linphone-desktop; # Added 2025-09-20
   linux-libre = throw "linux_libre has been removed due to lack of maintenance"; # Added 2025-10-01


### PR DESCRIPTION
- Rename to `turso`
- Update to [v0.3.2](https://github.com/tursodatabase/turso/releases/tag/v0.3.2) ([diff](https://github.com/tursodatabase/turso/compare/v0.0.14...v0.3.2))
- Remove `rec`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
