### PR TITLE
python3Packages.docling-parse: mark as broken

### DIFF
--- a/pkgs/development/python-modules/docling-parse/default.nix
+++ b/pkgs/development/python-modules/docling-parse/default.nix
@@ -102,5 +102,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/DS4SD/docling-parse";
     license = lib.licenses.mit;
     maintainers = [ ];
+    # error: no matching conversion for functional-style cast from 'bool' to 'nlohmann::basic_json<>'
+    # See https://github.com/docling-project/docling-parse/issues/172 for context
+    broken = true;
   };
 }


### PR DESCRIPTION
## Things done

```
/nix/store/5ibw2ya5h690yv3qs378x97q3ri7zjgg-nlohmann_json-3.12.0/include/nlohmann/detail/input/json_sax.hpp:832:22: error: no matching conversion for functional-style cast from 'bool' to 'nlohmann::basic_json<>'
  832 |         auto value = BasicJsonType(std::forward<Value>(v));
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

See https://github.com/docling-project/docling-parse/issues/172 for context.

cc @sarahec


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
