### PR TITLE
dockerTools: Refactor common writing code into writeImageStream

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -102,6 +102,9 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-dockerTools-writeImageStream-streamNixShellImage": [
+    "index.html#ex-dockerTools-writeImageStream-streamNixShellImage"
+  ],
   "ex-pkgs-replace-vars": [
     "index.html#ex-pkgs-replace-vars",
     "index.html#ex-pkgs-substituteAll",
@@ -670,6 +673,18 @@
   ],
   "ssec-cosmic-settings-fallback": [
     "index.html#ssec-cosmic-settings-fallback"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-examples": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-examples"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-inputs": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-inputs"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-passthru-outputs": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-passthru-outputs"
   ],
   "ssec-stdenv-dependencies": [
     "index.html#ssec-stdenv-dependencies"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -114,6 +114,9 @@
   "ex-build-helpers-extendMkDerivation-transformDrv-wrapper": [
     "index.html#ex-build-helpers-extendMkDerivation-transformDrv-wrapper"
   ],
+  "ex-dockerTools-writeImageStream-streamNixShellImage": [
+    "index.html#ex-dockerTools-writeImageStream-streamNixShellImage"
+  ],
   "ex-first-package-go": [
     "index.html#ex-first-package-go"
   ],
@@ -902,6 +905,18 @@
   ],
   "ssec-cosmic-settings-fallback": [
     "index.html#ssec-cosmic-settings-fallback"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-examples": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-examples"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-inputs": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-inputs"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-passthru-outputs": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-passthru-outputs"
   ],
   "ssec-stdenv-dependencies": [
     "index.html#ssec-stdenv-dependencies"

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -575,6 +575,10 @@ rec {
       '';
     };
 
+  # Wrapper around `streamLayeredImage` to build an image from the result.
+  #
+  # To support image stream overrides, use `streamLayeredImage` with
+  # `writeImageStream` instead.
   buildLayeredImage = lib.makeOverridable (
     {
       name,
@@ -582,24 +586,15 @@ rec {
       meta ? { },
       ...
     }@args:
-    let
+    writeImageStream {
+      inherit compressor meta name;
       stream = streamLayeredImage (
         removeAttrs args [
           "compressor"
           "meta"
         ]
       );
-      compress = compressorForImage compressor name;
-    in
-    runCommand "${baseNameOf name}.tar${compress.ext}" {
-      inherit (stream) imageName;
-      passthru = stream.passthru // {
-        inherit (stream) imageTag;
-        inherit stream;
-      };
-      nativeBuildInputs = compress.nativeInputs;
-      inherit meta;
-    } "${stream} | ${compress.compress} > $out"
+    }
   );
 
   # 1. extract the base image
@@ -1428,6 +1423,9 @@ rec {
 
   # Wrapper around `streamNixShellImage` to build an image from the result.
   #
+  # To support image stream overrides, use `streamNixShellImage` with
+  # `writeImageStream` instead.
+  #
   # Docs: doc/build-helpers/images/dockertools.section.md
   # Tests: nixos/tests/docker-tools-nix-shell.nix
   buildNixShellImage =
@@ -1436,13 +1434,32 @@ rec {
       compressor ? "gz",
       ...
     }@args:
-    let
+    writeImageStream {
+      inherit compressor;
+      name = drv.name;
       stream = streamNixShellImage (removeAttrs args [ "compressor" ]);
-      compress = compressorForImage compressor drv.name;
+    };
+
+  # Writes out an image tarball stream with optional compression.
+  #
+  # Docs: doc/build-helpers/images/dockertools.section.md
+  writeImageStream =
+    {
+      name,
+      stream,
+      compressor ? "gz",
+      meta ? { },
+    }:
+    let
+      compress = compressorForImage compressor stream.name;
     in
-    runCommand "${drv.name}-env.tar${compress.ext}" {
+    runCommand "${baseNameOf name}.tar${compress.ext}" {
       inherit (stream) imageName;
-      passthru = { inherit (stream) imageTag; };
+      passthru = stream.passthru // {
+        inherit (stream) imageTag;
+        inherit stream;
+      };
       nativeBuildInputs = compress.nativeInputs;
+      inherit meta;
     } "${stream} | ${compress.compress} > $out";
 }


### PR DESCRIPTION
Previously, the `buildLayeredImage` and `buildNixShellImage` functions
duplicated image compression functionality that was used to store the
output of `streamLayeredImage` and `streamNixShellImage`.
    
This patch factors out the common code into a combined function:
`writeImageStream`.
    
Doing this also makes it far more practical to customize and override
the behaviour of `streamLayeredImage` and `streamNixShellImage`, because
`buildLayeredImage` and `buildNixShellImage` formed an opaque wrapping
around the stream functions.
    
Therefore, this patch deprecates `buildLayeredImage` and
`buildNixShellImage`, and encourages users to write images by combining
one of the stream functions with `writeImageStream`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
