### PR TITLE
nixos/scx: support temporarily overriding scheduler

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -101,13 +101,14 @@ in
 
       serviceConfig = {
         Type = "simple";
-        ExecStart = utils.escapeSystemdExecArgs (
-          [
-            (lib.getExe' cfg.package cfg.scheduler)
-          ]
-          ++ cfg.extraArgs
-        );
+        ExecStart = ''
+          ${pkgs.runtimeShell} -c 'exec ${cfg.package}/bin/''${SCX_SCHEDULER_OVERRIDE:-$SCX_SCHEDULER} ''${SCX_FLAGS_OVERRIDE:-$SCX_FLAGS}'
+        '';
         Restart = "on-failure";
+      };
+      environment = {
+        SCX_SCHEDULER = cfg.scheduler;
+        SCX_FLAGS = lib.escapeShellArgs cfg.extraArgs;
       };
 
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
One of the nicest perks of using scx is the ability to easily switch between schedulers at run-time, but this is currently not possible in NixOS, given that the scx service only uses the scheduler from the config file.

It's possible, however, to override the scheduler and its flags using the `SCX_SCHEDULER_OVERRIDE` and `SCX_FLAGS_OVERRIDE` environment variables, respectively (see [more details](https://en.opensuse.org/Pluggable_CPU_schedulers#Temporarily_switch_to_a_different_scheduler)).

So the solution here is to change the scx service executable and pass those env vars to the service at run-time falling back to the values from the module config as defaults.

After this change, it would be possible to override schedulers like so:

```shellSession
$ sudo systemctl set-environment SCX_SCHEDULER_OVERRIDE='scx_lavd'
$ sudo systemctl set-environment SCX_FLAGS_OVERRIDE='--performance'
$ sudo systemctl restart scx.service
```
```shellSession
$ journalctl -u scx.service -b 0 -e
Oct 18 13:09:25 nixos systemd[1]: Started SCX scheduler daemon.
Oct 18 13:09:25 nixos bash[1829848]: 13:09:25 [INFO] Performance mode is enabled.
Oct 18 13:09:25 nixos bash[1829848]: 13:09:25 [INFO] Energy model won't be used for CPU preference order.
# ...
Oct 18 13:09:26 nixos bash[1829848]: 13:09:26 [WARN] libbpf: map 'lavd_ops': BPF map skeleton link is uninitialized
Oct 18 13:09:26 nixos bash[1829848]: 13:09:26 [INFO] scx_lavd scheduler is initialized (build ID: 1.0.16 x86_64-unknown-linux-gnu)
Oct 18 13:09:26 nixos bash[1829848]: 13:09:26 [INFO] scx_lavd scheduler starts running.
```

And also restore to the module defaults:

```shellSession
$ sudo systemctl unset-environment SCX_SCHEDULER_OVERRIDE
$ sudo systemctl unset-environment SCX_FLAGS_OVERRIDE
$ sudo systemctl restart scx.service
```
```shellSession
$ journalctl -u scx.service -b 0 -e
Oct 18 13:12:56 nixos systemd[1]: Stopped SCX scheduler daemon.
Oct 18 13:12:56 nixos systemd[1]: Started SCX scheduler daemon.
Oct 18 13:12:56 nixos bash[1833220]: 13:12:56 [INFO] NUMA nodes: 1
Oct 18 13:12:56 nixos bash[1833220]: 13:12:56 [INFO] Disabling NUMA optimizations
Oct 18 13:12:56 nixos bash[1833220]: 13:12:56 [INFO] scx_bpfland 1.0.16 x86_64-unknown-linux-gnu SMT on
```

I've been running this on my system for a while, and I haven't had any issues so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
