### PR TITLE
nixos/homepage-dashboard: prefix path

### DIFF
--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default HOMEPAGE_CONFIG_DIR /var/lib/homepage-dashboard \
       --set-default NIXPKGS_HOMEPAGE_CACHE_DIR /var/cache/homepage-dashboard \
       --add-flags "$out/share/homepage/server.js" \
-      --set PATH "${lib.makeBinPath [ unixtools.ping ]}"
+      --prefix PATH : "${lib.makeBinPath [ unixtools.ping ]}"
 
     ${if enableLocalIcons then installLocalIcons else ""}
 


### PR DESCRIPTION
The `disk` option in the 'resources' widget of homepage-dashboard seems to be broken since 1.5.0 and shows "API Error" instead of the actual disk usage:

<img width="526" height="75" alt="image" src="https://github.com/user-attachments/assets/f275272c-09ce-4735-96ff-73e6447c64c4" />

I could pinpoint the issue to `command df not found` messages in the journalctl logs of the service, which is a coreutil that homepage-dashboard needs to parse the disk usage.

~~I think this bug got introduced in v1.5.0 by this change:~~ 
Edit: It seems this bug got added to v.1.4.6 after v1.4.6 got released (https://github.com/NixOS/nixpkgs/commit/4058df754ee65c3b5105245be75ef31437082288)
 https://github.com/NixOS/nixpkgs/blob/544961dfcce86422ba200ed9a0b00dd4b1486ec5/pkgs/by-name/ho/homepage-dashboard/package.nix#L94

This change overwrites `$PATH`, causing `df` to no longer be found.
By prefixing the path instead, we can preserve implicit dependencies such as `df` that are needed to display disk usage in the resources widget.

Alternatively, we could explicitly add runtime dependencies like `df` to `$PATH`, similar to how `unixtools.ping` is handled in the referenced line above. However, I’m not sure which other binaries would need to be included to make the list complete.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
