### PR TITLE
stdenv: pURL implementation - fix checkMeta

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -713,6 +713,7 @@ let
                 }
               ) possibleCPEPartsFuns;
 
+          evaluateSrc = !isMarkedBroken attrs && !hasUnsupportedPlatform attrs;
           purlParts = attrs.meta.identifiers.purlParts or { };
           purlPartsFormatted =
             if purlParts ? type && purlParts ? spec then "pkg:${purlParts.type}/${purlParts.spec}" else null;
@@ -722,6 +723,8 @@ let
             # 1) locally set through API
             if purlPartsFormatted != null then
               purlPartsFormatted
+            else if !evaluateSrc then
+              null
             else
               # 2) locally overwritten through meta.identifiers.purl
               (attrs.src.meta.identifiers.purl or null);
@@ -733,6 +736,8 @@ let
               # 2) locally set through API
               if purlPartsFormatted != null then
                 [ purlPartsFormatted ]
+              else if !evaluateSrc then
+                [ ]
               else
                 # 3) src.meta.PURL
                 (attrs.src.meta.identifiers.purls or (

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -723,7 +723,7 @@ let
             # 1) locally set through API
             if purlPartsFormatted != null then
               purlPartsFormatted
-            else if !evaluateSrc then
+            else if !evaluateSrc || !(builtins.tryEval attrs.src or null).success then
               null
             else
               # 2) locally overwritten through meta.identifiers.purl
@@ -736,7 +736,11 @@ let
               # 2) locally set through API
               if purlPartsFormatted != null then
                 [ purlPartsFormatted ]
-              else if !evaluateSrc then
+              else if
+                !evaluateSrc
+                || !(builtins.tryEval attrs.src or [ ]).success
+                || !(builtins.tryEval attrs.srcs or [ ]).success
+              then
                 [ ]
               else
                 # 3) src.meta.PURL


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/421125 introduced a problem with checkMeta=true for nixpkgs-review. checkMeta defaults to false in general.

The scenario happened for thunderbird-bin in combination with an unsupported platform. 
This PR prevents any evaluation which might be problematic

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
