### PR TITLE
art-standalone: add vixl for arm platform support

### DIFF
--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -16,6 +16,7 @@
   openssl,
   libbsd,
   lz4,
+  vixl,
   runtimeShell,
   libpng,
   makeWrapper,
@@ -42,6 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs .
     substituteInPlace build/core/config.mk build/core/main.mk \
       --replace-fail "/bin/bash" "${runtimeShell}"
+    substituteInPlace art/build/Android.common_build.mk \
+      --replace-fail "/usr/include/vixl" "${vixl}/include/vixl"
   '';
 
   enableParallelBuilding = true;
@@ -65,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     lz4
     openssl
+    vixl
     (wolfssl.overrideAttrs (oldAttrs: {
       configureFlags = oldAttrs.configureFlags ++ [
         "--enable-jni"
@@ -99,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/android_translation_layer/art_standalone";
     # No license specified yet
     license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ onny ];
   };
 })


### PR DESCRIPTION
Added vixl for arm builds

Fixes https://github.com/NixOS/nixpkgs/pull/442288#issuecomment-3306472210

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
