### PR TITLE
treewide: remove "with lib" from all Prometheus exporters

### DIFF
--- a/pkgs/by-name/pr/prometheus-borgmatic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-borgmatic-exporter/package.nix
@@ -40,13 +40,13 @@ python3Packages.buildPythonApplication rec {
     pytest-mock
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Borgmatic";
     homepage = "https://github.com/maxim-mityutko/borgmatic-exporter";
     changelog = "https://github.com/maxim-mityutko/borgmatic-exporter/releases/tag/${src.tag}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ flandweber ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ flandweber ];
     mainProgram = "borgmatic-exporter";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
@@ -42,12 +42,12 @@ buildGoModule rec {
     patchelf --add-needed libnvidia-ml.so "$out/bin/dcgm-exporter"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "NVIDIA GPU metrics exporter for Prometheus leveraging DCGM";
     homepage = "https://github.com/NVIDIA/dcgm-exporter";
-    license = licenses.asl20;
-    teams = [ teams.deshaw ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.deshaw ];
     mainProgram = "dcgm-exporter";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pr/prometheus-deluge-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-deluge-exporter/package.nix
@@ -31,11 +31,11 @@ python3.pkgs.buildPythonApplication {
     "deluge_exporter"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Deluge";
     homepage = "https://github.com/ibizaman/deluge_exporter";
-    license = licenses.isc;
-    maintainers = with maintainers; [ ibizaman ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ ibizaman ];
     mainProgram = "deluge-exporter";
   };
 }

--- a/pkgs/by-name/pr/prometheus-dnssec-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dnssec-exporter/package.nix
@@ -16,10 +16,10 @@ buildGoModule {
 
   vendorHash = "sha256-u7X8v7h1aL8B1el4jFzGRKHvnaK+Rz0OCitaC6xgyjw=";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/chrj/prometheus-dnssec-exporter";
     description = "DNSSEC Exporter for Prometheus";
-    license = licenses.mit;
-    maintainers = with maintainers; [ swendel ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ swendel ];
   };
 }

--- a/pkgs/by-name/pr/prometheus-elasticsearch-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-elasticsearch-exporter/package.nix
@@ -16,11 +16,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-NAaVz5AqhfaEiWqBAeQZVWwjMIwX9jEw0oycXq7uLNw=";
 
-  meta = with lib; {
+  meta = {
     description = "Elasticsearch stats exporter for Prometheus";
     mainProgram = "elasticsearch_exporter";
     homepage = "https://github.com/prometheus-community/elasticsearch_exporter";
-    license = licenses.asl20;
-    teams = [ teams.deshaw ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.deshaw ];
   };
 }

--- a/pkgs/by-name/pr/prometheus-frr-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-frr-exporter/package.nix
@@ -24,7 +24,7 @@ buildGoModule {
     "-X github.com/prometheus/common/version.Branch=unknown"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for FRR version 3.0+";
     longDescription = ''
       Prometheus exporter for FRR version 3.0+ that collects metrics from the
@@ -32,8 +32,8 @@ buildGoModule {
       Prometheus.
     '';
     homepage = "https://github.com/tynany/frr_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ javaes ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ javaes ];
     mainProgram = "frr_exporter";
   };
 }

--- a/pkgs/by-name/pr/prometheus-klipper-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-klipper-exporter/package.nix
@@ -28,11 +28,11 @@ buildGoModule rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus Exporter for Klipper";
     homepage = "https://github.com/scross01/prometheus-klipper-exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ wulfsta ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wulfsta ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
@@ -25,10 +25,10 @@ buildGoModule rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus metrics exporter for libvirt";
     homepage = "https://github.com/Tinkoff/libvirt-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ farcaller ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ farcaller ];
   };
 }

--- a/pkgs/by-name/pr/prometheus-mysqld-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-mysqld-exporter/package.nix
@@ -36,13 +36,13 @@ buildGoModule rec {
     "-short"
   ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/prometheus/mysqld_exporter/blob/${src.tag}/CHANGELOG.md";
     description = "Prometheus exporter for MySQL server metrics";
     mainProgram = "mysqld_exporter";
     homepage = "https://github.com/prometheus/mysqld_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       benley
       globin
     ];

