### PR TITLE
python3Packages.grpclib: replace async-timeout with asyncio.timeout

### DIFF
--- a/pkgs/development/python-modules/grpclib/default.nix
+++ b/pkgs/development/python-modules/grpclib/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  async-timeout,
   buildPythonPackage,
   certifi,
   faker,
   fetchFromGitHub,
+  fetchpatch,
   googleapis-common-protos,
   h2,
   multidict,
@@ -28,6 +28,15 @@ buildPythonPackage rec {
     hash = "sha256-Z+DMwGMUxNTQ7ABd4q/FgMHEZ/NCOtst+6QfQJm3jVU=";
   };
 
+  patches = [
+    # https://github.com/vmagamedov/grpclib/pull/209
+    (fetchpatch {
+      name = "replace-async-timeout-with-asyncio-timeout-patch";
+      url = "https://github.com/vmagamedov/grpclib/commit/36b23ce3ca3f1742e39b50f939d13cd08b4f28ac.patch";
+      hash = "sha256-3ztLBOFpTK8CFIp8a6suhWXY5kIBCBRWBX/oAyYU4yI=";
+    })
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -38,7 +47,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio_0
-    async-timeout
     faker
     googleapis-common-protos
     certifi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
