### PR TITLE
lens-desktop: 2024.11.261604 -> 2026.3.251250, add update script

### DIFF
--- a/pkgs/by-name/le/lens/darwin.nix
+++ b/pkgs/by-name/le/lens/darwin.nix
@@ -3,6 +3,7 @@
   pname,
   version,
   src,
+  passthru,
   meta,
   undmg,
 }:
@@ -12,6 +13,7 @@ stdenv.mkDerivation {
     pname
     version
     src
+    passthru
     meta
     ;
 

--- a/pkgs/by-name/le/lens/linux.nix
+++ b/pkgs/by-name/le/lens/linux.nix
@@ -2,6 +2,7 @@
   pname,
   version,
   src,
+  passthru,
   meta,
   appimageTools,
   makeWrapper,
@@ -18,6 +19,7 @@ appimageTools.wrapType2 {
     pname
     version
     src
+    passthru
     meta
     ;
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -8,20 +8,20 @@
 let
 
   pname = "lens-desktop";
-  version = "2025.10.230725";
+  version = "2026.1.161237";
 
   sources = {
     x86_64-linux = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.x86_64.AppImage";
-      hash = "sha256-FlpkXhgHg1gyWEtSpO03cVhFfAEUxv2dgViR0ptfU7s=";
+      hash = "sha256-lVVp5ilFYcMMCpsR2zHxziQRwwPVJgtVu2mLYvSKmIs=";
     };
     x86_64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.dmg";
-      hash = "sha256-Nl9iv4K2tq88XDMABZDHk3GJ1A6RqmZc92kD+oAJAJw=";
+      hash = "sha256-Zj6zRnb63uASd8cKaUy5dkKV5y8LZXbEwAJJsGUfbts=";
     };
     aarch64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest-arm64.dmg";
-      hash = "sha256-vqzpKAU7nlNzTB5c8IBdKOnnvNKAC1jVZRzub/YG1hM=";
+      hash = "sha256-x0meCUkeHUw1LhirnNmEaXNqm9ImMRN69DACYiyfADc=";
     };
   };
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -8,20 +8,20 @@
 let
 
   pname = "lens-desktop";
-  version = "2024.11.261604";
+  version = "2025.10.230725";
 
   sources = {
     x86_64-linux = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.x86_64.AppImage";
-      hash = "sha256-AbuEU5gOckVU+eDIFnomc7ryLq68ihuk3c0XosoJp74=";
+      hash = "sha256-FlpkXhgHg1gyWEtSpO03cVhFfAEUxv2dgViR0ptfU7s=";
     };
     x86_64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.dmg";
-      hash = "sha256-MQQRGTCe+LEHXJi6zjnpENbtlWNP+XVH9rWXRMk+26w=";
+      hash = "sha256-Nl9iv4K2tq88XDMABZDHk3GJ1A6RqmZc92kD+oAJAJw=";
     };
     aarch64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest-arm64.dmg";
-      hash = "sha256-aakJCLnQBAnUdrrniTcahS+q3/kP09mlaPTV8FW5afI=";
+      hash = "sha256-vqzpKAU7nlNzTB5c8IBdKOnnvNKAC1jVZRzub/YG1hM=";
     };
   };
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -8,20 +8,20 @@
 let
 
   pname = "lens-desktop";
-  version = "2026.1.161237";
+  version = "2026.3.251250";
 
   sources = {
     x86_64-linux = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.x86_64.AppImage";
-      hash = "sha256-lVVp5ilFYcMMCpsR2zHxziQRwwPVJgtVu2mLYvSKmIs=";
+      hash = "sha256-8wSJ46njHtC2qhCRNMmVwI/YNs06qoVQn5qkXICACy4=";
     };
     x86_64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.dmg";
-      hash = "sha256-Zj6zRnb63uASd8cKaUy5dkKV5y8LZXbEwAJJsGUfbts=";
+      hash = "sha256-Je5+MjhedffRyKFjoh1hJedHXDUASvXZKVd1saLwacc=";
     };
     aarch64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest-arm64.dmg";