--- a/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
@@ -22,11 +22,11 @@ buildGoModule {
   # predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
   patches = [ ./gomod.patch ];
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for SSL certificate";
     mainProgram = "node-cert-exporter";
     homepage = "https://github.com/amimof/node-cert-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ ibizaman ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ibizaman ];
   };
 }

--- a/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
@@ -38,13 +38,13 @@ stdenvNoCC.mkDerivation rec {
     restic-exporter = nixosTests.prometheus-exporters.restic;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for the Restic backup system";
     homepage = "https://github.com/ngosang/restic-exporter";
     changelog = "https://github.com/ngosang/restic-exporter/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ minersebas ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ minersebas ];
     mainProgram = "restic-exporter.py";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/pr/prometheus-smartctl-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-smartctl-exporter/package.nix
@@ -30,13 +30,13 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) smartctl; };
 
-  meta = with lib; {
+  meta = {
     description = "Export smartctl statistics for Prometheus";
     mainProgram = "smartctl_exporter";
     homepage = "https://github.com/prometheus-community/smartctl_exporter";
-    license = licenses.lgpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       hexa
       Frostman
     ];

--- a/pkgs/by-name/pr/prometheus-surfboard-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-surfboard-exporter/package.nix
@@ -24,12 +24,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) surfboard; };
 
-  meta = with lib; {
+  meta = {
     description = "Arris Surfboard signal metrics exporter";
     mainProgram = "surfboard_exporter";
     homepage = "https://github.com/ipstatic/surfboard_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ disassembler ];
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ disassembler ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/apcupsd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/apcupsd-exporter.nix
@@ -20,12 +20,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) apcupsd; };
 
-  meta = with lib; {
+  meta = {
     description = "Provides a Prometheus exporter for the apcupsd Network Information Server (NIS)";
     mainProgram = "apcupsd_exporter";
     homepage = "https://github.com/mdlayher/apcupsd_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       _1000101
       mdlayher
     ];

--- a/pkgs/servers/monitoring/prometheus/artifactory-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/artifactory-exporter.nix
@@ -32,12 +32,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) artifactory; };
 
-  meta = with lib; {
+  meta = {
     description = "JFrog Artifactory Prometheus Exporter";
     mainProgram = "artifactory_exporter";
     homepage = "https://github.com/peimanja/artifactory_exporter";
     changelog = "https://github.com/peimanja/artifactory_exporter/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ lbpdt ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lbpdt ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/atlas-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/atlas-exporter.nix
@@ -17,11 +17,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-tR+OHxj/97AixuAp0Kx9xQsKPAxpvF6hDha5BgMBha0=";
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for RIPE Atlas measurement results";
     mainProgram = "atlas_exporter";
     homepage = "https://github.com/czerwonk/atlas_exporter";
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ clerie ];
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ clerie ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/aws-s3-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/aws-s3-exporter.nix
@@ -22,11 +22,11 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Exports Prometheus metrics about S3 buckets and objects";
     mainProgram = "s3_exporter";
     homepage = "https://github.com/ribbybibby/s3_exporter";
-    license = licenses.asl20;
-    maintainers = [ maintainers.mmahut ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.mmahut ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/bind-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/bind-exporter.nix
@@ -20,11 +20,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) bind; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for bind9 server";
     mainProgram = "bind_exporter";
     homepage = "https://github.com/digitalocean/bind_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ rtreffer ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rtreffer ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/bird-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/bird-exporter.nix
@@ -20,11 +20,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) bird; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for the bird routing daemon";
     mainProgram = "bird_exporter";
     homepage = "https://github.com/czerwonk/bird_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ lukegb ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lukegb ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/bitcoin-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/bitcoin-exporter.nix
