### PR TITLE
watchgha: init at 2.4.2

### DIFF
--- a/pkgs/by-name/wa/watchgha/package.nix
+++ b/pkgs/by-name/wa/watchgha/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "watchgha";
+  version = "2.4.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "watchgha";
+    hash = "sha256-RtmCC+twOk+viWY7WTbTzuxHTM3MOww+sRuEvlemCcI=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    dulwich
+    exceptiongroup
+    httpx
+    rich
+    trio
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "watchgha" ];
+
+  meta = {
+    description = "Live display of current GitHub action runs";
+    mainProgram = "watch_gha_runs";
+    homepage = "https://github.com/nedbat/watchgha";
+    license = lib.licenses.apsl20;
+    maintainers = with lib.maintainers; [ purcell ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
This adds a new package for watchgha, which provides a small TUI utility for watching the current state of all GitHub Actions runs for a branch or repo.

(Replaces #453839, which was created against the wrong branch in my fork.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
