### PR TITLE
ocamlPackages.{…}: 0.17.0 → 0.17.1

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1567,13 +1567,25 @@ with self;
     ];
   };
 
-  ppx_pattern_bind = janePackage {
-    pname = "ppx_pattern_bind";
-    hash = "sha256-IVDvFU9ERB2YFJOgP/glYcO4KhEH5VdQ7wCCfreboqA=";
-    meta.description = "PPX for writing fast incremental bind nodes in a pattern match";
-    propagatedBuildInputs = [ ppx_let ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  ppx_pattern_bind = janePackage (
+    {
+      pname = "ppx_pattern_bind";
+      meta.description = "PPX for writing fast incremental bind nodes in a pattern match";
+      propagatedBuildInputs = [ ppx_let ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-O3FtpXrFoyMI3iPL3BUwquREy+8TygOlyaTUGBUPk4Q=$";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-IVDvFU9ERB2YFJOgP/glYcO4KhEH5VdQ7wCCfreboqA=";
+        }
+    )
+  );
 
   ppx_pipebang = janePackage {
     pname = "ppx_pipebang";

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1606,26 +1606,38 @@ with self;
     doCheck = false; # test rules broken
   };
 
-  ppx_quick_test = janePackage {
-    pname = "ppx_quick_test";
-    hash = "sha256-Kxb0IJcosC4eYlUjEfZE9FhY8o1/gDHHLWD5Cby5hXY=";
-    meta.description = "Spiritual equivalent of let%expect_test, but for property based tests";
-    propagatedBuildInputs = [
-      async
-      async_kernel
-      base
-      base_quickcheck
-      core
-      core_kernel
-      expect_test_helpers_core
-      ppx_expect
-      ppx_here
-      ppx_jane
-      ppx_sexp_conv
-      ppx_sexp_message
-    ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  ppx_quick_test = janePackage (
+    {
+      pname = "ppx_quick_test";
+      meta.description = "Spiritual equivalent of let%expect_test, but for property based tests";
+      propagatedBuildInputs = [
+        async
+        async_kernel
+        base
+        base_quickcheck
+        core
+        core_kernel
+        expect_test_helpers_core
+        ppx_expect
+        ppx_here
+        ppx_jane
+        ppx_sexp_conv
+        ppx_sexp_message
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-nSgi0MAmOWhk53x6U5Wmv/5zTxBiErWQqoT6ATBOv3w=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-Kxb0IJcosC4eYlUjEfZE9FhY8o1/gDHHLWD5Cby5hXY=";
+        }
+    )
+  );
 
   ppx_sexp_conv = janePackage (
     {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1437,18 +1437,30 @@ with self;
     ];
   };
 
-  ppx_jsonaf_conv = janePackage {
-    pname = "ppx_jsonaf_conv";
-    hash = "sha256-v7CYOJ1g4LkqIv5De5tQjjkBWXqKHbvqfSr0X5jBUuM=";
-    meta.description = "[@@deriving] plugin to generate Jsonaf conversion functions";
-    propagatedBuildInputs = [
-      base
-      jsonaf
-      ppx_jane
-      ppxlib
-    ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  ppx_jsonaf_conv = janePackage (
+    {
+      pname = "ppx_jsonaf_conv";
+      meta.description = "[@@deriving] plugin to generate Jsonaf conversion functions";
+      propagatedBuildInputs = [
+        base
+        jsonaf
+        ppx_jane
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-BnkYY+Td9zV++PuPs/gm5U58rCZjew1OJQ2k8KE+dfA=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-v7CYOJ1g4LkqIv5De5tQjjkBWXqKHbvqfSr0X5jBUuM=";
+        }
+    )
+  );
 
   ppx_js_style = janePackage (
     {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1759,17 +1759,29 @@ with self;
     )
   );
 
-  ppx_typed_fields = janePackage {
-    pname = "ppx_typed_fields";
-    hash = "sha256-aTPEBBc1zniZkEmzubGkU064bwGnefBOjVDqTdPm2w8=";
-    meta.description = "GADT-based field accessors and utilities";
-    propagatedBuildInputs = [
-      core
-      ppx_jane
-      ppxlib
-    ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  ppx_typed_fields = janePackage (
+    {
+      pname = "ppx_typed_fields";
+      meta.description = "GADT-based field accessors and utilities";
+      propagatedBuildInputs = [
+        core
+        ppx_jane
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-M+UhZst98gRg6pVg828UZn8AEFK2a/KAzGkuUkWoBaI=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-aTPEBBc1zniZkEmzubGkU064bwGnefBOjVDqTdPm2w8=";
+        }
+    )
+  );
 
   ppx_typerep_conv = janePackage (
     {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -2100,21 +2100,33 @@ with self;
     ];
   };
 
-  streamable = janePackage {
-    pname = "streamable";
-    hash = "sha256-FtrAX4nsacCO5HTVxwLgwwT8R2sASJ05qu4gT2ZVSDg=";
-    meta.description = "Collection of types suitable for incremental serialization";
-    propagatedBuildInputs = [
-      async_kernel
-      async_rpc_kernel
-      base
-      core
-      core_kernel
-      ppx_jane
-      ppxlib
-    ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  streamable = janePackage (
+    {
+      pname = "streamable";
+      meta.description = "Collection of types suitable for incremental serialization";
+      propagatedBuildInputs = [
+        async_kernel
+        async_rpc_kernel
+        base
+        core
+        core_kernel
+        ppx_jane
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-3d7tByQCOfA44wSBKbHXDvyomenWVaEDMHujlK++n8Y=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-FtrAX4nsacCO5HTVxwLgwwT8R2sASJ05qu4gT2ZVSDg=";
+        }
+    )
+  );
 
   textutils = janePackage {
     pname = "textutils";

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1217,18 +1217,30 @@ with self;
     ];
   };
 
-  ppx_derive_at_runtime = janePackage {
-    pname = "ppx_derive_at_runtime";
-    hash = "sha256-Y/z4BKFRt3z1lUGdc7SznIv/ys//dZHoPSnsouj1GtI=";
-    meta.description = "Define a new ppx deriver by naming a runtime module";
-    propagatedBuildInputs = [
-      base
-      expect_test_helpers_core
-      ppx_jane
-      ppxlib
-    ];
-    meta.broken = lib.versionAtLeast ppxlib.version "0.36";
-  };
+  ppx_derive_at_runtime = janePackage (
+    {
+      pname = "ppx_derive_at_runtime";
+      meta.description = "Define a new ppx deriver by naming a runtime module";
+      propagatedBuildInputs = [
+        base
+        expect_test_helpers_core
+        ppx_jane
+        ppxlib
+      ];
+    }
+    // (
+      if lib.versionAtLeast ppxlib.version "0.36" then
+        {
+          version = "0.17.1";
+          hash = "sha256-bbUV2t8MhqDCHDJp7fqJTnRrfZdYO8DLnygqQF0+ouY=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-Y/z4BKFRt3z1lUGdc7SznIv/ys//dZHoPSnsouj1GtI=";
+        }
+    )
+  );
 
   ppx_diff = janePackage (
     {


### PR DESCRIPTION
Update (and fix) a few libraries that are currently broken.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
