### PR TITLE
vimPlugins.fff-nvim: init at 0-unstable-2025-10-18

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/fff-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/fff-nvim/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  perl,
+  openssl,
+  vimUtils,
+  nix-update-script,
+}:
+let
+  version = "0-unstable-2025-10-18";
+  src = fetchFromGitHub {
+    owner = "dmtrKovalenko";
+    repo = "fff.nvim";
+    rev = "ee8bd6e839ff3e70660e794d79d4ce26a33a8e1e";
+    hash = "sha256-Wj6YLTUqLzOngiSDkM3ci85WwdQgjoonwHbvXyvN9cE=";
+  };
+  fff-nvim-lib = rustPlatform.buildRustPackage {
+    pname = "fff-nvim-lib";
+    inherit version src;
+
+    postPatch = ''
+      substituteInPlace $cargoDepsCopy/neo_frizbee*/src/lib.rs \
+        --replace-fail "#![feature(avx512_target_feature)]" ""
+    '';
+
+    cargoHash = "sha256-ZZt4BlMgRik4LH92F5cgS84WI1Jeuw68jP+y1+QXfDE=";
+
+    nativeBuildInputs = [
+      pkg-config
+      perl
+    ];
+
+    buildInputs = [
+      openssl
+    ];
+
+    env = {
+      RUSTC_BOOTSTRAP = 1; # We need rust unstable features
+
+      OPENSSL_NO_VENDOR = true;
+    };
+  };
+in
+vimUtils.buildVimPlugin {
+  pname = "fff.nvim";
+  inherit version src;
+
+  postPatch = ''
+    substituteInPlace lua/fff/download.lua \
+      --replace-fail \
+        "return plugin_dir .. '/../target'" \
+        "return '${fff-nvim-lib}/lib'"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+      attrPath = "vimPlugins.fff-nvim.fff-nvim-lib";
+    };
+
+    # needed for the update script
+    inherit fff-nvim-lib;
+  };
+
+  meta = {
+    description = "Fast Fuzzy File Finder for Neovim";
+    homepage = "https://github.com/dmtrKovalenko/fff.nvim";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
+  };
+}


### PR DESCRIPTION
## Things done

Add [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim), a fast fuzzy file finder for Neovim.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
