### PR TITLE
realvnc-vnc-viewer: 7.12.1 -> 7.15.1

### DIFF
--- a/pkgs/by-name/re/realvnc-vnc-viewer/darwin.nix
+++ b/pkgs/by-name/re/realvnc-vnc-viewer/darwin.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchurl rec {
     name = "VNC-Viewer-${finalAttrs.version}-MacOSX-universal.dmg";
     url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
-    hash = "sha256-SiBlw9ihKDLDWBPUxn3cfM0jbUaWDxQ9JDaeDNczQ7c=";
+    hash = "sha256-nWS7XsAQFcp2uoXXzT+a542Q9vwloZEQHqf4eieKqUA=";
   };
   sourceRoot = ".";
 

--- a/pkgs/by-name/re/realvnc-vnc-viewer/linux.nix
+++ b/pkgs/by-name/re/realvnc-vnc-viewer/linux.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux" = fetchurl rec {
         name = "VNC-Viewer-${finalAttrs.version}-Linux-x64.rpm";
         url = "https://downloads.realvnc.com/download/file/viewer.files/${name}";
-        hash = "sha256-fwMfQdOyLnYVfdBj80JHWT+CnKpq/9oM5oNF3aP+jgo=";
+        hash = "sha256-rIOP7d8qrOeMgaQRYo+GRXT1fLnPegdpONT0p5aBCxM=";
       };
     }
     .${stdenv.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");

--- a/pkgs/by-name/re/realvnc-vnc-viewer/package.nix
+++ b/pkgs/by-name/re/realvnc-vnc-viewer/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "realvnc-vnc-viewer";
-  version = "7.12.1";
+  version = "7.15.1";
 
   meta = {
     description = "VNC remote desktop client software by RealVNC";


### PR DESCRIPTION
Resolves #453112

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
