### PR TITLE
nixos/test/login: Fix uaccess test.

### DIFF
--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -48,12 +48,13 @@
         machine.wait_for_file("/home/alice/done")
 
     with subtest("Systemd gives and removes device ownership as needed"):
-        machine.succeed("getfacl /dev/snd/timer | grep -q alice")
+        # Change back to /dev/snd/timer after systemd-258.1
+        machine.succeed("getfacl /dev/dri/card0 | grep -q alice")
         machine.send_key("alt-f1")
         machine.wait_until_succeeds("[ $(fgconsole) = 1 ]")
-        machine.fail("getfacl /dev/snd/timer | grep -q alice")
+        machine.fail("getfacl /dev/dri/card0 | grep -q alice")
         machine.succeed("chvt 2")
-        machine.wait_until_succeeds("getfacl /dev/snd/timer | grep -q alice")
+        machine.wait_until_succeeds("getfacl /dev/dri/card0 | grep -q alice")
 
     with subtest("Virtual console logout"):
         machine.send_chars("exit\n")


### PR DESCRIPTION
This PR https://github.com/systemd/systemd/pull/36444 caused this bug https://github.com/systemd/systemd/issues/39043, which is fixed in this PR https://github.com/systemd/systemd/pull/39071. In short, `uaccess` doesn't work with `OPTIONS+="static_node=..."` udev rules, and `/dev/snd/timer` is a static node. 258.1 needs to wait for the next staging cycle, so for now let's just use a non-static node.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
