### PR TITLE
dpp: init at 0.6.0

### DIFF
--- a/pkgs/by-name/dp/dplusplus/dub-lock.json
+++ b/pkgs/by-name/dp/dplusplus/dub-lock.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "libclang": {
+      "version": "0.3.3",
+      "sha256": "0abmwx294zrnmpzdqbwnw74i07wmvsvycsbh5j0yy1kcz411n6r8"
+    },
+    "sumtype": {
+      "version": "1.2.8",
+      "sha256": "0zvl0nncmrqvj2x96qjry2ws67fi3mykz1zr11pnpvwp9xdkw9zx"
+    },
+    "unit-threaded": {
+      "version": "2.1.9",
+      "sha256": "0x3d8jv65v4sh4nk4fkah202vbqnkhbzdc7k40yjqbjlgx76h1hy"
+    }
+  }
+}

--- a/pkgs/by-name/dp/dplusplus/package.nix
+++ b/pkgs/by-name/dp/dplusplus/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  dtools,
+  libclang,
+  buildDubPackage,
+  fetchFromGitHub,
+}:
+
+buildDubPackage (finalAttrs: {
+  pname = "dpp";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "atilaneves";
+    repo = "dpp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8zcjZ8EV5jdZrRCHkzxu9NeehY2/5AfOSdzreFC9z3c=";
+  };
+
+  nativeBuildInputs = [ dtools ];
+  buildInputs = [ libclang ];
+
+  dubLock = ./dub-lock.json;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/d++ -t $out/d++
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Directly include C headers in D source code";
+    changelog = "https://github.com/atilaneves/dpp/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/atilaneves/dpp";
+    mainProgram = "d++";
+    maintainers = with lib.maintainers; [ ipsavitsky ];
+    license = lib.licenses.boost;
+  };
+})


### PR DESCRIPTION
This change adds a converter from c++ to dlang code called dpp

> [!warning]
> dpp name is taken, and, as far as I know, I can't put pluses in package names, so this package is called dplusplus

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
