### PR TITLE
asterisk: drop v18, bump asterisk-lts and asterisk alias, add v23

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -296,6 +296,8 @@
 
 - [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
 
+- The `asterisk-lts` package was changed to v22 from v18. The default `asterisk` package was changed to v22 from v20. Asterisk version 18 has been dropped due to being EOL. The `asterisk-stable` (v20) package was unchanged. You may need to update /var/lib/asterisk to match the template files in `${asterisk-...}/var/lib/asterisk`.
+
 - NixOS display manager modules now strictly use tty1, where many of them previously used tty7. Options to configure display managers' VT have been dropped. A configuration with a display manager enabled will not start `getty@tty1.service`, even if the system is forced to boot into `multi-user.target` instead of `graphical.target`.
 
 - `river` 0.3.x has been renamed to `river-classic` upstream, and the package renamed accordingly. `programs.river` has been renamed to `programs.river-classic`.

--- a/pkgs/by-name/as/asterisk-module-sccp/package.nix
+++ b/pkgs/by-name/as/asterisk-module-sccp/package.nix
@@ -40,5 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Replacement for the SCCP channel driver in Asterisk";
     license = lib.licenses.gpl1Only;
     maintainers = with lib.maintainers; [ das_j ];
+    # https://github.com/chan-sccp/chan-sccp/issues/609
+    broken = lib.versionAtLeast (lib.getVersion asterisk) "21";
   };
 })

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -209,20 +209,20 @@ let
 
 in
 {
-  # Supported releases (as of 2023-04-19).
-  # v16 and v19 have been dropped because they go EOL before the NixOS 23.11 release.
+  # Supported releases (as of 2025-10-19).
   # Source: https://wiki.asterisk.org/wiki/display/AST/Asterisk+Versions
   # Exact version can be found at https://www.asterisk.org/downloads/asterisk/all-asterisk-versions/
   #
   # Series  Type       Rel. Date   Sec. Fixes  EOL
-  # 16.x    LTS        2018-10-09  2022-10-09  2023-10-09 (dropped)
-  # 18.x    LTS        2020-10-20  2024-10-20  2025-10-20
+  # 18.x    LTS        2020-10-20  2024-10-20  2025-10-20 (dropped)
   # 19.x    Standard   2021-11-02  2022-11-02  2023-11-02 (dropped)
   # 20.x    LTS        2022-11-02  2026-10-19  2027-10-19
-  # 21.x    Standard   2023-10-18  2025-10-18  2026-10-18 (unreleased)
-  asterisk-lts = versions.asterisk_18;
+  # 21.x    Standard   2023-10-18  2025-10-18  2026-10-18
+  # 22.x    LTS        2024-10-16  2028-10-16  2029-10-16
+  # 23.x    Standard   2025-10-15  2026-10-15  2027-10-15
+  asterisk-lts = versions.asterisk_22;
   asterisk-stable = versions.asterisk_20;
-  asterisk = versions.asterisk_20.overrideAttrs (o: {
+  asterisk = versions.asterisk_22.overrideAttrs (o: {
     passthru = (o.passthru or { }) // {
       inherit updateScript;
     };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -478,6 +478,7 @@ mapAliases {
   armcord = throw "ArmCord was renamed to legcord by the upstream developers. Action is required to migrate configurations between the two applications. Please see this PR for more details: https://github.com/NixOS/nixpkgs/pull/347971"; # Added 2024-10-11
   aseprite-unfree = aseprite; # Added 2023-08-26
   asitop = macpm; # 'macpm' is a better-maintained downstream; keep 'asitop' for backwards-compatibility
+  asterisk_18 = throw "asterisk_18: Asterisk 18 is end of life and has been removed"; # Added 2025-10-19
   async = throw "'async' has been removed due to lack of upstream maintenance"; # Added 2025-01-26
   atlassian-bamboo = throw "Atlassian software has been removed, as support for the Atlassian Server products ended in February 2024 and there was insufficient interest in maintaining the Atlassian Data Center replacements"; # Added 2024-11-02
   atlassian-confluence = throw "Atlassian software has been removed, as support for the Atlassian Server products ended in February 2024 and there was insufficient interest in maintaining the Atlassian Data Center replacements"; # Added 2024-11-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9277,6 +9277,7 @@ with pkgs;
     asterisk-lts
     asterisk_20
     asterisk_22
+    asterisk_23
     ;
 
   asterisk-ldap = lowPrio (asterisk.override { ldapSupport = true; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9275,7 +9275,6 @@ with pkgs;
     asterisk
     asterisk-stable
     asterisk-lts
-    asterisk_18
     asterisk_20
     asterisk_22
     ;


### PR DESCRIPTION
Asterisk v18 is going EOL tomorrow. Sadly, we forgot to bump LTS for the previous nixos release.
This changes asterisk-lts from v18 to v22 and asterisk default from v20 to v22. It also adds the v23 alias.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
