### PR TITLE
ob-xf: init at 0-unstable-2025-11-17

### DIFF
--- a/pkgs/by-name/ob/ob-xf/0001-juce-formats.diff
+++ b/pkgs/by-name/ob/ob-xf/0001-juce-formats.diff
@@ -1,0 +1,17 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,14 +89,6 @@ add_compile_definitions(JUCE_USE_CURL=0)
+
+ list(APPEND OBXF_JUCE_FORMATS VST3 Standalone)
+
+-if(APPLE)
+-    list(APPEND OBXF_JUCE_FORMATS AU)
+-endif()
+-
+-if(UNIX AND NOT APPLE)
+-    list(APPEND OBXF_JUCE_FORMATS LV2)
+-endif()
+-
+ juce_add_plugin(OB-Xf
+     COMPANY_NAME "Surge Synth Team"
+     BUNDLE_ID "org.surge-synth-team.OB-Xf"

--- a/pkgs/by-name/ob/ob-xf/0002-disable-clap.diff
+++ b/pkgs/by-name/ob/ob-xf/0002-disable-clap.diff
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2fb354a..3fb84e3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -180,10 +180,6 @@ else()
+     endif()
+ endif()
+ 
+-clap_juce_extensions_plugin(TARGET OB-Xf
+-    CLAP_ID "org.surge-synth-team.OB-Xf"
+-    CLAP_FEATURES instrument synthesizer "virtual analog" analog)
+-
+ target_compile_definitions(OB-Xf PRIVATE)
+ 
+ add_subdirectory(assets)

--- a/pkgs/by-name/ob/ob-xf/package.nix
+++ b/pkgs/by-name/ob/ob-xf/package.nix
@@ -1,0 +1,168 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+  alsa-lib,
+  libx11,
+  libxcursor,
+  libxrandr,
+  libxinerama,
+  libxext,
+  freetype,
+  fontconfig,
+  expat,
+
+  buildVST3 ? true,
+  buildCLAP ? true,
+  buildStandalone ? true,
+  buildLV2 ? stdenv.targetPlatform.isLinux,
+
+  supplyAssets ? true,
+  ...
+}:
+let
+  inherit (lib) optional optionalString strings;
+
+  versionDay = 16;
+  date = "2025-11-${toString versionDay}";
+  fakeVersion = "0.8.${toString (versionDay + 1)}";
+
+  juceFormats = strings.join " " [
+    (optionalString buildVST3 "VST3")
+    (optionalString buildStandalone "Standalone")
+    (optionalString buildLV2 "LV2")
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ob-xf";
+  version = "0-unstable-${date}";
+
+  src = fetchFromGitHub {
+    owner = "surge-synthesizer";
+    repo = "OB-Xf";
+    tag = "ReWork";
+    hash = "sha256-RwN40PEGWcwn0IwaFYu2VFpOgRUWt2utsHO6y0nbdr4=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    ./0001-juce-formats.diff
+  ]
+  ++ optional (!buildCLAP) ./0002-disable-clap.diff;
+
+  postPatch = ''
+    # Bypass versioning logic that relies on current date
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '0.''${PART0}.''${PART1}' "${fakeVersion}"
+
+    # Ignore warnings
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "-Werror" "-Wno-error"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "list(APPEND OBXF_JUCE_FORMATS VST3 Standalone)" \
+                     "list(APPEND OBXF_JUCE_FORMATS ${juceFormats})"
+
+    cat > BUILD_VERSION << EOF
+    SST_VERSION_INFO
+    ${finalAttrs.src.rev}
+    -no-tag-
+    main
+    Nightly-${date}
+    EOF
+  '';
+
+  cmakeFlags = [
+    "-DDISPLAY_VERSION=${fakeVersion}"
+    "-DCOMMIT_HASH=${finalAttrs.src.rev}"
+    "-DBRANCH=main"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libx11
+    libxcursor
+    libxrandr
+    libxinerama
+    libxext
+    freetype
+    fontconfig
+    expat
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+    cmake -B Builds/Release -DCMAKE_BUILD_TYPE=Release .
+    runHook postConfigure
+  '';
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  buildPhase = ''
+    runHook preBuild
+    cmake --build Builds/Release --config Release --target obxf-staged
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd Builds/Release/obxf_products
+      ${optionalString buildStandalone ''
+        mkdir -p $out/bin
+        install -Dm755 OB-Xf -t $out/bin
+      ''}
+
+      ${optionalString buildCLAP ''
+        mkdir -p $out/lib/clap
+        install -Dm755 OB-Xf.clap -t $out/lib/clap
+      ''}
+
+      ${optionalString buildVST3 ''
+        mkdir -p $out/lib/vst3
+        cp -r OB-Xf.vst3 $out/lib/vst3
+      ''}
+
+      ${optionalString buildLV2 ''
+        mkdir -p $out/lib/lv2
+        cp -r OB-Xf.lv2 $out/lib/lv2
+      ''}
+    popd
+
+    ${optionalString supplyAssets ''
+      mkdir -p $out/share
+      cp -r "assets/installer/Surge Synth Team" $out/share/
+    ''}
+
+    runHook postInstall
+  '';
+
+  # TODO: enable auto-updates when OB-Xf is no longer in beta state
+  # passthru.updateScript = nix-update-script { };
+
+  # Needed for standalone
+  NIX_LDFLAGS = [
+    "-lX11"
+  ];
+
+  meta = {
+    description = "Continuation of the last open source version of OB-Xd";
+    homepage = "https://github.com/surge-synthesizer/OB-Xf";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.mrtnvgr ];
+  }
+  // lib.optionalAttrs buildStandalone {
+    mainProgram = "OB-Xf";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
