### PR TITLE
hypr{launcher,pwcenter,toolkit,wire}: init at 0.1.0

### DIFF
--- a/pkgs/by-name/hy/hyprlauncher/package.nix
+++ b/pkgs/by-name/hy/hyprlauncher/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  aquamarine,
+  cairo,
+  hyprgraphics,
+  hyprlang,
+  hyprtoolkit,
+  hyprutils,
+  hyprwire,
+  libdrm,
+  libqalculate,
+  libxkbcommon,
+  pixman,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprlauncher";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprlauncher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6JVor77g1LR/22lZYCArUm/geIXE0aGJZ4DHIlgSOj4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    aquamarine
+    cairo
+    hyprgraphics
+    hyprlang
+    hyprtoolkit
+    hyprutils
+    hyprwire
+    libdrm
+    libqalculate
+    libxkbcommon
+    pixman
+  ];
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A multipurpose and versatile launcher / picker for Hyprland";
+    license = lib.licenses.bsd3;
+    teams = [ lib.teams.hyprland ];
+    platforms = with lib.platforms; linux ++ freebsd;
+    mainProgram = "hyprlauncher";
+  };
+})

--- a/pkgs/by-name/hy/hyprpwcenter/package.nix
+++ b/pkgs/by-name/hy/hyprpwcenter/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  aquamarine,
+  cairo,
+  hyprgraphics,
+  hyprtoolkit,
+  hyprutils,
+  libdrm,
+  pipewire,
+  pixman,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprpwcenter";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprpwcenter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/kE3VlkJjpFxjbgdKCFumg/Oxn4n7Z//5atAObpPiRY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    aquamarine
+    cairo
+    hyprgraphics
+    hyprtoolkit
+    hyprutils
+    libdrm
+    pipewire
+    pixman
+  ];
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A GUI Pipewire control center";
+    license = lib.licenses.bsd3;
+    teams = [ lib.teams.hyprland ];
+    platforms = with lib.platforms; linux ++ freebsd;
+    mainProgram = "hyprpwcenter";
+  };
+})

--- a/pkgs/by-name/hy/hyprtoolkit/package.nix
+++ b/pkgs/by-name/hy/hyprtoolkit/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  hyprwayland-scanner,
+  wayland-scanner,
+  aquamarine,
+  cairo,
+  hyprgraphics,
+  hyprlang,
+  hyprutils,
+  iniparser,
+  libdrm,
+  libgbm,
+  libGL,
+  libxkbcommon,
+  pango,
+  pixman,
+  wayland,
+  wayland-protocols,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprtoolkit";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprtoolkit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AQCTRH8VsrHzOHL0ueXt/6OQtSSfZbT3XUBI4sq8rx4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    hyprwayland-scanner
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    aquamarine
+    cairo
+    hyprgraphics
+    hyprlang
+    hyprutils
+    iniparser
+    libdrm
+    libgbm
+    libGL
+    libxkbcommon
+    pango
+    pixman
+    wayland
+    wayland-protocols
+  ];
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A modern C++ Wayland-native GUI toolkit";
+    license = lib.licenses.bsd3;
+    teams = [ lib.teams.hyprland ];
+    platforms = with lib.platforms; linux ++ freebsd;
+  };
+})

--- a/pkgs/by-name/hy/hyprtoolkit/package.nix
+++ b/pkgs/by-name/hy/hyprtoolkit/package.nix
@@ -24,13 +24,13 @@
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprtoolkit";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprtoolkit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AQCTRH8VsrHzOHL0ueXt/6OQtSSfZbT3XUBI4sq8rx4=";
+    hash = "sha256-SjZAlFpZ/ZpYXj59toamF4qx5rC8RP0U/yEsPVniyI8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hyprwire/package.nix
+++ b/pkgs/by-name/hy/hyprwire/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  hyprutils,
+  libffi,
+  pugixml,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprwire";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprwire";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-84KqFPakU1Pv7axkwbSi1D5XssSHIW8B2xduOUq5Mw4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    pugixml
+    hyprutils
+    libffi
+  ];
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "A fast and consistent wire protocol for IPC ";
+    license = lib.licenses.bsd3;
+    teams = [ lib.teams.hyprland ];
+    platforms = with lib.platforms; linux ++ freebsd;
+    mainProgram = "hyprwire";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/hyprwm/hyprlauncher/releases/tag/v0.1.0
https://github.com/hyprwm/hyprpwcenter/releases/tag/v0.1.0
https://github.com/hyprwm/hyprtoolkit/releases/tag/v0.1.0
https://github.com/hyprwm/hyprwire/releases/tag/v0.1.0

`hyprtoolkit` and `hyprwire` are libraries used for `hyprlauncher` and `hyprpwcenter`
These are the initial releases for those packages and these packages are kinda buggy in the current state.

All of those packages don't build with the standard `stdenv` but with `gcc15Stdenv`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
