### PR TITLE
qview: migrate to `Qt6` and add `HEIF` support

### DIFF
--- a/pkgs/by-name/qv/qview/package.nix
+++ b/pkgs/by-name/qv/qview/package.nix
@@ -3,18 +3,19 @@
   stdenv,
   fetchFromGitHub,
   qt6,
+  nix-update-script,
   kdePackages,
   x11Support ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qview";
   version = "7.1";
 
   src = fetchFromGitHub {
     owner = "jurplel";
     repo = "qView";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-EcXhwJcgBLdXa/FQ5LuENlzwnLw4Gt2BGlBO1p5U8tI=";
   };
 
@@ -37,12 +38,15 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals (!x11Support) [ "CONFIG+=NO_X11" ];
 
-  meta = with lib; {
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     description = "Practical and minimal image viewer";
     mainProgram = "qview";
+    changelog = "https://github.com/jurplel/qView/releases/tag/${finalAttrs.version}";
     homepage = "https://interversehq.com/qview/";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ acowley ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ acowley ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/qv/qview/package.nix
+++ b/pkgs/by-name/qv/qview/package.nix
@@ -2,7 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  libsForQt5,
+  qt6,
+  kdePackages,
   x11Support ? true,
 }:
 
@@ -17,20 +18,24 @@ stdenv.mkDerivation rec {
     hash = "sha256-EcXhwJcgBLdXa/FQ5LuENlzwnLw4Gt2BGlBO1p5U8tI=";
   };
 
-  qmakeFlags = lib.optionals (!x11Support) [ "CONFIG+=NO_X11" ];
-
   nativeBuildInputs = [
-    libsForQt5.qmake
-    libsForQt5.wrapQtAppsHook
+    qt6.qmake
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qttools
-    libsForQt5.qtimageformats
-    libsForQt5.qtsvg
+    qt6.qtbase
+    qt6.qttools
+    qt6.qtimageformats
+    qt6.qtsvg
+    kdePackages.kimageformats
+  ];
+
+  qmakeFlags = [
+    # See https://github.com/NixOS/nixpkgs/issues/214765
+    "QT_TOOL.lrelease.binary=${lib.getDev qt6.qttools}/bin/lrelease"
   ]
-  ++ lib.optionals x11Support [ libsForQt5.qtx11extras ];
+  ++ lib.optionals (!x11Support) [ "CONFIG+=NO_X11" ];
 
   meta = with lib; {
     description = "Practical and minimal image viewer";


### PR DESCRIPTION
### Migrate to `Qt6` and add `HEIF` support to `qView`

#### Migrate to Qt6

- `qView` has supported `Qt6` since version 5.0, see the [changelog](https://github.com/jurplel/qView/releases/tag/5.0).

- Migrating to `Qt6` allows the use of the `Qt6` library `kdePackages.kimageformats`, which adds support, among other formats, for `HEIF` to `qView`.

- Qt X11 Extras was removed in `Qt6`, see [Qt6 docs](https://doc.qt.io/qt-6/extras-changes-qt6.html#changes-to-qt-x11-extras).

#### Add Support for `HEIF`
- Upstream `qView` supports `HEIF` formats (e.g., `HEIC` used by iPhones), but `qView` fails to open these images with the error:

> "Error occurred opening "IMG_XXXX.HEIC": Unsupported image format (Error 3)".

- The addition of `kdePackages.kimageformats` adds support for `HEIF` fixing the error.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
