### PR TITLE
nixos/coolercontrol: fix nvidia support

### DIFF
--- a/nixos/modules/programs/coolercontrol.nix
+++ b/nixos/modules/programs/coolercontrol.nix
@@ -13,17 +13,15 @@ in
   options = {
     programs.coolercontrol = {
       enable = lib.mkEnableOption "CoolerControl GUI & its background services";
-
-      nvidiaSupport = lib.mkOption {
-        type = lib.types.bool;
-        default = lib.elem "nvidia" config.services.xserver.videoDrivers;
-        defaultText = lib.literalExpression "lib.elem \"nvidia\" config.services.xserver.videoDrivers";
-        description = ''
-          Enable support for Nvidia GPUs.
-        '';
-      };
     };
   };
+
+  imports = [
+    # Added 2025-10-25
+    (lib.mkRemovedOptionModule [ "programs" "coolercontrol" "nvidiaSupport" ] ''
+      This option is deprecated as Nvidia drivers are automatically loaded at runtime.
+    '')
+  ];
 
   ##### implementation
   config = lib.mkIf cfg.enable (
@@ -47,18 +45,6 @@ in
           };
         };
       }
-
-      # Nvidia support
-      (lib.mkIf cfg.nvidiaSupport {
-        systemd.services.coolercontrold.path =
-          let
-            nvidiaPkg = config.hardware.nvidia.package;
-          in
-          [
-            nvidiaPkg # nvidia-smi
-            nvidiaPkg.settings # nvidia-settings
-          ];
-      })
     ]
   );
 

--- a/pkgs/applications/system/coolercontrol/coolercontrold.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrold.nix
@@ -4,6 +4,7 @@
   libdrm,
   coolercontrol,
   runtimeShell,
+  addDriverRunpath,
 }:
 
 {
@@ -20,6 +21,7 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-ZyYyQcaYd3VZ7FL0Hki33JO3LscPfBT5gl+nw2cXvUs=";
 
   buildInputs = [ libdrm ];
+  nativeBuildInputs = [ addDriverRunpath ];
 
   postPatch = ''
     # copy the frontend static resources to a directory for embedding
@@ -35,6 +37,10 @@ rustPlatform.buildRustPackage {
     install -Dm444 "${src}/packaging/systemd/coolercontrold.service" -t "$out/lib/systemd/system"
     substituteInPlace "$out/lib/systemd/system/coolercontrold.service" \
       --replace-fail '/usr/bin' "$out/bin"
+  '';
+
+  postFixup = ''
+    addDriverRunpath "$out/bin/coolercontrold"
   '';
 
   passthru.tests.version = testers.testVersion {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description

Fix nvidia support in the coolercontrol module by ensuring GPU driver libraries are available at runtime.

The change addresses the issue where `coolercontrold` cannot detect Nvidia GPUs by adding the necessary driver library paths in the package itself. This ensures the application can dynamically load NVML at runtime, allowing `coolercontrold` to properly detect and monitor Nvidia GPUs.

The change also deprecates the `nvidiaSupport` option, as it is no longer needed with this approach.

<img width="169" height="232" alt="image" src="https://github.com/user-attachments/assets/fe1575d0-5192-443b-a110-c127e25843da" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
