### PR TITLE
outfly: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/by-name/ou/outfly/package.nix
+++ b/pkgs/by-name/ou/outfly/package.nix
@@ -17,12 +17,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "outfly";
-  version = "0.14.0";
+  version = "0.15.0";
   src = fetchFromCodeberg {
     owner = "outfly";
     repo = "outfly";
     tag = "v${version}";
-    hash = "sha256-FRvu3FgbT3i5888ll573nhb7naYx04Oi8nrcfgEHxUo=";
+    hash = "sha256-BOm5SxpWowq5LCTqRqDkbKGPnZo0pJYz8w3kB/WnH9M=";
   };
 
   runtimeInputs = [
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage rec {
     --add-rpath ${lib.makeLibraryPath runtimeInputs}
   '';
 
-  cargoHash = "sha256-5t6PPlfV/INqb4knz1Bv6dqw47RxUmVO0DSlQNUIQL4=";
+  cargoHash = "sha256-UXqS4JfKuLxeTW1MDMnKLzw8oHf1Gpgv8SktTtf12mc=";
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/ou/outfly/package.nix
+++ b/pkgs/by-name/ou/outfly/package.nix
@@ -13,6 +13,7 @@
   libxcursor,
   libx11,
   libxi,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -58,6 +59,8 @@ rustPlatform.buildRustPackage rec {
       categories = [ "Game" ];
     })
   ];
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Breathtaking 3D space game in the rings of Jupiter";
     homepage = "https://yunicode.itch.io/outfly";


### PR DESCRIPTION
<!--
Updates outfly to release 0.15.0
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
