### PR TITLE
lomiri.lomiri-download-manager: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   boost,
@@ -29,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-download-manager";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-download-manager";
     tag = finalAttrs.version;
-    hash = "sha256-dVyel4NL5LFORNTQzOyeTFkt9Wn23+4uwHsKcj+/0rk=";
+    hash = "sha256-e4HyUi8GXImEtM5I7dH27cDceUn+VCFpb9xgbMpQBJU=";
   };
 
   outputs = [
@@ -43,15 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ]
   ++ lib.optionals withDocumentation [ "doc" ];
-
-  patches = [
-    # Remove when version > 0.2.1
-    (fetchpatch {
-      name = "0001-lomiri-download-manager-treewide-Make-pkg-config-includedir-values-reasonable.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/commit/230aa1965917f90d235f55477a257eca1f5eaf46.patch";
-      hash = "sha256-Kdmu4U98Yc213pHS0o4DjpG8T5p50Q5hijRgdvscA/c=";
-    })
-  ];
 
   postPatch = ''
     # Substitute systemd's prefix in pkg-config call


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-download-manager/-/blob/0.2.2/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
