### PR TITLE
shellspec: Add `passthru` tests

### DIFF
--- a/pkgs/by-name/sh/shellspec/package.nix
+++ b/pkgs/by-name/sh/shellspec/package.nix
@@ -3,6 +3,11 @@
   stdenv,
   fetchFromGitHub,
   bash,
+
+  # Test-only
+  dash,
+  ksh,
+  zsh,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,11 +27,30 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkPhase = ''
     ./shellspec --no-banner --task fixture:stat:prepare
-    ./shellspec --no-banner spec --jobs "$(nproc)"
+    ./shellspec --no-banner spec --jobs "$(nproc)" ${finalAttrs.extraTestArgs or ""}
   '';
 
   # "Building" the script happens in Docker
   dontBuild = true;
+
+  passthru.tests =
+    let
+      # Tests are not enabled by default, so enable them.
+      enabled = finalAttrs.overrideAttrs { doCheck = true; };
+      # For adding variations. Use testWith (finalAttrs: prevAttrs: { }) if needed.
+      testWith = enabled.overrideAttrs;
+    in
+    {
+      # Enable tests in all variations
+      # Some of these may log failures, which are later treated as SKIPPED.
+      # This is normal. Look for "0 failures" and a successful derivation build.
+      with-bin-sh = enabled;
+      with-bash = testWith { extraTestArgs = "--shell ${lib.getExe bash}"; };
+      # with-dash: Broken as of shellspec 0.28.1, dash 0.5.13.1
+      # with-dash = testWith { extraTestArgs = "--shell ${lib.getExe dash}"; };
+      with-ksh = testWith { extraTestArgs = "--shell ${lib.getExe ksh}"; };
+      with-zsh = testWith { extraTestArgs = "--shell ${lib.getExe zsh}"; };
+    };
 
   meta = {
     description = "Full-featured BDD unit testing framework for bash, ksh, zsh, dash and all POSIX shells";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This adds the following attributes, to be picked up by ofborg and other tooling.
- `shellspec.tests.with-bin-sh`
- `shellspec.tests.with-bash`
- `shellspec.tests.with-dash`
- `shellspec.tests.with-ksh`
- `shellspec.tests.with-zsh`


I'll follow this up with reverse dependency smoke tests in `dash.tests` and other shells if the maintainers approve of that.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
