### PR TITLE
regclient: Remove usage of rec and with

### DIFF
--- a/pkgs/by-name/re/regclient/package.nix
+++ b/pkgs/by-name/re/regclient/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildGoModule,
   fetchFromGitHub,
@@ -16,15 +17,14 @@ let
   ];
 in
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "regclient";
   version = "0.11.3";
-  tag = "v${version}";
 
   src = fetchFromGitHub {
     owner = "regclient";
     repo = "regclient";
-    rev = tag;
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-/gKvjyFOzyTsgMuqCqZaWl2yun7f+eboQ0iLuXHh4lI=";
   };
   vendorHash = "sha256-P9ayAWvQY4WgmFTWzk2ZLQ5uwMvIsSfL73C99ROmze8=";
@@ -34,30 +34,37 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/regclient/regclient/internal/version.vcsTag=${tag}"
+    "-X github.com/regclient/regclient/internal/version.vcsTag=${finalAttrs.src.tag}"
   ];
+
+  env.CGO_ENABLED = 0;
 
   nativeBuildInputs = [
     installShellFiles
     lndir
   ];
 
-  postInstall = lib.concatMapStringsSep "\n" (bin: ''
-    export bin=''$${bin}
-    export outputBin=bin
+  postInstall = lib.concatMapStringsSep "\n" (
+    bin:
+    ''
+      export bin=''$${bin}
+      export outputBin=bin
 
-    mkdir -p $bin/bin
-    mv $out/bin/${bin} $bin/bin
+      mkdir -p $bin/bin
+      mv $out/bin/${bin} $bin/bin
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd ${bin} \
+        --bash <($bin/bin/${bin} completion bash) \
+        --fish <($bin/bin/${bin} completion fish) \
+        --zsh <($bin/bin/${bin} completion zsh)
+    ''
+    + ''
+      lndir -silent $bin $out
 
-    installShellCompletion --cmd ${bin} \
-      --bash <($bin/bin/${bin} completion bash) \
-      --fish <($bin/bin/${bin} completion fish) \
-      --zsh <($bin/bin/${bin} completion zsh)
-
-    lndir -silent $bin $out
-
-    unset bin outputBin
-  '') bins;
+      unset bin outputBin
+    ''
+  ) bins;
 
   checkFlags = [
     # touches network
@@ -69,7 +76,7 @@ buildGoModule rec {
       "${bin}Version" = testers.testVersion {
         package = regclient;
         command = "${bin} version";
-        version = tag;
+        version = finalAttrs.src.tag;
       };
     }) bins
   );
@@ -80,6 +87,6 @@ buildGoModule rec {
     description = "Docker and OCI Registry Client in Go and tooling using those libraries";
     homepage = "https://github.com/regclient/regclient";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ maxbrunet ];
+    maintainers = [ lib.maintainers.maxbrunet ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Replace usage of `rec` by `finalAttrs`
* Remove usage of `with`
* Only install shell completions if host can execute the binaries 
* Remove `tag` unconventional attribute
* Disable CGo

I am open to any other suggestions to further improve/modernize this derivation

Other improvements I would like to do, but not sure how to:

* Clean up the generated packages

	Currently this generates the following packages
	
	> - regbot (regbot.regbot, regbot.regctl, regbot.regsync, regclient.regbot)
	> - regclient
	> - regctl (regclient.regctl, regctl.regbot, regctl.regctl, regctl.regsync)
	> - regsync (regclient.regsync, regsync.regbot, regsync.regctl, regsync.regsync)
	
	I think ideally it should be:
	
	> - regbot (regclient.regbot)
	> - regclient
	> - regctl (regclient.regctl)
	> - regsync (regclient.regsync)

* Set `mainProgram` for each sub-package for `nix run nixpkgs#regctl` to work

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
