### PR TITLE
nixos: tests: kernelGeneric: Fix testsForKernel when accessed outside nixosTests

### DIFF
--- a/nixos/tests/kernel-generic/default.nix
+++ b/nixos/tests/kernel-generic/default.nix
@@ -55,6 +55,14 @@ let
         nodes.machine =
           { config, ... }:
           {
+            # we could/would do something like below, but linuxPackages comes from outside
+            # the machine closure, so an overlay doesn't apply to the kernelPackages.
+            # nixpkgs.overlays = [
+            #   (final: prev: {
+            #     kernelPackagesExtensions = prev.kernelPackagesExtensions ++ [ helloWorldExtension ];
+            #   })
+            # ]
+
             boot.kernelPackages = linuxPackages;
 
             boot.extraModulePackages = [ config.boot.kernelPackages.hello-world ];
@@ -93,6 +101,6 @@ mapAttrs (_: lP: testsForLinuxPackages lP) kernels
     # Useful for development testing of all Kernel configs without building full Kernel
     configfiles = mapAttrs (_: lP: lP.kernel.configfile) kernels;
 
-    testsForKernel = kernel: testsForLinuxPackages (pkgs.linuxPackagesFor kernel);
+    testsForKernel = kernel: testsForLinuxPackages (patchedPkgs.linuxPackagesFor kernel);
   };
 }


### PR DESCRIPTION
Use patchedPkgs.linuxPackagesFor to ensure the hello-world extension is applied to a kernel passed from, for example,
linuxKernel.kernels.linux_6_12.tests.testsForKernel

Also add a comment about why we can't use nixpkgs.overlays in this particular test.

Fixes: fa533ecbdf1c ("nixos: tests: kernel-generic: Add kernelPackagesExtensions test")

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
