### PR TITLE
ltspice: init at 24.1.10

### DIFF
--- a/pkgs/by-name/lt/ltspice/ltspice.sh
+++ b/pkgs/by-name/lt/ltspice/ltspice.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Original Authors: fenugrec <fenugrec users sourceforge net> and Max Stabel <max dot stabel03 at gmail dot com>
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ltspice"
+
+if [[ ! -d $CONFIG_DIR ]]; then
+   mkdir -p "$CONFIG_DIR"
+fi
+if [[ ! -f "$CONFIG_DIR/LTspice.ini" ]]; then
+   # disable sending telemetry
+   echo -e "[Options]\nCaptureAnalytics=false" > "$CONFIG_DIR/LTspice.ini"
+fi
+
+WINEPREFIX="${WINEPREFIX-"${XDG_DATA_HOME-"$HOME/.local/share"}"/ltspice}"
+if [[ ! -d $WINEPREFIX ]]; then
+   mkdir -p "$WINEPREFIX"
+fi
+WINEARCH=win64 WINEPREFIX=$WINEPREFIX WINEDLLOVERRIDES=winemenubuilder.exe=d wine start.exe /unix @outpath@/libexec/ltspice/LTspice.exe -ini $CONFIG_DIR/LTspice.ini "$@"

--- a/pkgs/by-name/lt/ltspice/package.nix
+++ b/pkgs/by-name/lt/ltspice/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  msitools,
+  icoutils,
+  imagemagick,
+  wine64,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ltspice";
+  version = "24.1.10";
+  src = fetchurl {
+    url = "https://web.archive.org/web/20251028221949/https://ltspice.analog.com/software/LTspice64.msi";
+    hash = "sha256-LSK84ogbBk9kP7LKg8rzCGDqq36XfsK4Kzn2Zwea8C4=";
+  };
+  dontUnpack = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    msitools
+    icoutils
+    imagemagick
+    copyDesktopItems
+  ];
+
+  postPatch = ''
+    cp ${./ltspice.sh} ./ltspice.sh
+    substituteInPlace ./ltspice.sh \
+      --replace-fail wine ${lib.getExe wine64} \
+      --replace-fail @outpath@ $out
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    msiextract $src
+    mv -f "APPDIR:."/* .
+    mv -f "LocalAppDataFolder/LTspice"/* .
+    wrestool -x -t 14 LTspice.exe | magick ICO:- ltspice.png
+    rm Remove.exe updater.exe
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    install -Dm644 ltspice.png $out/share/pixmaps/ltspice.png
+
+    install -m755 -d $out/libexec/ltspice
+    install -m755 *.exe $out/libexec/ltspice
+    install -m655 *.zip $out/libexec/ltspice
+
+    install -Dm755 ltspice.sh $out/bin/ltspice
+    runHook postInstall
+  '';
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ltspice";
+      desktopName = "LTspice";
+      comment = finalAttrs.meta.description;
+      exec = "${finalAttrs.meta.mainProgram} %f";
+      icon = "ltspice";
+      mimeTypes = [
+        "application/raw"
+        "application/asc"
+        "application/res"
+        "application/asy"
+        "application/bead"
+        "application/bjt"
+        "application/cap"
+        "application/dio"
+        "application/ind"
+        "application/jft"
+        "application/mos"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "SPICE simulator, schematic capture and waveform viewer";
+    homepage = "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html";
+    license = lib.licenses.unfree;
+    mainProgram = "ltspice";
+    maintainers = [ lib.maintainers.zimward ];
+    #technically windows too, but for that the builder would need some conditionals
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Packageing windows software using wine is a bit ugly, but i think in this case its useful as LTspice is heavly used in the electrical engineering departments of a lot of universities. Most of this has been adapted from the arch [AUR package](https://aur.archlinux.org/packages/ltspice), i do want to add attribution in some way but i am not sure what the correct way to do that would be, so far i added a comment to the script files.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