@@ -35,12 +35,12 @@ python3Packages.buildPythonApplication rec {
     cp -r dashboard README.md $out/share/${pname}/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Bitcoin Core nodes";
     mainProgram = "bitcoind-monitor.py";
     homepage = "https://github.com/jvstein/bitcoin-prometheus-exporter";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ mmilata ];
-    platforms = platforms.all;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ mmilata ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
@@ -34,12 +34,12 @@ buildGoModule rec {
     "-X github.com/prometheus/common/version.BuildDate=unknown"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP";
     mainProgram = "blackbox_exporter";
     homepage = "https://github.com/prometheus/blackbox_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       globin
       fpletz
       Frostman

--- a/pkgs/servers/monitoring/prometheus/cloudflare-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/cloudflare-exporter.nix
@@ -27,12 +27,12 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus Cloudflare Exporter";
     mainProgram = "cloudflare-exporter";
     homepage = "https://github.com/lablabs/cloudflare-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ bbigras ];
-    platforms = platforms.linux;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bbigras ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/collectd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/collectd-exporter.nix
@@ -25,11 +25,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) collectd; };
 
-  meta = with lib; {
+  meta = {
     description = "Relay server for exporting metrics from collectd to Prometheus";
     mainProgram = "collectd_exporter";
     homepage = "https://github.com/prometheus/collectd_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ benley ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ benley ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/consul-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/consul-exporter.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Consul metrics";
     mainProgram = "consul_exporter";
     homepage = "https://github.com/prometheus/consul_exporter";
     changelog = "https://github.com/prometheus/consul_exporter/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ hectorj ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hectorj ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dnsmasq-exporter.nix
@@ -23,12 +23,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) dnsmasq; };
 
-  meta = with lib; {
+  meta = {
     inherit (src.meta) homepage;
     description = "Dnsmasq exporter for Prometheus";
     mainProgram = "dnsmasq_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       globin
     ];
     # Broken on darwin for Go toolchain > 1.22, with error:

--- a/pkgs/servers/monitoring/prometheus/domain-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/domain-exporter.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) domain; };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/caarlos0/domain_exporter";
     description = "Exports the expiration time of your domains as prometheus metrics";
     mainProgram = "domain_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       mmilata
       peterhoeg
       caarlos0

--- a/pkgs/servers/monitoring/prometheus/fastly-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/fastly-exporter.nix
@@ -22,11 +22,11 @@ buildGoModule rec {
     inherit (nixosTests.prometheus-exporters) fastly;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for the Fastly Real-time Analytics API";
     homepage = "https://github.com/fastly/fastly-exporter";
-    license = licenses.asl20;
-    teams = [ teams.deshaw ];
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.deshaw ];
     mainProgram = "fastly-exporter";
   };
 }

--- a/pkgs/servers/monitoring/prometheus/flow-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/flow-exporter.nix
@@ -17,12 +17,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-2raOUOPiMUMydIsfSsnwUAAiM7WyMio1NgL1EoADr2s=";
 
-  meta = with lib; {
+  meta = {
     description = "Export network flows from kafka to Prometheus";
     mainProgram = "flow-exporter";
     homepage = "https://github.com/neptune-networks/flow-exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ kloenk ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kloenk ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/fritzbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/fritzbox-exporter.nix
@@ -22,12 +22,12 @@ buildGoModule {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) fritzbox; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus Exporter for FRITZ!Box (TR64 and UPnP)";
     mainProgram = "exporter";
     homepage = "https://github.com/mxschmitt/fritzbox_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       bachp
       flokli
       sbruder

--- a/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
@@ -24,12 +24,12 @@ buildGoModule rec {
   vendorHash = "sha256-LPS0paXtzNAOFW8FUAFbcEcVTtp3WFh6N/f6tuFPT50=";
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus / OpenMetrics exporter for GitLab CI pipelines insights";
     mainProgram = "gitlab-ci-pipelines-exporter";
     homepage = "https://github.com/mvisonneau/gitlab-ci-pipelines-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       mmahut
       mvisonneau
     ];

--- a/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/haproxy-exporter.nix
@@ -22,11 +22,11 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "HAProxy Exporter for the Prometheus monitoring system";
     mainProgram = "haproxy_exporter";
     homepage = "https://github.com/prometheus/haproxy_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ benley ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ benley ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/idrac-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/idrac-exporter.nix
@@ -29,11 +29,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) idrac; };
 
