### PR TITLE
precice: 3.2.0-unstable-2025-05-23 -> 3.3.0; python3Packages.pyprecice: 3.2.1 -> 3.3.1

### DIFF
--- a/pkgs/by-name/pr/precice/package.nix
+++ b/pkgs/by-name/pr/precice/package.nix
@@ -3,29 +3,32 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  pkg-config,
   boost,
   eigen,
   libxml2,
   mpi,
   python3Packages,
   petsc,
-  pkg-config,
+  ctestCheckHook,
+  mpiCheckPhaseHook,
 }:
 
-stdenv.mkDerivation {
+assert petsc.mpiSupport;
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "precice";
-  version = "3.2.0-unstable-2025-05-23";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "precice";
     repo = "precice";
-    rev = "6ee3e347843d4d3c416a32917f6505d35b822445";
-    hash = "sha256-BxNAbpeLqJPzQ9dvvgC9jJQQFBdVMunSqIekz7SIHv4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1FbTNo2F+jH1EVV6gXc9o0T31UHY/wBK3vQeCV7wW5E=";
   };
 
   cmakeFlags = [
-    (lib.cmakeBool "PRECICE_PETScMapping" false)
-    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
   ];
 
   nativeBuildInputs = [
@@ -43,12 +46,26 @@ stdenv.mkDerivation {
     python3Packages.numpy
   ];
 
+  __darwinAllowLocalNetworking = true;
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    ctestCheckHook
+    mpiCheckPhaseHook
+  ];
+
+  disabledTests = [
+    # Because preciceDt becomes very small. Test is likely to fail on other platform.
+    "precice.Integration/Serial/Time/Explicit/ParallelCoupling/ReadWriteScalarDataWithSubcycling6400Steps"
+  ];
+
   meta = {
     description = "PreCICE stands for Precise Code Interaction Coupling Environment";
     homepage = "https://precice.org/";
-    license = with lib.licenses; [ gpl3 ];
+    license = with lib.licenses; [ lgpl3Only ];
     maintainers = with lib.maintainers; [ Scriptkiddi ];
-    mainProgram = "binprecice";
+    mainProgram = "precice-tools";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/pyprecice/default.nix
+++ b/pkgs/development/python-modules/pyprecice/default.nix
@@ -5,9 +5,9 @@
 
   # build-system
   cython,
-  pip,
   pkgconfig,
   setuptools,
+  setuptools-git-versioning,
 
   # dependencies
   mpi4py,
@@ -17,38 +17,38 @@
 
 buildPythonPackage rec {
   pname = "pyprecice";
-  version = "3.2.1";
+  version = "3.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "precice";
     repo = "python-bindings";
     tag = "v${version}";
-    hash = "sha256-8AM2wbPX54UaMO4MzLOV0TljLTAPOqR9gUbtT2McNjs=";
+    hash = "sha256-NkTrMZ7UKB5O2jIlhLhgkOm8ZeWJA1FoursA1df7XOk=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=61,<72" "setuptools"
-  '';
 
   build-system = [
     cython
-    pip
     pkgconfig
     setuptools
+    setuptools-git-versioning
   ];
 
   dependencies = [
     numpy
     mpi4py
+  ];
+
+  buildInputs = [
     precice
   ];
 
-  # Disable Test because everything depends on open mpi which requires network
+  # no official test instruction
   doCheck = false;
 
-  # Do not use pythonImportsCheck because this will also initialize mpi which requires a network interface
+  pythonImportsCheck = [
+    "precice"
+  ];
 
   meta = {
     description = "Python language bindings for preCICE";


### PR DESCRIPTION
Changelog: 
precice: https://github.com/precice/precice/releases/tag/v3.3.0
pyprecice: https://github.com/precice/python-bindings/releases/tag/v3.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
