### PR TITLE
systemd: 258 -> 258.1

### DIFF
--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -48,13 +48,12 @@
         machine.wait_for_file("/home/alice/done")
 
     with subtest("Systemd gives and removes device ownership as needed"):
-        # Change back to /dev/snd/timer after systemd-258.1
-        machine.succeed("getfacl /dev/dri/card0 | grep -q alice")
+        machine.succeed("getfacl /dev/snd/timer | grep -q alice")
         machine.send_key("alt-f1")
         machine.wait_until_succeeds("[ $(fgconsole) = 1 ]")
-        machine.fail("getfacl /dev/dri/card0 | grep -q alice")
+        machine.fail("getfacl /dev/snd/timer | grep -q alice")
         machine.succeed("chvt 2")
-        machine.wait_until_succeeds("getfacl /dev/dri/card0 | grep -q alice")
+        machine.wait_until_succeeds("getfacl /dev/snd/timer | grep -q alice")
 
     with subtest("Virtual console logout"):
         machine.send_chars("exit\n")

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -202,7 +202,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "258";
+  version = "258.1";
 
   # We use systemd/systemd-stable for src, and ship NixOS-specific patches inside nixpkgs directly
   # This has proven to be less error-prone than the previous systemd fork.
@@ -210,7 +210,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "systemd";
     repo = "systemd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-xtGZaVNsBNxkidgfVBu8xtvj0SxpY6OyJCUE+gq59qE=";
+    hash = "sha256-LA+6/d9W3CxK0G2sXsPHM4BVLf8IzsWW6IxJFby6/JU=";
   };
 
   # On major changes, or when otherwise required, you *must* :
@@ -224,14 +224,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # https://github.com/systemd/systemd/pull/39094
     (fetchpatch {
-      url = "https://github.com/systemd/systemd/commit/0f44a6c64aebc64a0611a605831206afee9cb730.patch";
-      hash = "sha256-DO6q17mE2U8iLezMYt4PX5Ror20N1gCrUbXeQmrW1is=";
+      url = "https://github.com/systemd/systemd/commit/8b4ee3d68d2e70d9a396b74d155eab3b11763311.patch";
+      hash = "sha256-JJDaSHQjd1QZ18CQHq40viB0AF/0MiescmZUcc/6LDg=";
     })
-
-    # https://github.com/systemd/systemd/pull/39069
     (fetchpatch {
-      url = "https://github.com/systemd/systemd/commit/b5fdfedf729712b9824a5cb457a07d5699d2946c.patch";
-      hash = "sha256-0SvAn9Dl4z80PRIvDbIVIjKp5DsT/IUoHa5IiH1HHFY=";
+      url = "https://github.com/systemd/systemd/commit/13b0e7fc6d2623800ba04b104f3b628388c9f5e6.patch";
+      hash = "sha256-X+tY3NjfRJpF6wvd++xEps0DIFTbX/6Zw9oO4Y9FmNI=";
     })
 
     ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/453603 so marking as draft until that's in staging. That PR is reverted here, but we have to have it for staging-next first.

`systemd.tests` has no new failures.

Changelog: https://github.com/systemd/systemd/compare/v258...v258.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
