### PR TITLE
enyo-launcher: 2.0.6 -> 2.0.7

### DIFF
--- a/pkgs/games/doom-ports/enyo-launcher/default.nix
+++ b/pkgs/games/doom-ports/enyo-launcher/default.nix
@@ -1,25 +1,26 @@
 {
-  mkDerivation,
+  stdenv,
   lib,
   fetchFromGitLab,
   cmake,
-  qtbase,
+  qt6,
 }:
-
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "enyo-launcher";
-  version = "2.0.6";
+  version = "2.0.7";
 
   src = fetchFromGitLab {
     owner = "sdcofer70";
     repo = "enyo-launcher";
     rev = version;
-    hash = "sha256-k6Stc1tQOcdS//j+bFUNfnOUlwuhIPKxf9DHU+ng164=";
+    hash = "sha256-Ig1b+JylRlxhl5k5ys9SOGMYw3eUxXyoVXt3YNeWNqI=";
   };
 
-  nativeBuildInputs = [ cmake ];
-
-  buildInputs = [ qtbase ];
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+  buildInputs = [ qt6.qtbase ];
 
   meta = {
     homepage = "https://gitlab.com/sdcofer70/enyo-launcher";


### PR DESCRIPTION
This also fixes the build issue with cmake 4, as noted in https://github.com/nixos/nixpkgs/issues/445447.

Tagging @usrfriendly.

Note: According to [this project's source page](https://gitlab.com/sdcofer70/enyo-launcher), it's no longer maintained.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
-  [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
