### PR TITLE
zsync2: 2.0.0-alpha-1-20230304 -> 2.0.0-alpha-1-20250926

### DIFF
--- a/pkgs/by-name/zs/zsync2/package.nix
+++ b/pkgs/by-name/zs/zsync2/package.nix
@@ -2,32 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   libgcrypt,
   libcpr,
   libargs,
+  zlib,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "zsync2";
-  version = "2.0.0-alpha-1-20230304";
+  version = "2.0.0-alpha-1-20250926";
 
   src = fetchFromGitHub {
     owner = "AppImageCommunity";
     repo = "zsync2";
     rev = finalAttrs.version;
-    hash = "sha256-OCeMEXQmbc34MZ1NyOfAASdrUyeSQqqfvWqAszJN4x0=";
+    hash = "sha256-dbIe47cDaQJAOiHcLRwEbLgvrDUHOnPkYqDbkX74gZk=";
   };
-
-  patches = [
-    # Add missing cstdint includes
-    (fetchpatch {
-      url = "https://github.com/AppImageCommunity/zsync2/commit/e57e1fce68194fa920542fd334488de5123e4832.patch";
-      hash = "sha256-iLXxD6v+pSwFKmwAEyzbYUJ3DmtpvV/DYr8kcD+t5Cg=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -46,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     libcpr
     libargs
+    zlib
   ];
 
   cmakeFlags = [
@@ -53,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "USE_SYSTEM_ARGS" true)
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  env.NIX_CFLAGS_COMPILE = "-lz -Wno-error=incompatible-pointer-types";
 
   meta = {
     description = "Rewrite of the advanced file download/sync tool zsync";


### PR DESCRIPTION
 This update also fixes the cmake 4 issue outlined in https://github.com/nixos/nixpkgs/issues/445447.

Tagging @Aleksanaa.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
