### PR TITLE
python313Packages.fastapi-azure-auth: init at 5.2.0

### DIFF
--- a/pkgs/development/python-modules/fastapi-azure-auth/default.nix
+++ b/pkgs/development/python-modules/fastapi-azure-auth/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  cryptography,
+  fastapi,
+  httpx,
+  pyjwt,
+
+  # nativeCheckInputs
+  asgi-lifespan,
+  openapi-spec-validator,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-freezer,
+  pytest-mock,
+  pytest-socket,
+  pydantic-settings,
+  respx,
+  uvicorn,
+}:
+buildPythonPackage rec {
+  pname = "fastapi-azure-auth";
+  version = "5.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "intility";
+    repo = "fastapi-azure-auth";
+    tag = version;
+    hash = "sha256-UHHYrorEUp18QQKOLg0k9o5jaRdkEchBAaOR6D7a/TU=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    cryptography
+    fastapi
+    httpx
+    pyjwt
+  ];
+
+  pythonImportsCheck = [
+    "fastapi_azure_auth"
+  ];
+
+  nativeCheckInputs = [
+    asgi-lifespan
+    openapi-spec-validator
+    pytestCheckHook
+    pydantic-settings
+    pytest-asyncio
+    pytest-freezer
+    pytest-mock
+    pytest-socket
+    respx
+    uvicorn
+  ];
+
+  # export all vars from the test env file
+  preCheck = ''
+    set -o allexport
+    source $src/tests/.env.test
+    set +o allexport
+  '';
+
+  disabledTests = [
+    # rely on old httpx interfaces
+    "test_openapi_schema"
+    "test_http_error_old_config_found[asyncio]"
+    "test_http_error_old_config_found[trio]"
+  ];
+
+  disabledTestPaths = [
+    # rely on old httpx interfaces
+    "tests/multi_tenant/test_multi_tenant.py"
+    "tests/multi_tenant_b2c/test_multi_tenant.py"
+    "tests/single_tenant/test_single_tenant.py"
+  ];
+
+  meta = {
+    description = "FastAPI compatible middleware to authenticate using Azure Entra ID";
+    homepage = "https://github.com/intility/fastapi-azure-auth";
+    changelog = "https://github.com/intility/fastapi-azure-auth/releases/tag/${src.tag}";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ parthiv-krishna ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5063,6 +5063,8 @@ self: super: with self; {
 
   fastapi = callPackage ../development/python-modules/fastapi { };
 
+  fastapi-azure-auth = callPackage ../development/python-modules/fastapi-azure-auth { };
+
   fastapi-cli = callPackage ../development/python-modules/fastapi-cli { };
 
   fastapi-github-oidc = callPackage ../development/python-modules/fastapi-github-oidc { };


### PR DESCRIPTION
Adds a package for [fastapi-azure-auth](https://github.com/intility/fastapi-azure-auth), a python package to add Azure Entra ID OIDC authentication for FastAPI apps. 

This is my first time creating a new package so any feedback is welcome. I tried to replicate other FastAPI python packages. Some of the tests appear to rely on an old version of `httpx`, so I'm not sure whether to just disable those or somehow add in that specific version as a dependency.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
