### PR TITLE
dockerTools: Replace bashInteractive with bash

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -1186,7 +1186,7 @@ This is currently implemented by linking to the `env` binary from the `coreutils
 
 ### binSh {#sssec-pkgs-dockerTools-helpers-binSh}
 
-This provides a `/bin/sh` link to the `bash` binary from the `bashInteractive` package.
+This provides a `/bin/sh` link to the `bash` binary from the `bash` package.
 Because of this, it supports cases such as running a command interactively in a container (for example by running `docker container run -it <image_name>`).
 
 ### caCertificates {#sssec-pkgs-dockerTools-helpers-caCertificates}
@@ -1490,7 +1490,7 @@ The environment in the image doesn't match `nix-shell` or `nix-build` exactly, a
   This shell is started when running the image.
   This can be seen as an equivalent of the `NIX_BUILD_SHELL` [environment variable](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html#environment-variables) for {manpage}`nix-shell(1)`.
 
-  _Default value:_ the `bash` binary from the `bashInteractive` package.
+  _Default value:_ the `bash` binary from the `bash` package.
 
 `command` (String or Null; _optional_)
 

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -1,5 +1,5 @@
 {
-  bashInteractive,
+  bash,
   buildPackages,
   cacert,
   callPackage,
@@ -959,11 +959,11 @@ rec {
     ln -s ${coreutils}/bin/env $out/usr/bin
   '';
 
-  # This provides /bin/sh, pointing to bashInteractive.
-  # The use of bashInteractive here is intentional to support cases like `docker run -it <image_name>`, so keep these use cases in mind if making any changes to how this works.
+  # This provides /bin/sh, pointing to bash (interactive).
+  # The use of bash (interactive) here is intentional to support cases like `docker run -it <image_name>`, so keep these use cases in mind if making any changes to how this works.
   binSh = runCommand "bin-sh" { } ''
     mkdir -p $out/bin
-    ln -s ${bashInteractive}/bin/bash $out/bin/sh
+    ln -s ${bash}/bin/bash $out/bin/sh
   '';
 
   # This provides the ca bundle in common locations
@@ -1256,7 +1256,7 @@ rec {
       #
       # https://github.com/NixOS/nix/issues/6379
       homeDirectory ? "/build",
-      shell ? bashInteractive + "/bin/bash",
+      shell ? bash + "/bin/bash",
       command ? null,
       run ? null,
     }:

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -88,7 +88,7 @@ rec {
     tag = "latest";
     copyToRoot = pkgs.buildEnv {
       name = "image-root";
-      paths = [ pkgs.bashInteractive ];
+      paths = [ pkgs.bash ];
       pathsToLink = [ "/bin" ];
     };
   };
@@ -541,7 +541,7 @@ rec {
     tag = "latest";
     compressor = "none";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
-    copyToRoot = pkgs.bashInteractive;
+    copyToRoot = pkgs.bash;
   };
 
   bashZstdCompressed = pkgs.dockerTools.buildImage {
@@ -549,20 +549,20 @@ rec {
     tag = "latest";
     compressor = "zstd";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
-    copyToRoot = pkgs.bashInteractive;
+    copyToRoot = pkgs.bash;
   };
 
   # buildImage without explicit tag
   bashNoTag = pkgs.dockerTools.buildImage {
     name = "bash-no-tag";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
-    copyToRoot = pkgs.bashInteractive;
+    copyToRoot = pkgs.bash;
   };
 
   # buildLayeredImage without explicit tag
   bashNoTagLayered = pkgs.dockerTools.buildLayeredImage {
     name = "bash-no-tag-layered";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # buildLayeredImage without compression
@@ -570,7 +570,7 @@ rec {
     name = "bash-layered-uncompressed";
     tag = "latest";
     compressor = "none";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # buildLayeredImage with zstd compression
@@ -578,13 +578,13 @@ rec {
     name = "bash-layered-zstd";
     tag = "latest";
     compressor = "zstd";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # streamLayeredImage without explicit tag
   bashNoTagStreamLayered = pkgs.dockerTools.streamLayeredImage {
     name = "bash-no-tag-stream-layered";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # buildLayeredImage with non-root user
@@ -832,7 +832,7 @@ rec {
     tag = "latest";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
     copyToRoot = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -841,7 +841,7 @@ rec {
     name = "layered-image-with-path";
     tag = "latest";
     contents = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -852,7 +852,7 @@ rec {
     architecture = "arm64";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
     copyToRoot = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -862,7 +862,7 @@ rec {
     tag = "latest";
     architecture = "arm64";
     contents = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };


### PR DESCRIPTION
`bash` has been interactive by default since this [PR](https://github.com/NixOS/nixpkgs/pull/379368) was merged. This commit simplifies `dockerTools` given that there is now no distinction between `bash` and `bashInteractive`.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
