### PR TITLE
nixos/tests/logkeys: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -853,6 +853,7 @@ in
   localsend = runTest ./localsend.nix;
   locate = runTest ./locate.nix;
   login = runTest ./login.nix;
+  logkeys = runTest ./logkeys.nix;
   logrotate = runTest ./logrotate.nix;
   loki = runTest ./loki.nix;
   #logstash = handleTest ./logstash.nix {};

--- a/nixos/tests/logkeys.nix
+++ b/nixos/tests/logkeys.nix
@@ -1,0 +1,34 @@
+{ lib, ... }:
+{
+  name = "logkeys";
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ./common/user-account.nix ];
+
+      services.getty.autologinUser = "alice";
+
+      services.logkeys = {
+        enable = true;
+        device = "virtio-kbd";
+      };
+
+      # logkeys doesn't support specifying a device in `by-path`.
+      # In order not to make the test dependend on the ordering of the input event devices,
+      # we'll create a custom symlink before starting the service.
+      systemd.services.logkeys.serviceConfig.ExecStartPre = [
+        "+${lib.getExe' pkgs.coreutils "ln"} -s /dev/input/by-path/pci-0000:00:0a.0-event-kbd /dev/input/virtio-kbd"
+      ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("getty@tty1.service")
+    machine.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
+    machine.wait_for_unit("logkeys.service")
+
+    machine.send_chars("hello world\n")
+    machine.wait_until_succeeds("grep 'hello world' /var/log/logkeys.log")
+  '';
+}

--- a/pkgs/by-name/lo/logkeys/package.nix
+++ b/pkgs/by-name/lo/logkeys/package.nix
@@ -7,6 +7,7 @@
   which,
   procps,
   kbd,
+  nixosTests,
 }:
 
 stdenv.mkDerivation {
@@ -37,6 +38,8 @@ stdenv.mkDerivation {
   '';
 
   preConfigure = "./autogen.sh";
+
+  passthru.tests.nixos = nixosTests.logkeys;
 
   meta = with lib; {
     description = "GNU/Linux keylogger that works";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
