### PR TITLE
python3Packages.zigpy-zboss: replace async-timeout with asyncio.timeout

### DIFF
--- a/pkgs/development/python-modules/zigpy-zboss/default.nix
+++ b/pkgs/development/python-modules/zigpy-zboss/default.nix
@@ -1,8 +1,8 @@
 {
-  async-timeout,
   buildPythonPackage,
   coloredlogs,
   fetchFromGitHub,
+  fetchpatch,
   jsonschema,
   lib,
   pytest-asyncio_0,
@@ -25,10 +25,21 @@ buildPythonPackage rec {
     hash = "sha256-T2R291GeFIsnDRI1tAydTlLamA3LF5tKxKFhPtcEUus=";
   };
 
+  patches = [
+    # https://github.com/kardia-as/zigpy-zboss/pull/66
+    (fetchpatch {
+      name = "replace-async-timeout-with-asyncio-timeout.patch";
+      url = "https://github.com/kardia-as/zigpy-zboss/commit/91688873ddbcd0c2196f0da69a857b2e2bec75a6.patch";
+      excludes = [ "setup.cfg" ];
+      hash = "sha256-aC0+FbbtuHDW3ApJDnTG3TUeNWhzecEYVuiSOik03uU=";
+    })
+  ];
+
+  pythonRemoveDeps = [ "async_timeout" ];
+
   build-system = [ setuptools ];
 
   dependencies = [
-    async-timeout
     coloredlogs
     jsonschema
     voluptuous


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
