### PR TITLE
various: add null guards for nullable `EnvironmentFile` options

### DIFF
--- a/nixos/modules/services/audio/lavalink.nix
+++ b/nixos/modules/services/audio/lavalink.nix
@@ -327,7 +327,7 @@ in
           Type = "simple";
           Restart = "on-failure";
 
-          EnvironmentFile = cfg.environmentFile;
+          EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
           WorkingDirectory = cfg.home;
         };
       };

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -928,7 +928,7 @@ let
               LimitCORE = "infinity";
               TasksMax = "infinity";
               TimeoutStartSec = 0;
-              EnvironmentFile = cfg.environmentFile;
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
               ExecStart = lib.concatStringsSep " \\\n " (
                 [ "${cfg.package}/bin/${name} ${cfg.role}" ]
                 ++ (lib.optional (cfg.serverAddr != "") "--server ${cfg.serverAddr}")

--- a/nixos/modules/services/development/livebook.nix
+++ b/nixos/modules/services/development/livebook.nix
@@ -97,7 +97,7 @@ in
     systemd.user.services.livebook = {
       serviceConfig = {
         Restart = "always";
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         ExecStart = "${cfg.package}/bin/livebook start";
         KillMode = "mixed";
 

--- a/nixos/modules/services/matrix/mautrix-discord.nix
+++ b/nixos/modules/services/matrix/mautrix-discord.nix
@@ -256,7 +256,7 @@ in
 
           ReadWritePaths = [ dataDir ];
           StateDirectory = "mautrix-discord";
-          EnvironmentFile = cfg.environmentFile;
+          EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         };
 
         restartTriggers = [ settingsFileUnformatted ];
@@ -285,7 +285,7 @@ in
             ${lib.getExe cfg.package} \
               --config='${settingsFile}'
           '';
-          EnvironmentFile = cfg.environmentFile;
+          EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
           ProtectSystem = "strict";
           ProtectHome = true;

--- a/nixos/modules/services/matrix/mautrix-meta.nix
+++ b/nixos/modules/services/matrix/mautrix-meta.nix
@@ -518,7 +518,7 @@ in
 
               ReadWritePaths = fullDataDir cfg;
               StateDirectory = cfg.dataDir;
-              EnvironmentFile = cfg.environmentFile;
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             };
 
             restartTriggers = [ (settingsFileUnsubstituted cfg) ];
@@ -565,7 +565,7 @@ in
               WorkingDirectory = fullDataDir cfg;
               ReadWritePaths = fullDataDir cfg;
               StateDirectory = cfg.dataDir;
-              EnvironmentFile = cfg.environmentFile;
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
               ExecStart = lib.escapeShellArgs [
                 (lib.getExe upperCfg.package)

--- a/nixos/modules/services/matrix/mautrix-meta.nix
+++ b/nixos/modules/services/matrix/mautrix-meta.nix
@@ -521,7 +521,7 @@ in
 
               ReadWritePaths = fullDataDir cfg;
               StateDirectory = cfg.dataDir;
-              EnvironmentFile = cfg.environmentFile;
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             };
 
             restartTriggers = [ (settingsFileUnsubstituted cfg) ];
@@ -568,7 +568,7 @@ in
               WorkingDirectory = fullDataDir cfg;
               ReadWritePaths = fullDataDir cfg;
               StateDirectory = cfg.dataDir;
-              EnvironmentFile = cfg.environmentFile;
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
               ExecStart = lib.escapeShellArgs [
                 (lib.getExe' upperCfg.package (packageName cfg.settings.network.mode))

--- a/nixos/modules/services/matrix/mautrix-signal.nix
+++ b/nixos/modules/services/matrix/mautrix-signal.nix
@@ -232,7 +232,7 @@ in
       serviceConfig = {
         User = "mautrix-signal";
         Group = "mautrix-signal";
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         StateDirectory = baseNameOf dataDir;
         WorkingDirectory = dataDir;
         ExecStart = ''

--- a/nixos/modules/services/matrix/mautrix-telegram.nix
+++ b/nixos/modules/services/matrix/mautrix-telegram.nix
@@ -242,7 +242,7 @@ in
         WorkingDirectory = cfg.package; # necessary for the database migration scripts to be found
         StateDirectory = baseNameOf dataDir;
         UMask = "0027";
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
         ExecStart = ''
           ${cfg.package}/bin/mautrix-telegram \

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -234,7 +234,7 @@ in
       serviceConfig = {
         User = "mautrix-whatsapp";
         Group = "mautrix-whatsapp";
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         StateDirectory = baseNameOf dataDir;
         WorkingDirectory = dataDir;
         ExecStart = ''

--- a/nixos/modules/services/misc/mollysocket.nix
+++ b/nixos/modules/services/misc/mollysocket.nix
@@ -98,7 +98,7 @@ in
       wants = [ "network-online.target" ];
       environment.RUST_LOG = cfg.logLevel;
       serviceConfig = {
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         ExecStart = "${getExe package} server";
         KillSignal = "SIGINT";
         Restart = "on-failure";

--- a/nixos/modules/services/misc/pufferpanel.nix
+++ b/nixos/modules/services/misc/pufferpanel.nix
@@ -151,7 +151,7 @@ in
         LogsDirectory = "pufferpanel";
         LogsDirectoryMode = "0700";
 
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
         # Command "pufferpanel shutdown --pid $MAINPID" sends SIGTERM (code 15)
         # to the main process and waits for termination. This is essentially

--- a/nixos/modules/services/misc/yarr.nix
+++ b/nixos/modules/services/misc/yarr.nix
@@ -76,7 +76,7 @@ in
         StateDirectory = "yarr";
         StateDirectoryMode = "0700";
         WorkingDirectory = "/var/lib/yarr";
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
         LoadCredential = mkIf (cfg.authFilePath != null) "authfile:${cfg.authFilePath}";
 

--- a/nixos/modules/services/monitoring/beszel-agent.nix
+++ b/nixos/modules/services/monitoring/beszel-agent.nix
@@ -146,7 +146,7 @@ in
           ${cfg.package}/bin/beszel-agent
         '';
 
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
 
         # adds ability to monitor docker/podman containers
         SupplementaryGroups =

--- a/nixos/modules/services/monitoring/beszel-agent.nix
+++ b/nixos/modules/services/monitoring/beszel-agent.nix
@@ -151,7 +151,7 @@ in
           ${cfg.package}/bin/beszel-agent
         '';
 
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         StateDirectory = baseNameOf cfg.dataDir;
 
         # adds ability to monitor docker/podman containers

--- a/nixos/modules/services/networking/jigasi.nix
+++ b/nixos/modules/services/networking/jigasi.nix
@@ -232,7 +232,7 @@ in
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           StateDirectory = baseNameOf stateDir;
-          EnvironmentFile = cfg.environmentFile;
+          EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         };
       };
 

--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -275,7 +275,7 @@ in
             Group = "fossorial";
             WorkingDirectory = cfg.dataDir;
             Restart = "always";
-            EnvironmentFile = cfg.environmentFile;
+            EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             # hardening
             ProtectSystem = "full";
             ProtectHome = true;
@@ -364,7 +364,7 @@ in
             Group = "fossorial";
             WorkingDirectory = cfg.dataDir;
             Restart = "always";
-            EnvironmentFile = cfg.environmentFile;
+            EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             ReadWritePaths = "${cfg.dataDir}/config";
             # hardening
             AmbientCapabilities = [

--- a/nixos/modules/services/web-apps/glance.nix
+++ b/nixos/modules/services/web-apps/glance.nix
@@ -182,7 +182,7 @@ in
         ExecStart = "${getExe cfg.package} --config ${settingsFile}";
         Restart = "on-failure";
         WorkingDirectory = "/var/lib/glance";
-        EnvironmentFile = cfg.environmentFile;
+        EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
         StateDirectory = "glance";
         RuntimeDirectory = "glance";
         RuntimeDirectoryMode = "0755";

--- a/nixos/modules/services/web-apps/kimai.nix
+++ b/nixos/modules/services/web-apps/kimai.nix
@@ -340,7 +340,7 @@ in
               Type = "oneshot";
               User = user;
               Group = webserver.group;
-              EnvironmentFile = [ cfg.environmentFile ];
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             };
           })
         ) eachSite)
