### PR TITLE
cerca: 0-unstable-2025-05-21 -> 0.3.3

### DIFF
--- a/pkgs/by-name/ce/cerca/package.nix
+++ b/pkgs/by-name/ce/cerca/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "cerca";
-  version = "0-unstable-2025-05-21";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "cblgh";
     repo = "cerca";
-    rev = "722c38d96160ccf69dd7a8122b62660102b64a59";
-    hash = "sha256-M5INnik/TIzH0Afi8/6/PnhwsAhd+kFaDHejfsmuhn0=";
+    tag = "v${version}";
+    hash = "sha256-T7hlvV3VTskBJx8szT55ekAFd/gCqAUDaKyX3YCfYj4=";
   };
 
-  vendorHash = "sha256-yfsI0nKfzyzmtbS9bSHRaD2pEgxN6gOKAA/FRDxJx40=";
+  vendorHash = "sha256-iIZMYIwIgnFvraowh2k8MUTl7L4zhgcm+UojlimpCTk=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ce/cerca/package.nix
+++ b/pkgs/by-name/ce/cerca/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "cerca";
-  version = "0-unstable-2025-05-21";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "cblgh";
     repo = "cerca";
-    rev = "722c38d96160ccf69dd7a8122b62660102b64a59";
-    hash = "sha256-M5INnik/TIzH0Afi8/6/PnhwsAhd+kFaDHejfsmuhn0=";
+    tag = "v${version}";
+    hash = "sha256-y+TVjtu/5rugY74mIFznHjEUxUmhrmQhdMpSomqLEWw=";
   };
 
-  vendorHash = "sha256-yfsI0nKfzyzmtbS9bSHRaD2pEgxN6gOKAA/FRDxJx40=";
+  vendorHash = "sha256-iIZMYIwIgnFvraowh2k8MUTl7L4zhgcm+UojlimpCTk=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
diff: https://github.com/cblgh/cerca/compare/722c38d96160ccf69dd7a8122b62660102b64a59...v0.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
