### PR TITLE
lixPackageSets.git: 2.94.0-pre-20251010_53d172a30838 -> 2.95.0-pre-20251121_b707403a3080, lixPackageSets.lix_2_94: init at 2.94.0

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -67,6 +67,7 @@ assert lib.assertMsg (
   removeReferencesTo,
   xz,
   yq,
+  zstd,
   nixosTests,
   rustPlatform,
   # Only used for versions before 2.92.
@@ -180,7 +181,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals pastaFod [ passt ]
   ++ lib.optionals parseToYAML [ yq ]
   ++ lib.optionals usesCapnp [ capnproto ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linuxMinimal ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linuxMinimal ]
+  ++ lib.optionals (lib.versionAtLeast version "2.94") [ zstd ];
 
   buildInputs = [
     boost

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -245,14 +245,14 @@ lib.makeExtensible (self: {
     attrName = "git";
 
     lix-args = rec {
-      version = "2.94.0-pre-20251010_${builtins.substring 0 12 src.rev}";
+      version = "2.94.0-pre-20251018_${builtins.substring 0 12 src.rev}";
 
       src = fetchFromGitea {
         domain = "git.lix.systems";
         owner = "lix-project";
         repo = "lix";
-        rev = "53d172a3083840846043f7579936e0a3e86737e5";
-        hash = "sha256-PPDHXtv6U5oIj8utzIqcH+ZSjMy4vXpv/y8c2I7dZ+g=";
+        rev = "6e2edbff930dbf5b17a23e23f0b563e1db201f5b";
+        hash = "sha256-t2f3YDiRTi6GTHc940lwozaxY7RFE1CW7EeNtVYG+FE=";
       };
 
       cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -245,14 +245,14 @@ lib.makeExtensible (self: {
     attrName = "git";
 
     lix-args = rec {
-      version = "2.94.0-pre-20251018_${builtins.substring 0 12 src.rev}";
+      version = "2.95.0-pre-20251121_${builtins.substring 0 12 src.rev}";
 
       src = fetchFromGitea {
         domain = "git.lix.systems";
         owner = "lix-project";
         repo = "lix";
-        rev = "6e2edbff930dbf5b17a23e23f0b563e1db201f5b";
-        hash = "sha256-t2f3YDiRTi6GTHc940lwozaxY7RFE1CW7EeNtVYG+FE=";
+        rev = "b707403a308030739dfeacc5b0aaaeef8ba3f633";
+        hash = "sha256-kas7FT2J86DVJlPH5dNNHM56OgdQQyfCE/dX/EOKDp8=";
       };
 
       cargoDeps = rustPlatform.fetchCargoVendor {
@@ -265,7 +265,7 @@ lib.makeExtensible (self: {
         # Bumping to toml11 ≥4.0.0 makes integer parsing throw (as it should) instead of saturate on overflow.
         # However, the updated version is not in nixpkgs yet, and the released versions still have the saturation bug.
         # Hence reverting the bump for now seems to be the least bad option.
-        ./revert-toml11-bump.patch
+        ./revert-toml11-bump-git.patch
       ];
     };
   };

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -241,6 +241,35 @@ lib.makeExtensible (self: {
     };
   };
 
+  lix_2_94 = self.makeLixScope {
+    attrName = "lix_2_94";
+
+    lix-args = rec {
+      version = "2.94.0";
+
+      src = fetchFromGitea {
+        domain = "git.lix.systems";
+        owner = "lix-project";
+        repo = "lix";
+        rev = version;
+        hash = "sha256-X6X3NhgLnpkgWUbLs0nLjusNx/el3L1EkVm6OHqY2z8=";
+      };
+
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        name = "lix-${version}";
+        inherit src;
+        hash = "sha256-APm8m6SVEAO17BBCka13u85/87Bj+LePP7Y3zHA3Mpg=";
+      };
+
+      patches = [
+        # Bumping to toml11 ≥4.0.0 makes integer parsing throw (as it should) instead of saturate on overflow.
+        # However, the updated version is not in nixpkgs yet, and the released versions still have the saturation bug.
+        # Hence reverting the bump for now seems to be the least bad option.
+        ./revert-toml11-bump-2_94.patch
+      ];
+    };
+  };
+
   git = self.makeLixScope {
     attrName = "git";
 
@@ -270,7 +299,7 @@ lib.makeExtensible (self: {
     };
   };
 
-  latest = self.lix_2_93;
+  latest = self.lix_2_94;
 
   # Note: This is not yet 2.92 because of a non-deterministic `curl` error.
   # See: https://git.lix.systems/lix-project/lix/issues/662

--- a/pkgs/tools/package-management/lix/revert-toml11-bump-2_94.patch
+++ b/pkgs/tools/package-management/lix/revert-toml11-bump-2_94.patch
@@ -1,0 +1,131 @@
+diff --git a/doc/manual/src/release-notes/rl-2.94.md b/doc/manual/src/release-notes/rl-2.94.md
+index c82b585737..a77ab00475 100644
+--- a/doc/manual/src/release-notes/rl-2.94.md
++++ b/doc/manual/src/release-notes/rl-2.94.md
+@@ -301,17 +301,6 @@
+ 
+   Many thanks to [Emily](https://git.lix.systems/emilazy) for this.
+ 
+-- Reject overflowing TOML integer literals [cl/3916](https://gerrit.lix.systems/c/lix/+/3916)
+-
+-  The toml11 library used by Lix was updated. The new
+-  version aligns with the [TOML v1.0.0 specification’s
+-  requirement](https://toml.io/en/v1.0.0#integer) to reject integer
+-  literals that cannot be losslessly parsed. This means that code like
+-  `builtins.fromTOML "v=0x8000000000000000"` will now produce an error
+-  rather than silently saturating the integer result.
+-
+-  Many thanks to [Emily](https://git.lix.systems/emilazy) for this.
+-
+ - uid-range depends on cgroups [cl/3230](https://gerrit.lix.systems/c/lix/+/3230)
+ 
+   `uid-range` builds now depends on `cgroups`, an experimental feature.
+diff --git a/lix/libexpr/primops/fromTOML.cc b/lix/libexpr/primops/fromTOML.cc
+index 9e2ecce588..7da2825fed 100644
+--- a/lix/libexpr/primops/fromTOML.cc
++++ b/lix/libexpr/primops/fromTOML.cc
+@@ -67,10 +67,13 @@
+             val,
+             toml::parse(
+                 tomlStream,
+-                "fromTOML", /* the "filename" */
++                "fromTOML" /* the "filename" */
++#if HAVE_TOML11_4
++                ,
+                 toml::spec::v(
+                     1, 0, 0
+                 ) // Be explicit that we are parsing TOML 1.0.0 without extensions
++#endif
+             )
+         );
+     } catch (std::exception & e) { // NOLINT(lix-foreign-exceptions) // TODO: toml::syntax_error
+diff --git a/meson.build b/meson.build
+index bede78a647..a72016522e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -363,7 +363,10 @@
+   dependency('gmock_main', required : enable_tests, include_type : 'system'),
+ ]
+ 
+-toml11 = dependency('toml11', version : '>=4.0.0', required : true, method : 'cmake', include_type : 'system')
++toml11 = dependency('toml11', version : '>=3.7.0', required : true, method : 'cmake', include_type : 'system')
++configdata += {
++  'HAVE_TOML11_4': toml11.version().version_compare('>= 4.0.0').to_int(),
++}
+ 
+ pegtl = dependency(
+   'pegtl',
+diff --git a/package.nix b/package.nix
+index fb86ce8446..2dc7d511c0 100644
+--- a/package.nix
++++ b/package.nix
+@@ -57,7 +57,6 @@
+   systemtap-lix ? __forDefaults.systemtap-lix,
+   # FIXME: remove default after dropping NixOS 25.05
+   toml11-lix ? __forDefaults.toml11-lix,
+-  toml11,
+   util-linuxMinimal ? utillinuxMinimal,
+   utillinuxMinimal ? null,
+   xz,
+@@ -132,8 +131,7 @@
+ 
+     passt-lix = callPackage ./misc/passt.nix { };
+ 
+-    toml11-lix =
+-      if lib.versionOlder toml11.version "4.4.0" then callPackage ./misc/toml11.nix { } else toml11;
++    toml11-lix = callPackage ./misc/toml11.nix { };
+   },
+ }:
+ 
+diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
+deleted file mode 100644
+index 0c90e85edf..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
++++ /dev/null
+@@ -1,13 +0,0 @@
+-error:
+-       … while calling the 'fromTOML' builtin
+-         at /pwd/in.nix:1:1:
+-            1| builtins.fromTOML ''attr = 9223372036854775808''
+-             | ^
+-            2|
+-
+-       error: while parsing TOML: [error] toml::parse_dec_integer: too large integer: current max digits = 2^63
+-        --> fromTOML
+-          |
+-        1 | attr = 9223372036854775808
+-          |                           ^-- must be < 2^63
+-       
+diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp
+deleted file mode 100644
+index a287e18655..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp
++++ /dev/null
+@@ -1,13 +0,0 @@
+-error:
+-       … while calling the 'fromTOML' builtin
+-         at /pwd/in.nix:1:1:
+-            1| builtins.fromTOML ''attr = -9223372036854775809''
+-             | ^
+-            2|
+-
+-       error: while parsing TOML: [error] toml::parse_dec_integer: too large integer: current max digits = 2^63
+-        --> fromTOML
+-          |
+-        1 | attr = -9223372036854775809
+-          |                            ^-- must be < 2^63
+-       
+diff --git a/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix b/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix
+deleted file mode 100644
+index 17f0448b3d..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix
++++ /dev/null
+@@ -1,1 +0,0 @@
+-builtins.fromTOML ''attr = 9223372036854775808''
+diff --git a/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix b/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix
+deleted file mode 100644
+index 923fdf3545..0000000000
+--- a/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix
++++ /dev/null
+@@ -1,1 +0,0 @@
+-builtins.fromTOML ''attr = -9223372036854775809''

--- a/pkgs/tools/package-management/lix/revert-toml11-bump-git.patch
+++ b/pkgs/tools/package-management/lix/revert-toml11-bump-git.patch
@@ -1,28 +1,30 @@
-diff --git a/doc/manual/rl-next/toml-number-overflow.md b/doc/manual/rl-next/toml-number-overflow.md
-deleted file mode 100644
-index 1522213cb4..0000000000
---- a/doc/manual/rl-next/toml-number-overflow.md
-+++ /dev/null
-@@ -1,14 +0,0 @@
-----
--synopsis: Reject overflowing TOML integer literals
--issues: []
--cls: [3916]
--category: "Breaking Changes"
--credits: [emilazy]
-----
+diff --git a/doc/manual/src/release-notes/rl-2.94.md b/doc/manual/src/release-notes/rl-2.94.md
+index c82b585737..a77ab00475 100644
+--- a/doc/manual/src/release-notes/rl-2.94.md
++++ b/doc/manual/src/release-notes/rl-2.94.md
+@@ -301,17 +301,6 @@
+ 
+   Many thanks to [Emily](https://git.lix.systems/emilazy) for this.
+ 
+-- Reject overflowing TOML integer literals [cl/3916](https://gerrit.lix.systems/c/lix/+/3916)
 -
--The toml11 library used by Lix was updated. The new
--version aligns with the [TOML v1.0.0 specification’s
--requirement](https://toml.io/en/v1.0.0#integer) to reject integer
--literals that cannot be losslessly parsed. This means that code like
--`builtins.fromTOML "v=0x8000000000000000"` will now produce an error
--rather than silently saturating the integer result.
+-  The toml11 library used by Lix was updated. The new
+-  version aligns with the [TOML v1.0.0 specification’s
+-  requirement](https://toml.io/en/v1.0.0#integer) to reject integer
+-  literals that cannot be losslessly parsed. This means that code like
+-  `builtins.fromTOML "v=0x8000000000000000"` will now produce an error
+-  rather than silently saturating the integer result.
+-
+-  Many thanks to [Emily](https://git.lix.systems/emilazy) for this.
+-
+ - uid-range depends on cgroups [cl/3230](https://gerrit.lix.systems/c/lix/+/3230)
+ 
+   `uid-range` builds now depends on `cgroups`, an experimental feature.
 diff --git a/lix/libexpr/primops/fromTOML.cc b/lix/libexpr/primops/fromTOML.cc
-index 9d4b5e6abf..3e26773eac 100644
+index 9e2ecce588..7da2825fed 100644
 --- a/lix/libexpr/primops/fromTOML.cc
 +++ b/lix/libexpr/primops/fromTOML.cc
-@@ -65,10 +65,13 @@
+@@ -67,10 +67,13 @@
              val,
              toml::parse(
                  tomlStream,
@@ -54,7 +56,7 @@ index bede78a647..a72016522e 100644
  pegtl = dependency(
    'pegtl',
 diff --git a/package.nix b/package.nix
-index eb0e5c602a..9357b8ebd1 100644
+index fb86ce8446..2dc7d511c0 100644
 --- a/package.nix
 +++ b/package.nix
 @@ -57,7 +57,6 @@
@@ -65,7 +67,7 @@ index eb0e5c602a..9357b8ebd1 100644
    util-linuxMinimal ? utillinuxMinimal,
    utillinuxMinimal ? null,
    xz,
-@@ -118,8 +117,7 @@
+@@ -132,8 +131,7 @@
  
      passt-lix = callPackage ./misc/passt.nix { };
  
@@ -75,10 +77,10 @@ index eb0e5c602a..9357b8ebd1 100644
    },
  }:
  
-diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
+diff --git a/tests/functional2/lang/builtins.fromTOML/eval-fail-overflow.err.exp b/tests/functional2/lang/builtins.fromTOML/eval-fail-overflow.err.exp
 deleted file mode 100644
 index 0c90e85edf..0000000000
---- a/tests/functional2/lang/fromTOML-overflowing/eval-fail-overflow.err.exp
+--- a/tests/functional2/lang/builtins.fromTOML/eval-fail-overflow.err.exp
 +++ /dev/null
 @@ -1,13 +0,0 @@
 -error:
@@ -94,10 +96,10 @@ index 0c90e85edf..0000000000
 -        1 | attr = 9223372036854775808
 -          |                           ^-- must be < 2^63
 -       
-diff --git a/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp b/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp
+diff --git a/tests/functional2/lang/builtins.fromTOML/eval-fail-underflow.err.exp b/tests/functional2/lang/builtins.fromTOML/eval-fail-underflow.err.exp
 deleted file mode 100644
 index a287e18655..0000000000
---- a/tests/functional2/lang/fromTOML-overflowing/eval-fail-underflow.err.exp
+--- a/tests/functional2/lang/builtins.fromTOML/eval-fail-underflow.err.exp
 +++ /dev/null
 @@ -1,13 +0,0 @@
 -error:
@@ -113,17 +115,17 @@ index a287e18655..0000000000
 -        1 | attr = -9223372036854775809
 -          |                            ^-- must be < 2^63
 -       
-diff --git a/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix b/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix
+diff --git a/tests/functional2/lang/builtins.fromTOML/in-overflow.nix b/tests/functional2/lang/builtins.fromTOML/in-overflow.nix
 deleted file mode 100644
 index 17f0448b3d..0000000000
---- a/tests/functional2/lang/fromTOML-overflowing/in-overflow.nix
+--- a/tests/functional2/lang/builtins.fromTOML/in-overflow.nix
 +++ /dev/null
 @@ -1,1 +0,0 @@
 -builtins.fromTOML ''attr = 9223372036854775808''
-diff --git a/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix b/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix
+diff --git a/tests/functional2/lang/builtins.fromTOML/in-underflow.nix b/tests/functional2/lang/builtins.fromTOML/in-underflow.nix
 deleted file mode 100644
 index 923fdf3545..0000000000
---- a/tests/functional2/lang/fromTOML-overflowing/in-underflow.nix
+--- a/tests/functional2/lang/builtins.fromTOML/in-underflow.nix
 +++ /dev/null
 @@ -1,1 +0,0 @@
 -builtins.fromTOML ''attr = -9223372036854775809''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
