### PR TITLE
foxotron: fix build issue due to cmake 4

### DIFF
--- a/pkgs/by-name/fo/foxotron/package.nix
+++ b/pkgs/by-name/fo/foxotron/package.nix
@@ -18,7 +18,6 @@
   alsa-lib,
   fontconfig,
 }:
-
 stdenv.mkDerivation rec {
   pname = "foxotron";
   version = "2024-09-23";
@@ -43,12 +42,17 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace "set(CMAKE_OSX_ARCHITECTURES x86_64)" ""
+      --replace-fail "set(CMAKE_OSX_ARCHITECTURES x86_64)" "" \
+      --replace-fail "cmake_minimum_required(VERSION 3.0)" "cmake_minimum_required(VERSION 3.10)"
+
+    substituteInPlace externals/glm/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 3.2 FATAL_ERROR)" "cmake_minimum_required(VERSION 3.10)" \
+      --replace-fail "cmake_policy(VERSION 3.2)" "cmake_policy(VERSION 3.10)"
 
     # Outdated vendored assimp, many warnings with newer compilers, too old for CMake option to control this
     # Note that this -Werror caused issues on darwin, so make sure to re-check builds there before removing this
     substituteInPlace externals/assimp/code/CMakeLists.txt \
-      --replace 'TARGET_COMPILE_OPTIONS(assimp PRIVATE -Werror)' ""
+      --replace-fail 'TARGET_COMPILE_OPTIONS(assimp PRIVATE -Werror)' ""
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
As noted in https://github.com/NixOS/nixpkgs/issues/445447.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
