### PR TITLE
wesnoth-devel: init at 1.19.16.1

### DIFF
--- a/pkgs/by-name/we/wesnoth/package.nix
+++ b/pkgs/by-name/we/wesnoth/package.nix
@@ -23,10 +23,12 @@
   lua5_4,
   curl,
   nix-update-script,
+  enableDevel ? false,
 }:
 
 let
   boost = boost186;
+  suffix = lib.optionalString enableDevel "-devel";
   # wesnoth requires lua built with c++, see https://github.com/wesnoth/wesnoth/pull/8234
   lua = lua5_4.override {
     postConfigure = ''
@@ -36,14 +38,18 @@ let
 in
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "wesnoth";
-  version = "1.18.5";
+  pname = "wesnoth${suffix}";
+  version = if enableDevel then "1.19.16.1" else "1.18.5";
 
   src = fetchFromGitHub {
     owner = "wesnoth";
     repo = "wesnoth";
     tag = finalAttrs.version;
-    hash = "sha256-0VZJAmaCg12x4S07H1kl5s2NGMEo/NSVnzMniREmPJk=";
+    hash =
+      if enableDevel then
+        "sha256-ekpyQnP5r3jl98qyNkO6SwUGc9qvz2OTidUu0k3m28c="
+      else
+        "sha256-0VZJAmaCg12x4S07H1kl5s2NGMEo/NSVnzMniREmPJk=";
   };
 
   nativeBuildInputs = [
@@ -73,10 +79,31 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DENABLE_SYSTEM_LUA=ON"
+    "-DBINARY_SUFFIX=${suffix}"
   ];
 
+  postPatch = lib.optionalString (suffix != "") ''
+    mv packaging/org.wesnoth.Wesnoth.desktop packaging/org.wesnoth.Wesnoth${suffix}.desktop
+    mv packaging/org.wesnoth.Wesnoth.appdata.xml packaging/org.wesnoth.Wesnoth${suffix}.appdata.xml
+
+    substituteInPlace packaging/org.wesnoth.Wesnoth${suffix}.desktop \
+      --replace-fail "Name=Battle for Wesnoth" "Name=Battle for Wesnoth${suffix}" \
+      --replace-fail "Exec=sh -c \"wesnoth >/dev/null 2>&1\"" "Exec=sh -c \"wesnoth${suffix} >/dev/null 2>&1\"" \
+      --replace-fail "Exec=sh -c \"wesnoth -e  >/dev/null 2>&1\"" "Exec=sh -c \"wesnoth${suffix} -e  >/dev/null 2>&1\""
+
+    substituteInPlace packaging/org.wesnoth.Wesnoth${suffix}.appdata.xml \
+      --replace-fail "<name>Battle for Wesnoth</name>" "<name>Battle for Wesnoth${suffix}</name>" \
+      --replace-fail "org.wesnoth.Wesnoth" "org.wesnoth.Wesnoth${suffix}" \
+      --replace-fail "<binary>wesnoth</binary>" "<binary>wesnoth${suffix}</binary>" \
+      --replace-fail "<binary>wesnothd</binary>" "<binary>wesnothd${suffix}</binary>"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "org.wesnoth.Wesnoth.desktop" "org.wesnoth.Wesnoth${suffix}.desktop" \
+      --replace-fail "org.wesnoth.Wesnoth.appdata.xml" "org.wesnoth.Wesnoth${suffix}.appdata.xml"
+  '';
+
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    app_name="The Battle for Wesnoth"
+    app_name="The Battle for Wesnoth${suffix}"
     app_bundle="$out/Applications/$app_name.app"
     app_contents="$app_bundle/Contents"
     mkdir -p "$app_contents"
@@ -85,8 +112,8 @@ stdenv.mkDerivation (finalAttrs: {
     mv $out/share/wesnoth "$app_contents/Resources"
     pushd ../projectfiles/Xcode
     substitute Info.plist "$app_contents/Info.plist" \
-      --replace-fail ''\'''${EXECUTABLE_NAME}' wesnoth \
-      --replace-fail '$(PRODUCT_BUNDLE_IDENTIFIER)' org.wesnoth.Wesnoth \
+      --replace-fail ''\'''${EXECUTABLE_NAME}' wesnoth${suffix} \
+      --replace-fail '$(PRODUCT_BUNDLE_IDENTIFIER)' org.wesnoth.Wesnoth${suffix} \
       --replace-fail ''\'''${PRODUCT_NAME}' "$app_name"
     cp -r Resources/SDLMain.nib "$app_contents/Resources/"
     install -m0644 Resources/{container-migration.plist,icon.icns} "$app_contents/Resources"
@@ -94,22 +121,27 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Make the game and dedicated server binary available for shell users
     mkdir -p "$out/bin"
-    ln -s "$app_contents/MacOS/wesnothd" "$out/bin/wesnothd"
+    ln -s "$app_contents/MacOS/wesnothd${suffix}" "$out/bin/wesnothd${suffix}"
     # Symlinking the game binary is unsifficient as it would be unable to
     # find the bundle resources
-    cat << EOF > "$out/bin/wesnoth"
+    cat << EOF > "$out/bin/wesnoth${suffix}"
     #!${stdenvNoCC.shell}
     open -na "$app_bundle" --args "\$@"
     EOF
-    chmod +x "$out/bin/wesnoth"
+    chmod +x "$out/bin/wesnoth${suffix}"
   '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      # the minor release number also denotes if this is a beta release:
-      # even is stable, odd is beta
-      "^(\\d+\\.\\d*[02468]\\.\\d+)$"
+      (
+        if enableDevel then
+          # Devel matches odd minor release numbers
+          "^(\\d+\\.\\d*[13579]\\.\\d+.*)$"
+        else
+          # Stable matches even minor release numbers
+          "^(\\d+\\.\\d*[02468]\\.\\d+)$"
+      )
     ];
   };
 
@@ -131,6 +163,6 @@ stdenv.mkDerivation (finalAttrs: {
       iedame
     ];
     platforms = lib.platforms.unix;
-    mainProgram = "wesnoth";
+    mainProgram = "wesnoth${suffix}";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13644,6 +13644,8 @@ with pkgs;
 
   warsow = callPackage ../games/warsow { };
 
+  wesnoth-devel = callPackage ../by-name/we/wesnoth/package.nix { enableDevel = true; };
+
   inherit (callPackage ../games/xonotic { })
     xonotic-data
     xonotic


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth
https://www.wesnoth.org/

Given the high degree of similarity between the stable and unstable versions, I decided to adopt this approach for the package definition. This structure is flexible and can be easily separated in the future if the versions diverge significantly.

I have verified the package on two architectures:

    x86_64-linux

    aarch64-darwin

Both `wesnoth` and `wesnoth-devel` are building and running as expected on these platforms.

The associated update script is also working correctly; I successfully tested it with deprecated version numbers, and it updated the package to the latest version as intended.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
