### PR TITLE
pulsar-engine: init at 0.2.42

### DIFF
--- a/pkgs/by-name/pu/pulsar-engine/package.nix
+++ b/pkgs/by-name/pu/pulsar-engine/package.nix
@@ -1,0 +1,42 @@
+{
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  protobuf,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pulsar-engine";
+  version = "0.1.130";
+
+  src = fetchFromGitHub {
+    owner = "Far-Beyond-Pulsar";
+    repo = "Pulsar-Native";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-vV7lePDto0IIJtlO3yB5f+tJKkHd7P0oCXXjvSCBIrE=";
+  };
+
+  cargoHash = "sha256-IJ1U6HhiBTA3YOb8Z1UJlxBgn3+CcYqJmJ9+8wkPCg4=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    protobuf
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Next-generation game engine built with GPUI";
+    homepage = "https://github.com/Far-Beyond-Pulsar/Pulsar-Native";
+    changelog = "https://github.com/Far-Beyond-Pulsar/Pulsar-Native/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.apsl20;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+  };
+})

--- a/pkgs/by-name/pu/pulsar-engine/package.nix
+++ b/pkgs/by-name/pu/pulsar-engine/package.nix
@@ -1,0 +1,42 @@
+{
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  protobuf,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pulsar-engine";
+  version = "0.2.42";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Far-Beyond-Pulsar";
+    repo = "Pulsar-Native";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-choWvca4SPPL+c2rhKCgnJRSqWDrI/mUZDES+NrBmQE=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-3uS5LpKb8ibg9/JMx8NFOgjj7mvsUastTkHrpXJwDGs=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    protobuf
+  ];
+
+  meta = {
+    description = "Next-generation game engine built with GPUI";
+    homepage = "https://github.com/Far-Beyond-Pulsar/Pulsar-Native";
+    changelog = "https://github.com/Far-Beyond-Pulsar/Pulsar-Native/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.apsl20;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds https://github.com/Far-Beyond-Pulsar/Pulsar-Native
UPDATE: I have notified the breakage on linux to the maintainer via discord, for now this is not ready for merge. 

Blocked by https://github.com/NixOS/nixpkgs/pull/387337 (needs to merge to master first and then this pr can rebase).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
