### PR TITLE
icesprog: init 1.1b

### DIFF
--- a/pkgs/by-name/ic/icesprog/package.nix
+++ b/pkgs/by-name/ic/icesprog/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  gnumake,
+  pkg-config,
+  libusb1,
+  hidapi,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "icesprog";
+  version = "1.1b";
+
+  src = fetchFromGitHub {
+    owner = "wuxx";
+    repo = "icesugar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LGmT+GEZvo0oxmr2kMfSztutnguPpNt2QJfVyBJo82w=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/tools/src";
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gnumake
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libusb1
+    hidapi
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin icesprog
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "iCESugar FPGA flash utility";
+    mainProgram = "icesprog";
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    homepage = "https://github.com/wuxx/icesugar";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
