### PR TITLE
python3Packages.betterproto: 2.0.0b6 -> 2.0.0b7

### DIFF
--- a/pkgs/development/python-modules/betterproto/default.nix
+++ b/pkgs/development/python-modules/betterproto/default.nix
@@ -2,7 +2,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
-  pythonOlder,
   poetry-core,
   grpclib,
   python-dateutil,
@@ -10,9 +9,10 @@
   jinja2,
   isort,
   python,
+  cachelib,
   pydantic,
-  pytest7CheckHook,
-  pytest-asyncio_0_21,
+  pytestCheckHook,
+  pytest-asyncio,
   pytest-mock,
   typing-extensions,
   tomlkit,
@@ -21,16 +21,14 @@
 
 buildPythonPackage rec {
   pname = "betterproto";
-  version = "2.0.0b6";
+  version = "2.0.0b7";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "danielgtaylor";
     repo = "python-betterproto";
     tag = "v.${version}";
-    hash = "sha256-ZuVq4WERXsRFUPNNTNp/eisWX1MyI7UtwqEI8X93wYI=";
+    hash = "sha256-T7QSPH8MFa1hxJOhXc3ZMM62/FxHWjCJJ59IpeM41rI=";
   };
 
   postPatch = ''
@@ -53,11 +51,12 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    cachelib
     grpcio-tools
     pydantic
-    pytest-asyncio_0_21
+    pytest-asyncio
     pytest-mock
-    pytest7CheckHook
+    pytestCheckHook
     tomlkit
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
@@ -73,13 +72,11 @@ buildPythonPackage rec {
     ${python.interpreter} -m tests.generate
   '';
 
-  disabledTestPaths = [
-    # https://github.com/danielgtaylor/python-betterproto/issues/530
-    "tests/inputs/oneof/test_oneof.py"
-  ];
-
   disabledTests = [
-    "test_pydantic_no_value"
+    # incompatible with pytest 8:
+    #     TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
+    "test_message_with_deprecated_field_not_set"
+    "test_service_with_deprecated_method"
     # Test is flaky
     "test_binary_compatibility"
   ];

--- a/pkgs/development/python-modules/sigstore-protobuf-specs/default.nix
+++ b/pkgs/development/python-modules/sigstore-protobuf-specs/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  pythonOlder,
   flit-core,
   fetchPypi,
   buildPythonPackage,
@@ -10,15 +9,13 @@
 
 buildPythonPackage rec {
   pname = "sigstore-protobuf-specs";
-  version = "0.3.2";
+  version = "0.5.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "sigstore_protobuf_specs";
     inherit version;
-    hash = "sha256-yuBBtAUCYAuKYz9DwldpXQIiqU76HlEQp+x62njDnZk=";
+    hash = "sha256-zvnrMrLGwlHeNuIoWkCq8glIJ+rhifXngE10jMw9W4E=";
   };
 
   nativeBuildInputs = [ flit-core ];
@@ -35,10 +32,10 @@ buildPythonPackage rec {
 
   passthru.skipBulkUpdate = true;
 
-  meta = with lib; {
+  meta = {
     description = "Library for serializing and deserializing Sigstore messages";
-    homepage = "https://pypi.org/project/sigstore-protobuf-specs/";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    homepage = "https://github.com/sigstore/protobuf-specs/tree/main/gen/pb-python";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/danielgtaylor/python-betterproto/compare/v.2.0.0b6...v.2.0.0b7

Changelog: https://github.com/danielgtaylor/python-betterproto/blob/v.2.0.0b7/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