@@ -349,7 +349,7 @@ in
           hostName: cfg:
           (nameValuePair "phpfpm-kimai-${hostName}" {
             serviceConfig = {
-              EnvironmentFile = [ cfg.environmentFile ];
+              EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             };
           })
         ) eachSite)

--- a/nixos/modules/services/web-apps/linkwarden.nix
+++ b/nixos/modules/services/web-apps/linkwarden.nix
@@ -21,7 +21,7 @@ let
     Restart = "on-failure";
     RestartSec = 3;
 
-    EnvironmentFile = cfg.environmentFile;
+    EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
     StateDirectory = "linkwarden";
     CacheDirectory = "linkwarden";
     User = cfg.user;

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -847,7 +847,7 @@ in
             ProtectSystem = "strict";
             RestrictNamespaces = true;
             RestrictSUIDSGID = true;
-            EnvironmentFile = cfg.environmentFile;
+            EnvironmentFile = lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ];
             WorkingDirectory = cfg.dataDir;
           }
           (mkIf (cfg.dataDir == "/var/lib/mattermost") {

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -577,7 +577,7 @@ in
         # Access write directories
         ReadWritePaths = cfg.dataDirs;
         # Environment
-        EnvironmentFile = cfg.serviceEnvironmentFile;
+        EnvironmentFile = lib.optionals (cfg.serviceEnvironmentFile != null) [ cfg.serviceEnvironmentFile ];
         # Sandboxing
         RestrictAddressFamilies = [
           "AF_UNIX"

--- a/nixos/modules/services/web-servers/pomerium.nix
+++ b/nixos/modules/services/web-servers/pomerium.nix
@@ -114,7 +114,7 @@ in
           LockPersonality = true;
           SystemCallArchitectures = "native";
 
-          EnvironmentFile = cfg.secretsFile;
+          EnvironmentFile = lib.optionals (cfg.secretsFile != null) [ cfg.secretsFile ];
           AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
           CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds null-guards to usage of nullable environment-file options.

I have avoided modules that used an assertion with a descriptive message, and modules where the type of the option was non-nullable.

<details>
  <summary>NixOS test coverage</summary>

- [ ] appservice-discord
- [X] glance
- [X] kimai
- [X] lavalink
- [X] linkwarden
- [X] mattermost
- [X] mautrix-discord
- [ ] mautrix-meta (depends on `envoy` which fails due to FOD hash mismatch)
- [ ] mautrix-signal
- [ ] mautrix-telegram
- [ ] mautrix-whatsapp
- [X] mollysocket
- [X] pangolin
- [X] peertube
- [ ] pomerium (depends on `envoy` which fails due to FOD hash mismatch)
- [X] pufferpanel
- [X] yarr

Built with:

`NIXPKGS_ALLOW_INSECURE=1 nix build .#nixosTests.mautrix-discord .#nixosTests.peertube .#nixosTests.linkwarden .#nixosTests.glance .#nixosTests.lavalink .#nixosTests.mattermost .#nixosTests.mollysocket .#nixosTests.pufferpanel .#nixosTests.yarr .#nixosTests.pangolin .#nixosTests.kimai -L --impure`

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
