### PR TITLE
nixos/sshguard: fix, various improvements, add nixos tests

### DIFF
--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -139,32 +139,6 @@ in
             systemd
           ];
 
-      # The sshguard ipsets must exist before we invoke
-      # iptables. sshguard creates the ipsets after startup if
-      # necessary, but if we let sshguard do it, we can't reliably add
-      # the iptables rules because postStart races with the creation
-      # of the ipsets. So instead, we create both the ipsets and
-      # firewall rules before sshguard starts.
-      preStart =
-        lib.optionalString config.networking.firewall.enable ''
-          ${pkgs.ipset}/bin/ipset -quiet create -exist sshguard4 hash:net family inet
-          ${pkgs.iptables}/bin/iptables  -I INPUT -m set --match-set sshguard4 src -j DROP
-        ''
-        + lib.optionalString (config.networking.firewall.enable && config.networking.enableIPv6) ''
-          ${pkgs.ipset}/bin/ipset -quiet create -exist sshguard6 hash:net family inet6
-          ${pkgs.iptables}/bin/ip6tables -I INPUT -m set --match-set sshguard6 src -j DROP
-        '';
-
-      postStop =
-        lib.optionalString config.networking.firewall.enable ''
-          ${pkgs.iptables}/bin/iptables  -D INPUT -m set --match-set sshguard4 src -j DROP
-          ${pkgs.ipset}/bin/ipset -quiet destroy sshguard4
-        ''
-        + lib.optionalString (config.networking.firewall.enable && config.networking.enableIPv6) ''
-          ${pkgs.iptables}/bin/ip6tables -D INPUT -m set --match-set sshguard6 src -j DROP
-          ${pkgs.ipset}/bin/ipset -quiet destroy sshguard6
-        '';
-
       documentation = [
         "man:sshguard(8)"
         "man:sshguard-setup(8)"
@@ -172,6 +146,22 @@ in
 
       serviceConfig = {
         Type = "simple";
+
+        # The sshguard ipsets must exist before we invoke
+        # iptables. sshguard creates the ipsets after startup if
+        # necessary, but if we let sshguard do it, we can't reliably add
+        # the iptables rules because postStart races with the creation
+        # of the ipsets. So instead, we create both the ipsets and
+        # firewall rules before sshguard starts.
+        ExecStartPre =
+          lib.optionals config.networking.firewall.enable [
+            "${pkgs.ipset}/bin/ipset -quiet create -exist sshguard4 hash:net family inet"
+            "${pkgs.iptables}/bin/iptables  -I INPUT -m set --match-set sshguard4 src -j DROP"
+          ]
+          ++ lib.optionals (config.networking.firewall.enable && config.networking.enableIPv6) [
+            "${pkgs.ipset}/bin/ipset -quiet create -exist sshguard6 hash:net family inet6"
+            "${pkgs.iptables}/bin/ip6tables -I INPUT -m set --match-set sshguard6 src -j DROP"
+          ];
         ExecStart =
           let
             args = lib.concatStringsSep " " (
@@ -187,6 +177,15 @@ in
             );
           in
           "${pkgs.sshguard}/bin/sshguard ${args}";
+        ExecStopPost =
+          lib.optionals config.networking.firewall.enable [
+            "${pkgs.iptables}/bin/iptables  -D INPUT -m set --match-set sshguard4 src -j DROP"
+            "${pkgs.ipset}/bin/ipset -quiet destroy sshguard4"
+          ]
+          ++ lib.optionals (config.networking.firewall.enable && config.networking.enableIPv6) [
+            "${pkgs.iptables}/bin/ip6tables -D INPUT -m set --match-set sshguard6 src -j DROP"
+            "${pkgs.ipset}/bin/ipset -quiet destroy sshguard6"
+          ];
         Restart = "always";
         ProtectSystem = "strict";
         ProtectHome = "tmpfs";

--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -8,11 +8,7 @@ let
   cfg = config.services.sshguard;
 in
 {
-
-  ###### interface
-
   options = {
-
     services.sshguard = {
       enable = lib.mkOption {
         default = false;
@@ -99,10 +95,7 @@ in
     };
   };
 
-  ###### implementation
-
   config = lib.mkIf cfg.enable {
-
     environment.etc."sshguard.conf".text =
       let
         backend = if config.networking.nftables.enable then "sshg-fw-nft-sets" else "sshg-fw-ipset";

--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -8,6 +8,8 @@ let
   cfg = config.services.sshguard;
 in
 {
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
   options = {
     services.sshguard = {
       enable = lib.mkOption {

--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -165,7 +165,10 @@ in
           ${pkgs.ipset}/bin/ipset -quiet destroy sshguard6
         '';
 
-      unitConfig.Documentation = "man:sshguard(8)";
+      documentation = [
+        "man:sshguard(8)"
+        "man:sshguard-setup(8)"
+      ];
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -217,9 +217,41 @@ in
             "${config.systemd.package}/bin/journalctl ${args}";
 
         DynamicUser = true;
+        User = "sshguard-logger";
         SupplementaryGroups = [
           # allow to read the systemd journal for opentelemetry-collector
           "systemd-journal"
+        ];
+
+        UMask = "0777";
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        MountAPIVFS = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = "strict";
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        BindPaths = [ "/run/systemd/journal/socket" ];
+        BindReadOnlyPaths = [ builtins.storeDir ];
+        RemoveIPC = true;
+        PrivateMounts = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
         ];
       };
     };
@@ -279,12 +311,12 @@ in
         # firewall rules before sshguard starts.
         ExecStartPre =
           lib.optionals config.networking.firewall.enable [
-            "${pkgs.ipset}/bin/ipset -quiet create -exist sshguard4 hash:net family inet"
-            "${pkgs.iptables}/bin/iptables  -I INPUT -m set --match-set sshguard4 src -j DROP"
+            "-${pkgs.ipset}/bin/ipset -quiet create -exist sshguard4 hash:net family inet"
+            "-${pkgs.iptables}/bin/iptables  -I INPUT -m set --match-set sshguard4 src -j DROP"
           ]
           ++ lib.optionals (config.networking.firewall.enable && config.networking.enableIPv6) [
-            "${pkgs.ipset}/bin/ipset -quiet create -exist sshguard6 hash:net family inet6"
-            "${pkgs.iptables}/bin/ip6tables -I INPUT -m set --match-set sshguard6 src -j DROP"
+            "-${pkgs.ipset}/bin/ipset -quiet create -exist sshguard6 hash:net family inet6"
+            "-${pkgs.iptables}/bin/ip6tables -I INPUT -m set --match-set sshguard6 src -j DROP"
           ];
         ExecStart =
           let
@@ -303,19 +335,63 @@ in
           "${pkgs.sshguard}/bin/sshguard ${args}";
         ExecStopPost =
           lib.optionals config.networking.firewall.enable [
-            "${pkgs.iptables}/bin/iptables  -D INPUT -m set --match-set sshguard4 src -j DROP"
-            "${pkgs.ipset}/bin/ipset -quiet destroy sshguard4"
+            "-${pkgs.iptables}/bin/iptables  -D INPUT -m set --match-set sshguard4 src -j DROP"
+            "-${pkgs.ipset}/bin/ipset -quiet destroy sshguard4"
           ]
           ++ lib.optionals (config.networking.firewall.enable && config.networking.enableIPv6) [
-            "${pkgs.iptables}/bin/ip6tables -D INPUT -m set --match-set sshguard6 src -j DROP"
-            "${pkgs.ipset}/bin/ipset -quiet destroy sshguard6"
+            "-${pkgs.iptables}/bin/ip6tables -D INPUT -m set --match-set sshguard6 src -j DROP"
+            "-${pkgs.ipset}/bin/ipset -quiet destroy sshguard6"
           ];
         Restart = "always";
-        ProtectSystem = "strict";
-        ProtectHome = "tmpfs";
         RuntimeDirectory = "sshguard";
         StateDirectory = "sshguard";
-        CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_RAW";
+
+        # Does not play nice with nftables
+        PrivateUsers = false;
+
+        ProtectProc = "invisible";
+        UMask = "0077";
+        CapabilityBoundingSet = [
+          "CAP_NET_ADMIN"
+          "CAP_NET_RAW"
+        ];
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        MountAPIVFS = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        BindReadOnlyPaths = [ builtins.storeDir ];
+        BindPaths = lib.mkIf (cfg.blacklist_file != "/var/lib/sshguard/blacklist.db") [
+          "${cfg.blacklist_file}:/var/lib/sshguard/blacklist.db"
+        ];
+        ReadWritePaths = [
+          "/run/sshguard-logger/sshguard-logger"
+        ];
+        RemoveIPC = true;
+        PrivateMounts = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
       };
     };
   };

--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -110,6 +110,10 @@ in
         LOGREADER="${lib.getExe' pkgs.coreutils "cat"} /run/sshguard-logger/sshguard-logger"
       '';
 
+    systemd.slices."system-sshguard" = {
+      description = "SSHGuard Intrusion Prevention Slice";
+    };
+
     systemd.services.sshguard-logger = {
       description = "SSHGuard Intrusion Prevention Log Provider";
       wantedBy = [ "sshguard.service" ];
@@ -119,6 +123,7 @@ in
       environment.LANG = "C";
 
       serviceConfig = {
+        Slice = "system-sshguard.slice";
         Type = "simple";
 
         Sockets = "sshguard-logger.socket";
@@ -159,7 +164,7 @@ in
     };
 
     systemd.services.sshguard = {
-      description = "SSHGuard brute-force attacks protection system";
+      description = "SSHGuard Intrusion Prevention System";
 
       wantedBy = [ "multi-user.target" ];
       after = [
@@ -194,6 +199,7 @@ in
       ];
 
       serviceConfig = {
+        Slice = "system-sshguard.slice";
         Type = "simple";
 
         # The sshguard ipsets must exist before we invoke

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1594,6 +1594,14 @@ in
   squid = runTest ./squid.nix;
   ssh-agent-auth = runTest ./ssh-agent-auth.nix;
   ssh-audit = runTest ./ssh-audit.nix;
+  sshguard-iptables = runTest {
+    imports = [ ./sshguard.nix ];
+    _module.args.useNftables = false;
+  };
+  sshguard-nftables = runTest {
+    imports = [ ./sshguard.nix ];
+    _module.args.useNftables = true;
+  };
   sshwifty = runTest ./web-apps/sshwifty/default.nix;
   sslh = handleTest ./sslh.nix { };
   sssd-ldap = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-ldap.nix { };

--- a/nixos/tests/sshguard.nix
+++ b/nixos/tests/sshguard.nix
@@ -1,0 +1,136 @@
+{
+  pkgs,
+  lib,
+  useNftables,
+  ...
+}:
+{
+  name = "sshguard";
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  nodes = {
+    server = {
+      imports = [ ./common/user-account.nix ];
+
+      virtualisation.vlans = [ 1 ];
+
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+        nftables.enable = useNftables;
+      };
+
+      systemd.network.networks."01-eth1" = {
+        name = "eth1";
+        networkConfig.Address = "10.0.0.1/24";
+      };
+
+      services.openssh = {
+        enable = true;
+        # Exempt all machines from the builtin guard system
+        settings.PerSourcePenaltyExemptList = "10.0.0.0/24";
+      };
+
+      services.sshguard = {
+        enable = true;
+
+        # The attacker should be temporarily blocked after the first attack
+        attack_threshold = 10;
+        # Block the attacker for 1 second
+        blocktime = 1;
+        # After the second attack, the attacker should be permanently banned
+        blacklist_threshold = 20;
+
+        enableInspectableLogStream = true;
+      };
+
+      systemd.services.sshguard.environment.SSHGUARD_DEBUG = "1";
+
+      specialisation."socket-activated-ssh".configuration = {
+        services.openssh.startWhenNeeded = true;
+      };
+    };
+
+    client =
+      { pkgs, ... }:
+      {
+        virtualisation.vlans = [ 1 ];
+
+        networking = {
+          useNetworkd = true;
+          useDHCP = false;
+        };
+
+        systemd.network.networks."01-eth1" = {
+          name = "eth1";
+          networkConfig.Address = "10.0.0.2/24";
+        };
+
+        environment.systemPackages = with pkgs; [ sshpass ];
+
+        programs.ssh.extraConfig = ''
+          StrictHostKeyChecking no
+          ConnectTimeout 10
+        '';
+      };
+
+    attacker =
+      { pkgs, ... }:
+      {
+        virtualisation.vlans = [ 1 ];
+
+        networking = {
+          useNetworkd = true;
+          useDHCP = false;
+        };
+
+        systemd.network.networks."01-eth1" = {
+          name = "eth1";
+          networkConfig.Address = "10.0.0.3/24";
+        };
+
+        environment.systemPackages = with pkgs; [ sshpass ];
+
+        programs.ssh.extraConfig = ''
+          StrictHostKeyChecking no
+          ConnectTimeout 10
+        '';
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    server.wait_for_unit("multi-user.target")
+    server.wait_for_unit("sshguard-logger.service")
+    server.wait_for_unit("sshguard.service")
+    server.wait_for_open_port(22)
+
+    def bantest():
+      with subtest("Ensure normal login works"):
+        client.succeed("sshpass -p foobar ssh alice@10.0.0.1 echo a")
+        attacker.succeed("sshpass -p foobar ssh -T alice@10.0.0.1 echo a")
+
+      with subtest("Ensure attacker gets banned"):
+        # Attack 1
+        attacker.fail("sshpass -p wrong ssh alice@10.0.0.1 echo a")
+
+        server.wait_for_console_text("10.0.0.3: unblocking")
+
+        # Attack 2
+        attacker.fail("sshpass -p wrong ssh alice@10.0.0.1 echo a")
+
+        server.wait_for_console_text("blacklist: added 10.0.0.3")
+        server.succeed("grep 10.0.0.3 /var/lib/sshguard/blacklist.db")
+
+      with subtest("Ensure normal login still works"):
+        client.succeed("sshpass -p foobar ssh alice@10.0.0.1 echo a")
+
+    bantest()
+
+    server.succeed("rm /var/lib/sshguard/blacklist.db")
+    server.succeed("/run/current-system/specialisation/socket-activated-ssh/bin/switch-to-configuration switch")
+
+    bantest()
+  '';
+}

--- a/pkgs/by-name/ss/sshguard/package.nix
+++ b/pkgs/by-name/ss/sshguard/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   bison,
   flex,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [ "--sysconfdir=/etc" ];
+
+  passthru.tests.nixos = nixosTests.sshguard;
 
   meta = {
     description = "Protects hosts from brute-force attacks";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR goes over the sshguard module, fixes an function-inhibiting bug and does various other improvements.

The most important part of this PR is fixing the log provider. We were earlier giving the wrong `-t` flag to `journalctl`, making it so that sshguard wouldn't get the relevant logs it needed to inspect. This has been resolved by expanding the type of the option, allowing for both `-u` and `-t` flags.

The default has been set so the service will work out of the box by setting `services.sshguard.enable = true`

**Other notable things done:**

- removed bash wrappers around pre exec post exec hooks
- split log provider into separate service, allowing for easier debugging and split hardening privileges.
- automatically handle sshd running in socket activation mode
- add myself as module maintainer
- systemd hardening
- added nixos test(s)

Ref https://github.com/NixOS/nixpkgs/issues/377827

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