-  meta = with lib; {
+  meta = {
     inherit (src.meta) homepage;
     description = "Simple iDRAC exporter for Prometheus";
     mainProgram = "idrac_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ codec ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ codec ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/imap-mailstat-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/imap-mailstat-exporter.nix
@@ -20,12 +20,12 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  meta = with lib; {
+  meta = {
     description = "Export Prometheus-style metrics about how many emails you have in your INBOX and in additional configured folders";
     mainProgram = "imap-mailstat-exporter";
     homepage = "https://github.com/bt909/imap-mailstat-exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ raboof ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ raboof ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/influxdb-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/influxdb-exporter.nix
@@ -31,12 +31,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) influxdb; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter that accepts InfluxDB metrics";
     mainProgram = "influxdb_exporter";
     homepage = "https://github.com/prometheus/influxdb_exporter";
     changelog = "https://github.com/prometheus/influxdb_exporter/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/ipmi-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/ipmi-exporter.nix
@@ -38,12 +38,12 @@ buildGoModule rec {
     "-X github.com/prometheus/common/version.BuildDate=unknown"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "IPMI exporter for Prometheus";
     mainProgram = "ipmi_exporter";
     homepage = "https://github.com/prometheus-community/ipmi_exporter";
     changelog = "https://github.com/prometheus-community/ipmi_exporter/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ snaar ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ snaar ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/jitsi-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/jitsi-exporter.nix
@@ -19,11 +19,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) jitsi; };
 
-  meta = with lib; {
+  meta = {
     description = "Export Jitsi Videobridge metrics to Prometheus";
     mainProgram = "jitsiexporter";
     homepage = "https://git.xsfx.dev/prometheus/jitsiexporter";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/json-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/json-exporter.nix
@@ -20,10 +20,10 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) json; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter which scrapes remote JSON by JSONPath";
     homepage = "https://github.com/prometheus-community/json_exporter";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     maintainers = [ ];
     mainProgram = "json_exporter";
   };

--- a/pkgs/servers/monitoring/prometheus/junos-czerwonk-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/junos-czerwonk-exporter.nix
@@ -17,11 +17,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-zD5QkpyeqrmX0zGgdQg9yQQrX/+0Xz+Q04IzpO+Qc5Q=";
 
-  meta = with lib; {
+  meta = {
     description = "Exporter for metrics from devices running JunOS";
     mainProgram = "junos_exporter";
     homepage = "https://github.com/czerwonk/junos_exporter";
-    license = licenses.mit;
-    teams = [ teams.wdz ];
+    license = lib.licenses.mit;
+    teams = [ lib.teams.wdz ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/kea-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/kea-exporter.nix
@@ -35,12 +35,12 @@ python3Packages.buildPythonApplication rec {
     inherit (nixosTests) kea;
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/mweinelt/kea-exporter/blob/v${version}/HISTORY";
     description = "Export Kea Metrics in the Prometheus Exposition Format";
     mainProgram = "kea-exporter";
     homepage = "https://github.com/mweinelt/kea-exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ hexa ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/keylight-exporter.nix
@@ -20,11 +20,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) keylight; };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/mdlayher/keylight_exporter";
     description = "Prometheus exporter for Elgato Key Light devices";
     mainProgram = "keylight_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mdlayher ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mdlayher ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/knot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/knot-exporter.nix
@@ -32,11 +32,11 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) knot; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Knot DNS";
     homepage = "https://gitlab.nic.cz/knot/knot-dns/-/tree/master/python/knot_exporter";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
       ma27
       hexa
     ];

--- a/pkgs/servers/monitoring/prometheus/lnd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/lnd-exporter.nix
@@ -23,11 +23,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) lnd; };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lightninglabs/lndmon";
     description = "Prometheus exporter for lnd (Lightning Network Daemon)";
     mainProgram = "lndmon";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mmilata ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mmilata ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/mail-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mail-exporter.nix
