### PR TITLE
helix-health: init at 1.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9838,6 +9838,12 @@
     githubId = 6578603;
     name = "Jonas Rembser";
   };
+  gunererd = {
+    email = "gunererd@gmail.com";
+    github = "gunererd";
+    githubId = 5788729;
+    name = "Erdem Guner";
+  };
   gurjaka = {
     name = "Gurami Esartia";
     email = "esartia.gurika@gmail.com";

--- a/pkgs/by-name/he/helix-health/package.nix
+++ b/pkgs/by-name/he/helix-health/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGo125Module,
+  fetchFromGitHub,
+  makeWrapper,
+  helix,
+}:
+
+buildGo125Module (finalAttrs: {
+  pname = "helix-health";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "gunererd";
+    repo = "helix-health";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-zfdensdAOo4VtJWl3k5o/zfeu/9DddW85aq6VI1ZZRw=";
+  };
+
+  vendorHash = "sha256-BStOOu6GxqKToSA9cEyIzJdgK2T7PPhfReuacFnh2fU=";
+
+  # Temporarily patch go.mod to work with available Go version
+  postPatch = ''
+    substituteInPlace go.mod \
+      --replace "go 1.25.2" "go 1.25.1"
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/helix-health \
+      --prefix PATH : ${lib.makeBinPath [ helix ]}
+  '';
+
+  meta = {
+    description = "Interactive TUI for viewing and searching Helix editor's health information";
+    homepage = "https://github.com/gunererd/helix-health";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gunererd ];
+    mainProgram = "helix-health";
+  };
+})

--- a/pkgs/by-name/he/helix-health/package.nix
+++ b/pkgs/by-name/he/helix-health/package.nix
@@ -1,29 +1,23 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
   fetchFromGitHub,
   makeWrapper,
   helix,
 }:
 
-buildGo125Module (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "helix-health";
-  version = "1.0.2";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "gunererd";
     repo = "helix-health";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-zfdensdAOo4VtJWl3k5o/zfeu/9DddW85aq6VI1ZZRw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fuU8LVV30QMqpYvw1It1YBtgZ1iYmOdELOhwXk9wYio=";
   };
 
   vendorHash = "sha256-BStOOu6GxqKToSA9cEyIzJdgK2T7PPhfReuacFnh2fU=";
-
-  # Temporarily patch go.mod to work with available Go version
-  postPatch = ''
-    substituteInPlace go.mod \
-      --replace "go 1.25.2" "go 1.25.1"
-  '';
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
Adds helix-health, an interactive TUI for viewing and searching Helix editor's health information.

  - **Homepage:** https://github.com/gunererd/helix-health
  - **License:** MIT
  - **Runtime dependency:** helix (handled via wrapProgram)
  
Note: Package includes a temporary workaround to use Go 1.25.1 instead of the required 1.25.2, as
  nixpkgs doesn't have Go 1.25.2 yet. This is safe as the functionality is compatible between these minor
  versions.

## Things done

 - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
