### PR TITLE
prometheus: 3.6.0 → 3.7.1

### DIFF
--- a/nixos/tests/prometheus/default.nix
+++ b/nixos/tests/prometheus/default.nix
@@ -8,4 +8,5 @@
   prometheus-pair = runTest ./prometheus-pair.nix;
   pushgateway = runTest ./pushgateway.nix;
   remote-write = runTest ./remote-write.nix;
+  ui = runTest ./ui.nix;
 }

--- a/nixos/tests/prometheus/ui.nix
+++ b/nixos/tests/prometheus/ui.nix
@@ -1,0 +1,86 @@
+{ lib, pkgs, ... }:
+
+{
+  name = "prometheus-ui";
+
+  nodes = {
+    browser =
+      { config, pkgs, ... }:
+      {
+        environment.systemPackages =
+          let
+            prometheusSeleniumScript =
+              pkgs.writers.writePython3Bin "prometheus-selenium-script"
+                {
+                  libraries = with pkgs.python3Packages; [ selenium ];
+                }
+                ''
+                  from selenium import webdriver
+                  from selenium.webdriver.common.by import By
+                  from selenium.webdriver.firefox.options import Options
+                  from selenium.webdriver.support.ui import WebDriverWait
+
+                  options = Options()
+                  options.add_argument("--headless")
+                  service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
+
+                  driver = webdriver.Firefox(options=options, service=service)
+                  driver.implicitly_wait(10)
+                  driver.get("http://prometheus:9090/")
+
+                  wait = WebDriverWait(driver, 60)
+
+                  assert len(driver.find_elements(By.CLASS_NAME, "mantine-AppShell-header")) > 0  # noqa: E501
+                  assert len(driver.find_elements(By.CLASS_NAME, "mantine-AppShell-main")) > 0  # noqa: E501
+
+                  driver.close()
+                '';
+          in
+          with pkgs;
+          [
+            curl
+            firefox-unwrapped
+            geckodriver
+            prometheusSeleniumScript
+          ];
+      };
+
+    prometheus =
+      { config, pkgs, ... }:
+      {
+        networking.firewall.allowedTCPPorts = [ config.services.prometheus.port ];
+
+        services.prometheus = {
+          enable = true;
+          globalConfig.scrape_interval = "2s";
+          scrapeConfigs = [
+            {
+              job_name = "prometheus";
+              static_configs = [
+                {
+                  targets = [
+                    "prometheus1:${toString config.services.prometheus.port}"
+                    "prometheus2:${toString config.services.prometheus.port}"
+                  ];
+                }
+              ];
+            }
+          ];
+        };
+      };
+  };
+
+  testScript = ''
+    prometheus.wait_for_unit("prometheus")
+    prometheus.wait_for_open_port(9090)
+    prometheus.wait_until_succeeds("curl -sSf http://localhost:9090/-/healthy")
+
+    browser.systemctl("start network-online.target")
+    browser.wait_for_unit("network-online.target")
+
+    browser.succeed("curl -kLs http://prometheus:9090/query | grep 'Prometheus Time Series Collection and Processing Server'")
+
+    # Ensure the application is actually rendered by the Javascript
+    browser.succeed("PYTHONUNBUFFERED=1 prometheus-selenium-script")
+  '';
+}

--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -33,7 +33,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "prometheus";
-  version = "3.6.0";
+  version = "3.7.1";
 
   outputs = [
     "out"
@@ -45,14 +45,14 @@ buildGoModule (finalAttrs: {
     owner = "prometheus";
     repo = "prometheus";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GowtA1iTx6lpRW+RBLYFc8s5H8ECPEmcbdVJvGHl5Cw=";
+    hash = "sha256-m5dQoEn/989gmG5Q4A/oCY6JKvOLzpAU8kaPQOsajlA=";
   };
 
-  vendorHash = "sha256-xGMBd/MhwjCbrQrP5d5aSd99F8GN6wB3jaHpOh0M7OA=";
+  vendorHash = "sha256-V+qLxjqGOaT1veEwtklqcS7iO31ufvDHBA9DbZLzDiE=";
 
   webUiStatic = fetchurl {
     url = "https://github.com/prometheus/prometheus/releases/download/v${finalAttrs.version}/prometheus-web-ui-${finalAttrs.version}.tar.gz";
-    hash = "sha256-lw097NTDJUWm2RY0RUg/5djNdbj+W9hRdIaF2cQz4Bo=";
+    hash = "sha256-88PNQfVM9le+2mqMBq9tyyZ+1J+yloWWIE4VJHSCS1g=";
   };
 
   excludedPackages = [


### PR DESCRIPTION
* https://github.com/prometheus/prometheus/releases/tag/v3.7.0
* https://github.com/prometheus/prometheus/releases/tag/v3.7.1

Also added a small Selenium UI test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
