### PR TITLE
python3Packages.asyncprawcore: 2.4.0 -> 3.0.2, python3Packages.asyncpraw: 7.8.1 -> 7.8.1-unstable-2025-10-08

### DIFF
--- a/pkgs/development/python-modules/asyncpraw/default.nix
+++ b/pkgs/development/python-modules/asyncpraw/default.nix
@@ -2,57 +2,52 @@
   lib,
   aiofiles,
   aiohttp,
-  aiosqlite,
   asyncprawcore,
   buildPythonPackage,
+  coverage,
+  defusedxml,
   fetchFromGitHub,
-  flit-core,
-  mock,
+  hatchling,
   pytestCheckHook,
-  pytest-asyncio_0,
+  pytest-asyncio,
   pytest-vcr,
-  pythonOlder,
-  requests-toolbelt,
   update-checker,
   vcrpy,
 }:
 
 buildPythonPackage rec {
   pname = "asyncpraw";
-  version = "7.8.1";
+  version = "7.8.1-unstable-2025-10-08";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "praw-dev";
     repo = "asyncpraw";
-    tag = "v${version}";
-    hash = "sha256-glWAQoUjMFbjU3C4+MGuRGSGJS9mun15+6udMPCf9nU=";
+    rev = "9221cbef5d94fce9ecc92376cbab084f0082502d";
+    hash = "sha256-/7x7XYw1JDVaoc2+wKWW3iUkyfI6MVtBNP9G1AEUp4Y=";
   };
 
-  pythonRelaxDeps = [ "aiosqlite" ];
+  pythonRelaxDeps = [
+    "coverage"
+    "defusedxml"
+  ];
 
-  # 'aiosqlite' is also checked when building the wheel
-  pypaBuildFlags = [ "--skip-dependency-check" ];
-
-  build-system = [ flit-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     aiofiles
     aiohttp
-    aiosqlite
     asyncprawcore
-    mock
+    coverage
+    defusedxml
     update-checker
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-asyncio_0
+    pytest-asyncio
     pytest-vcr
     vcrpy
-    requests-toolbelt
   ];
 
   disabledTestPaths = [
@@ -70,7 +65,7 @@ buildPythonPackage rec {
   meta = {
     description = "Asynchronous Python Reddit API Wrapper";
     homepage = "https://asyncpraw.readthedocs.io/";
-    changelog = "https://github.com/praw-dev/asyncpraw/blob/v${version}/CHANGES.rst";
+    changelog = "https://github.com/praw-dev/asyncpraw/blob/${src.rev}/CHANGES.rst";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.amadejkastelic ];
   };

--- a/pkgs/development/python-modules/asyncprawcore/default.nix
+++ b/pkgs/development/python-modules/asyncprawcore/default.nix
@@ -4,43 +4,35 @@
   buildPythonPackage,
   fetchFromGitHub,
   flit-core,
-  mock,
   pytestCheckHook,
-  pytest-asyncio_0,
+  pytest-asyncio,
   pytest-vcr,
-  requests,
-  requests-toolbelt,
-  testfixtures,
   vcrpy,
   yarl,
 }:
 
 buildPythonPackage rec {
   pname = "asyncprawcore";
-  version = "2.4.0";
+  version = "3.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "praw-dev";
     repo = "asyncprawcore";
     tag = "v${version}";
-    hash = "sha256-FDQdtnNjsbiEp9BUYdQFMC/hkyJDhCh2WHhQWSQwrFY=";
+    hash = "sha256-0FOMY/0LXGcHwDe4t+NMAovMhX83/mMv8sWvIf5gxok=";
   };
 
   build-system = [ flit-core ];
 
   dependencies = [
-    requests
     aiohttp
     yarl
   ];
 
   nativeCheckInputs = [
-    testfixtures
-    mock
-    requests-toolbelt
     pytestCheckHook
-    pytest-asyncio_0
+    pytest-asyncio
     pytest-vcr
     vcrpy
   ];
@@ -49,6 +41,11 @@ buildPythonPackage rec {
     # Ignored due to error with request cannot pickle 'BufferedReader' instances
     # Upstream issue: https://github.com/kevin1024/vcrpy/issues/737
     "tests/integration/test_sessions.py"
+  ];
+
+  disabledTests = [
+    # Test requires network access
+    "test_initialize"
   ];
 
   pythonImportsCheck = [ "asyncprawcore" ];


### PR DESCRIPTION
Diff: https://github.com/praw-dev/asyncprawcore/compare/v2.4.0...v3.0.2

Changelog: https://github.com/praw-dev/asyncprawcore/blob/v3.0.2/CHANGES.rst

Diff: https://github.com/praw-dev/asyncpraw/compare/v7.8.1...9221cbef5d94fce9ecc92376cbab084f0082502d

Changelog: https://github.com/praw-dev/asyncpraw/blob/9221cbef5d94fce9ecc92376cbab084f0082502d/CHANGES.rst
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