@@ -28,14 +28,14 @@ buildGoModule {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) mail; };
 
-  meta = with lib; {
+  meta = {
     description = "Export Prometheus-style metrics about mail server functionality";
     mainProgram = "mailexporter";
     homepage = "https://github.com/cherti/mailexporter";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
       globin
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/mikrotik-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mikrotik-exporter.nix
@@ -22,11 +22,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) mikrotik; };
 
-  meta = with lib; {
+  meta = {
     inherit (src.meta) homepage;
     description = "Prometheus MikroTik device(s) exporter";
     mainProgram = "mikrotik-exporter";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ mmilata ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ mmilata ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/modemmanager-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/modemmanager-exporter.nix
@@ -20,11 +20,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) modemmanager; };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/mdlayher/modemmanager_exporter";
     description = "Prometheus exporter for ModemManager and its devices";
     mainProgram = "modemmanager_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mdlayher ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mdlayher ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/mongodb-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mongodb-exporter.nix
@@ -32,11 +32,11 @@ buildGoModule rec {
   # nixpkgs doesn't have mongodb application available;
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for MongoDB including sharding, replication and storage engines";
     homepage = "https://github.com/percona/mongodb_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ undefined-moe ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ undefined-moe ];
     mainProgram = "mongodb_exporter";
   };
 }

--- a/pkgs/servers/monitoring/prometheus/nats-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nats-exporter.nix
@@ -40,10 +40,10 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Exporter for NATS metrics";
     homepage = "https://github.com/nats-io/prometheus-nats-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ bbigras ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bbigras ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nextcloud-exporter.nix
@@ -20,10 +20,10 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) nextcloud; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Nextcloud servers";
     homepage = "https://github.com/xperimental/nextcloud-exporter";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "nextcloud-exporter";
   };

--- a/pkgs/servers/monitoring/prometheus/nginx-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nginx-exporter.nix
@@ -33,12 +33,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) nginx; };
 
-  meta = with lib; {
+  meta = {
     description = "NGINX Prometheus Exporter for NGINX and NGINX Plus";
     mainProgram = "nginx-prometheus-exporter";
     homepage = "https://github.com/nginxinc/nginx-prometheus-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       benley
       fpletz
       globin

--- a/pkgs/servers/monitoring/prometheus/nginxlog-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nginxlog-exporter.nix
@@ -22,11 +22,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) nginxlog; };
 
-  meta = with lib; {
+  meta = {
     description = "Export metrics from Nginx access log files to Prometheus";
     mainProgram = "prometheus-nginxlog-exporter";
     homepage = "https://github.com/martin-helmich/prometheus-nginxlog-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ mmahut ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mmahut ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/nut-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nut-exporter.nix
@@ -17,11 +17,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-cMZ4GSal03LIZi7ESr/sQx8zLHNepOTZGEEsdvsNhec=";
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Network UPS Tools";
     mainProgram = "nut_exporter";
     homepage = "https://github.com/DRuggeri/nut_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ jhh ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jhh ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/pgbouncer-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/pgbouncer-exporter.nix
@@ -17,12 +17,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-IBIJWA/arARPV0ErAQdGJXbPAaryCN22mHwKL08M8QA=";
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for PgBouncer";
     mainProgram = "pgbouncer_exporter";
     homepage = "https://github.com/prometheus-community/pgbouncer_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ _1000101 ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _1000101 ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/php-fpm-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/php-fpm-exporter.nix
@@ -53,11 +53,11 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/hipages/php-fpm_exporter";
     description = "Prometheus exporter for PHP-FPM";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ gaelreyrol ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ gaelreyrol ];
     mainProgram = "php-fpm_exporter";
   };
 }

