### PR TITLE
kairpods: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10371,6 +10371,12 @@
     github = "hitsmaxft";
     githubId = 352727;
   };
+  hjsmarais = {
+    name = "Hennie Marais";
+    email = "hennie@sulimo.co.za";
+    github = "hjsmarais";
+    githubId = 77006791;
+  };
   hkjn = {
     email = "me@hkjn.me";
     name = "Henrik Jonsson";

--- a/pkgs/by-name/ka/kairpods/package.nix
+++ b/pkgs/by-name/ka/kairpods/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-y/WO0y3IPdhXOnsa+//HLXWEk7gs+MH0K62QUcnveiw=";
 
-  sourceRoot = "${src.name}/service";
+  sourceRoot = "${finalAttrs.src.name}/service";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ka/kairpods/package.nix
+++ b/pkgs/by-name/ka/kairpods/package.nix
@@ -1,0 +1,58 @@
+{
+  rustPlatform,
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  dbus,
+  bluez,
+  kdePackages,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kairpods";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "can1357";
+    repo = "kAirPods";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+FifFWwd4aAEk5ihDGVbTrW8f3AVnPZwBoPgM6VECu0=";
+  };
+
+  cargoHash = "sha256-y/WO0y3IPdhXOnsa+//HLXWEk7gs+MH0K62QUcnveiw=";
+
+  sourceRoot = "${src.name}/service";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    bluez
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/plasma/plasmoids
+    cp -r ../plasmoid $out/share/plasma/plasmoids/org.kairpods.plasma
+
+    install -Dm755 "target/${stdenv.hostPlatform.config}/release/kairpodsd" $out/bin/kairpodsd
+
+    mkdir -p $out/lib/systemd/user
+    substitute systemd/user/kairpodsd.service \
+      $out/lib/systemd/user/kairpodsd.service \
+      --replace-fail /usr/bin/kairpodsd $out/bin/kairpodsd
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Native AirPods® integration for KDE Plasma 6 powered by a modern, low-latency Rust backend.";
+    homepage = "https://github.com/can1357/kAirPods";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ hjsmarais ];
+    inherit (kdePackages.kwindowsystem.meta) platforms;
+  };
+})


### PR DESCRIPTION
Packaged kAirPods and added myself as maintainer for it.

https://github.com/can1357/kAirPods
"Native AirPods integration for KDE Plasma 6 with real-time battery monitoring, noise control, and panel widget."

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
