### PR TITLE
flatpak: patch trigger paths

### DIFF
--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -151,6 +151,31 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace doc/meson.build \
       --replace-fail '$MESON_INSTALL_DESTDIR_PREFIX/@1@/@2@' '@1@/@2@'
+
+    substituteInPlace triggers/gtk-icon-cache.trigger \
+      --replace-fail '/usr/share/icons/hicolor/index.theme' '/run/current-system/sw/share/icons/hicolor/index.theme'
+  '';
+
+  # Fixup PATHs in trigger scripts
+  postInstall = ''
+    wrapProgram $out/share/flatpak/triggers/desktop-database.trigger --prefix PATH : ${
+      lib.makeBinPath [
+        desktop-file-utils
+      ]
+    }
+
+    wrapProgram $out/share/flatpak/triggers/gtk-icon-cache.trigger --prefix PATH : ${
+      lib.makeBinPath [
+        coreutils
+        gtk3
+      ]
+    }
+
+    wrapProgram $out/share/flatpak/triggers/mime-database.trigger --prefix PATH : ${
+      lib.makeBinPath [
+        shared-mime-info
+      ]
+    }
   '';
 
   strictDeps = true;


### PR DESCRIPTION
Fixes #404619, #442823, #448015

Flatpak is using a post-installation trigger to update mime database and icons after packages are installed. Currently, these triggers are not patched, and thus the trigger script cannot find the appropriate binary to run, so users cannot use applications installed by Flatpak as a default application, or associate it to a mime types.

This PR introduce a new patch to properly patch the path.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
