### PR TITLE
mermaid-cli: 11.6.0 -> 11.12.0

### DIFF
--- a/pkgs/by-name/me/mermaid-cli/package.nix
+++ b/pkgs/by-name/me/mermaid-cli/package.nix
@@ -7,24 +7,24 @@
   nix-update-script,
 }:
 let
-  version = "11.6.0";
+  version = "11.12.0";
 in
 buildNpmPackage {
   pname = "mermaid-cli";
-  version = version;
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "mermaid-js";
     repo = "mermaid-cli";
     rev = version;
-    hash = "sha256-9Ozi5mAeFVdwGMjvlLG4hMWnCGi552SsT5RuvRiF9ww=";
+    hash = "sha256-OpYq0nOYCGTorzDxybsEjJmhL646wMBbQw3eHVxTuqU=";
   };
 
   patches = [
     ./remove-puppeteer-from-dev-deps.patch # https://github.com/mermaid-js/mermaid-cli/issues/830
   ];
 
-  npmDepsHash = "sha256-SHGYv/IwrCB02M8w5HsEsB7BwWVRFYNDYJFRDgG3a14=";
+  npmDepsHash = "sha256-Ex+tEm13feR/Vru0CHlvM3xS5wgGlYyqANeIquvRHwM=";
 
   env = {
     PUPPETEER_SKIP_DOWNLOAD = true;

--- a/pkgs/by-name/me/mermaid-cli/remove-puppeteer-from-dev-deps.patch
+++ b/pkgs/by-name/me/mermaid-cli/remove-puppeteer-from-dev-deps.patch
@@ -9,7 +9,7 @@ diff --git a/package.json b/package.json
 @@ -45,7 +45,6 @@
      "@tsconfig/node18": "^18.2.4",
      "@types/node": "~18.19.31",
-     "jest": "^29.0.1",
+     "jest": "^30.0.5",
 -    "puppeteer": "^23.1.1",
      "standard": "^17.0.0",
      "typescript": "^5.0.1-rc",


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
