### PR TITLE
fish-irssi: unstable-2021-04-16 -> unstable-2023-08-05

### DIFF
--- a/pkgs/by-name/fi/fish-irssi/package.nix
+++ b/pkgs/by-name/fi/fish-irssi/package.nix
@@ -8,16 +8,15 @@
   openssl,
   irssi,
 }:
-
 stdenv.mkDerivation {
   pname = "fish-irssi";
-  version = "unstable-2021-04-16";
+  version = "unstable-2023-08-05";
 
   src = fetchFromGitHub {
     owner = "falsovsky";
     repo = "FiSH-irssi";
-    rev = "fcc484f09ce6941ba2e499605270593ddd13b81a";
-    hash = "sha256-KIPnz17a0CFfoPO2dZz90j+wG/dR4pv5d0iZMRf7Vkc=";
+    rev = "75f754fbcc3c68a078d23ae3e2baab71acc8ed9b";
+    hash = "sha256-fFu0E9uLQXPYrbBjEneXSEKm2uipwRE4A3D54XYLczE=";
   };
 
   patches = [ ./irssi-include-dir.patch ];


### PR DESCRIPTION
* see https://github.com/NixOS/nixpkgs/issues/445447

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
