### PR TITLE
guile-colorized: init at 0-unstable-2019-12-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18214,6 +18214,11 @@
     githubId = 50854675;
     name = "Nelson Jeppesen";
   };
+  nemin = {
+    name = "Nemin";
+    github = "Nemin32";
+    githubId = 2953293;
+  };
   neosimsim = {
     email = "me@abn.sh";
     github = "neosimsim";

--- a/pkgs/by-name/gu/guile-colorized/package.nix
+++ b/pkgs/by-name/gu/guile-colorized/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchgit,
+  stdenv,
+  guile,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "guile-colorized";
+  version = "0-unstable-2019-12-05";
+
+  src = fetchgit {
+    url = "https://gitlab.com/NalaGinrut/guile-colorized";
+    rev = "1625a79f0e31849ebd537e2a58793fb45678c58f";
+    hash = "sha256-MxRFt3dPOBA/u2RbdnwWCfS6qjnVYtiuV7K+B6SFp4w=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ guile ];
+  buildInputs = [ guile ];
+
+  preConfigure = ''
+    export GUILE_AUTO_COMPILE=0
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    site_dir="$out/share/guile/3.0"
+    lib_dir="$out/lib/guile/3.0/site-ccache"
+
+    export GUILE_LOAD_PATH=.:$site_dir:...:$GUILE_LOAD_PATH
+    export GUILE_LOAD_COMPILED_PATH=.:$lib_dir:...:$GUILE_LOAD_COMPILE
+
+    mkdir -p $site_dir/ice-9
+    cp $src/ice-9/colorized.scm $site_dir/ice-9
+    guild compile $site_dir/ice-9/colorized.scm -o $lib_dir/ice-9/colorized.go
+
+    runHook postBuild
+  '';
+
+  dontInstall = true;
+
+  meta = {
+    description = "Colorized REPL for GNU Guile";
+    homepage = "https://gitlab.com/NalaGinrut/guile-colorized/";
+    license = lib.licenses.gpl3Plus;
+    platforms = guile.meta.platforms;
+    maintainers = with lib.maintainers; [ nemin ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [guile-colorized](https://gitlab.com/NalaGinrut/guile-colorized) to the list of packages. It's a small library that allows colorized REPL output. Tutorials occasionally [refer to the library](https://guix.gnu.org/manual/en/html_node/Using-Guix-Interactively.html) as a way of making the output easier to parse for newcomers, but until now the package was not in Nixpkgs. Packaged based on the [work of knightpp](https://github.com/NixOS/nixpkgs/pull/400634).

Also adds myself to maintainers as this is my first PR and the package is new.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
