### PR TITLE
ci/nixpkgs-vet: try to fix race

### DIFF
--- a/ci/nixpkgs-vet.nix
+++ b/ci/nixpkgs-vet.nix
@@ -32,6 +32,7 @@ runCommand "nixpkgs-vet"
   }
   ''
     export NIX_STATE_DIR=$(mktemp -d)
+    $NIXPKGS_VET_NIX_PACKAGE/bin/nix-store --init
 
     nixpkgs-vet --base ${filteredBase} ${filteredHead}
 


### PR DESCRIPTION
This is another attempt at fixing the annoying nixpkgs-vet errors in CI, which just throw with `error: SQLite database '...' is busy`.

The assumption is that this happens while initially setting up the state directories. nixpkgs-vet runs `nix-instantiate` on both the base and the head commit and these two could interfere.

## Things done

Since I can't reproduce the error locally, I have no idea whether this works.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
