### PR TITLE
still: init at 0.0.7

### DIFF
--- a/pkgs/by-name/st/still/package.nix
+++ b/pkgs/by-name/st/still/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  pixman,
+  kdePackages,
+  wayland-scanner,
+  scdoc,
+}:
+
+let
+  version = "0.0.7";
+in
+stdenv.mkDerivation {
+  pname = "still";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "faergeek";
+    repo = "still";
+    tag = "v${version}";
+    hash = "sha256-tPDPEUBVfNNnTULRNuqyshfvjb1otiko3KlsAj46qRY=";
+  };
+
+  buildInputs = [
+    pixman
+    kdePackages.wayland
+    kdePackages.wayland-protocols
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    wayland-scanner
+    scdoc
+  ];
+
+  meta = {
+    description = "Freeze the screen of a Wayland compositor until a provided command exits";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/faergeek/still";
+    changelog = "https://github.com/faergeek/still/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ bbenno ];
+    mainProgram = "still";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
[still](https://github.com/faergeek/still) is a Wayland utility that freezes the screen of a compositor until a provided command exits.
It is implemented in C and built with Meson.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
