### PR TITLE
ci/parse: only show first error

### DIFF
--- a/ci/parse.nix
+++ b/ci/parse.nix
@@ -23,21 +23,11 @@ runCommand "nix-parse-${nix.name}"
 
     cd "${nixpkgs}"
 
-    # Passes all files to nix-instantiate at once.
-    # Much faster, but will only show first error.
-    parse-all() {
-      find . -type f -iname '*.nix' | xargs -P $(nproc) nix-instantiate --parse >/dev/null 2>/dev/null
-    }
-
-    # Passes each file separately to nix-instantiate with -n1.
-    # Much slower, but will show all errors.
-    parse-each() {
-      find . -type f -iname '*.nix' | xargs -n1 -P $(nproc) nix-instantiate --parse >/dev/null
-    }
-
-    if ! parse-all; then
-      parse-each
-    fi
+    # This will only show the first parse error, not all of them. That's fine, because
+    # the other CI jobs will report in more detail. This job is about checking parsing
+    # across different implementations / versions, not about providing the best DX.
+    # Returning all parse errors requires significantly more resources.
+    find . -type f -iname '*.nix' | xargs -P $(nproc) nix-instantiate --parse >/dev/null
 
     touch $out
   ''

--- a/ci/parse.nix
+++ b/ci/parse.nix
@@ -20,6 +20,7 @@ runCommand "nix-parse-${nix.name}"
   ''
     export NIX_STORE_DIR=$TMPDIR/store
     export NIX_STATE_DIR=$TMPDIR/state
+    nix-store --init
 
     cd "${nixpkgs}"
 


### PR DESCRIPTION
There is no point in running the much slower `parse-each` part for each interpreter/version. The CI job is not meant as a development tool that should report all parse errors at once, but as a confirmation that no parse errors are present on *different interpreter versions*.

Once this test fails, Eval, nixpkgs-vet and treefmt will most likely fail as well - with more information for multiple parse errors.

## Things done

- [x] Tested locally
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
