### PR TITLE
k3s: k3s_1_33 -> k3s_1_34

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11642,7 +11642,7 @@ with pkgs;
     k3s_1_33
     k3s_1_34
     ;
-  k3s = k3s_1_33;
+  k3s = k3s_1_34;
 
   kapow = libsForQt5.callPackage ../applications/misc/kapow { };
 


### PR DESCRIPTION
k3s: k3s_1_33 -> k3s_1_34

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md

https://github.com/k3s-io/k3s/releases/tag/v1.34.1%2Bk3s1

Since `k3s_1_34` is now available in nixpkgs, we all can test it in our clusters, whenever you think this version bump is fine, please approve this PR.

I have `v1.34.1+k3s1` running in my RPi4 cluster without issues so far.

CC @NixOS/k3s 