### PR TITLE
nixos/nix.gc: cleanups

### DIFF
--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -1,104 +1,101 @@
 { config, lib, ... }:
-
 let
   cfg = config.nix.gc;
+  inherit (lib)
+    mkEnableOption
+    mkRenamedOptionModule
+    mkOption
+    types
+    ;
 in
-
 {
+  imports = [
+    (mkRenamedOptionModule [ "nix" "gc" "automatic" ] [ "nix" "gc" "enable" ])
+  ];
 
-  ###### interface
-
-  options = {
-
-    nix.gc = {
-
-      automatic = lib.mkOption {
-        default = false;
-        type = lib.types.bool;
-        description = "Automatically run the garbage collector at a specific time.";
-      };
-
-      dates = lib.mkOption {
-        type = with lib.types; either singleLineStr (listOf str);
-        apply = lib.toList;
-        default = [ "03:15" ];
-        example = "weekly";
-        description = ''
-          How often or when garbage collection is performed. For most desktop and server systems
-          a sufficient garbage collection is once a week.
-
-          This value must be a calendar event in the format specified by
-          {manpage}`systemd.time(7)`.
-        '';
-      };
-
-      randomizedDelaySec = lib.mkOption {
-        default = "0";
-        type = lib.types.singleLineStr;
-        example = "45min";
-        description = ''
-          Add a randomized delay before each garbage collection.
-          The delay will be chosen between zero and this value.
-          This value must be a time span in the format specified by
-          {manpage}`systemd.time(7)`
-        '';
-      };
-
-      persistent = lib.mkOption {
-        default = true;
-        type = lib.types.bool;
-        example = false;
-        description = ''
-          Takes a boolean argument. If true, the time when the service
-          unit was last triggered is stored on disk. When the timer is
-          activated, the service unit is triggered immediately if it
-          would have been triggered at least once during the time when
-          the timer was inactive. Such triggering is nonetheless
-          subject to the delay imposed by RandomizedDelaySec=. This is
-          useful to catch up on missed runs of the service when the
-          system was powered down.
-        '';
-      };
-
-      options = lib.mkOption {
-        default = "";
-        example = "--max-freed $((64 * 1024**3))";
-        type = lib.types.singleLineStr;
-        description = ''
-          Options given to [`nix-collect-garbage`](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage) when the garbage collector is run automatically.
-        '';
-      };
-
+  options.nix.gc = {
+    enable = mkEnableOption "" // {
+      description = "Whether to automatically run the garbage collector at a specific time.";
     };
 
+    dates = mkOption {
+      type = with types; either singleLineStr (listOf str);
+      apply = lib.toList;
+      default = [ "03:15" ];
+      example = "weekly";
+      description = ''
+        How often or when garbage collection is performed. For most desktop and server systems
+        a sufficient garbage collection is once a week.
+
+        This value must be a calendar event in the format specified by
+        {manpage}`systemd.time(7)`.
+      '';
+    };
+
+    randomizedDelaySec = mkOption {
+      default = "0";
+      type = types.singleLineStr;
+      example = "45min";
+      description = ''
+        Add a randomized delay before each garbage collection.
+        The delay will be chosen between zero and this value.
+        This value must be a time span in the format specified by
+        {manpage}`systemd.time(7)`
+      '';
+    };
+
+    persistent = mkOption {
+      default = true;
+      type = types.bool;
+      example = false;
+      description = ''
+        Takes a boolean argument. If true, the time when the service
+        unit was last triggered is stored on disk. When the timer is
+        activated, the service unit is triggered immediately if it
+        would have been triggered at least once during the time when
+        the timer was inactive. Such triggering is nonetheless
+        subject to the delay imposed by RandomizedDelaySec=. This is
+        useful to catch up on missed runs of the service when the
+        system was powered down.
+      '';
+    };
+
+    options = mkOption {
+      default = "";
+      example = "--max-freed $((64 * 1024**3))";
+      type = types.singleLineStr;
+      description = ''
+        Options given to [`nix-collect-garbage`](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage) when the garbage collector is run automatically.
+      '';
+    };
   };
 
-  ###### implementation
-
-  config = {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.automatic -> config.nix.enable;
-        message = "nix.gc.automatic requires nix.enable";
+        assertion = cfg.enable -> config.nix.enable;
+        message = "`nix.gc.enable` requires `nix.enable = true`";
       }
     ];
 
-    systemd.services.nix-gc = lib.mkIf config.nix.enable {
+    systemd.services.nix-gc = {
       description = "Nix Garbage Collector";
-      script = "exec ${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
+      # No point in this if the nix daemon (and thus the nix store) is outside
+      unitConfig.ConditionPathIsReadWrite = "/nix/var/nix/daemon-socket";
+      serviceConfig.ExecStart = "${config.nix.package}/bin/nix-collect-garbage ${cfg.options}";
       serviceConfig.Type = "oneshot";
-      startAt = lib.optionals cfg.automatic cfg.dates;
+      startAt = cfg.dates;
       # do not start and delay when switching
       restartIfChanged = false;
     };
 
-    systemd.timers.nix-gc = lib.mkIf cfg.automatic {
+    systemd.timers.nix-gc = {
       timerConfig = {
         RandomizedDelaySec = cfg.randomizedDelaySec;
         Persistent = cfg.persistent;
       };
     };
-
   };
 
+  meta.maintainers = with lib.maintainers; [ qweered ];
 }


### PR DESCRIPTION
## Changes

- Rename `nix.gc.automatic` to `nix.gc.enable` (with `mkRenamedOptionModule` for backwards compatibility)
- Wrap the entire config block with `mkIf cfg.enable` so no timer/service is generated when disabled
- Add `ConditionPathIsReadWrite=/nix/var/nix/daemon-socket` to skip execution when nix daemon is unavailable
- Replace `script` with `serviceConfig.ExecStart` for cleaner systemd configuration
- Modernize module style: use `inherit (lib)` and flatten option declarations

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
