### PR TITLE
python312Packages.qcs-sdk-python: 0.21.19 -> 0.21.20

### DIFF
--- a/pkgs/development/python-modules/qcs-sdk-python/default.nix
+++ b/pkgs/development/python-modules/qcs-sdk-python/default.nix
@@ -16,19 +16,19 @@
 
 buildPythonPackage rec {
   pname = "qcs-sdk-python";
-  version = "0.21.19";
+  version = "0.21.20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rigetti";
     repo = "qcs-sdk-rust";
     tag = "python/v${version}";
-    hash = "sha256-116+DbsvLBNWjyeGcm3+zrmY9HKWONii2Me0XjEGACo=";
+    hash = "sha256-B0wMOMbsoqkaJ61ula/9w6EBta13UKf5APyOD6NDle4=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-+F7PRBg73GFSeUCmt5NWa+gBhuZU5J7F5TGqRJKqwGc=";
+    hash = "sha256-cbcSwjeIU/Unm4Y48h3AWTz/f3McyXs9/BhXWDZnL9Q=";
   };
 
   buildAndTestSubdir = "crates/python";


### PR DESCRIPTION
Diff: https://github.com/rigetti/qcs-sdk-rust/compare/python/v0.21.19...python/v0.21.20

Changelog: https://github.com/rigetti/qcs-sdk-rust/blob/python/v0.21.20/crates/python/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
