### PR TITLE
naja: 0.2.2 -> 0.2.12

### DIFF
--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "naja";
-  version = "0.2.2";
+  version = "0.2.12";
 
   src = fetchFromGitHub {
     owner = "najaeda";
     repo = "naja";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cm9MwN60R/K2bL4FWpvusFmb2ENYEYg8NcMVgmeTj0c=";
+    hash = "sha256-NqxgFAD/JHh1rgtuv/NTda5oEx79NgdafL3fDLJO2kU=";
     fetchSubmodules = true;
   };
 
@@ -39,11 +39,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace cmake/CMakeLists.txt \
       --replace-fail 'DESTINATION cmake' 'DESTINATION ''${CMAKE_INSTALL_LIBDIR}/cmake'
 
-    # Fix install location for bne library & headers
-    # Remove when https://github.com/najaeda/naja/pull/278 merged & in release
-    substituteInPlace src/bne/CMakeLists.txt \
-      --replace-fail 'LIBRARY DESTINATION lib' 'LIBRARY DESTINATION ''${CMAKE_INSTALL_LIBDIR}' \
-      --replace-fail 'PUBLIC_HEADER DESTINATION include' 'PUBLIC_HEADER DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}'
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "cmake_minimum_required(VERSION 3.21)" \
+      "cmake_minimum_required(VERSION 4.0)"
   ''
   # disable building tests for cross build
   + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -56,6 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     patchShebangs --build test/test_utils/diff_files.py
   '';
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals stdenv.cc.isClang [
+      "-Wno-character-conversion"
+    ]
+  );
 
   strictDeps = true;
 


### PR DESCRIPTION
Bump, fix build with cmake 4, address over-zealous clang error.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
