### PR TITLE
applesauce: 0.5.19 -> 0.5.20

### DIFF
--- a/pkgs/by-name/ap/applesauce/package.nix
+++ b/pkgs/by-name/ap/applesauce/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "applesauce";
-  version = "0.5.19";
+  version = "0.5.20";
 
   src = fetchFromGitHub {
     owner = "Dr-Emann";
     repo = "applesauce";
     tag = "applesauce-cli-v${finalAttrs.version}";
-    hash = "sha256-OJZOB7h3qFkaCaPi+EJxIFX8q/Q38vtI0CmDK4PMD1g=";
+    hash = "sha256-KiivMFp772x/rFHh9PpDBjCxxC/6n6+KyAaZTmhnZV0=";
   };
 
-  cargoHash = "sha256-gQQpvS2LtlDBXjTqQvSUCXv5UCiQm1kiS/yPcG5KGxY=";
+  cargoHash = "sha256-WyDHp34NQi3/OotM4+4/d4ySOSYg+PDDmnLUn5R9yaU=";
 
   meta = {
     description = "Transparent compression for Apple File System Compression (AFSC)";


### PR DESCRIPTION
Changelog: https://github.com/Dr-Emann/applesauce/releases/tag/applesauce-cli-v0.5.20

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
