### PR TITLE
crystal_1_18: init at 1.18.2

### DIFF
--- a/pkgs/by-name/am/ameba/package.nix
+++ b/pkgs/by-name/am/ameba/package.nix
@@ -1,10 +1,12 @@
 {
   lib,
   fetchFromGitHub,
-  crystal,
+  crystal_1_17,
   coreutils,
 }:
-
+let
+  crystal = crystal_1_17;
+in
 crystal.buildCrystalPackage rec {
   pname = "ameba";
   version = "1.6.4";

--- a/pkgs/by-name/bl/blahaj/package.nix
+++ b/pkgs/by-name/bl/blahaj/package.nix
@@ -1,13 +1,16 @@
 {
   lib,
   stdenv,
-  crystal,
+  crystal_1_17,
   fetchFromGitHub,
   # https://crystal-lang.org/2019/09/06/parallelism-in-crystal/
   multithreading ? true,
   static ? stdenv.hostPlatform.isStatic,
 }:
 
+let
+  crystal = crystal_1_17;
+in
 crystal.buildCrystalPackage rec {
   pname = "blahaj";
   version = "2.2.0";

--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -27,7 +27,7 @@
 let
   # normally video.js is downloaded at build time
   videojs = callPackage ./videojs.nix { inherit versions; };
-  crystal = crystal_1_17;
+  crystal = crystal_1_16;
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";

--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   callPackage,
-  crystal_1_17,
+  crystal_1_16,
   fetchFromGitHub,
   librsvg,
   pkg-config,

--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   callPackage,
-  crystal,
+  crystal_1_17,
   fetchFromGitHub,
   librsvg,
   pkg-config,
@@ -27,6 +27,7 @@
 let
   # normally video.js is downloaded at build time
   videojs = callPackage ./videojs.nix { inherit versions; };
+  crystal = crystal_1_17;
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -325,5 +325,13 @@ rec {
     doCheck = false;
   };
 
-  crystal = crystal_1_16;
+  crystal_1_18 = generic {
+    version = "1.18.1";
+    sha256 = "sha256-6bJnonQyPtWIl1ex1tw3QercDl4ZQcvuVNYiWzMpGZ0=";
+    binary = binaryCrystal_1_10;
+    llvmPackages = llvmPackages_21;
+    doCheck = false;
+  };
+
+  crystal = crystal_1_18;
 }

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -326,8 +326,8 @@ rec {
   };
 
   crystal_1_18 = generic {
-    version = "1.18.1";
-    sha256 = "sha256-6bJnonQyPtWIl1ex1tw3QercDl4ZQcvuVNYiWzMpGZ0=";
+    version = "1.18.2";
+    sha256 = "sha256-bwKs9bwD1WfS95DSxVY5AjT5Q61jOsfAH897tmiurng=";
     binary = binaryCrystal_1_10;
     llvmPackages = llvmPackages_21;
     doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4524,6 +4524,7 @@ with pkgs;
     crystal_1_15
     crystal_1_16
     crystal_1_17
+    crystal_1_18
     crystal
     ;
 


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/blob/release/1.18/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
