### PR TITLE
libxls: fix build against gettext >= 0.25

### DIFF
--- a/pkgs/by-name/li/libxls/package.nix
+++ b/pkgs/by-name/li/libxls/package.nix
@@ -17,6 +17,21 @@ stdenv.mkDerivation rec {
     hash = "sha256-KbITHQ9s2RUeo8zR53R9s4WUM6z8zzddz1k47So0Mlw=";
   };
 
+  # workaround required to build against gettext >= 0.25
+  # https://savannah.gnu.org/support/index.php?111272
+  preAutoreconf = ''
+    autopoint --force
+  '';
+
+  # workaround required to build against gettext >= 0.25
+  # https://savannah.gnu.org/support/index.php?111273
+  autoreconfFlags = [
+    "--include=m4"
+    "--install"
+    "--force"
+    "--verbose"
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     autoconf-archive

--- a/pkgs/by-name/li/libxls/package.nix
+++ b/pkgs/by-name/li/libxls/package.nix
@@ -6,14 +6,14 @@
   autoconf-archive,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxls";
   version = "1.6.3";
 
   src = fetchFromGitHub {
     owner = "libxls";
     repo = "libxls";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-KbITHQ9s2RUeo8zR53R9s4WUM6z8zzddz1k47So0Mlw=";
   };
 
@@ -41,12 +41,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Extract Cell Data From Excel xls files";
+    changelog = "https://github.com/libxls/libxls/releases/tag/v${finalAttrs.version}";
     homepage = "https://github.com/libxls/libxls";
-    license = licenses.bsd2;
+    license = lib.licenses.bsd2;
     maintainers = [ ];
     mainProgram = "xls2csv";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libxls/package.nix
+++ b/pkgs/by-name/li/libxls/package.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doCheck = true;
+
   meta = with lib; {
     description = "Extract Cell Data From Excel xls files";
     homepage = "https://github.com/libxls/libxls";


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `ced6225c49d2abe66b550b5e83ebc970b7744d80`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>libxls</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

#457852

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc