### PR TITLE
handheld-daemon: 3.18.5 -> 3.19.22

### DIFF
--- a/pkgs/by-name/ha/handheld-daemon/package.nix
+++ b/pkgs/by-name/ha/handheld-daemon/package.nix
@@ -16,14 +16,14 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "handheld-daemon";
-  version = "3.18.5";
+  version = "3.19.22";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hhd-dev";
     repo = "hhd";
     tag = "v${version}";
-    hash = "sha256-T/0qKHF/BmVtVO19pd4/iqIZP1/G7iayDzHdhjRIA7U=";
+    hash = "sha256-mvIB2lgFaHMCGEshKvagOFUrvcgEbyUS9VXJpXbvzTs=";
   };
 
   # Handheld-daemon runs some selinux-related utils which are not in nixpkgs.
@@ -49,7 +49,7 @@ python3Packages.buildPythonApplication rec {
 
     substituteInPlace src/hhd/plugins/power/power.py \
       --replace-fail '"efibootmgr"' '"${lib.getExe' efibootmgr "id"}"' \
-      --replace-fail '"systemctl"' '"${lib.getExe' systemd "systemctl"}"' \
+      --replace-fail '"systemctl' '"${lib.getExe' systemd "systemctl"}' \
       --replace-fail '"stat"' '"${lib.getExe' coreutils "stat"}"' \
       --replace-fail '"swapon"' '"${lib.getExe' util-linux "swapon"}"' \
       --replace-fail '"swapoff"' '"${lib.getExe' util-linux "swapoff"}"' \


### PR DESCRIPTION
## Things done

* Update version
* power.py also seems to have switched to using subprocess with arguments inside the same string, so the replace now only matches the opening quote.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
