### PR TITLE
[staging-next] ceph.python.pkgs.cryptography: disable mem leak tests on all platforms

### DIFF
--- a/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
+++ b/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
@@ -109,10 +109,12 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # save compute time by not running benchmarks
     "tests/bench"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     # aarch64-darwin forbids W+X memory, but this tests depends on it:
     # * https://cffi.readthedocs.io/en/latest/using.html#callbacks
+    # furthermore, this test fails with OpenSSL 3.6.0, probably due to:
+    # * https://github.com/openssl/openssl/issues/28757
+    # * https://github.com/openssl/openssl/issues/28770
+    # * https://github.com/openssl/openssl/issues/28888
     "tests/hazmat/backends/test_openssl_memleak.py"
   ];
 


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/310250393.

Disables the mem leak test. This test was later removed by upstream in https://github.com/pyca/cryptography/commit/0e0e46f5f73f477b8ee9682738c42129d5d60177 (released in v42.0.3).

For more context, see https://github.com/NixOS/nixpkgs/pull/451118.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
