### PR TITLE
mpris-timer: 2.1.1 -> 2.2.2

### DIFF
--- a/pkgs/by-name/mp/mpris-timer/package.nix
+++ b/pkgs/by-name/mp/mpris-timer/package.nix
@@ -12,20 +12,18 @@
   wrapGAppsHook4,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "mpris-timer";
   version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "efogdev";
     repo = "mpris-timer";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-JuOBLm7+/zOSNhH+sBqvUQV0+AhTAmr+UxhPFtt0NU8=";
   };
 
   vendorHash = "sha256-Htni2cMc1vYewVL8oOXL2gPS4h+S3d5y4i5yAZdqFJo=";
-
-  strictDeps = true;
 
   nativeBuildInputs = [
     pkg-config
@@ -45,13 +43,10 @@ buildGoModule rec {
     "-w"
   ];
 
-  tags = [
-    "wayland"
-  ];
+  tags = [ "wayland" ];
 
   postInstall = ''
-    mv $out/bin/cmd $out/bin/mpris-timer
-
+    mv $out/bin/{cmd,mpris-timer}
     install -Dm644 internal/ui/res/icon.svg $out/share/icons/hicolor/scalable/apps/io.github.efogdev.mpris-timer.svg
     install -Dm644 misc/io.github.efogdev.mpris-timer.desktop -t $out/share/applications
     install -Dm644 misc/io.github.efogdev.mpris-timer.metainfo.xml -t $out/share/metainfo
@@ -59,9 +54,7 @@ buildGoModule rec {
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Timer app with seamless GNOME integration";
@@ -72,7 +65,6 @@ buildGoModule rec {
       getchoo
     ];
     mainProgram = "mpris-timer";
-    # Always uses ALSA
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux; # Always uses ALSA
   };
-}
+})

--- a/pkgs/by-name/mp/mpris-timer/package.nix
+++ b/pkgs/by-name/mp/mpris-timer/package.nix
@@ -14,16 +14,16 @@
 
 buildGoModule rec {
   pname = "mpris-timer";
-  version = "2.1.1";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "efogdev";
     repo = "mpris-timer";
     tag = version;
-    hash = "sha256-uFQJSKQ9k0fiOhzydJ7frs2kns9pSdZGILPGCW3QA1w=";
+    hash = "sha256-JuOBLm7+/zOSNhH+sBqvUQV0+AhTAmr+UxhPFtt0NU8=";
   };
 
-  vendorHash = "sha256-vCzQiQsljNyI7nBYvq+C/dv0T186Lsj7rOq5xHMs3c0=";
+  vendorHash = "sha256-Htni2cMc1vYewVL8oOXL2gPS4h+S3d5y4i5yAZdqFJo=";
 
   strictDeps = true;
 


### PR DESCRIPTION
Resolves #453674

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
