### PR TITLE
python3Packages.hawkmoth: 0.21.0 -> 0.22.0

### DIFF
--- a/pkgs/development/python-modules/hawkmoth/default.nix
+++ b/pkgs/development/python-modules/hawkmoth/default.nix
@@ -3,40 +3,35 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  llvmPackages_20,
   libclang,
   sphinx,
+  clang,
   pytestCheckHook,
   strictyaml,
 }:
-let
-  libclang_20 = libclang.override {
-    llvmPackages = llvmPackages_20;
-  };
 
-in
 buildPythonPackage rec {
   pname = "hawkmoth";
-  version = "0.21.0";
+  version = "0.22.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jnikula";
     repo = "hawkmoth";
     tag = "v${version}";
-    hash = "sha256-ePi7whsibStYwG75Eso7A0GkSbn8JesacaDU5IRF9iE=";
+    hash = "sha256-iFyTayPC4TWOfTZrfJJILJyi5BWrsVLwnSFnSeMpB2c=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
-    libclang_20
+    libclang
     sphinx
   ];
-  propagatedBuildInputs = [ llvmPackages_20.clang ];
+  propagatedBuildInputs = [ clang ];
 
   nativeCheckInputs = [
-    llvmPackages_20.clang
+    clang
     pytestCheckHook
     strictyaml
   ];


### PR DESCRIPTION
Followup on https://github.com/NixOS/nixpkgs/pull/453276.

## Things done

This removes LLVM version pin added in
786c47896e030a060f58de4f969193a498bc6fcd.



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
