### PR TITLE
siril: 1.2.6 -> 1.4.0-beta4

### DIFF
--- a/pkgs/by-name/si/siril/package.nix
+++ b/pkgs/by-name/si/siril/package.nix
@@ -11,7 +11,7 @@
   gtk3,
   libconfig,
   gnuplot,
-  opencv,
+  opencv4,
   json-glib,
   fftwFloat,
   cfitsio,
@@ -30,17 +30,25 @@
   curl,
   versionCheckHook,
   nix-update-script,
+  gtksourceview4,
+  lcms2,
+  gettext,
+  desktop-file-utils,
+  appstream-glib,
+  yyjson,
+  libjxl,
+  libxisf,
+  libgit2,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "siril";
-  version = "1.2.6";
+  version = "1.4.0-beta4";
 
   src = fetchFromGitLab {
     owner = "free-astro";
     repo = "siril";
     tag = finalAttrs.version;
-    hash = "sha256-pSJp4Oj8x4pKuwPSaSyGbyGfpnanoWBxAdXtzGTP7uA=";
+    hash = "sha256-oWw8LmcFXQkbpZz1Vvo1MSCRjAa3WexHrKGsJWpZnIA=";
   };
 
   nativeBuildInputs = [
@@ -51,6 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
     git
     criterion
     wrapGAppsHook3
+    gettext
+    desktop-file-utils
+    appstream-glib
   ];
 
   buildInputs = [
@@ -59,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     gsl
     exiv2
     gnuplot
-    opencv
+    opencv4
     fftwFloat
     librtprocess
     wcslib
@@ -73,6 +84,12 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     json-glib
     curl
+    gtksourceview4
+    lcms2
+    yyjson
+    libjxl
+    libxisf
+    libgit2
   ];
 
   # Necessary because project uses default build dir for flatpaks/snaps
@@ -81,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Meson fails to find libcurl unless the option is specifically enabled
   configureScript = ''
-    ${meson}/bin/meson setup -Denable-libcurl=yes --buildtype release nixbld .
+    ${meson}/bin/meson setup -Dlibcurl=true --buildtype release nixbld .
   '';
 
   postConfigure = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update to upstream 1.4.0-beta4 (Sep 28, 2025) in scope of #403409. Seems to be stable, been running it for weeks; less glitches/crashes than the current 1.2.6.

Meson dependencies updated (various new dependancies added, `opencv`->`opencv4`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
