### PR TITLE
Julia 1.12 tests

### DIFF
--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -97,4 +97,13 @@ in
       ];
     }) { }
   );
+  julia_112 = wrapJulia (
+    callPackage (import ./generic.nix {
+      version = "1.12.1";
+      hash = "sha256-iR0Wu5HIqU1aY1WoLBf6PCRY64kWDUKEQ6CyobhB6lI=";
+      patches = [
+        ./patches/1.12/0001-skip-failing-and-flaky-tests.patch
+      ];
+    }) { }
+  );
 }

--- a/pkgs/development/compilers/julia/default.nix
+++ b/pkgs/development/compilers/julia/default.nix
@@ -51,6 +51,17 @@ in
       };
     }) { }
   );
+  julia_112-bin = wrapJulia (
+    callPackage (import ./generic-bin.nix {
+      version = "1.12.1";
+      sha256 = {
+        x86_64-linux = "7d2add9ee74ee2f12b5c268bc194794cc52ea440f8687fbab29db6afefbf69b7";
+        aarch64-linux = "2e3d6ca07e251721fa3e0cd3460fc240e60f2a9bd97bae0ea2144f586da19297";
+        x86_64-darwin = "7dd841cd853ad64f5e90a4b459631b49ee388891ceaba81857f5b8959392c4b2";
+        aarch64-darwin = "cc65620b71a725380e59d0e31dc0b4140f30229b70a4b8eec8e32c222bc54fc1";
+      };
+    }) { }
+  );
   julia_19 = wrapJulia (
     callPackage (import ./generic.nix {
       version = "1.9.4";

--- a/pkgs/development/compilers/julia/generic-bin.nix
+++ b/pkgs/development/compilers/julia/generic-bin.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation {
   doInstallCheck = true;
 
   preInstallCheck = ''
-    export JULIA_TEST_USE_MULTIPLE_WORKERS=true
+    export JULIA_TEST_USE_MULTIPLE_WORKERS=${if stdenv.hostPlatform.isDarwin then "false" else "true"}
     # Some tests require read/write access to $HOME.
     # And $HOME cannot be equal to $TMPDIR as it causes test failures
     export HOME=$(mktemp -d)

--- a/pkgs/development/compilers/julia/generic-bin.nix
+++ b/pkgs/development/compilers/julia/generic-bin.nix
@@ -17,7 +17,7 @@ let
     "channels"
     # Test flaky because of our RPATH patching
     # https://github.com/NixOS/nixpkgs/pull/230965#issuecomment-1545336489
-    "compiler/codegen"
+    "Compiler/codegen"
     # Test flaky
     "read"
   ]
@@ -33,6 +33,10 @@ let
     # https://github.com/JuliaLang/julia/issues/54280
     "loading"
     "cmdlineargs"
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "1.12") [
+    "precompile"
+    "compileall"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Test flaky on ofborg

--- a/pkgs/development/compilers/julia/generic.nix
+++ b/pkgs/development/compilers/julia/generic.nix
@@ -60,6 +60,11 @@ stdenv.mkDerivation rec {
     substituteInPlace deps/curl.mk \
       --replace-fail 'cd $(dir $<) && $(TAR) jxf $(notdir $<)' \
                      'cd $(dir $<) && $(TAR) jxf $(notdir $<) && sed -i "s|/usr/bin/env perl|${lib.getExe buildPackages.perl}|" curl-$(CURL_VER)/scripts/cd2nroff'
+  ''
+  + lib.optionalString (lib.versionAtLeast version "1.12") ''
+    substituteInPlace deps/openssl.mk \
+      --replace-fail 'cd $(dir $<) && $(TAR) -zxf $<' \
+                     'cd $(dir $<) && $(TAR) -zxf $< && sed -i "s|/usr/bin/env perl|${lib.getExe buildPackages.perl}|" openssl-$(OPENSSL_VER)/Configure'
   '';
 
   makeFlags = [

--- a/pkgs/development/compilers/julia/patches/1.12/0001-skip-failing-and-flaky-tests.patch
+++ b/pkgs/development/compilers/julia/patches/1.12/0001-skip-failing-and-flaky-tests.patch
@@ -1,0 +1,25 @@
+From e26b82d0c162b6c22b65b2a5d2cd03d98fd9f5d4 Mon Sep 17 00:00:00 2001
+From: Sergey Volkov <taranarmo@gmail.com>
+Date: Thu, 9 Oct 2025 13:00:31 +0200
+Subject: [PATCH] disable failing and flaky tests
+
+---
+ test/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/Makefile b/test/Makefile
+index 69b7ad1451..583e64a287 100644
+--- a/test/Makefile
++++ b/test/Makefile
+@@ -30,7 +30,7 @@ default:
+ 
+ $(TESTS):
+ 	@cd $(SRCDIR) && \
+-	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
++	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --skip NetworkOptions REPL channels FileWatching ccall loading cmdlineargs Distributed precompile compileall $@)
+ 
+ $(addprefix revise-, $(TESTS)): revise-% :
+ 	@cd $(SRCDIR) && \
+-- 
+2.51.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5184,10 +5184,11 @@ with pkgs;
     julia_19
     julia_110
     julia_111
+    julia_112
     ;
 
   julia-lts = julia_110-bin;
-  julia-stable = julia_111;
+  julia-stable = julia_112;
   julia = julia-stable;
 
   julia-lts-bin = julia_110-bin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5180,6 +5180,7 @@ with pkgs;
     julia_19-bin
     julia_110-bin
     julia_111-bin
+    julia_112-bin
     julia_19
     julia_110
     julia_111
@@ -5190,7 +5191,7 @@ with pkgs;
   julia = julia-stable;
 
   julia-lts-bin = julia_110-bin;
-  julia-stable-bin = julia_111-bin;
+  julia-stable-bin = julia_112-bin;
   julia-bin = julia-stable-bin;
 
   kotlin = callPackage ../development/compilers/kotlin { };


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
