### PR TITLE
rbspy: 0.34.0 -> 0.38.0

### DIFF
--- a/pkgs/by-name/rb/rbspy/package.nix
+++ b/pkgs/by-name/rb/rbspy/package.nix
@@ -8,23 +8,18 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rbspy";
-  version = "0.34.0";
+  version = "0.38.0";
 
   src = fetchFromGitHub {
     owner = "rbspy";
     repo = "rbspy";
-    tag = "v${version}";
-    hash = "sha256-yVcVuMCyvk9RbkbKomqjkLY+p5tUzW2zcAKZ8XfsjM0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6pQoCPwrIKaEUYgaHNgFLz+bY4p+ImlhZ2l2vehA4Ic=";
   };
 
-  cargoHash = "sha256-WiIHFwB6BE9VYuC2dCHNnrEFjVsesp0c5i4bH01cXis=";
-
-  # error: linker `aarch64-linux-gnu-gcc` not found
-  postPatch = ''
-    rm .cargo/config
-  '';
+  cargoHash = "sha256-6Q1ebXEknP3qEiU5qMXhHykRwahMZEVXGJGE4EToohA=";
 
   doCheck = true;
 
@@ -32,11 +27,11 @@ rustPlatform.buildRustPackage rec {
   # from nixpkgs during tests.
   preCheck = ''
     substituteInPlace src/core/process.rs \
-      --replace /usr/bin/which '${which}/bin/which'
+      --replace-fail "/usr/bin/which" "${lib.getExe which}"
     substituteInPlace src/sampler/mod.rs \
-      --replace /usr/bin/which '${which}/bin/which'
+      --replace-fail "/usr/bin/which" "${lib.getExe which}"
     substituteInPlace src/core/ruby_spy.rs \
-      --replace /usr/bin/ruby '${ruby}/bin/ruby'
+      --replace-fail "/usr/bin/ruby" "${lib.getExe ruby}"
   '';
 
   checkFlags = [
@@ -60,9 +55,9 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://rbspy.github.io/";
     description = "Sampling CPU Profiler for Ruby";
     mainProgram = "rbspy";
-    changelog = "https://github.com/rbspy/rbspy/releases/tag/v${version}";
+    changelog = "https://github.com/rbspy/rbspy/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ viraptor ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/rbspy/rbspy/releases/tag/v0.38.0
https://github.com/rbspy/rbspy/compare/v0.34.0...v0.38.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
