### PR TITLE
alacritty{-graphics}: 0.15.1 -> 0.16.0

### DIFF
--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -144,7 +144,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Cross-platform, GPU-accelerated terminal emulator";
-    homepage = "https://github.com/alacritty/alacritty";
+    homepage =
+      if !withGraphics then
+        "https://github.com/alacritty/alacritty"
+      else
+        "https://github.com/ayosec/alacritty";
     license = lib.licenses.asl20;
     mainProgram = "alacritty";
     maintainers = with lib.maintainers; [
@@ -152,6 +156,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       rvdp
     ];
     platforms = lib.platforms.unix;
-    changelog = "https://github.com/alacritty/alacritty/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog =
+      if !withGraphics then
+        "https://github.com/alacritty/alacritty/blob/v${finalAttrs.version}/CHANGELOG.md"
+      else
+        "https://github.com/ayosec/alacritty/blob/v${finalAttrs.version}/CHANGELOG.md";
   };
 })

--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -44,7 +44,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "alacritty";
-  version = if !withGraphics then "0.16.1" else "0.15.0-graphics";
+  version = if !withGraphics then "0.16.1" else "0.16.0-graphics";
 
   src =
     # by default we want the official package
@@ -61,14 +61,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
         owner = "ayosec";
         repo = "alacritty";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-n8vO6Q4bzWLaOqg8YhZ+aLOtBBTQ9plKIEJHXq+hhnM=";
+        hash = "sha256-JbsHozYMh7hFMAsu823IcVZTzvMEGQP+oKpUnlmM7Nk=";
       };
 
   cargoHash =
     if !withGraphics then
       "sha256-OBhrd4q44LCUGnjDEedhrOuoSC2UFR90IKSQfEPY/Q4="
     else
-      "sha256-UtxZFqU974N+YcHoEHifBjNSyaVuMvuc1clTDgUPuoQ=";
+      "sha256-fsTs37w4CvYvFN8ZgWxMA2hmgW0hJcIvhLiuhYxs4+Y=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -42,9 +42,9 @@ let
     wayland
   ];
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "alacritty";
-  version = "0.15.1" + lib.optionalString withGraphics "-graphics";
+  version = if !withGraphics then "0.15.1" else "0.15.0-graphics";
 
   src =
     # by default we want the official package
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage rec {
       fetchFromGitHub {
         owner = "alacritty";
         repo = "alacritty";
-        tag = "v${version}";
+        tag = "v${finalAttrs.version}";
         hash = "sha256-/yERMNfCFLPb1S17Y9OacVH8UobDIIZDhM2qPzf5Vds=";
       }
     # optionally we want to build the sixels feature fork
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
       fetchFromGitHub {
         owner = "ayosec";
         repo = "alacritty";
-        tag = "v${version}";
+        tag = "v${finalAttrs.version}";
         hash = "sha256-n8vO6Q4bzWLaOqg8YhZ+aLOtBBTQ9plKIEJHXq+hhnM=";
       };
 
@@ -152,6 +152,6 @@ rustPlatform.buildRustPackage rec {
       rvdp
     ];
     platforms = lib.platforms.unix;
-    changelog = "https://github.com/alacritty/alacritty/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/alacritty/alacritty/blob/v${finalAttrs.version}/CHANGELOG.md";
   };
-}
+})

--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -44,7 +44,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "alacritty";
-  version = if !withGraphics then "0.15.1" else "0.15.0-graphics";
+  version = if !withGraphics then "0.16.1" else "0.15.0-graphics";
 
   src =
     # by default we want the official package
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         owner = "alacritty";
         repo = "alacritty";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-/yERMNfCFLPb1S17Y9OacVH8UobDIIZDhM2qPzf5Vds=";
+        hash = "sha256-IOPhnJ76kZ2djJjxJEUwWPvHDeeXbJAn1ClipTH7nWs=";
       }
     # optionally we want to build the sixels feature fork
     else
@@ -66,7 +66,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash =
     if !withGraphics then
-      "sha256-uXwefUV1NAKqwwPIWj4Slkx0c5b+RfLR3caTb42fc4M="
+      "sha256-OBhrd4q44LCUGnjDEedhrOuoSC2UFR90IKSQfEPY/Q4="
     else
       "sha256-UtxZFqU974N+YcHoEHifBjNSyaVuMvuc1clTDgUPuoQ=";
 


### PR DESCRIPTION
Changelog: https://github.com/alacritty/alacritty/releases/tag/v0.16.0
Diff: https://github.com/alacritty/alacritty/compare/v0.15.1...v0.16.0

Changelog: https://github.com/ayosec/alacritty/releases/tag/v0.16.0-graphics
Diff: https://github.com/ayosec/alacritty/compare/v0.15.1-graphics...v0.16.0-graphics

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
