### PR TITLE
scalp: fix build

### DIFF
--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -19,16 +19,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-bUq/9cxqqpM66ObBeiJt8PwLZxxDj2lxXUHQn+gfkC8=";
   };
 
-  nativeBuildInputs = [
-    binutils
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    cctools
-    fixDarwinDylibNames
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    autoSignDarwinBinariesHook
-  ];
+  nativeBuildInputs =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      binutils
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      cctools
+      fixDarwinDylibNames
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+      autoSignDarwinBinariesHook
+    ];
 
   env = {
     NIX_CFLAGS_COMPILE = "-Wno-error=implicit-int";

--- a/pkgs/by-name/fl/flopoco/package.nix
+++ b/pkgs/by-name/fl/flopoco/package.nix
@@ -74,6 +74,10 @@ stdenv.mkDerivation {
     ./flopoco BuildAutocomplete
   '';
 
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/pa/pagsuite/package.nix
+++ b/pkgs/by-name/pa/pagsuite/package.nix
@@ -1,44 +1,35 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitLab,
   cmake,
-  unzip,
   gmp,
   scalp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pagsuite";
-  version = "1.80";
+  version = "1.80-unstable-2025-05-03";
 
-  src = fetchurl {
-    url = "https://gitlab.com/kumm/pagsuite/-/raw/master/releases/pagsuite_${
-      lib.replaceStrings [ "." ] [ "_" ] version
-    }.zip";
-    hash = "sha256-TYd+dleVPWEWU9Cb3XExd7ixJZyiUAp9QLtorYJSIbQ=";
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "kumm";
+    repo = "pagsuite";
+    rev = "1cc657765658cb2eb622d4a9c656ab9854150e7d";
+    hash = "sha256-jyp3h5n6SkyTpLzqMezvu2nri6rDkX3ACcCO9r4/bBA=";
   };
-
-  patches = [
-    # Fix issue with latest ScaLP update
-    (fetchpatch {
-      url = "https://gitlab.com/kumm/pagsuite/-/commit/cae9f78bec93a7f197461358f2f796f6b5778781.patch";
-      hash = "sha256-12IisS6oGYLRicORTemHB7bw9EB9cuQjxG8f6X0WMrU=";
-    })
-  ];
-
-  sourceRoot = "pagsuite_${lib.replaceStrings [ "." ] [ "_" ] version}";
 
   nativeBuildInputs = [
     cmake
-    unzip
   ];
 
   buildInputs = [
     gmp
     scalp
   ];
+
+  # make[2]: ***  No rule to make target 'lib/libpag.dylib', needed by 'bin/osr'.  Stop.
+  enableParallelBuilding = false;
 
   meta = with lib; {
     description = "Optimization tools for the (P)MCM problem";

--- a/pkgs/by-name/sc/scalp/package.nix
+++ b/pkgs/by-name/sc/scalp/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required (VERSION 3.3.2)" "cmake_minimum_required (VERSION 3.5)" \
       --replace-fail "\''$ORIGIN" "\''${CMAKE_INSTALL_PREFIX}/lib" \
       --replace-fail "-m64" ""
     substituteInPlace src/tests/CMakeLists.txt \


### PR DESCRIPTION
Also fixes a regression of lp_solve on darwin, introduced in #419322.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
