### PR TITLE
linux_xanmod: Sync config with upstream

### DIFF
--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -47,46 +47,52 @@ let
           inherit hash;
         };
 
-        structuredExtraConfig = with lib.kernel; {
-          # CPUFreq governor Performance
-          CPU_FREQ_DEFAULT_GOV_PERFORMANCE = lib.mkOverride 60 yes;
-          CPU_FREQ_DEFAULT_GOV_SCHEDUTIL = lib.mkOverride 60 no;
+        structuredExtraConfig =
+          with lib.kernel;
+          {
+            # CPUFreq governor Performance
+            CPU_FREQ_DEFAULT_GOV_PERFORMANCE = lib.mkOverride 60 yes;
+            CPU_FREQ_DEFAULT_GOV_SCHEDUTIL = lib.mkOverride 60 no;
 
-          # Lazy preemption
-          PREEMPT_LAZY = yes;
-          PREEMPT_VOLUNTARY = lib.mkOverride 60 no;
-          PREEMPTIRQ_DELAY_TEST = unset;
+            # Preemption
+            PREEMPT = lib.mkOverride 60 yes;
+            PREEMPT_VOLUNTARY = lib.mkOverride 60 no;
 
-          # Google's BBRv3 TCP congestion Control
-          TCP_CONG_BBR = yes;
-          DEFAULT_BBR = yes;
+            # Google's BBRv3 TCP congestion Control
+            TCP_CONG_BBR = yes;
+            DEFAULT_BBR = yes;
 
-          # Preemptive tickless idle kernel
-          HZ = freeform "250";
-          HZ_250 = yes;
-          NO_HZ = no;
-          NO_HZ_FULL = lib.mkOverride 60 no;
-          NO_HZ_IDLE = yes;
+            # Preemptive tickless idle kernel
+            HZ = freeform "250";
+            HZ_250 = yes;
+            NO_HZ = no;
+            NO_HZ_FULL = lib.mkOverride 60 no;
+            NO_HZ_IDLE = yes;
 
-          # CPU idle governors favored
-          CPU_IDLE_GOV_HALTPOLL = yes; # Already enabled
-          CPU_IDLE_GOV_LADDER = yes;
-          CPU_IDLE_GOV_TEO = yes;
+            # CPU idle governors favored
+            CPU_IDLE_GOV_HALTPOLL = yes; # Already enabled
+            CPU_IDLE_GOV_LADDER = yes;
+            CPU_IDLE_GOV_TEO = yes;
 
-          # RCU_BOOST and RCU_EXP_KTHREAD
-          RCU_EXPERT = yes;
-          RCU_FANOUT = freeform "64";
-          RCU_FANOUT_LEAF = freeform "16";
-          RCU_BOOST = yes;
-          RCU_BOOST_DELAY = freeform "0";
-          RCU_EXP_KTHREAD = yes;
-          RCU_NOCB_CPU = yes;
-          RCU_DOUBLE_CHECK_CB_TIME = yes;
+            # RCU_BOOST and RCU_EXP_KTHREAD
+            RCU_EXPERT = yes;
+            RCU_FANOUT = freeform "64";
+            RCU_FANOUT_LEAF = freeform "16";
+            RCU_BOOST = yes;
+            RCU_BOOST_DELAY = freeform "0";
+            RCU_EXP_KTHREAD = yes;
+            RCU_NOCB_CPU = yes;
+            RCU_DOUBLE_CHECK_CB_TIME = yes;
 
-          # x86 features
-          X86_FRED = yes;
-          X86_POSTED_MSI = yes;
-        };
+            # x86 features
+            X86_FRED = yes;
+            X86_POSTED_MSI = yes;
+          }
+          // lib.optionalAttrs (lib.versionAtLeast (lib.versions.majorMinor version) "6.13") {
+            # Lazy preemption
+            PREEMPT = lib.mkOverride 70 no;
+            PREEMPT_LAZY = yes;
+          };
 
         extraPassthru.updateScript = {
           command = [

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -52,18 +52,26 @@ let
           CPU_FREQ_DEFAULT_GOV_PERFORMANCE = lib.mkOverride 60 yes;
           CPU_FREQ_DEFAULT_GOV_SCHEDUTIL = lib.mkOverride 60 no;
 
-          # Full preemption
-          PREEMPT = lib.mkOverride 60 yes;
+          # Lazy preemption
+          PREEMPT_LAZY = yes;
           PREEMPT_VOLUNTARY = lib.mkOverride 60 no;
+          PREEMPTIRQ_DELAY_TEST = unset;
 
           # Google's BBRv3 TCP congestion Control
           TCP_CONG_BBR = yes;
           DEFAULT_BBR = yes;
 
-          # Preemptive Full Tickless Kernel at 250Hz
+          # Preemptive tickless idle kernel
           HZ = freeform "250";
           HZ_250 = yes;
-          HZ_1000 = no;
+          NO_HZ = no;
+          NO_HZ_FULL = lib.mkOverride 60 no;
+          NO_HZ_IDLE = yes;
+
+          # CPU idle governors favored
+          CPU_IDLE_GOV_HALTPOLL = yes; # Already enabled
+          CPU_IDLE_GOV_LADDER = yes;
+          CPU_IDLE_GOV_TEO = yes;
 
           # RCU_BOOST and RCU_EXP_KTHREAD
           RCU_EXPERT = yes;
@@ -72,6 +80,12 @@ let
           RCU_BOOST = yes;
           RCU_BOOST_DELAY = freeform "0";
           RCU_EXP_KTHREAD = yes;
+          RCU_NOCB_CPU = yes;
+          RCU_DOUBLE_CHECK_CB_TIME = yes;
+
+          # x86 features
+          X86_FRED = yes;
+          X86_POSTED_MSI = yes;
         };
 
         extraPassthru.updateScript = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Upstream config (v6.17.3): https://gitlab.com/xanmod/linux/-/blob/6.17.3-xanmod1/CONFIGS/x86_64/config
Upstream config (6.12.53): https://gitlab.com/xanmod/linux/-/blob/6.12.53-xanmod1/CONFIGS/xanmod/gcc/config_x86-64-v1

Generate diff:
```sh
# For linux_xanmod_latest
curl https://gitlab.com/xanmod/linux/-/raw/6.17.3-xanmod1/CONFIGS/x86_64/config > /tmp/xanmod-6.17.3.config
diff $(nix build .#linuxKernel.packages.linux_xanmod_latest.kernel.configfile --print-out-paths --no-link) /tmp/xanmod-6.17.3.config -u

# For linux_xanmod
curl https://gitlab.com/xanmod/linux/-/raw/6.12.53-xanmod1/CONFIGS/xanmod/gcc/config_x86-64-v1 > /tmp/xanmod-6.12.53.config
diff $(nix build .#linuxKernel.packages.linux_xanmod.kernel.configfile --print-out-paths --no-link) /tmp/xanmod-6.12.53.config -u
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
