### PR TITLE
pkgs/README: clarify active committer role for browsers

### DIFF
--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -58,7 +58,7 @@ Because entries in the Nix store are inert and do nothing by themselves, package
   For example:
   * Any package which does not follow upstream security policies should be considered vulnerable.
     In particular, packages that vendor or fork web engines like Blink, Gecko or Webkit need to keep up with the frequent updates of those projects.
-  * Any security-critical fast-moving package such as Chrome or Firefox (or their forks) must have at least one active committer among the maintainers.
+  * Any security-critical fast-moving package such as Chrome or Firefox (or their forks) must have at least one committer among the maintainers, who actively reviews, merges and backports updates.
     This ensures no critical fixes are delayed unnecessarily, endangering unsuspecting users.
   * Services which typically work on web traffic are working on untrusted input.
   * Data (such as archives or rich documents) commonly shared over untrusted channels (e.g. email) is untrusted.


### PR DESCRIPTION
A small carification of what "active committer" actually means for security-critical, fast-moving packages.

Resolves https://github.com/NixOS/nixpkgs/issues/439236#issuecomment-3242933835.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
