### PR TITLE
ci/github-script/labels: prevent closing purposely-empty PRs

### DIFF
--- a/ci/github-script/labels.js
+++ b/ci/github-script/labels.js
@@ -26,7 +26,10 @@ module.exports = async ({ github, context, core, dry }) => {
     // be detected, no maintainers pinged.
     // We can just check the temporary merge commit, and if it's empty the PR can safely be
     // closed - there are no further changes.
-    if (pull_request.merge_commit_sha) {
+    // We only do this for PRs, which are non-empty to start with. This avoids closing PRs
+    // which have been created with an empty commit for notification purposes, for example
+    // the yearly election notification for voters.
+    if (pull_request.merge_commit_sha && pull_request.changed_files > 0) {
       const commit = (
         await github.rest.repos.getCommit({
           ...context.repo,


### PR DESCRIPTION
Some PRs are empty on purpose, for example the [yearly notification about the election for voters](https://github.com/NixOS/nixpkgs/pull/444914). We should not close these because the merge commit is empty - only if there was a change intended, but the merge commit *becomes* empty, we should act.

This currently causes the labels workflow to fail: https://github.com/NixOS/nixpkgs/actions/runs/18626537685/job/53105351255

The failure only happens because the PR is also locked - which "saved" us from closing this specific PR accidentally. I did not try to work around such a failure to post a comment here on purpose - I'd say a locked PR needing this treatment should be rare enough to be able to look into manually.

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
