### PR TITLE
opensmt: 2.7.0 -> 2.9.2

### DIFF
--- a/pkgs/by-name/op/opensmt/package.nix
+++ b/pkgs/by-name/op/opensmt/package.nix
@@ -10,24 +10,28 @@
   enableReadline ? false,
   readline,
   gtest,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "opensmt";
   version = "2.9.2";
 
   src = fetchFromGitHub {
     owner = "usi-verification-and-security";
     repo = "opensmt";
-    rev = "v${version}";
-    sha256 = "sha256-xKpYABMn2bsXRg2PMjiMhsx6+FbAsxitLRnmqa1kmu0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xKpYABMn2bsXRg2PMjiMhsx6+FbAsxitLRnmqa1kmu0=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
     bison
     flex
   ];
+
   buildInputs = [
     libedit
     gmpxx
@@ -36,17 +40,19 @@ stdenv.mkDerivation rec {
   ++ lib.optional enableReadline readline;
 
   preConfigure = ''
-    substituteInPlace test/CMakeLists.txt \
-      --replace-fail 'FetchContent_MakeAvailable' '#FetchContent_MakeAvailable'
+    substituteInPlace test/CMakeLists.txt --replace-fail \
+      'FetchContent_MakeAvailable' '#FetchContent_MakeAvailable'
   '';
 
-  meta = with lib; {
-    broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    broken = with stdenv.hostPlatform; (isLinux && isAarch64);
     description = "Satisfiability modulo theory (SMT) solver";
     mainProgram = "opensmt";
-    maintainers = [ maintainers.raskin ];
-    platforms = platforms.linux;
-    license = if enableReadline then licenses.gpl2Plus else licenses.mit;
+    maintainers = [ lib.maintainers.raskin ];
+    platforms = lib.platforms.linux;
+    license = if enableReadline then lib.licenses.gpl2Plus else lib.licenses.mit;
     homepage = "https://github.com/usi-verification-and-security/opensmt";
   };
-}
+})

--- a/pkgs/by-name/op/opensmt/package.nix
+++ b/pkgs/by-name/op/opensmt/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "opensmt";
-  version = "2.7.0";
+  version = "2.9.2";
 
   src = fetchFromGitHub {
     owner = "usi-verification-and-security";
     repo = "opensmt";
     rev = "v${version}";
-    sha256 = "sha256-zhNNnwc41B4sNq50kPub29EYhqV+FoDKRD/CLHnVyZw=";
+    sha256 = "sha256-xKpYABMn2bsXRg2PMjiMhsx6+FbAsxitLRnmqa1kmu0=";
   };
 
   nativeBuildInputs = [
@@ -31,17 +31,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libedit
     gmpxx
+    gtest
   ]
   ++ lib.optional enableReadline readline;
 
   preConfigure = ''
     substituteInPlace test/CMakeLists.txt \
-      --replace 'FetchContent_Populate' '#FetchContent_Populate'
+      --replace-fail 'FetchContent_MakeAvailable' '#FetchContent_MakeAvailable'
   '';
-  cmakeFlags = [
-    "-Dgoogletest_SOURCE_DIR=${gtest.src}"
-    "-Dgoogletest_BINARY_DIR=./gtest-build"
-  ];
 
   meta = with lib; {
     broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);


### PR DESCRIPTION
Resolves #453395

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
