### PR TITLE
[Backport staging-25.05] libarchive: 3.8.0 -> 3.8.2

### DIFF
--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   acl,
   attr,
   autoreconfHook,
@@ -33,29 +32,14 @@
 assert xarSupport -> libxml2 != null;
 stdenv.mkDerivation (finalAttrs: {
   pname = "libarchive";
-  version = "3.8.0";
+  version = "3.8.1";
 
   src = fetchFromGitHub {
     owner = "libarchive";
     repo = "libarchive";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-nL2p2h+U25fhQQjbj16yhxhU8xEEuhNynIx7SNzl6Mo=";
+    hash = "sha256-KN5SvQ+/g/OOa+hntMX3D8p5IEWO0smke5WK+DwrOH0=";
   };
-
-  patches = [
-    # Remove in next release
-    #
-    # Fixes macOS metadata file handling when reading certain tarballs
-    # (e.g, bsdtar-produced tar containing a file with xattrs whose name is exactly 99 bytes long)
-    # <https://github.com/libarchive/libarchive/pull/2636>
-    #
-    # This also fixes test_copy in the test suite.
-    (fetchpatch {
-      name = "reset-header-state-after-mac-metadata.patch";
-      url = "https://github.com/libarchive/libarchive/commit/5bb36db5e19aecabccec8f351ec22f8c3a8695f0.patch";
-      hash = "sha256-eNGSunYZ5b0TrkBUtOO7MYGXc+SEn1Sxm8MYyI+4JsQ=";
-    })
-  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -59,9 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
         # access-time-related tests flakey on some systems
         "cpio/test/test_option_a.c"
         "cpio/test/test_option_t.c"
-      ]
-      ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
-        # only on some aarch64-linux systems?
+        # fails tests on filesystems with 64-bit inode values:
+        # FAIL: bsdcpio_test
+        #   bsdcpio: linkfile: large inode number truncated: Numerical result out of range
         "cpio/test/test_basic.c"
         "cpio/test/test_format_newc.c"
       ];

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -32,13 +32,13 @@
 assert xarSupport -> libxml2 != null;
 stdenv.mkDerivation (finalAttrs: {
   pname = "libarchive";
-  version = "3.8.1";
+  version = "3.8.2";
 
   src = fetchFromGitHub {
     owner = "libarchive";
     repo = "libarchive";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-KN5SvQ+/g/OOa+hntMX3D8p5IEWO0smke5WK+DwrOH0=";
+    hash = "sha256-s7duwuNFyYq8obTS3qc6JewJ9f8LJhItlEx8wxnMgwk=";
   };
 
   outputs = [


### PR DESCRIPTION
 - Changes: https://github.com/libarchive/libarchive/releases/tag/v3.8.1
 - Changes: https://github.com/libarchive/libarchive/releases/tag/v3.8.2

This backports:

 - https://github.com/NixOS/nixpkgs/pull/452612
 - https://github.com/NixOS/nixpkgs/pull/413493

And additionally:

 - https://github.com/NixOS/nixpkgs/pull/435487

The latter backport done under the assumption that 25.05 could benefit from this, and we're already causing the mass rebuild this would cause. cc @trofi for any comment regarding this.

cc @vcunat for [the backport question](https://github.com/NixOS/nixpkgs/pull/452612#issuecomment-3421808306). I believe it's better to ship the software as upstream intended. We're already using `3.8`, and both minor updates in the `3.8` series are bugfixes/security fixes (going from their release notes). I don't think it would be worth the headache to extricate the security fixes, and double-triple-check that it's still working as intended, even if trivial.

**NOTE**: The branch is based off of `25.05`, and I verified that it can be re-targeted to `staging` as well as `staging-next`. So **feel free to move it into `staging-next` if appropriate here.** I don't know what the current status of the staging workflow is with `25.05`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I have built the package using `nix-build --attr libarchive`, and `libarchive.tests`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
