### PR TITLE
monotone: vendor botan2 for limited use of the most stable functionality

### DIFF
--- a/pkgs/applications/version-management/monotone/botan2.nix
+++ b/pkgs/applications/version-management/monotone/botan2.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkgsStatic,
+  python3,
+  docutils,
+  bzip2,
+  zlib,
+  darwin,
+  static ? stdenv.hostPlatform.isStatic, # generates static libraries *only*
+  enableForMonotone ? false, # Is it being imported for Monotone use?
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "botan";
+  version = "2.19.5";
+
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+  strictDeps = true;
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+    "doc"
+    "man"
+  ];
+
+  src = fetchurl {
+    url = "http://botan.randombit.net/releases/Botan-${finalAttrs.version}.tar.xz";
+    hash = "sha256-3+6g4KbybWckxK8B2pp7iEh62y2Bunxy/K9S21IsmtQ=";
+  };
+
+  nativeBuildInputs = [
+    python3
+    docutils
+  ];
+
+  buildInputs = [
+    bzip2
+    zlib
+  ];
+
+  buildTargets = [
+    "cli"
+  ]
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [ "tests" ]
+  ++ lib.optionals static [ "static" ]
+  ++ lib.optionals (!static) [ "shared" ];
+
+  botanConfigureFlags = [
+    "--prefix=${placeholder "out"}"
+    "--bindir=${placeholder "bin"}/bin"
+    "--docdir=${placeholder "doc"}/share/doc"
+    "--mandir=${placeholder "man"}/share/man"
+    "--no-install-python-module"
+    "--build-targets=${lib.concatStringsSep "," finalAttrs.buildTargets}"
+    "--with-bzip2"
+    "--with-zlib"
+    "--with-rst2man"
+    "--cpu=${stdenv.hostPlatform.parsed.cpu.name}"
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    "--cc=clang"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isMinGW) [
+    "--os=mingw"
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+    python configure.py ''${botanConfigureFlags[@]}
+    runHook postConfigure
+  '';
+
+  preInstall = ''
+    if [ -d src/scripts ]; then
+      patchShebangs src/scripts
+    fi
+  '';
+
+  postInstall = ''
+    cd "$out"/lib/pkgconfig
+    ln -s botan-*.pc botan.pc || true
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Cryptographic algorithms library";
+    homepage = "https://botan.randombit.net";
+    mainProgram = "botan";
+    maintainers = with maintainers; [
+      raskin
+    ];
+    platforms = platforms.unix;
+    license = licenses.bsd2;
+    knownVulnerabilities = lib.optional (
+      !enableForMonotone
+    ) "Botan2 is EOL and its full interface surface contains unpatched vulnerabilities";
+  };
+})

--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   boost,
   zlib,
-  botan2,
   libidn,
   lua,
   pcre,
@@ -19,11 +18,14 @@
   autoreconfHook,
   texinfo,
   fetchpatch,
+  callPackage,
 }:
 
 let
   version = "1.1-unstable-2021-05-01";
   perlVersion = lib.getVersion perl;
+
+  botan = callPackage ./botan2.nix { enableForMonotone = true; };
 in
 
 assert perlVersion != "";
@@ -79,7 +81,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost
     zlib
-    botan2
+    botan
     libidn
     lua
     pcre


### PR DESCRIPTION
Motivation: Botan2 is EOL and has vulnerabilities, but Monotone only uses a small part of Botan1 functionality which seems to have been solid by Botan1→Botan2 migration.

Here I vendor Botan2 for Monotone in a way that warns about any other use.

Detaches Monotone migration to Botan3 from #445861 

Will self-merge if CI passes and shows 0 rebuilds. It is 0-rebuild locally.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
