### PR TITLE
treewide: ensure `ExecReload` kill fields has absolute path

### DIFF
--- a/nixos/modules/services/networking/opengfw.nix
+++ b/nixos/modules/services/networking/opengfw.nix
@@ -390,7 +390,7 @@ in
 
         serviceConfig = rec {
           WorkingDirectory = cfg.dir;
-          ExecReload = "kill -HUP $MAINPID";
+          ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -HUP $MAINPID";
           Restart = "always";
           User = cfg.user;
           StandardOutput = mkIf (cfg.logFile != null) "append:${cfg.logFile}";

--- a/nixos/modules/services/web-apps/open-web-calendar.nix
+++ b/nixos/modules/services/web-apps/open-web-calendar.nix
@@ -130,7 +130,7 @@ in
             open_web_calendar.app:app
         '';
         EnvironmentFile = settingsFormat.generate "open-web-calendar.env" cfg.settings;
-        ExecReload = "kill -s HUP $MAINPID";
+        ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -s HUP $MAINPID";
         KillMode = "mixed";
         PrivateTmp = true;
         RuntimeDirectory = "open-web-calendar";

--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -374,7 +374,7 @@ in
               --bind='unix:///run/weblate.socket' \
               weblate.wsgi
           '';
-        ExecReload = "kill -s HUP $MAINPID";
+        ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -s HUP $MAINPID";
         KillMode = "mixed";
         PrivateTmp = true;
         WorkingDirectory = dataDir;

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -166,7 +166,7 @@ in
       serviceConfig = {
         Type = "notify";
         ExecStart = "${cfg.package}/bin/crio";
-        ExecReload = "/bin/kill -s HUP $MAINPID";
+        ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -s HUP $MAINPID";
         TasksMax = "infinity";
         LimitNOFILE = "1048576";
         LimitNPROC = "1048576";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Systemd expects absolute paths to the binaries run in its `Exec*` directives. This PR goes over and fixes some of the `ExecReload` fields with an invalid reference to the `kill` binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
