### PR TITLE
ksh93: init at 1.0.10

### DIFF
--- a/pkgs/by-name/ks/ksh93/darwin-install-names.patch
+++ b/pkgs/by-name/ks/ksh93/darwin-install-names.patch
@@ -1,0 +1,10 @@
+--- a/src/cmd/INIT/dylink.sh
++++ b/src/cmd/INIT/dylink.sh
+@@ -126,6 +126,6 @@
+ 	case $HOSTTYPE in
+ 	darwin.*)
+ 		do_link "lib/$lib_file" -dynamiclib \
+-			-Wl,-dylib_install_name -Wl,"$lib_linkname" \
++			-Wl,-dylib_install_name -Wl,"$out/$lib_linkname" \
+ 			"$@" -L"$dest_dir/lib" $l_flags
+ 		;;

--- a/pkgs/by-name/ks/ksh93/package.nix
+++ b/pkgs/by-name/ks/ksh93/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromGitHub,
+  fixDarwinDylibNames,
+  lib,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ksh93";
+  version = "1.0.10";
+
+  src = fetchFromGitHub {
+    owner = "ksh93";
+    repo = "ksh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hrXW+PKQ6v0CCKiZ8E3HAEcrt9m4ZO5QfwFT9rCgbxc=";
+  };
+
+  patches = [
+    ./darwin-install-names.patch
+  ];
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ./bin/package make
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    ./bin/package test
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ./bin/package install $out
+    runHook postInstall
+  '';
+
+  passthru = {
+    shellPath = "/bin/ksh";
+  };
+
+  meta = {
+    description = "KornShell 93u+m";
+    branch = "1.0";
+    homepage = "https://github.com/ksh93/ksh";
+    downloadPage = "https://github.com/ksh93/ksh";
+    changelog = "https://github.com/ksh93/ksh/blob/${finalAttrs.src.tag}/NEWS";
+    license = lib.licenses.epl20;
+    maintainers = with lib.maintainers; [ prince213 ];
+    mainProgram = "ksh";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
This simply adds the package, it does not affect stdenv (yet).

Closes https://github.com/NixOS/nixpkgs/issues/453415.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
