### PR TITLE
urserver: add support for aarch64-linux

### DIFF
--- a/pkgs/by-name/ur/urserver/package.nix
+++ b/pkgs/by-name/ur/urserver/package.nix
@@ -9,46 +9,66 @@
   makeWrapper,
   versionCheckHook,
 }:
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    sources = {
+      "x86_64-linux" = {
+        url = "https://www.unifiedremote.com/static/builds/server/linux-x64/${builtins.elemAt (builtins.splitVersion finalAttrs.version) 3}/urserver-${finalAttrs.version}.tar.gz";
+        hash = "sha256-4wA2VPb5QN30TWa72pUVTYfvsxlGTO8Vngh7wDHXhDE=";
+      };
+      "aarch64-linux" = {
+        url = "https://www.unifiedremote.com/static/builds/server/linux-arm64/${builtins.elemAt (builtins.splitVersion finalAttrs.version) 3}/urserver-${finalAttrs.version}.tar.gz";
+        hash = "sha256-GmYekCGb64GdFdABEJl9CgqycnsBX95W9/b0xZJntEs=";
+      };
+    };
+  in
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "urserver";
-  version = "3.14.0.2574";
+  {
+    pname = "urserver";
+    version = "3.14.0.2574";
 
-  src = fetchurl {
-    url = "https://www.unifiedremote.com/static/builds/server/linux-x64/${builtins.elemAt (builtins.splitVersion finalAttrs.version) 3}/urserver-${finalAttrs.version}.tar.gz";
-    hash = "sha256-4wA2VPb5QN30TWa72pUVTYfvsxlGTO8Vngh7wDHXhDE=";
-  };
+    src =
+      let
+        platformSource =
+          sources."${stdenv.hostPlatform.system}"
+            or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+      in
+      fetchurl {
+        inherit (platformSource) url hash;
+      };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
-  ];
+    nativeBuildInputs = [
+      autoPatchelfHook
+      makeWrapper
+    ];
 
-  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
+    buildInputs = [ (lib.getLib stdenv.cc.cc) ];
 
-  installPhase = ''
-    install -m755 -D urserver $out/bin/urserver
-    wrapProgram $out/bin/urserver --prefix LD_LIBRARY_PATH : "${
-      lib.makeLibraryPath [
-        libX11
-        libXtst
-        bluez
-      ]
-    }"
-    cp -r remotes $out/bin/remotes
-    cp -r manager $out/bin/manager
-  '';
+    installPhase = ''
+      install -m755 -D urserver $out/bin/urserver
+      wrapProgram $out/bin/urserver --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libX11
+          libXtst
+          bluez
+        ]
+      }"
+      cp -r remotes $out/bin/remotes
+      cp -r manager $out/bin/manager
+    '';
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  doInstallCheck = true;
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
 
-  meta = {
-    homepage = "https://www.unifiedremote.com/";
-    description = "One-and-only remote for your computer";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ sfrijters ];
-    platforms = [ "x86_64-linux" ];
-    mainProgram = "urserver";
-  };
-})
+    meta = {
+      homepage = "https://www.unifiedremote.com/";
+      description = "One-and-only remote for your computer";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [ sfrijters ];
+      platforms = lib.attrNames sources;
+      mainProgram = "urserver";
+    };
+  }
+)


### PR DESCRIPTION
Sources for platforms other than x86-linux are available: https://www.unifiedremote.com/download/other
In principle more could be added but this is the only one I can test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
