### PR TITLE
lib/trivial: add inheritFunctionArgs

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -163,6 +163,7 @@ let
         isFunction
         toFunction
         mirrorFunctionArgs
+        inheritFunctionArgs
         fromHexString
         toHexString
         toBaseDigits

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1094,6 +1094,58 @@ in
     g: setFunctionArgs g fArgs;
 
   /**
+    `inheritFunctionArgs f g` creates a new function `g'` with the same behavior as `g` (`g' x == g x`)
+    but whose function arguments inherit from both `f` and `g`, with `g` overriding duplicates.
+    In other words, `g'` keeps all argument metadata of `g` and adds any missing ones from `f`.
+
+    # Inputs
+
+    `f`
+
+    : Source function providing argument metadata to inherit
+
+    `g`
+
+    : Target function that receives (inherits) argument metadata
+
+    # Type
+
+    ```
+    inheritFunctionArgs :: (a -> b) -> (a -> c) -> (a -> c)
+    ```
+
+    # Examples
+    :::{.example}
+    ## `delib.trivial.inheritFunctionArgs` usage example
+
+    ```nix
+    addab = {a, b, unused ? 1}: a + b
+    lib.functionArgs addab
+    => { a = false; b = false; unused = true; }
+
+    addab1 = {unused, ...}@attrs: addab attrs * unused
+    lib.functionArgs addab1
+    => { unused = false; }
+
+    addab1' = lib.inheritFunctionArgs addab addab1
+    addab1' { a = 2; b = 4; unused = 10; }
+    => 60
+
+    lib.functionArgs addab1'
+    => { a = false; b = false; unused = false; }
+    ```
+
+    :::
+  */
+  inheritFunctionArgs =
+    f: g:
+    let
+      fArgs = functionArgs f;
+      gArgs = functionArgs g;
+    in
+    lib.setFunctionArgs g (fArgs // gArgs);
+
+  /**
     Turns any non-callable values into constant functions.
     Returns callable values as is.
 


### PR DESCRIPTION
I can't really say this function is essential, but I find it logically better than the way it usually handled:
```nix
addab = {a, b, ...}: a + b
addab1 = {c, ...}@attrs: addab attrs * c

lib.setFunctionArgs addab1 (lib.functionArgs addab // lib.functionArgs addab1)
# {a = false; b = false; c = false;}
```
```nix
addab = {a, b, ...}: a + b
addab1 = {c, ...}@attrs: addab attrs * c

lib.inheritFunctionArgs addab addab1
# {a = false; b = false; c = false;}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
