### PR TITLE
darwin.mkAppleDerivation: use `lib.extendMkDerivation`

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/AvailabilityVersions/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/AvailabilityVersions/package.nix
@@ -19,8 +19,6 @@ mkAppleDerivation (finalAttrs: {
     ./patches/0001-Support-setting-an-upper-bound-on-versions.patch
   ];
 
-  noCC = true;
-
   nativeBuildInputs = [ unifdef ];
 
   buildPhase = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
@@ -8,8 +8,6 @@ in
   fetchFromGitHub,
   meson,
   ninja,
-  stdenv,
-  stdenvNoCC,
   xcodeProjectCheckHook,
 }:
 
@@ -21,15 +19,8 @@ lib.makeOverridable (
   let
     attrs' = if lib.isFunction attrs then attrs else _: attrs;
     attrsFixed = lib.fix attrs';
-    stdenv' =
-      if attrsFixed.noCC or false then
-        stdenvNoCC
-      else if attrsFixed.noBootstrap or false then
-        stdenv
-      else
-        bootstrapStdenv;
   in
-  stdenv'.mkDerivation (
+  bootstrapStdenv.mkDerivation (
     lib.extends (
       self: super:
       assert super ? releaseName;

--- a/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
@@ -14,68 +14,61 @@ in
 let
   hasBasenamePrefix = prefix: file: lib.hasPrefix prefix (baseNameOf file);
 in
-lib.makeOverridable (
-  attrs:
-  let
-    attrs' = if lib.isFunction attrs then attrs else _: attrs;
-    attrsFixed = lib.fix attrs';
-  in
-  bootstrapStdenv.mkDerivation (
-    lib.extends (
-      self: super:
-      assert super ? releaseName;
-      let
-        inherit (super) releaseName;
-        info = versions.${releaseName};
-        files = lib.filesystem.listFilesRecursive (lib.path.append ./. releaseName);
-        mesonFiles = lib.filter (hasBasenamePrefix "meson") files;
-      in
-      # You have to have at least `meson.build.in` when using xcodeHash to trigger the Meson
-      # build support in `mkAppleDerivation`.
-      assert super ? xcodeHash -> lib.length mesonFiles > 0;
-      {
-        pname = super.pname or releaseName;
-        inherit (info) version;
+lib.extendMkDerivation {
+  constructDrv = bootstrapStdenv.mkDerivation;
+  extendDrvArgs =
+    self: super:
+    assert super ? releaseName;
+    let
+      inherit (super) releaseName;
+      info = versions.${releaseName};
+      files = lib.filesystem.listFilesRecursive (lib.path.append ./. releaseName);
+      mesonFiles = lib.filter (hasBasenamePrefix "meson") files;
+    in
+    # You have to have at least `meson.build.in` when using xcodeHash to trigger the Meson
+    # build support in `mkAppleDerivation`.
+    assert super ? xcodeHash -> lib.length mesonFiles > 0;
+    {
+      pname = super.pname or releaseName;
+      inherit (info) version;
 
-        src = super.src or fetchFromGitHub {
-          owner = "apple-oss-distributions";
-          repo = releaseName;
-          rev = info.rev or "${releaseName}-${info.version}";
-          inherit (info) hash;
-        };
+      src = super.src or fetchFromGitHub {
+        owner = "apple-oss-distributions";
+        repo = releaseName;
+        rev = info.rev or "${releaseName}-${info.version}";
+        inherit (info) hash;
+      };
 
-        strictDeps = true;
-        __structuredAttrs = true;
+      strictDeps = true;
+      __structuredAttrs = true;
 
-        meta = {
-          homepage = "https://opensource.apple.com/releases/";
-          license = lib.licenses.apple-psl20;
-          teams = [ lib.teams.darwin ];
-          platforms = lib.platforms.darwin;
-        }
-        // super.meta or { };
+      meta = {
+        homepage = "https://opensource.apple.com/releases/";
+        license = lib.licenses.apple-psl20;
+        teams = [ lib.teams.darwin ];
+        platforms = lib.platforms.darwin;
       }
-      // lib.optionalAttrs (super ? xcodeHash) {
-        postUnpack =
-          super.postUnpack or ""
-          + lib.concatMapStrings (
-            file:
-            if baseNameOf file == "meson.build.in" then
-              "substitute ${lib.escapeShellArg "${file}"} \"$sourceRoot/meson.build\" --subst-var version\n"
-            else
-              "cp ${lib.escapeShellArg "${file}"} \"$sourceRoot/\"${lib.escapeShellArg (baseNameOf file)}\n"
-          ) mesonFiles;
+      // super.meta or { };
+    }
+    // lib.optionalAttrs (super ? xcodeHash) {
+      postUnpack =
+        super.postUnpack or ""
+        + lib.concatMapStrings (
+          file:
+          if baseNameOf file == "meson.build.in" then
+            "substitute ${lib.escapeShellArg "${file}"} \"$sourceRoot/meson.build\" --subst-var version\n"
+          else
+            "cp ${lib.escapeShellArg "${file}"} \"$sourceRoot/\"${lib.escapeShellArg (baseNameOf file)}\n"
+        ) mesonFiles;
 
-        xcodeProject = super.xcodeProject or "${releaseName}.xcodeproj";
+      xcodeProject = super.xcodeProject or "${releaseName}.xcodeproj";
 
-        nativeBuildInputs = super.nativeBuildInputs or [ ] ++ [
-          meson
-          ninja
-          xcodeProjectCheckHook
-        ];
+      nativeBuildInputs = super.nativeBuildInputs or [ ] ++ [
+        meson
+        ninja
+        xcodeProjectCheckHook
+      ];
 
-        mesonBuildType = "release";
-      }
-    ) attrs'
-  )
-)
+      mesonBuildType = "release";
+    };
+}


### PR DESCRIPTION
I recommend reviewing this commit‐by‐commit and with whitespace changes hidden.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
