### PR TITLE
luaPackages.lux-lua: use toLuaModule

### DIFF
--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -12,82 +12,84 @@
   perl,
   pkg-config,
   rustPlatform,
-  toLuaModule
+  toLuaModule,
 }:
 let
   luaMajorMinor = lib.take 2 (lib.splitVersion lua.version);
   luaVersionDir = if isLuaJIT then "jit" else lib.concatStringsSep "." luaMajorMinor;
   luaFeature = if isLuaJIT then "luajit" else "lua${lib.concatStringsSep "" luaMajorMinor}";
 in
-toLuaModule (rustPlatform.buildRustPackage rec {
-  pname = "lux-lua";
+toLuaModule (
+  rustPlatform.buildRustPackage rec {
+    pname = "lux-lua";
 
-  version = lux-cli.version;
+    version = lux-cli.version;
 
-  src = lux-cli.src;
+    src = lux-cli.src;
 
-  buildAndTestSubdir = "lux-lua";
-  buildNoDefaultFeatures = true;
-  buildFeatures = [ luaFeature ];
+    buildAndTestSubdir = "lux-lua";
+    buildNoDefaultFeatures = true;
+    buildFeatures = [ luaFeature ];
 
-  cargoHash = lux-cli.cargoHash;
+    cargoHash = lux-cli.cargoHash;
 
-  nativeBuildInputs = [
-    perl
-    pkg-config
-  ];
-
-  buildInputs = [
-    gnupg
-    gpgme
-    libgit2
-    libgpg-error
-    openssl
-  ];
-
-  propagatedBuildInputs = [
-    lua
-  ];
-
-  doCheck = false; # lux-lua tests are broken in nixpkgs
-  useNextest = true;
-  nativeCheckInputs = [
-    lua
-    nix
-  ];
-
-  env = {
-    LIBGIT2_NO_VENDOR = 1;
-    LIBSSH2_SYS_USE_PKG_CONFIG = 1;
-    LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
-  };
-
-  buildPhase = ''
-    runHook preBuild
-    cargo xtask-${luaFeature} dist
-    mkdir -p $out
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    cp -r target/dist/share $out
-    cp -r target/dist/lib $out
-    mkdir -p $out/lib/lua
-    ln -s $out/share/lux-lua/${luaVersionDir} $out/lib/lua/${luaVersionDir}
-    runHook postInstall
-  '';
-
-  cargoTestFlags = "--lib"; # Disable impure integration tests
-
-  meta = {
-    description = "Lua API for the Lux package manager";
-    homepage = "https://lux.lumen-labs.org/";
-    changelog = "https://github.com/lumen-oss/lux/blob/${src.tag}/CHANGELOG.md";
-    license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [
-      mrcjkb
+    nativeBuildInputs = [
+      perl
+      pkg-config
     ];
-    platforms = lib.platforms.all;
-  };
-})
+
+    buildInputs = [
+      gnupg
+      gpgme
+      libgit2
+      libgpg-error
+      openssl
+    ];
+
+    propagatedBuildInputs = [
+      lua
+    ];
+
+    doCheck = false; # lux-lua tests are broken in nixpkgs
+    useNextest = true;
+    nativeCheckInputs = [
+      lua
+      nix
+    ];
+
+    env = {
+      LIBGIT2_NO_VENDOR = 1;
+      LIBSSH2_SYS_USE_PKG_CONFIG = 1;
+      LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      cargo xtask-${luaFeature} dist
+      mkdir -p $out
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r target/dist/share $out
+      cp -r target/dist/lib $out
+      mkdir -p $out/lib/lua
+      ln -s $out/share/lux-lua/${luaVersionDir} $out/lib/lua/${luaVersionDir}
+      runHook postInstall
+    '';
+
+    cargoTestFlags = "--lib"; # Disable impure integration tests
+
+    meta = {
+      description = "Lua API for the Lux package manager";
+      homepage = "https://lux.lumen-labs.org/";
+      changelog = "https://github.com/lumen-oss/lux/blob/${src.tag}/CHANGELOG.md";
+      license = lib.licenses.lgpl3Plus;
+      maintainers = with lib.maintainers; [
+        mrcjkb
+      ];
+      platforms = lib.platforms.all;
+    };
+  }
+)

--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -12,13 +12,14 @@
   perl,
   pkg-config,
   rustPlatform,
+  toLuaModule
 }:
 let
   luaMajorMinor = lib.take 2 (lib.splitVersion lua.version);
   luaVersionDir = if isLuaJIT then "jit" else lib.concatStringsSep "." luaMajorMinor;
   luaFeature = if isLuaJIT then "luajit" else "lua${lib.concatStringsSep "" luaMajorMinor}";
 in
-rustPlatform.buildRustPackage rec {
+toLuaModule (rustPlatform.buildRustPackage rec {
   pname = "lux-lua";
 
   version = lux-cli.version;
@@ -89,4 +90,4 @@ rustPlatform.buildRustPackage rec {
     ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #452815.

Lua  packages that aren't built using either `buildLuarocksPackage` or `buildLuaPackage` have to apply `toLuaModule`, otherwise the Lua modules won't be added in `buildEnv` (when calling `lua.withPackages`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
