### PR TITLE
orocos-kdl: 1.5.1 -> 1.5.3

### DIFF
--- a/pkgs/by-name/or/orocos-kdl/package.nix
+++ b/pkgs/by-name/or/orocos-kdl/package.nix
@@ -14,9 +14,8 @@ stdenv.mkDerivation rec {
     owner = "orocos";
     repo = "orocos_kinematics_dynamics";
     tag = "${version}";
-    # Needed to build Python bindings
     hash = "sha256-4pPU+6uMMYLGq2V46wmg6lHFVhwFXrEg7PfnWGAI2is=";
-    fetchSubmodules = true;
+    fetchSubmodules = true; # Needed to build Python bindings
   };
 
   sourceRoot = "${src.name}/orocos_kdl";

--- a/pkgs/by-name/or/orocos-kdl/package.nix
+++ b/pkgs/by-name/or/orocos-kdl/package.nix
@@ -8,14 +8,14 @@
 
 stdenv.mkDerivation rec {
   pname = "orocos-kdl";
-  version = "1.5.1";
+  version = "1.5.3";
 
   src = fetchFromGitHub {
     owner = "orocos";
     repo = "orocos_kinematics_dynamics";
-    tag = "v${version}";
-    sha256 = "15ky7vw461005axx96d0f4zxdnb9dxl3h082igyd68sbdb8r1419";
+    tag = "${version}";
     # Needed to build Python bindings
+    hash = "sha256-4pPU+6uMMYLGq2V46wmg6lHFVhwFXrEg7PfnWGAI2is=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/pykdl/default.nix
+++ b/pkgs/development/python-modules/pykdl/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   toPythonModule,
-  fetchpatch,
   cmake,
   pybind11,
   orocos-kdl,
@@ -16,15 +15,6 @@ toPythonModule (
     inherit (orocos-kdl) version src;
 
     sourceRoot = "${orocos-kdl.src.name}/python_orocos_kdl";
-
-    patches = [
-      # Support system pybind11; the vendored copy doesn't support Python 3.11
-      (fetchpatch {
-        url = "https://github.com/orocos/orocos_kinematics_dynamics/commit/e25a13fc5820dbca6b23d10506407bca9bcdd25f.patch";
-        hash = "sha256-NGMVGEYsa7hVX+SgRZgeSm93BqxFR1uiyFvzyF5H0Y4=";
-        stripLen = 1;
-      })
-    ];
 
     # Fix hardcoded installation path
     postPatch = ''


### PR DESCRIPTION
- #445447
  - https://github.com/orocos/orocos_kinematics_dynamics/commit/93d8ccf9b45133812183427958746f3beb7b9d30 
- https://github.com/orocos/orocos_kinematics_dynamics/releases/tag/1.5.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
