### PR TITLE
traverso: 0.49.6 -> 0-unstable-2024-09-28

### DIFF
--- a/pkgs/by-name/tr/traverso/package.nix
+++ b/pkgs/by-name/tr/traverso/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchgit,
   cmake,
   pkg-config,
   alsa-lib,
@@ -15,24 +15,26 @@
   libsndfile,
   libvorbis,
   portaudio,
+  qt6,
   wavpack,
-  libsForQt5,
 }:
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "traverso";
-  version = "0.49.6";
+  version = "0-unstable-2024-09-28";
 
-  src = fetchurl {
-    url = "https://traverso-daw.org/traverso-${finalAttrs.version}.tar.gz";
-    sha256 = "12f7x8kw4fw1j0xkwjrp54cy4cv1ql0zwz2ba5arclk4pf6bhl7q";
+  src = fetchgit {
+    url = "https://git.savannah.nongnu.org/git/traverso.git";
+    rev = "f34717623a8d19dd7c04d9604ef4468734140abc";
+    hash = "sha256-eobQFJohndwQjXRXBAehkTWS9jR/1bQOjrOF1XJN5L4=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
-
   buildInputs = [
     alsa-lib
     fftw
@@ -45,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile.dev
     libvorbis
     portaudio
-    libsForQt5.qtbase
+    qt6.qtbase
     wavpack
   ];
 
@@ -56,17 +58,16 @@ stdenv.mkDerivation (finalAttrs: {
     "-DWANT_LV2=0"
   ];
 
-  hardeningDisable = [ "format" ];
-
   meta = {
     description = "Cross-platform multitrack audio recording and audio editing suite";
     mainProgram = "traverso";
-    homepage = "https://traverso-daw.org/";
+    homepage = "https://savannah.nongnu.org/projects/traverso";
     license = with lib.licenses; [
       gpl2Plus
       lgpl21Plus
     ];
     platforms = lib.platforms.all;
+    broken = stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAarch64;
     maintainers = with lib.maintainers; [ coconnor ];
   };
-})
+}


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

Moved to pkgs/by-name and updated to latest unstable version, switched to git since old website doesn't exist anymore.
<img width="1492" height="1214" alt="Screenshot_20251020_124104" src="https://github.com/user-attachments/assets/2a25e088-567c-47da-880a-c38bdc13e3f7" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
