### PR TITLE
Revert "stdenv: pURL implementation (#421125)"

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -237,9 +237,6 @@
   "sec-meta-identifiers-cpe": [
     "index.html#sec-meta-identifiers-cpe"
   ],
-  "sec-meta-identifiers-purl": [
-    "index.html#sec-meta-identifiers-purl"
-  ],
   "sec-modify-via-packageOverrides": [
     "index.html#sec-modify-via-packageOverrides"
   ],
@@ -663,15 +660,6 @@
   ],
   "var-meta-identifiers-possibleCPEs": [
     "index.html#var-meta-identifiers-possibleCPEs"
-  ],
-  "var-meta-identifiers-purl": [
-    "index.html#var-meta-identifiers-purl"
-  ],
-  "var-meta-identifiers-purlParts": [
-    "index.html#var-meta-identifiers-purlParts"
-  ],
-  "var-meta-identifiers-purls": [
-    "index.html#var-meta-identifiers-purls"
   ],
   "var-meta-teams": [
     "index.html#var-meta-teams"

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -238,8 +238,6 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Metadata identifier purl (Package URL, https://github.com/package-url/purl-spec) has been added for fetchgit, fetchpypi and fetchFromGithub fetchers and mkDerivation has been adjusted to reuse these informations. Package URL's enables a reliable identification and locatization of software packages. Maintainers of derivations using the adopted fetchers should rely on the `drv.src.meta.identifiers.v1.purl` default identifier and can enhance their `drv.meta.identifiers.v1.purls` list once they would like to have additional identifiers. Maintainers using fetchurl for `drv.src` are urged to adopt their `drv.meta.identifiers.purlParts` for proper identification.
-
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
 - Added `hashedMirrors` attribute to the nixpkgs `config`, to allow for customization of the hashed mirrors used by `fetchurl`.
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -319,22 +319,3 @@ A readonly attribute that concatenates all CPE parts in one string.
 #### `meta.identifiers.possibleCPEs` {#var-meta-identifiers-possibleCPEs}
 
 A readonly attribute containing the list of guesses for what CPE for this package can look like. It includes all variants of version handling mentioned above. Each item is an attrset with attributes `cpeParts` and `cpe` for each guess.
-
-### Package URL {#sec-meta-identifiers-purl}
-
-[Package-URL](https://github.com/package-url/purl-spec) (PURL) is a specification to reliably identify and locate software packages. Through identification of software packages, additional (non-major) use cases are e.g. software license cross-verification via third party databases or initial vulnerability response management. Package URL's default to the mkDerivation.src, as the original consumed software package is the single point of truth.
-
-#### `meta.identifiers.purlParts` {#var-meta-identifiers-purlParts}
-
-This attribute contains an attribute set of all parts of the PURL for this package.
-
-* `type` mandatory [type](https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/docs/standard/summary.md) which needs to be provided
-* `spec` specify the PURL in accordance with the [purl-spec](https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/purl-specification.md)
-
-#### `meta.identifiers.purl` {#var-meta-identifiers-purl}
-
-An extendable attribute which is built based on purlParts. It is the main identifier, consumers should consider using the PURL's list interface to be prepared for edge cases.
-
-#### `meta.identifiers.purls` {#var-meta-identifiers-purls}
-
-An extendable attribute list which defaults to a single element equal to the main PURL. It provides an interface for additional identifiers of mkDerivation.src and / or vendored dependencies inside mkDerivation.src, which maintainers can conciously decide to use on top. Identifiers different to the default src identifier are not recommended by default as they might cause maintenance overhead or may diverge (e.g. differences between source distribution pkg:github and binary distribution like pkg:pypi).

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -190,18 +190,7 @@ lib.makeOverridable (
             "FETCHGIT_HTTP_PROXIES"
           ];
 
-        inherit preferLocalBuild allowedRequisites;
-
-        meta = meta // {
-          identifiers = {
-            purlParts = {
-              type = "generic";
-              # https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/types-doc/generic-definition.md
-              spec = "${name}?vcs_url=${url}@${(lib.revOrTag rev tag)}";
-            };
-          }
-          // meta.identifiers or { };
-        };
+        inherit preferLocalBuild meta allowedRequisites;
 
         passthru = {
           gitRepoUrl = url;

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -47,28 +47,11 @@ lib.makeOverridable (
       meta
       // {
         homepage = meta.homepage or baseUrl;
-        identifiers = {
-          purlParts =
-            if githubBase == "github.com" then
-              {
-                type = "github";
-                # https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/types-doc/github-definition.md
-                spec = "${owner}/${repo}@${(lib.revOrTag rev tag)}";
-              }
-            else
-              {
-                type = "generic";
-                # https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/types-doc/generic-definition.md
-                spec = "${repo}?vcs_url=https://${githubBase}/${owner}/${repo}@${(lib.revOrTag rev tag)}";
-              };
-        }
-        // meta.identifiers or { };
       }
       // lib.optionalAttrs (position != null) {
         # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
         position = "${position.file}:${toString position.line}";
       };
-
     passthruAttrs = removeAttrs args [
       "owner"
       "repo"
@@ -172,12 +155,12 @@ lib.makeOverridable (
       // passthruAttrs
       // {
         inherit name;
-        meta = newMeta;
       };
   in
 
   fetcher fetcherArgs
   // {
+    meta = newMeta;
     inherit owner repo tag;
     rev = revWithTag;
   }

--- a/pkgs/build-support/fetchpypi/default.nix
+++ b/pkgs/build-support/fetchpypi/default.nix
@@ -51,8 +51,6 @@ makeOverridable (
     format ? "setuptools",
     sha256 ? "",
     hash ? "",
-    pname,
-    version,
     ...
   }@attrs:
   let
@@ -62,20 +60,8 @@ makeOverridable (
         "hash"
       ]
     );
-    meta = {
-      identifiers.purlParts = {
-        type = "pypi";
-        # https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/types-doc/pypi-definition.md
-        spec = "${pname}@${version}";
-      };
-    };
   in
   fetchurl {
-    inherit
-      url
-      sha256
-      hash
-      meta
-      ;
+    inherit url sha256 hash;
   }
 )

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -134,9 +134,5 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     mainProgram = "jq";
-    identifiers.purlParts = {
-      type = "github";
-      spec = "jqlang/jq@jq-${finalAttrs.version}";
-    };
   };
 })

