### PR TITLE
`nixDependencies`, `lixPackageSets`: prevent redundant updates

### DIFF
--- a/pkgs/tools/package-management/nix/dependencies.nix
+++ b/pkgs/tools/package-management/nix/dependencies.nix
@@ -7,32 +7,39 @@ regular@{
 }:
 
 {
+  # Remove updateScript from a package to prevent redundant updates.
+  removeUpdateScript = pkg: lib.removeAttrs pkg [ "updateScript" ];
+
   scopeFunction = scope: {
-    boehmgc = regular.boehmgc.override {
-      enableLargeConfig = true;
+    boehmgc = removeUpdateScript (
+      regular.boehmgc.override {
+        enableLargeConfig = true;
 
-      # Increase the initial mark stack size to avoid stack overflows, since these inhibit parallel
-      # marking (see `GC_mark_some()` in `mark.c`).
-      #
-      # Run Nix with `GC_PRINT_STATS=1` set to see if the mark stack is too small.
-      # Look for messages such as `Mark stack overflow`, `No room to copy back mark stack`, and
-      # `Grew mark stack to ... frames`.
-      initialMarkStackSize = 1048576;
-    };
+        # Increase the initial mark stack size to avoid stack overflows, since these inhibit parallel
+        # marking (see `GC_mark_some()` in `mark.c`).
+        #
+        # Run Nix with `GC_PRINT_STATS=1` set to see if the mark stack is too small.
+        # Look for messages such as `Mark stack overflow`, `No room to copy back mark stack`, and
+        # `Grew mark stack to ... frames`.
+        initialMarkStackSize = 1048576;
+      }
+    );
 
-    aws-sdk-cpp = regular.aws-sdk-cpp.override {
-      # Nix only needs these AWS APIs.
-      apis = [
-        "identity-management"
-        "s3"
-        "transfer"
-      ];
+    aws-sdk-cpp = removeUpdateScript (
+      regular.aws-sdk-cpp.override {
+        # Nix only needs these AWS APIs.
+        apis = [
+          "identity-management"
+          "s3"
+          "transfer"
+        ];
 
-      # Don't use AWS' custom memory management.
-      customMemoryManagement = false;
+        # Don't use AWS' custom memory management.
+        customMemoryManagement = false;
 
-      # only a stripped down version is built which takes a lot less resources to build
-      requiredSystemFeatures = [ ];
-    };
+        # only a stripped down version is built which takes a lot less resources to build
+        requiredSystemFeatures = [ ];
+      }
+    );
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Motivation

This is one way we can prevent update PRs like
- https://github.com/NixOS/nixpkgs/pull/453400
- https://github.com/NixOS/nixpkgs/pull/453397

Thank you @zowoq for closing those. What are your thoughts?

Alternatively, whole package sets could be disabled. This might work for `nixDependencies`, but for this PR I've kept it simple, for the reason that explicit is good. You won't accidentally *not* have updates this way.


## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
