### PR TITLE
hypre: 2.33.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/hy/hypre/package.nix
+++ b/pkgs/by-name/hy/hypre/package.nix
@@ -2,46 +2,119 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
+  cmake,
+  pkg-config,
+  gfortran,
+  blas,
+  lapack,
   mpi,
+  llvmPackages,
+  mpiCheckPhaseHook,
+  isILP64 ? false,
+  mpiSupport ? true,
+  precision ? "double",
+  testers,
+  hypre,
 }:
+
+assert lib.elem precision [
+  "single"
+  "double"
+  "long-double"
+];
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hypre";
-  version = "2.33.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "hypre-space";
     repo = "hypre";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OrpClN9xd+8DdELVnI4xBg3Ih/BaoBiO0w/QrFjUclw=";
+    hash = "sha256-zu9YWfBT2WJxPg6JHrXjZWRM9Ai1p28EpvAx6xfdPsY=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/src";
-
-  buildInputs = [ mpi ];
-
-  configureFlags = [
-    "--enable-mpi"
-    "--enable-shared"
+  outputs = [
+    "out"
+    "dev"
   ];
 
-  preBuild = ''
-    makeFlagsArray+=(AR="ar -rcu")
+  patches = [
+    (fetchpatch2 {
+      url = "https://raw.githubusercontent.com/spack/spack-packages/eb4b23847f0079d0c9c8de99aaa32557ad4c9194/repos/builtin/packages/hypre/hypre-precision-fix.patch?full_index=1";
+      hash = "sha256-Ni5xlfFmok884x5Hctf9VOsAgZp8ICG7QNVGTdVKPzE=";
+    })
+  ];
+
+  # fix sequence check
+  postPatch = lib.optionalString (!mpiSupport) ''
+    substituteInPlace src/test/CMakeLists.txt \
+      --replace-fail ''\'''${MPIEXEC_EXECUTABLE} ''${MPIEXEC_NUMPROC_FLAG} 1' ""
   '';
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/{include,lib}
-    cp -r hypre/include/* $out/include
-    cp -r hypre/lib/* $out/lib
-    runHook postInstall
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    gfortran
+  ];
+
+  propagatedBuildInputs = [
+    (blas.override { inherit isILP64; })
+    (lapack.override { inherit isILP64; })
+  ]
+  ++ lib.optional mpiSupport mpi
+  ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  cmakeDir = "../src";
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BLA_PREFER_PKGCONFIG" true)
+    (lib.cmakeBool "HYPRE_ENABLE_HYPRE_BLAS" false)
+    (lib.cmakeBool "HYPRE_ENABLE_HYPRE_LAPACK" false)
+    (lib.cmakeBool "HYPRE_ENABLE_FORTRAN" true)
+    (lib.cmakeBool "HYPRE_ENABLE_BIGINT" isILP64)
+    (lib.cmakeBool "HYPRE_ENABLE_SINGLE" (precision == "single"))
+    (lib.cmakeBool "HYPRE_ENABLE_LONG_DOUBLE" (precision == "long-double"))
+    (lib.cmakeBool "HYPRE_ENABLE_OPENMP" true)
+    (lib.cmakeBool "HYPRE_ENABLE_MPI" mpiSupport)
+    (lib.cmakeBool "HYPRE_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  __darwinAllowLocalNetworking = mpiSupport;
+
+  nativeCheckInputs = lib.optional mpiSupport mpiCheckPhaseHook;
+
+  doCheck = true;
+
+  postInstall = lib.optionalString finalAttrs.finalPackage.doCheck ''
+    rm -rf $out/bin
   '';
 
-  meta = with lib; {
+  passthru = {
+    tests = {
+      cmake-config = testers.hasCmakeConfigModules {
+        moduleNames = [ "HYPRE" ];
+        package = finalAttrs.finalPackage;
+      };
+      ilp64 = hypre.override { isILP64 = true; };
+      single = hypre.override { precision = "single"; };
+      serial = hypre.override { mpiSupport = false; };
+    };
+  };
+
+  meta = {
     description = "Parallel solvers for sparse linear systems featuring multigrid methods";
     homepage = "https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods";
-    platforms = platforms.unix;
-    license = licenses.mit;
-    maintainers = with maintainers; [ mkez ];
+    platforms = lib.platforms.unix;
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      mkez
+      qbisi
+    ];
   };
 })


### PR DESCRIPTION
supersed https://github.com/NixOS/nixpkgs/pull/446371, switch to modern cmake build system

ref: 
1. petsc: https://gitlab.com/petsc/petsc/-/blob/main/config/BuildSystem/config/packages/hypre.py
2. gentoo: https://gitweb.gentoo.org/repo/gentoo.git/tree/sci-libs/hypre/hypre-2.32.0.ebuild
3. spack: https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/hypre/package.py
4. aur: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=hypre

Hypre's complex value support is broken for now, even one can force build with "-Wno-incompatible-pointer-types", the implemention has something wrong.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