--- a/pkgs/by-name/po/popt/package.nix
+++ b/pkgs/by-name/po/popt/package.nix
@@ -49,9 +49,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ qyliss ];
     license = licenses.mit;
     platforms = platforms.unix;
-    identifiers.purlParts = {
-      type = "github";
-      spec = "rpm-software-management/popt@popt-${version}-release";
-    };
   };
 }

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -77,13 +77,6 @@ lib.makeOverridable (
               attrs.source.remotes or [ "https://rubygems.org" ]
             );
             inherit (attrs.source) sha256;
-            meta = {
-              identifiers.purlParts = {
-                type = "gem";
-                # https://github.com/package-url/purl-spec/blob/18fd3e395dda53c00bc8b11fe481666dc7b3807a/types-doc/gem-definition.md
-                spec = "${gemName}@${version}?platform=${platform}";
-              };
-            };
           }
         else if type == "git" then
           fetchgit {

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -34,8 +34,6 @@ let
     toList
     isList
     elem
-    flatten
-    filter
     ;
 
   inherit (lib.meta)
@@ -301,7 +299,7 @@ let
     let
       expectedOutputs = attrs.meta.outputsToInstall or [ ];
       actualOutputs = attrs.outputs or [ "out" ];
-      missingOutputs = filter (output: !builtins.elem output actualOutputs) expectedOutputs;
+      missingOutputs = builtins.filter (output: !builtins.elem output actualOutputs) expectedOutputs;
     in
     ''
       The package ${getNameWithVersion attrs} has set meta.outputsToInstall to: ${builtins.concatStringsSep ", " expectedOutputs}
@@ -477,7 +475,7 @@ let
     let
       expectedOutputs = attrs.meta.outputsToInstall or [ ];
       actualOutputs = attrs.outputs or [ "out" ];
-      missingOutputs = filter (output: !builtins.elem output actualOutputs) expectedOutputs;
+      missingOutputs = builtins.filter (output: !builtins.elem output actualOutputs) expectedOutputs;
     in
     if config.checkMeta then builtins.length missingOutputs > 0 else false;
 
@@ -712,54 +710,14 @@ let
                   cpe = makeCPE guessedParts;
                 }
               ) possibleCPEPartsFuns;
-
-          purlParts = attrs.meta.identifiers.purlParts or { };
-          purlPartsFormatted =
-            if purlParts ? type && purlParts ? spec then "pkg:${purlParts.type}/${purlParts.spec}" else null;
-
-          # search for a PURL in the following order:
-          purl =
-            # 1) locally set through API
-            if purlPartsFormatted != null then
-              purlPartsFormatted
-            else
-              # 2) locally overwritten through meta.identifiers.purl
-              (attrs.src.meta.identifiers.purl or null);
-
-          # search for a PURL in the following order:
-          purls =
-            # 1) locally overwritten through meta.identifiers.purls (e.g. extension of list)
-            attrs.meta.identifiers.purls or (
-              # 2) locally set through API
-              if purlPartsFormatted != null then
-                [ purlPartsFormatted ]
-              else
-                # 3) src.meta.PURL
-                (attrs.src.meta.identifiers.purls or (
-                  # 4) srcs.meta.PURL
-                  if !attrs ? srcs then
-                    [ ]
-                  else if isList attrs.srcs then
-                    concatMap (drv: drv.meta.identifiers.purls or [ ]) attrs.srcs
-                  else
-                    attrs.srcs.meta.identifiers.purls or [ ]
-                )
-                )
-            );
-
           v1 = {
-            inherit
-              cpeParts
-              possibleCPEs
-              purls
-              ;
+            inherit cpeParts possibleCPEs;
             ${if cpe != null then "cpe" else null} = cpe;
-            ${if purl != null then "purl" else null} = purl;
           };
         in
         v1
         // {
-          inherit v1 purlParts;
+          inherit v1;
         };
 
       # Expose the result of the checks for everyone to see.


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/421125 introduced a problem with checkMeta=true for nixpkgs-review. checkMeta defaults to false in general.

The scenario happened for thunderbird-bin in combination with an unsupported platform.
This PR prevents any evaluation which might be problematic

There were concerns, that a revert may be a better option. I keep this PR open and let the community decide: https://github.com/NixOS/nixpkgs/pull/453291

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
