### PR TITLE
thunderbird-bin: throw on unsupported system

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -45,7 +45,9 @@ let
     x86_64-darwin = "mac";
   };
 
-  arch = mozillaPlatforms.${stdenv.hostPlatform.system};
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  arch = mozillaPlatforms.${stdenv.hostPlatform.system} or throwSystem;
 
   isPrefixOf = prefix: string: builtins.substring 0 (builtins.stringLength prefix) string == prefix;
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/421125#issuecomment-3418668213

It's probably the only thing to fix on aarch64-linux, as there's still a large user base using nixpkgs-review there. For exotic platforms, sorry — just try `blast-bin`. See #420442 for the current situation on riscv64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
