### PR TITLE
[Backport release-25.05] dprint-plugins.dprint-plugin-json: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-json.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-json.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "JSON/JSONC code formatter.";
-  hash = "sha256-uFcFLi9aYsBrAqkhFmg9GI+LKiV19LxdNjxQ85EH9To=";
+  description = "JSON/JSONC code formatter";
+  hash = "sha256-GIoIkW7szyQU4GyLUdj0TTaV8FWg1jzvOerOChHiR7w=";
   initConfig = {
     configExcludes = [ "**/*-lock.json" ];
     configKey = "json";
@@ -9,6 +9,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-json";
   updateUrl = "https://plugins.dprint.dev/dprint/json/latest.json";
-  url = "https://plugins.dprint.dev/json-0.20.0.wasm";
-  version = "0.20.0";
+  url = "https://plugins.dprint.dev/json-0.21.0.wasm";
+  version = "0.21.0";
 }


### PR DESCRIPTION
Manual backport to `release-25.05`, for #453857.
* [x]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-10-05T08%3A53%3A44Z#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.

