### PR TITLE
openboardview: update to 9.95.2 supporting cmake 4, a new update.sh script

### DIFF
--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -3,7 +3,6 @@
   lib,
   fetchFromGitHub,
   fetchpatch,
-  gitUpdater,
   cmake,
   pkg-config,
   python3,
@@ -67,9 +66,7 @@ stdenv.mkDerivation rec {
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gtk3 ]}
     '';
 
-  passthru.updateScript = gitUpdater {
-    ignoredVersions = ''.*\.90\..*'';
-  };
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Linux SDL/ImGui edition software for viewing .brd files";

--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -14,22 +14,21 @@
 
 stdenv.mkDerivation rec {
   pname = "openboardview";
-  version = "9.95.0";
+  version = "9.95.2";
 
   src = fetchFromGitHub {
     owner = "OpenBoardView";
     repo = "OpenBoardView";
     tag = version;
-    hash = "sha256-sKDDOPpCagk7rBRlMlZhx+RYYbtoLzJsrnL8qKZMKW8=";
+    hash = "sha256-B5VnuycRt8h7Cz3FTIbhcGcXuA60zPCz0FMvFENTwws=";
     fetchSubmodules = true;
   };
 
   patches = [
-    # Fix gcc-13 build failure
     (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/OpenBoardView/OpenBoardView/commit/b03d0f69ec1611f5eb93f81291b4ba8c58cd29eb.patch";
-      hash = "sha256-Hp7KgzulPC2bPtRsd6HJrTLu0oVoQEoBHl0p2DcOLQw=";
+      name = "fix-darwin-build.patch";
+      url = "https://github.com/OpenBoardView/OpenBoardView/commit/a1de2e5de908afd83eceed757260f6425314af2e.patch?full_index=1";
+      hash = "sha256-DK+K4F0+QGqaoWCyc8AvuIsaiTCqhAG6AsTNg2hegh0=";
     })
   ];
 

--- a/pkgs/by-name/op/openboardview/update.sh
+++ b/pkgs/by-name/op/openboardview/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update git jq
+# shellcheck shell=bash
+
+ROOT=$(git rev-parse --show-toplevel)
+ATTR=openboardview
+
+cd "$ROOT" || exit 1
+
+# get current version in nixpkgs
+CURRENT_VERSION=$(nix eval -f ./default.nix --raw "$ATTR.version")
+
+# get latest release tag
+LATEST_VERSION=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s 'https://api.github.com/repos/OpenBoardView/OpenBoardView/releases' | jq -r  'map(select(.prerelease == false)) | .[0].tag_name')
+
+# strip quotes
+LATEST_VERSION=${LATEST_VERSION%\"}
+LATEST_VERSION=${LATEST_VERSION#\"}
+
+if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ];
+then
+  echo Already on latest version
+  exit 0
+fi
+
+PKGDIR=$(dirname "$0")
+
+# change to package directory
+cd "$PKGDIR" || exit 1
+
+# update package
+cd "$ROOT" || exit 1
+nix-update --version "$LATEST_VERSION" "$ATTR"
+


### PR DESCRIPTION
A new update.sh script to fetch the latest release which is not a pre-release.
Updates the version to the latest one, including a patch fixing build on darwin.
Replaces #452764.
References: https://github.com/OpenBoardView/OpenBoardView/pull/340

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc