### PR TITLE
quint: 0.25.1 -> 0.29.1

### DIFF
--- a/pkgs/by-name/qu/quint/package.nix
+++ b/pkgs/by-name/qu/quint/package.nix
@@ -18,8 +18,8 @@
 }:
 
 let
-  version = "0.29.0";
-  apalacheVersion = "0.50.3";
+  version = "0.29.1";
+  apalacheVersion = "0.51.1";
   evaluatorVersion = "0.3.0";
 
   metaCommon = {
@@ -34,7 +34,7 @@ let
     owner = "informalsystems";
     repo = "quint";
     tag = "v${version}";
-    hash = "sha256-q2pahCsNNJEVivRBijFw5YUCWDzLAtZSYRgxaaROTLo=";
+    hash = "sha256-lnvtyL4GKOyKdBDC5vevx5LgaiB7xTkfuN1rRTxKyv4=";
   };
 
   # Build the Quint CLI from source
@@ -46,7 +46,7 @@ let
 
     sourceRoot = "${src.name}/quint";
 
-    npmDepsHash = "sha256-wbjktm7A1ey25rWbtBD5uvD1mM9vbwBhGIX5ECzJThI=";
+    npmDepsHash = "sha256-CBwovC7PTdjJHwL9lKRlJbl8rNjd9J3hVBFJz24+cbw=";
 
     npmBuildScript = "compile";
 
@@ -88,7 +88,7 @@ let
   # Download Apalache. It runs on the JVM, so no need to build it from source.
   apalacheDist = fetchzip {
     url = "https://github.com/apalache-mc/apalache/releases/download/v${apalacheVersion}/apalache.tgz";
-    hash = "sha256-pePoXbuJq1UNt0yY/Is3jFHtvvX3r/yjOoqG4clsgBw=";
+    hash = "sha256-xYQQH9XxPwf3+YmjiRs7XlW49LdHrEnMeuvd16Ir0B4=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/qu/quint/package.nix
+++ b/pkgs/by-name/qu/quint/package.nix
@@ -9,12 +9,18 @@
   jre,
   fetchzip,
   buildNpmPackage,
+  _experimental-update-script-combinators,
+  nix-update-script,
+  writeShellScript,
+  gnugrep,
+  nix-update,
+  common-updater-scripts,
 }:
 
 let
-  version = "0.25.1";
-  apalacheVersion = "0.47.2";
-  evaluatorVersion = "0.2.0";
+  version = "0.29.0";
+  apalacheVersion = "0.50.3";
+  evaluatorVersion = "0.3.0";
 
   metaCommon = {
     description = "Formal specification language with TLA+ semantics";
@@ -28,7 +34,7 @@ let
     owner = "informalsystems";
     repo = "quint";
     tag = "v${version}";
-    hash = "sha256-CYQesIoDlIGCKXIJ/hpZqOZBVd19Or5VEKVERchJz68=";
+    hash = "sha256-q2pahCsNNJEVivRBijFw5YUCWDzLAtZSYRgxaaROTLo=";
   };
 
   # Build the Quint CLI from source
@@ -40,7 +46,7 @@ let
 
     sourceRoot = "${src.name}/quint";
 
-    npmDepsHash = "sha256-FYNSr5B0/oJ4PbU/HUVqSdPG8kFvq4vRFnYwwdMf+jQ=";
+    npmDepsHash = "sha256-wbjktm7A1ey25rWbtBD5uvD1mM9vbwBhGIX5ECzJThI=";
 
     npmBuildScript = "compile";
 
@@ -82,7 +88,7 @@ let
   # Download Apalache. It runs on the JVM, so no need to build it from source.
   apalacheDist = fetchzip {
     url = "https://github.com/apalache-mc/apalache/releases/download/v${apalacheVersion}/apalache.tgz";
-    hash = "sha256-P0QOxB14OSlphqBALR1YL9WJ0XYaUYE/R52yZytVzds=";
+    hash = "sha256-pePoXbuJq1UNt0yY/Is3jFHtvvX3r/yjOoqG4clsgBw=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -112,6 +118,30 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    inherit
+      quint-cli
+      quint-evaluator
+      apalacheDist
+      apalacheVersion
+      ;
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script {
+        extraArgs = [
+          "--subpackage"
+          "quint-cli"
+        ];
+      })
+      (writeShellScript "update" ''
+        src=$(nix build --print-out-paths --no-link .#quint.src)
+        QUINT_EVALUATOR_VERSION=$(${lib.getExe gnugrep} -m1 "const QUINT_EVALUATOR_VERSION" $src/quint/src/quintRustWrapper.ts | sed -E "s/.*= 'v?([^']+)'.*/\1/")
+        ${lib.getExe nix-update} quint.quint-evaluator --version $QUINT_EVALUATOR_VERSION
+        DEFAULT_APALACHE_VERSION_TAG=$(${lib.getExe gnugrep} "DEFAULT_APALACHE_VERSION_TAG" $src/quint/src/apalache.ts | sed -E "s/.*= '([^']+)'.*/\1/")
+        ${lib.getExe' common-updater-scripts "update-source-version"} quint $DEFAULT_APALACHE_VERSION_TAG --version-key=apalacheVersion --source-key=apalacheDist --ignore-same-version --ignore-same-hash
+      '')
+    ];
+  };
 
   meta = metaCommon // {
     mainProgram = "quint";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/informalsystems/quint/blob/v0.29.1/CHANGELOG.md#v0291----2025-11-11
https://github.com/informalsystems/quint/releases/tag/v0.29.1
https://github.com/informalsystems/quint/compare/v0.25.1...v0.29.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
