### PR TITLE
ptouch-print: 1.5-unstable-2024-02-11 -> 1.7

### DIFF
--- a/pkgs/by-name/pt/ptouch-print/argp.patch
+++ b/pkgs/by-name/pt/ptouch-print/argp.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 61f7c40..2740d3d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,11 +28,18 @@ target_include_directories(${PROJECT_NAME} PUBLIC
+ 	${Intl_INCLUDE_DIRS}
+ )
+ 
++set(EXTRA_LIBS "")
++find_library(ARGP argp)
++if(ARGP)
++	list(APPEND EXTRA_LIBS argp)
++endif()
++
+ target_link_libraries(${PROJECT_NAME} PRIVATE
+ 	${GD_LIBRARIES}
+ 	${LIBUSB_LIBRARIES}
+ 	${LIBUSB_LINK_LIBRARIES}
+ 	${Intl_LIBRARIES}
++	${EXTRA_LIBS}
+ )
+ 
+ target_sources(${PROJECT_NAME} PRIVATE
+

--- a/pkgs/by-name/pt/ptouch-print/package.nix
+++ b/pkgs/by-name/pt/ptouch-print/package.nix
@@ -1,4 +1,5 @@
 {
+  argp-standalone,
   cmake,
   fetchgit,
   gd,
@@ -15,12 +16,12 @@
 
 stdenv.mkDerivation {
   pname = "ptouch-print";
-  version = "1.5-unstable-2024-02-11";
+  version = "1.7";
 
   src = fetchgit {
     url = "https://git.familie-radermacher.ch/linux/ptouch-print.git";
-    rev = "8aaeecd84b619587dc3885dd4fea4b7310c82fd4";
-    hash = "sha256-IIq3SmMfsgwSYbgG1w/wrBnFtb6xdFK2lkK27Qqk6mw=";
+    rev = "v1.7";
+    hash = "sha256-OdWdDjgA0Jltho9IB9btZW3UsU+EDm21iltQ1McgiqU=";
   };
 
   nativeBuildInputs = [
@@ -36,6 +37,13 @@ stdenv.mkDerivation {
     libpng
     zlib
     libusb1
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isGnu) [
+    argp-standalone
+  ];
+
+  patches = [
+    ./argp.patch
   ];
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
