### PR TITLE
mobilizon: 5.1.5 -> 5.2.0

### DIFF
--- a/pkgs/servers/mobilizon/common.nix
+++ b/pkgs/servers/mobilizon/common.nix
@@ -2,13 +2,13 @@
 rec {
 
   pname = "mobilizon";
-  version = "5.1.5";
+  version = "5.2.0";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "kaihuri";
     repo = pname;
     tag = version;
-    hash = "sha256-nwEmW43GO0Ta7O7mUSJaEtm4hBfXInPqatBRdaWrhBU=";
+    hash = "sha256-wsiu0f0M0SMjgskMJuA/wUx6IxT7bTzHrOnxX8eFq9g=";
   };
 }

--- a/pkgs/servers/mobilizon/default.nix
+++ b/pkgs/servers/mobilizon/default.nix
@@ -75,12 +75,12 @@ mixRelease rec {
         };
         icalendar = buildMix rec {
           name = "icalendar";
-          version = "unstable-2022-04-10";
+          version = "1.1.2";
           src = fetchFromGitHub {
-            owner = "tcitworld";
+            owner = "mobilizon-tools";
             repo = name;
-            rev = "1033d922c82a7223db0ec138e2316557b70ff49f";
-            hash = "sha256-N3bJZznNazLewHS4c2B7LP1lgxd1wev+EWVlQ7rOwfU=";
+            rev = "b8fc5360b1755f60f2768d40f6aca949ef598a00";
+            hash = "sha256-UAdlYTRt1itkR/dmC2/AM89MlJIABJw9N0XfYR6IcVI=";
           };
           beamDeps = with final; [
             mix_test_watch

--- a/pkgs/servers/mobilizon/frontend.nix
+++ b/pkgs/servers/mobilizon/frontend.nix
@@ -11,7 +11,7 @@ in
 buildNpmPackage {
   inherit (common) pname version src;
 
-  npmDepsHash = "sha256-5ilhuFaIvksXsJmNu20m8MV3hYtyPUz4zp8NIvhR5Nw=";
+  npmDepsHash = "sha256-0eemOn96ciiqdNBZC+cFbcaEvZ5nkV9IndsXOzIgelQ=";
 
   nativeBuildInputs = [ imagemagick ];
 


### PR DESCRIPTION
Changelog: https://framagit.org/kaihuri/mobilizon/-/releases/5.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
