### PR TITLE
sforzando: init at 1.982~beta3

### DIFF
--- a/pkgs/by-name/sf/sforzando/package.nix
+++ b/pkgs/by-name/sf/sforzando/package.nix
@@ -1,0 +1,77 @@
+{
+  stdenvNoCC,
+  fetchzip,
+  dpkg,
+  autoPatchelfHook,
+  libx11,
+  libpulseaudio,
+  alsa-lib,
+  glibmm,
+  gtk3,
+  gtkmm3,
+  lib,
+
+  installStandalone ? true,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "sforzando";
+  version = "1.982~beta3";
+
+  src = fetchzip {
+    url = "https://sforzando.s3.us-east-1.amazonaws.com/LINUX_plogue-sforzando_${finalAttrs.version}_x86_64.zip";
+    hash = "sha256-yTz+ZfBIi6jN2IZWYnk8AZsIRT2qc6lpaWKUfxaAJrs=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    libx11
+    libpulseaudio
+    alsa-lib
+    glibmm
+    gtk3.dev
+    gtkmm3
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg -x $src/plogue-sforzando_${finalAttrs.version}_amd64.deb ./
+    runHook postUnpack
+  '';
+
+  patchPhase = ''
+    runHook prePatch
+    sed -i "s+Exec=/opt/+Exec=$out/opt/+" usr/share/applications/plogue-sforzando.desktop
+    runHook postPatch
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/* $out/
+    cp -r opt $out/opt
+
+    ${lib.optionalString installStandalone ''
+      mkdir -p $out/bin
+      ln -s $out/opt/Plogue/sforzando/sforzando $out/bin/sforzando
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Free, highly SFZ 2.0 compliant sample player";
+    homepage = "https://www.plogue.com/products/sforzando.html";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  }
+  // lib.optionalAttrs installStandalone {
+    mainProgram = "sforzando";
+  };
+})


### PR DESCRIPTION
This PR adds sforzando to the nixpkgs repo.

TODO:
- [ ] [Patch "/opt" and some binaries](https://www.plogue.com/plgfrms/viewtopic.php?p=52719#p52719)
- [ ] _???_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