--- a/pkgs/servers/monitoring/prometheus/pihole-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/pihole-exporter.nix
@@ -17,11 +17,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-4qbfXRXEViR/2fCmanlU88zvbJb5oppHWC7rVQaneLc=";
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for PI-Hole's Raspberry PI ad blocker";
     mainProgram = "pihole-exporter";
     homepage = "https://github.com/eko/pihole-exporter";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/ping-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/ping-exporter.nix
@@ -17,11 +17,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-bEJstamu0+EfHL2cduWb/iDeYCp8tzGCS2Lvc7Onp48=";
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for ICMP echo requests";
     mainProgram = "ping_exporter";
     homepage = "https://github.com/czerwonk/ping_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ nudelsalat ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nudelsalat ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -37,12 +37,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) postfix; };
 
-  meta = with lib; {
+  meta = {
     inherit (src.meta) homepage;
     description = "Prometheus exporter for Postfix";
     mainProgram = "postfix_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       globin
     ];
   };

--- a/pkgs/servers/monitoring/prometheus/postgres-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postgres-exporter.nix
@@ -36,12 +36,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) postgres; };
 
-  meta = with lib; {
+  meta = {
     inherit (src.meta) homepage;
     description = "Prometheus exporter for PostgreSQL";
     mainProgram = "postgres_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       fpletz
       globin
       ma27

--- a/pkgs/servers/monitoring/prometheus/process-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/process-exporter.nix
@@ -26,11 +26,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) process; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter that mines /proc to report on selected processes";
     homepage = "https://github.com/ncabatoff/process-exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ _1000101 ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _1000101 ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/pve-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/pve-exporter.nix
@@ -32,11 +32,11 @@ python3.pkgs.buildPythonApplication rec {
     inherit (nixosTests.prometheus-exporters) pve;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Exposes information gathered from Proxmox VE cluster for use by the Prometheus monitoring system";
     mainProgram = "pve_exporter";
     homepage = "https://github.com/prometheus-pve/prometheus-pve-exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ nukaduka ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nukaduka ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/redis-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/redis-exporter.nix
@@ -55,12 +55,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) redis; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for Redis metrics";
     mainProgram = "redis_exporter";
     homepage = "https://github.com/oliver006/redis_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       eskytthe
       srhb
       ma27

--- a/pkgs/servers/monitoring/prometheus/rtl_433-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/rtl_433-exporter.nix
@@ -23,11 +23,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) rtl_433; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus time-series DB exporter for rtl_433 433MHz radio packet decoder";
     mainProgram = "rtl_433_prometheus";
     homepage = "https://github.com/mhansen/rtl_433_prometheus";
-    license = licenses.mit;
-    maintainers = with maintainers; [ zopieux ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zopieux ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/sabnzbd-exporter.nix
@@ -39,12 +39,12 @@ python3Packages.buildPythonApplication rec {
     inherit (nixosTests.prometheus-exporters) sabnzbd;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for sabnzbd";
     homepage = "https://github.com/msroest/sabnzbd_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fugi ];
-    platforms = platforms.all;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fugi ];
+    platforms = lib.platforms.all;
     mainProgram = "sabnzbd_exporter.py";
   };
 }

--- a/pkgs/servers/monitoring/prometheus/script-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/script-exporter.nix
@@ -30,12 +30,12 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) script; };
 
-  meta = with lib; {
+  meta = {
     description = "Shell script prometheus exporter";
     mainProgram = "script_exporter";
     homepage = "https://github.com/ricoberger/script_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ Flakebi ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Flakebi ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/servers/monitoring/prometheus/shelly-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/shelly-exporter.nix
@@ -20,11 +20,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) shelly; };
 
-  meta = with lib; {
+  meta = {
     description = "Shelly humidity sensor exporter for prometheus";
     mainProgram = "shelly_exporter";
     homepage = "https://github.com/aexel90/shelly_exporter";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
@@ -25,11 +25,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) snmp; };
 
