### PR TITLE
termirs: init at 0.2.0

### DIFF
--- a/pkgs/by-name/te/termirs/package.nix
+++ b/pkgs/by-name/te/termirs/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "termirs";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "caelansar";
+    repo = "termirs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yQ9WmvnIJJHhhXNTHZeHGz2uYVAxuFPf2U1WzybjJqU=";
+  };
+
+  cargoHash = "sha256-J/TgFi0iyhaj9/aF3Gd46PNq/QE+hQfF2YawbJf/5AA=";
+
+  passthru.updateScript = nix-update-script { };
+
+  # Try to access network stack in sandboxed darwin
+  checkFlags = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    "--skip=async_ssh_client::tests::test_connect_embedded_server"
+    "--skip=async_ssh_client::tests::test_port_forwarding"
+    "--skip=async_ssh_client::tests::test_port_forwarding_recovers_after_session_drop"
+    "--skip=async_ssh_client::tests::test_sftp_receive_large_file"
+    "--skip=async_ssh_client::tests::test_sftp_send_large_file"
+    "--skip=async_ssh_client::tests::test_sftp_send_receive_roundtrip"
+  ];
+
+  meta = {
+    description = "Modern async SSH terminal client built with Rust and Ratatui";
+    longDescription = ''
+      TermiRs provides a fast, secure, and user-friendly terminal
+      interface for managing SSH connections with advanced features
+      like secure file transfers and encrypted configuration storage.
+    '';
+    homepage = "https://github.com/caelansar/termirs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "termirs";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
