### PR TITLE
nixos/modules/config/users-groups.nix: Fix shellcheck errors when building with systemd.enableStrictShellChecks

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -908,13 +908,19 @@ in
           ''
             mkdir -vp ${lingerDir}
             cd ${lingerDir}
-            for user in $(ls); do
-              if ! id "$user" >/dev/null; then
-                echo "Removing linger for missing user $user"
-                rm --force -- "$user"
+            for user in *; do
+              # empty glob will run once
+              if [ -e "$user" ]; then
+                if ! id "$user" >/dev/null; then
+                  echo "Removing linger for missing user $user"
+                  rm --force -- "$user"
+                fi
               fi
             done
+            # using find here is overkill, suppress shellcheck warning re iterating over ls output
+            # shellcheck disable=2012
             ls | sort | comm -3 -1 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl disable-linger
+            # shellcheck disable=2012
             ls | sort | comm -3 -2 ${lingeringUsersFile} - | xargs -r ${pkgs.systemd}/bin/loginctl  enable-linger
           '';
 

--- a/nixos/tests/systemd-user-linger.nix
+++ b/nixos/tests/systemd-user-linger.nix
@@ -18,6 +18,7 @@
           uid = 10001;
         };
       };
+      systemd.enableStrictShellChecks = true;
     };
 
   testScript =


### PR DESCRIPTION
A few small tweaks to make it possible to build the configuration if you have both `enableStrictShellChecks` and `linger` enable for any of the users. I've also updated corresponding VM test to enable shell checks.

In another news, more as an open-ended note/question - whole logic in linger isn't terribly well behaved.
* If we don't have any users with `linger = true`, nixos will not generate corresponding systemd unit and won't interfere with any manual `enable-linger` settings.
* As soon as we add single user with `linger = true`, it will generate the systemd unit and will start resetting `linger` settings on restart and some configuration changes.
* If there are non-declarative users, they are considered `linger=false` and it will be disabling linger for them.
* It's not clear off the top of my head that sorting usernames inline in the `users-groups.nix` and whatever `sort` does agree for non-ASCII user names - that might wreck `comm` results.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
