### PR TITLE
minc_tools, minc_widgets: CMake 4 compatibility

### DIFF
--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation {
   pname = "minc-tools";
-  version = "2.3.06-unstable-2023-08-12";
+  version = "2.3.06-unstable-2024-11-28";
 
   src = fetchFromGitHub {
     owner = "BIC-MNI";
     repo = "minc-tools";
-    rev = "c86a767dbb63aaa05ee981306fa09f6133bde427";
-    hash = "sha256-PLNcuDU0ht1PcjloDhrPzpOpE42gbhPP3rfHtP7WnM4=";
+    rev = "a72077d92266f9ea4c49b6dd3efd5766b81a104c";
+    hash = "sha256-YafO5UjeADO/658Xm973JtqldRYkGQ4v8m1oNJoZrbM=";
   };
 
   nativeBuildInputs = [
@@ -58,12 +58,12 @@ stdenv.mkDerivation {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/BIC-MNI/minc-tools";
     description = "Command-line utilities for working with MINC files";
-    maintainers = with maintainers; [ bcdarwin ];
-    platforms = platforms.unix;
-    license = licenses.free;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.free;
     broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/applications/science/biology/minc-tools/default.nix
+++ b/pkgs/applications/science/biology/minc-tools/default.nix
@@ -25,6 +25,13 @@ stdenv.mkDerivation {
     hash = "sha256-YafO5UjeADO/658Xm973JtqldRYkGQ4v8m1oNJoZrbM=";
   };
 
+  # Fix for CMake > 4 in which the old policy for CMP0026 was removed.
+  # Note this breaks the tests, but they are not enabled anyway.
+  # Upstream issue: https://github.com/BIC-MNI/minc-tools/issues/123
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail "SET CMP0026 OLD" "SET CMP0026 NEW"
+  '';
+
   nativeBuildInputs = [
     cmake
     flex

--- a/pkgs/by-name/mi/minc_widgets/package.nix
+++ b/pkgs/by-name/mi/minc_widgets/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   makeWrapper,
   perlPackages,
@@ -21,6 +22,14 @@ stdenv.mkDerivation {
     rev = "f08b643894c81a1a2e0fbfe595a17a42ba8906db";
     sha256 = "1b9g6lf37wpp211ikaji4rf74rl9xcmrlyqcw1zq3z12ji9y33bm";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "cmake4-fix.patch";
+      url = "https://github.com/BIC-MNI/minc-widgets/commit/9f5bc1996d2f9b4702efdb010834e2c7f1e3fbf1.patch";
+      hash = "sha256-qqMKbxQS+HTRQaOP2DH/m8Z3DqoCMGLFp1AEKaQ6l5s=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -50,11 +59,11 @@ stdenv.mkDerivation {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/BIC-MNI/minc-widgets";
     description = "Collection of Perl and shell scripts for processing MINC files";
-    maintainers = with maintainers; [ bcdarwin ];
-    platforms = platforms.unix;
-    license = licenses.free;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.free;
   };
 }


### PR DESCRIPTION
minc_tools: 2.3.06-unstable-2023-08-12 -> 2.3.06-unstable-2024-11-28

Routine update and compatibility fix (#445447).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
