### PR TITLE
boringssl: refactor, add maintainers

### DIFF
--- a/pkgs/by-name/bo/boringssl/package.nix
+++ b/pkgs/by-name/bo/boringssl/package.nix
@@ -6,6 +6,7 @@
   ninja,
   perl,
   buildGoModule,
+  gitUpdater,
 }:
 
 # reference: https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20250818.0/BUILDING.md
@@ -80,6 +81,8 @@ buildGoModule (finalAttrs: {
     "bin"
     "dev"
   ];
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Free TLS/SSL implementation";

--- a/pkgs/by-name/bo/boringssl/package.nix
+++ b/pkgs/by-name/bo/boringssl/package.nix
@@ -90,7 +90,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://boringssl.googlesource.com";
     maintainers = [ lib.maintainers.thoughtpolice ];
     license = with lib.licenses; [
-      openssl
+      asl20
       isc
       mit
       bsd3

--- a/pkgs/by-name/bo/boringssl/package.nix
+++ b/pkgs/by-name/bo/boringssl/package.nix
@@ -52,7 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Free TLS/SSL implementation";
     mainProgram = "bssl";
     homepage = "https://boringssl.googlesource.com";
-    maintainers = [ lib.maintainers.thoughtpolice ];
+    maintainers = with lib.maintainers; [
+      thoughtpolice
+      theoparis
+      niklaskorz
+    ];
     license = with lib.licenses; [
       asl20
       isc

--- a/pkgs/by-name/bo/boringssl/package.nix
+++ b/pkgs/by-name/bo/boringssl/package.nix
@@ -5,12 +5,11 @@
   cmake,
   ninja,
   perl,
-  buildGoModule,
   gitUpdater,
 }:
 
 # reference: https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20250818.0/BUILDING.md
-buildGoModule (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "boringssl";
   version = "0.20251002.0";
 
@@ -31,18 +30,6 @@ buildGoModule (finalAttrs: {
     perl
   ];
 
-  vendorHash = "sha256-IXmnoCYLoiQ/XL2wjksRFv5Kwsje0VNkcupgGxG6rSY=";
-  proxyVendor = true;
-
-  # hack to get both go and cmake configure phase
-  # (if we use postConfigure then cmake will loop runHook postConfigure)
-  preBuild = ''
-    cmakeConfigurePhase
-  ''
-  + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    export GOARCH=$(go env GOHOSTARCH)
-  '';
-
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals stdenv.cc.isGNU [
       # Needed with GCC 12 but breaks on darwin (with clang)
@@ -52,29 +39,6 @@ buildGoModule (finalAttrs: {
       "-Wno-error=character-conversion"
     ]
   );
-
-  buildPhase = ''
-    ninjaBuildPhase
-  '';
-
-  # CMAKE_OSX_ARCHITECTURES is set to x86_64 by Nix, but it confuses boringssl on aarch64-linux.
-  cmakeFlags = [
-    "-GNinja"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ "-DCMAKE_OSX_ARCHITECTURES=" ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $bin/bin $dev $out/lib
-
-    install -Dm755 bssl -t $bin/bin
-    install -Dm644 {libcrypto,libdecrepit,libpki,libssl}.a -t $out/lib
-
-    cp -r ../include $dev
-
-    runHook postInstall
-  '';
 
   outputs = [
     "out"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Supersedes #393230, #447429, #448952
- Partially based on #393230 (and credited accordingly through Co-Authored-By)
- ~~Marked primp as vulnerable until there is a decision on whether to drop it entirely, as it's unlikely that the patches for boring2 will be rebased on recent versions of boringssl (but I still fixed its build to be compatible to the refactoring)~~ Primp has been dropped in #453960
- Added myself as well as @theoparis as maintainers (as wished in the original PR, let me know if this is still up to date)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
