### PR TITLE
fluidsynth: 2.4.8 -> 2.5.0

### DIFF
--- a/pkgs/by-name/fl/fluidsynth/package.nix
+++ b/pkgs/by-name/fl/fluidsynth/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   cmake,
   alsa-lib,
-  glib,
   libjack2,
   libsndfile,
   libpulseaudio,
@@ -14,13 +13,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fluidsynth";
-  version = "2.4.8";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "FluidSynth";
     repo = "fluidsynth";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rOPoRV0NWrlFZohqQ76gnXvt4/ryEI4nSlX+mNW+qf8=";
+    hash = "sha256-ouPCbXg9vgxSAHsReC7dmF1cstQZ1HaUoWcLChE35Hk=";
+    fetchSubmodules = true;
   };
 
   outputs = [
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    glib
+    stdenv.cc.cc.lib
     libsndfile
     libjack2
   ]
@@ -47,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-Denable-framework=off"
+    "-Dosal=cpp11"
+    "-Denable-libinstpatch=0"
   ];
 
   meta = {


### PR DESCRIPTION
 - upgrade fluidsynth from 2.4.8 to 2.5.0
 - add missing gcem submodule preventing upgrade by enabling fetchSubmodules = true;
 - Add stdenv.cc.cc.lib to buildInputs to ensure libfluidsynth is properly linked against the C++ standard library, as required.
 - Update cmakeFlags to include -Dosal=cpp11 and -Denable-libinstpatch=0 to build fluidsynth without GLib and libinstpatch support.

<strong>Breaking Changes:</strong>

- Support for SDL2 has been removed - pls. use SDL3 instead https://github.com/FluidSynth/fluidsynth/pull/1594
- The processing order of fluidsynth's configuration files has been changed (https://github.com/FluidSynth/fluidsynth/pull/1573, refer to [wiki]https://github.com/FluidSynth/fluidsynth/wiki/FluidSynth-configuration-files for details
- The legacy shell commands for reverb and chorus have been removed (https://github.com/FluidSynth/fluidsynth/pull/1659, refer to [UserManual]https://github.com/FluidSynth/fluidsynth/wiki/UserManual#reverb for details

<strong>Musically Breaking Changes:</strong>

- It was discovered that fluidsynth was mapping some modulators slightly inaccurately into their normalized range https://github.com/FluidSynth/fluidsynth/issues/1651, thanks to @baskanov
- Some Roland GS NPRN Params are now mapped to CC numbers https://github.com/FluidSynth/fluidsynth/pull/1519, refer to [wiki]https://github.com/FluidSynth/fluidsynth/wiki/FluidFeatures#roland-nrpns for details
- Fluidsynth now auto-detects whether Portamento Time is 7bit or 14bit wide - this fixes the infamous Descent Game08 tune (https://github.com/FluidSynth/fluidsynth/issues/705, https://github.com/FluidSynth/fluidsynth/issues/1232, https://github.com/FluidSynth/fluidsynth/issues/1311, https://github.com/FluidSynth/fluidsynth/issues/1456, https://github.com/FluidSynth/fluidsynth/discussions/1495, https://github.com/FluidSynth/fluidsynth/issues/1517, see [synth.portamento-time]https://www.fluidsynth.org/api/fluidsettings.xml#synth.portamento-time for details
- Previously, fluidsynth's default behavior was to use portamento only for those notes, that were played in a successive / legato manner; to further improve the portamento experience, this was changed and fluidsynth now plays portamento for all notes by default https://github.com/FluidSynth/fluidsynth/pull/1656
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
