### PR TITLE
adjustor: init at 3.11.8

### DIFF
--- a/nixos/modules/services/hardware/handheld-daemon.nix
+++ b/nixos/modules/services/hardware/handheld-daemon.nix
@@ -7,6 +7,10 @@
 with lib;
 let
   cfg = config.services.handheld-daemon;
+  hhdPackage = cfg.package.override {
+    withAdjustor = cfg.adjustor.enable;
+    adjustor = cfg.adjustor.package;
+  };
 in
 {
   options.services.handheld-daemon = {
@@ -16,6 +20,18 @@ in
     ui = {
       enable = mkEnableOption "Handheld Daemon UI";
       package = mkPackageOption pkgs "handheld-daemon-ui" { };
+    };
+
+    adjustor = {
+      enable = mkEnableOption "Handheld Daemon TDP control plugin";
+      package = mkPackageOption pkgs "adjustor" { };
+      loadAcpiCallModule = mkOption {
+        type = types.bool;
+        description = ''
+          Whether to load the acpi_call kernel module.
+          Required for TDP control by adjustor on most devices.
+        '';
+      };
     };
 
     user = mkOption {
@@ -28,12 +44,18 @@ in
 
   config = mkIf cfg.enable {
     services.handheld-daemon.ui.enable = mkDefault true;
+    services.handheld-daemon.adjustor.loadAcpiCallModule = mkDefault cfg.adjustor.enable;
     environment.systemPackages = [
-      cfg.package
+      hhdPackage
     ]
     ++ lib.optional cfg.ui.enable cfg.ui.package;
     services.udev.packages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
+
+    boot.kernelModules = mkIf cfg.adjustor.loadAcpiCallModule [ "acpi_call" ];
+    boot.extraModulePackages = mkIf cfg.adjustor.loadAcpiCallModule [
+      config.boot.kernelPackages.acpi_call
+    ];
 
     systemd.services.handheld-daemon = {
       description = "Handheld Daemon";
@@ -48,7 +70,7 @@ in
       ];
 
       serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} --user ${cfg.user}";
+        ExecStart = "${lib.getExe hhdPackage} --user ${cfg.user}";
         Nice = "-12";
         Restart = "on-failure";
         RestartSec = "10";
@@ -56,5 +78,5 @@ in
     };
   };
 
-  meta.maintainers = [ maintainers.appsforartists ];
+  meta.maintainers = [ maintainers.toast ];
 }

--- a/pkgs/by-name/ad/adjustor/package.nix
+++ b/pkgs/by-name/ad/adjustor/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  # Dependencies
+  kmod,
+  util-linux,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "adjustor";
+  version = "3.11.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hhd-dev";
+    repo = "adjustor";
+    tag = "v${version}";
+    hash = "sha256-BS0zV8nan61fTUs3v6nmGBuqPEDjATxBG792ZrrreAI=";
+  };
+
+  # This package relies on several programs expected to be on the user's PATH.
+  # We take a more reproducible approach by patching the absolute path to each of these required
+  # binaries.
+  postPatch = ''
+    substituteInPlace src/adjustor/core/acpi.py \
+      --replace-fail '"modprobe"' '"${lib.getExe' kmod "modprobe"}"'
+    substituteInPlace src/adjustor/fuse/utils.py \
+      --replace-fail 'f"mount' 'f"${lib.getExe' util-linux "mount"}'
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    rich
+    pyroute2
+    fuse
+    pygobject3
+    dbus-python
+    kmod
+  ];
+
+  # This package doesn't have upstream tests.
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/hhd-dev/adjustor/";
+    description = "Adjustor TDP plugin for Handheld Daemon";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.toast ];
+    mainProgram = "hhd";
+  };
+}

--- a/pkgs/by-name/ha/handheld-daemon/package.nix
+++ b/pkgs/by-name/ha/handheld-daemon/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  withAdjustor ? false,
 
   # dependencies
   systemd,
@@ -13,6 +14,7 @@
   lsof,
   btrfs-progs,
   util-linux,
+  adjustor,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "handheld-daemon";
@@ -79,14 +81,19 @@ python3Packages.buildPythonApplication rec {
     setuptools
   ];
 
-  dependencies = with python3Packages; [
-    evdev
-    pyserial
-    pyyaml
-    rich
-    setuptools
-    xlib
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      evdev
+      pyserial
+      pyyaml
+      rich
+      setuptools
+      xlib
+    ]
+    ++ lib.optionals withAdjustor [
+      adjustor
+    ];
 
   # This package doesn't have upstream tests.
   doCheck = false;


### PR DESCRIPTION
adjustor is a helper tool for handheld-daemon that controls TDP and provides fan control

based of work from #347279 by @toast003 (let me know if you can maintain this; this is probably a one-off for me)

also drops appsforartists as module maintainer #431825

extracted from my overlay, only tested with #453535

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