-      hash = "sha256-x0meCUkeHUw1LhirnNmEaXNqm9ImMRN69DACYiyfADc=";
+      hash = "sha256-jJRlz4l5hMnk/bDvRuSVVuoe2SMQuZdAZ3RnGaUuvhU=";
     };
   };
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -17,15 +17,15 @@ let
   sources = {
     x86_64-linux = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.x86_64.AppImage";
-      hash = "sha256-8wSJ46njHtC2qhCRNMmVwI/YNs06qoVQn5qkXICACy4=";
+      hash = "sha512-q0vb6sl4XqoNhV83z16TWoqGNLA6J6wAyVmz28cBzzA5O9xSpMDIMiQPwQlgAnbCnCDaWc//HhXMmobaKWAUxA==";
     };
     x86_64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest.dmg";
-      hash = "sha256-Je5+MjhedffRyKFjoh1hJedHXDUASvXZKVd1saLwacc=";
+      hash = "sha512-rnbhxhL7pMED4uN7+8iVEY1a65FvweNwDxtbKwRZf9sRMntzFSVxhME9dqQKGIgHVZbGppC20ZAHX9JSG0iPXQ==";
     };
     aarch64-darwin = {
       url = "https://api.k8slens.dev/binaries/Lens-${version}-latest-arm64.dmg";
-      hash = "sha256-jJRlz4l5hMnk/bDvRuSVVuoe2SMQuZdAZ3RnGaUuvhU=";
+      hash = "sha512-FBVF1OtQCGlmMLSOCTMQjwFswV5P7chZEz9WhEIaKwjD/DIA9d4Id9kLsG02KDytOfVjeQFxYrRSpzkLepe6wA==";
     };
   };
 

--- a/pkgs/by-name/le/lens/package.nix
+++ b/pkgs/by-name/le/lens/package.nix
@@ -3,6 +3,10 @@
   callPackage,
   fetchurl,
   lib,
+  writeShellApplication,
+  common-updater-scripts,
+  curl,
+  jq,
 }:
 
 let
@@ -29,6 +33,41 @@ let
     inherit (sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}")) url hash;
   };
 
+  passthru = {
+    updateScript = writeShellApplication {
+      name = "update-lens";
+      runtimeInputs = [
+        common-updater-scripts
+        curl
+        jq
+      ];
+      text = ''
+        linux=$(curl -sSfL https://api.k8slens.dev/binaries/latest-linux.json)
+        mac=$(curl -sSfL https://api.k8slens.dev/binaries/latest-mac.json)
+
+        linuxVersion=$(jq -r '.version' <<<"$linux")
+        macVersion=$(jq -r '.version' <<<"$mac")
+        if [[ "$linuxVersion" != "$macVersion" ]]; then
+          echo "error: linux and mac manifest versions differ: $linuxVersion vs $macVersion" >&2
+          exit 1
+        fi
+        version=''${linuxVersion%-latest}
+
+        hashFor() {
+          echo "sha512-$(jq -r --arg s "$2" '[.files[] | select(.url | endswith($s))][0].sha512' <<<"$1")"
+        }
+
+        update() {
+          update-source-version lens "$version" "$2" --system="$1" --ignore-same-version --ignore-same-hash
+        }
+
+        update x86_64-linux   "$(hashFor "$linux" .AppImage)"
+        update x86_64-darwin  "$(hashFor "$mac"   -latest.dmg)"
+        update aarch64-darwin "$(hashFor "$mac"   -arm64.dmg)"
+      '';
+    };
+  };
+
   meta = {
     description = "Kubernetes IDE";
     homepage = "https://k8slens.dev/";
@@ -48,6 +87,7 @@ if stdenv.hostPlatform.isDarwin then
       pname
       version
       src
+      passthru
       meta
       ;
   }
@@ -57,6 +97,7 @@ else
       pname
       version
       src
+      passthru
       meta
       ;
   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Lens 2025.10.230725-latest - Release Changelog](https://forums.k8slens.dev/t/lens-2025-10-230725-latest-release/6515)
[Lens 2026.1.161237-latest - Release Changelog](https://forums.k8slens.dev/t/lens-2026-1-161237-latest-release/6748)
[Lens 2026.3.251250-latest - Release Changelog](https://forums.k8slens.dev/t/lens-release-2026-3-251250-latest-release/6959)

Also add an `updateScript` that pulls upstream's `latest-{linux,mac}.json` from `api.k8slens.dev`. Hashes are now `sha512` because that's what upstream publishes directly.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
