### PR TITLE
add openziti's ziti and ziti-edge-tunnel programs

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12554,6 +12554,11 @@
     githubId = 56727311;
     keys = [ { fingerprint = "B1B2 2BA0 FC39 D4B4 2240  5F55 D86C D68E 8DB2 E368"; } ];
   };
+  jamalhabash = {
+    name = "Jamal Habash";
+    github = "jamalhabash";
+    githubId = 19367263;
+  };
   jamerrq = {
     name = "Jamer José";
     email = "jamerrq@gmail.com";

--- a/pkgs/by-name/zi/ziti-edge-tunnel/package.nix
+++ b/pkgs/by-name/zi/ziti-edge-tunnel/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  json_c,
+  libsodium,
+  libuv,
+  llhttp,
+  openssl,
+  pkg-config,
+  protobufc,
+  systemd,
+  versionCheckHook,
+  zlib,
+  stc,
+}:
+
+let
+  inherit (lib) cmakeBool cmakeFeature;
+
+  ziti_sdk_src = fetchFromGitHub {
+    owner = "openziti";
+    repo = "ziti-sdk-c";
+    tag = "1.18.2";
+    hash = "sha256-2hikN/Xm9M1cTWgWgW0sqmDawCq5EiX/TbtjtTnKIdY=";
+  };
+  lwip_src = fetchFromGitHub {
+    owner = "lwip-tcpip";
+    repo = "lwip";
+    rev = "STABLE-2_2_1_RELEASE";
+    hash = "sha256-8TYbUgHNv9SV3l203WVfbwDEHFonDAQqdykiX9OoM34=";
+  };
+  lwip_contrib_src = fetchFromGitHub {
+    owner = "netfoundry";
+    repo = "lwip-contrib";
+    rev = "STABLE-2_1_0_RELEASE";
+    hash = "sha256-Ypn/QfkiTGoKLCQ7SXozk4D/QIdo4lyza4yq3tAoP/0=";
+  };
+  subcommand_c_src = fetchFromGitHub {
+    owner = "openziti";
+    repo = "subcommands.c";
+    rev = "87350797774530b6ba9c00017f0f53dd57e6c38e";
+    hash = "sha256-Gz0/b9jcC1I0fmguSMkV0xiqKWq7vzUVT0Bd1F4iqkA=";
+  };
+  tlsuv_src = fetchFromGitHub {
+    owner = "openziti";
+    repo = "tlsuv";
+    rev = "v0.42.3";
+    hash = "sha256-otDCYZbfZMubWaMNYibplmFr0CypW0WBttmAMzH8mgQ=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ziti-edge-tunnel";
+  version = "1.18.3";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "openziti";
+    repo = "ziti-tunnel-sdk-c";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tQzDJfIlbrV/wGPqKbVREIvqoo+AHktqSkZ0jq70SJ8=";
+  };
+
+  postPatch = ''
+    # Patch hardcoded paths to systemd tools
+    substituteInPlace programs/ziti-edge-tunnel/netif_driver/linux/resolvers.h \
+      --replace-fail '"/usr/bin/busctl"' '"${systemd}/bin/busctl"' \
+      --replace-fail '"/usr/bin/resolvectl"' '"${systemd}/bin/resolvectl"' \
+      --replace-fail '"/usr/bin/systemd-resolve"' '"${systemd}/bin/systemd-resolve"'
+  '';
+
+  preConfigure = ''
+    # Copy dependencies
+    cp -r ${lwip_src} ./deps/lwip
+
+    chmod -R +w ./deps/
+  '';
+
+  cmakeFlags = [
+    (cmakeBool "ENABLE_VCPKG" false)
+    (cmakeBool "DISABLE_SEMVER_VERIFICATION" true)
+    (cmakeBool "DISABLE_LIBSYSTEMD_FEATURE" true) # Disable direct integration to use resolvectl fallback
+    (cmakeFeature "ZITI_SDK_DIR" "${ziti_sdk_src}")
+    (cmakeFeature "ZITI_SDK_VERSION" ziti_sdk_src.tag)
+    # Ensure a concrete version is embedded; upstream library stringifies ZITI_VERSION
+    (cmakeFeature "CMAKE_C_FLAGS" "-DZITI_VERSION=v${finalAttrs.version}")
+    (cmakeFeature "CMAKE_CXX_FLAGS" "-DZITI_VERSION=v${finalAttrs.version}")
+    (cmakeFeature "CMAKE_C_FLAGS" "-DGIT_VERSION=${finalAttrs.version}")
+    (cmakeFeature "CMAKE_CXX_FLAGS" "-DGIT_VERSION=${finalAttrs.version}")
+    (cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_LWIP" "../../deps/lwip")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_LWIP-CONTRIB" "${lwip_contrib_src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_SUBCOMMAND" "${subcommand_c_src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_TLSUV" "${tlsuv_src}")
+    (cmakeFeature "DOXYGEN_OUTPUT_DIR" "/tmp/doxygen")
+    (cmakeFeature "CMAKE_BUILD_TYPE" "release")
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    stc
+    json_c
+    libsodium
+    libuv
+    llhttp
+    openssl
+    protobufc
+    zlib
+  ];
+
+  runtimeDependencies = [
+    systemd # For the resolvectl command at runtime
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "Provides protocol translation and other common functions that are useful to Ziti Tunnelers";
+    changelog = "https://github.com/openziti/ziti-tunnel-sdk-c/releases/tag/v${finalAttrs.version}";
+    homepage = "https://openziti.io/";
+    maintainers = with lib.maintainers; [ andrewzah ];
+    license = lib.licenses.asl20;
+    mainProgram = "ziti-edge-tunnel";
+  };
+})

--- a/pkgs/by-name/zi/ziti/package.nix
+++ b/pkgs/by-name/zi/ziti/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ziti";
+  version = "2.0.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "openziti";
+    repo = "ziti";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Aq/DpL9yYzdG270MzASbXJPzQ7AYEv91qGKAhEqOJk8=";
+  };
+
+  vendorHash = "sha256-oL53p692Txkc2xS2iARcjZRMig2GGtcsLrMt5msW/qw=";
+
+  subPackages = [
+    "ziti"
+    "controller"
+    "router"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/openziti/ziti/v2/common/version.Version=${finalAttrs.version}"
+    "-X github.com/openziti/ziti/v2/common/version.Revision=v${finalAttrs.src.rev}"
+    "-X github.com/openziti/ziti/v2/common/version.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "CLI for working with a Ziti deployment";
+    changelog = "https://github.com/openziti/ziti/releases/tag/v${finalAttrs.version}";
+    homepage = "https://openziti.io/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jamalhabash
+      andrewzah
+    ];
+    mainProgram = "ziti";
+  };
+})


### PR DESCRIPTION
This PR bumps the `ziti` version in #425154 (thanks @jamalhabash!) and adds `ziti-edge-tunnel` (thanks @rochecompaan!). These tools go hand in hand.

This closes #189696 and #425154.

## Things done:

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
