### PR TITLE
dedoc: init at 0.2.8

### DIFF
--- a/pkgs/by-name/de/dedoc/package.nix
+++ b/pkgs/by-name/de/dedoc/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dedoc";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "toiletbril";
+    repo = "dedoc";
+    rev = "1a889de59d642f6b82036b21d0f0f058d8acf9cc";
+    hash = "sha256-NCXsinihB/86SgRzER7UfQ6ZbpmyuJowo7fi84PYGfE=";
+  };
+
+  cargoHash = "sha256-NrHWr+uaCxXBUy+DWO9XlAESchXuArLIbpvlua8rB+g=";
+
+  meta = {
+    description = "Terminal based viewer for DevDocs";
+    homepage = "https://github.com/toiletbril/dedoc";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ mmkaram ];
+    mainProgram = "dedoc";
+  };
+})


### PR DESCRIPTION
## Things done

Added a useful terminal based documentation viewer based on the FreeCodeCamp DevDovs platform. [Here](https://crates.io/crates/dedoc) is the crates.io page for it.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