-  meta = with lib; {
+  meta = {
     description = "SNMP Exporter for Prometheus";
     homepage = "https://github.com/prometheus/snmp_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       Frostman
     ];
   };

--- a/pkgs/servers/monitoring/prometheus/sql-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/sql-exporter.nix
@@ -38,11 +38,11 @@ buildGoModule rec {
     command = "sql_exporter -version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Flexible SQL exporter for Prometheus";
     mainProgram = "sql_exporter";
     homepage = "https://github.com/justwatchcom/sql_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ justinas ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ justinas ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/statsd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/statsd-exporter.nix
@@ -31,13 +31,13 @@ buildGoModule rec {
 
   vendorHash = "sha256-QKDvoctvvdijQ+ZlClqTyJZfDzqAIikAwOQds9+NQIc=";
 
-  meta = with lib; {
+  meta = {
     description = "Receives StatsD-style metrics and exports them to Prometheus";
     mainProgram = "statsd_exporter";
     homepage = "https://github.com/prometheus/statsd_exporter";
     changelog = "https://github.com/prometheus/statsd_exporter/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       benley
       ivan
     ];

--- a/pkgs/servers/monitoring/prometheus/systemd-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/systemd-exporter.nix
@@ -30,11 +30,11 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) systemd; };
 
-  meta = with lib; {
+  meta = {
     description = "Exporter for systemd unit metrics";
     mainProgram = "systemd_exporter";
     homepage = "https://github.com/prometheus-community/systemd_exporter";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ chkno ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ chkno ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/unbound-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/unbound-exporter.nix
@@ -25,12 +25,12 @@ buildGoModule {
     inherit (nixosTests.prometheus-exporters) unbound;
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/letsencrypt/unbound_exporter/releases/tag/v${version}";
     description = "Prometheus exporter for Unbound DNS resolver";
     mainProgram = "unbound_exporter";
     homepage = "https://github.com/letsencrypt/unbound_exporter/tree/main";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ hexa ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/v2ray-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/v2ray-exporter.nix
@@ -17,11 +17,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-+jrD+QatTrMaAdbxy5mpCm8lF37XDIy1GFyEiUibA2k=";
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for V2Ray daemon";
     mainProgram = "v2ray-exporter";
     homepage = "https://github.com/wi1dcard/v2ray-exporter";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
@@ -31,11 +31,11 @@ rustPlatform.buildRustPackage rec {
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) wireguard; };
 
-  meta = with lib; {
+  meta = {
     description = "Prometheus exporter for WireGuard, written in Rust";
     homepage = "https://github.com/MindFlavor/prometheus_wireguard_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       ma27
       globin
     ];

--- a/pkgs/servers/monitoring/prometheus/zfs-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/zfs-exporter.nix
@@ -31,11 +31,11 @@ buildGoModule rec {
     install -Dm444 -t $out/share/doc/${pname} *.md
   '';
 
-  meta = with lib; {
+  meta = {
     description = "ZFS Exporter for the Prometheus monitoring system";
     mainProgram = "zfs_exporter";
     homepage = "https://github.com/pdf/zfs_exporter";
-    license = licenses.mit;
-    maintainers = with maintainers; [ peterhoeg ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ peterhoeg ];
   };
 }


### PR DESCRIPTION
I know some are against the removal of targeted usage of `with lib` in `meta` but the problem this PR seeks to address is new PRs being marked for revisions when they use `with lib` because they copy an existing package as the foundation for a new package, e.g. https://github.com/NixOS/nixpkgs/pull/453075#discussion_r2441529819.

As discussed in https://github.com/NixOS/nixpkgs/issues/208242 this commit eliminates usage of `with lib` from all Prometheus exporters to prevent new exporters copied from existing files from re-introducing the same pattern.

It's possible that the mentioned request for changes wrong and the correct solution is actually to push back on nixpkgs maintainers and insist that targeted use of `with lib` is actually acceptable. If that's the case, then I'm fine with closing this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
