### PR TITLE
nixos/flood: add runDir option

### DIFF
--- a/nixos/modules/services/torrent/flood.nix
+++ b/nixos/modules/services/torrent/flood.nix
@@ -30,6 +30,13 @@ in
       default = "localhost";
       example = "::";
     };
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/flood";
+      description = ''
+        The directory where flood stores its data files.
+      '';
+    };
     extraArgs = lib.mkOption {
       type = with lib.types; listOf str;
       description = "Extra arguments passed to `flood`.";
@@ -56,7 +63,7 @@ in
             cfg.host
             "--port"
             (toString cfg.port)
-            "--rundir=/var/lib/flood"
+            "--rundir=${cfg.stateDir}"
           ]
           ++ cfg.extraArgs
         );


### PR DESCRIPTION
Added `runDir` option to the flood module. It was hardcoded to `/var/lib/flood`, and now that is the default for the added option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
