### PR TITLE
comodoro: 0.0.10 -> 0.1.2

### DIFF
--- a/pkgs/by-name/co/comodoro/package.nix
+++ b/pkgs/by-name/co/comodoro/package.nix
@@ -11,26 +11,27 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "comodoro";
-  version = "0.0.10";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "soywod";
     repo = "comodoro";
     rev = "v${version}";
-    hash = "sha256-Y9SuxqI8wvoF0+X6CLNDlSFCwlSU8R73NYF/LjACP18=";
+    hash = "sha256-FnNNJ6WHR8KCsW+1hPIYddxQlUvpPc+SRbaxAcdVEUk=";
   };
 
-  cargoHash = "sha256-HzutYDphJdhNJ/jwyA5KVYr6fIutf73rYzKxrzVki9k=";
+  cargoHash = "sha256-2Drty/dj9HCG86rPt4RgexU83vKMnGFETbOT11Puy/0=";
 
   nativeBuildInputs = lib.optional (installManPages || installShellCompletions) installShellFiles;
 
-  buildNoDefaultFeatures = true;
+  # Enable upstream default features to include hooks.
+  buildNoDefaultFeatures = false;
   buildFeatures = lib.optional withTcp "tcp";
 
   postInstall =
     lib.optionalString installManPages ''
       mkdir -p $out/man
-      $out/bin/comodoro man $out/man
+      $out/bin/comodoro manual $out/man
       installManPage $out/man/*
     ''
     + lib.optionalString installShellCompletions ''
@@ -47,5 +48,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ soywod ];
     mainProgram = "comodoro";
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
- Updated `comodoro` from **0.0.10 → 0.1.2**.  
- Switched `postInstall` to use the new `manual` subcommand for man page generation (upstream changed from `man`).  
- Fixed build failure by re‑enabling upstream default features (needed for new hook support).  
- Restricted to Linux platforms: on Darwin, 0.1.x introduces `mac-notification-sys`, which fails in the Nix sandbox.  

- Upstream changelog: https://github.com/soywod/comodoro/blob/v0.1.2/CHANGELOG.md  
- Homepage: https://github.com/pimalaya/comodoro  

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.