### PR TITLE
nixos/utils: Add support for LoadCredential= with genJqSecretsReplacementSnippet

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 let
@@ -9,10 +10,9 @@ let
   format = pkgs.formats.json { };
   isPostgresUnixSocket = lib.hasPrefix "/" cfg.database.host;
   isRedisUnixSocket = lib.hasPrefix "/" cfg.redis.host;
-
-  # convert a Nix attribute path to jq object identifier-index:
-  # https://jqlang.org/manual/#object-identifier-index
-  attrPathToIndex = attrPath: "." + lib.concatStringsSep "." attrPath;
+  secretsReplacement = utils.genJqSecretsReplacement {
+    loadCredential = true;
+  } cfg.settings "/run/immich/config.json";
 
   commonServiceConfig = {
     Type = "simple";
@@ -55,6 +55,22 @@ let
     if cfg.database.enable then config.services.postgresql.package else pkgs.postgresql;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "services"
+        "immich"
+        "secretSettings"
+      ]
+      ''
+        `secretSettings` has been deprecated as secrets can now be specified
+        directly in `settings`. To do so, set `_secret` of the desired
+        attribute to a file path, for example:
+          `services.immich.settings.oauth.clientSecret._secret = "/path/to/secret/file";`
+      ''
+    )
+  ];
+
   options.services.immich = {
     enable = mkEnableOption "Immich";
     package = lib.mkPackageOption pkgs "immich" { };
@@ -128,6 +144,7 @@ in
         <https://my.immich.app/admin/system-settings> for
         options and defaults.
         Setting it to `null` allows configuring Immich in the web interface.
+        You can load secret values from a file in this configuration by setting `somevalue._secret = "/path/to/file"` instead of setting `somevalue` directly.
       '';
       type = types.nullOr (
         types.submodule {
@@ -149,27 +166,6 @@ in
           };
         }
       );
-    };
-
-    secretSettings = mkOption {
-      default = { };
-      description = ''
-        Secrets to to be added to the JSON file generated from {option}`settings`, read from files.
-      '';
-      example = lib.literalExpression ''
-        {
-          notifications.smtp.transport.password = "/path/to/secret";
-          oauth.clientSecret = "/path/to/other/secret";
-        }
-      '';
-      type =
-        let
-          inherit (types) attrsOf either path;
-          recursiveType = either (attrsOf recursiveType) path // {
-            description = "nested " + (attrsOf path).description;
-          };
-        in
-        recursiveType;
     };
 
     machine-learning = {
@@ -424,24 +420,10 @@ in
         postgresqlPackage
       ];
 
-      preStart = mkIf (cfg.settings != null) (
-        ''
-          cat '${format.generate "immich-config.json" cfg.settings}' > /run/immich/config.json
-        ''
-        + lib.concatStrings (
-          lib.mapAttrsToListRecursive (attrPath: _: ''
-            tmp="$(mktemp)"
-            ${lib.getExe pkgs.jq} --rawfile secret "$CREDENTIALS_DIRECTORY/${attrPathToIndex attrPath}" \
-              '${attrPathToIndex attrPath} = ($secret | rtrimstr("\n"))' /run/immich/config.json > "$tmp"
-            mv "$tmp" /run/immich/config.json
-          '') cfg.secretSettings
-        )
-      );
+      preStart = mkIf (cfg.settings != null) secretsReplacement.script;
 
       serviceConfig = commonServiceConfig // {
-        LoadCredential = lib.mapAttrsToListRecursive (
-          attrPath: file: "${attrPathToIndex attrPath}:${file}"
-        ) cfg.secretSettings;
+        LoadCredential = secretsReplacement.credentials;
         ExecStart = lib.getExe cfg.package;
         EnvironmentFile = mkIf (cfg.secretsFile != null) cfg.secretsFile;
         Slice = "system-immich.slice";

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -17,14 +17,14 @@
       services.immich = {
         enable = true;
         environment.IMMICH_LOG_LEVEL = "verbose";
-        settings.backup.database = {
-          enabled = true;
-          cronExpression = "invalid";
-        };
-        secretSettings = {
-          backup.database.cronExpression = "${pkgs.writeText "cron" "0 02 * * *"}";
+        settings = {
+          backup.database = {
+            enabled = true;
+            # Test loading secrets from files:
+            cronExpression._secret = "${pkgs.writeText "cron" "0 02 * * *"}";
+          };
           # thanks to LoadCredential files only readable by root should work
-          notifications.smtp.transport.password = "/etc/shadow";
+          notifications.smtp.transport.password._secret = "/etc/shadow";
         };
       };
 


### PR DESCRIPTION
With genJqSecretsReplacementScript we already have a nice way to template arbitrary secret values (and json sub-trees) into json files.
But currently this requires the executing process to have access to the underlying secret files, which
is not always easily possible when using services that use DynamicUser=true.

This PR extends genJqSecretsReplacementScript in a fully backwards compatible way to allow generating a script that loads
files from `$CREDENTIALS_DIRECTORY` together with a new utility that generates the required credential list for `LoadCredential=`.

I find the names quite unwieldy, but couldn't come up with something better. Feel free to suggest clearer naming.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
