### PR TITLE
dprint-plugins: update all plugins

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-dockerfile.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-dockerfile.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "Dockerfile code formatter";
-  hash = "sha256-gsfMLa4zw8AblOS459ZS9OZrkGCQi5gBN+a3hvOsspk=";
+  hash = "sha256-GaK1sYdZPwQWJmz2ULcsGpWDiKjgPhqNRoGgQfGOkqc=";
   initConfig = {
     configExcludes = [ ];
     configKey = "dockerfile";
@@ -9,6 +9,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-dockerfile";
   updateUrl = "https://plugins.dprint.dev/dprint/dockerfile/latest.json";
-  url = "https://plugins.dprint.dev/dockerfile-0.3.2.wasm";
-  version = "0.3.2";
+  url = "https://plugins.dprint.dev/dockerfile-0.3.3.wasm";
+  version = "0.3.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "Ruff (Python) wrapper plugin";
-  hash = "sha256-15InHQgF9c0Js4yUJxmZ1oNj1O16FBU12u/GOoaSAJ8=";
+  hash = "sha256-qT+6zPbX3KrONXshwzLoGTWRXM93VKO0lN9ycJujEDM=";
   initConfig = {
     configExcludes = [ ];
     configKey = "ruff";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-ruff";
   updateUrl = "https://plugins.dprint.dev/dprint/ruff/latest.json";
-  url = "https://plugins.dprint.dev/ruff-0.3.9.wasm";
-  version = "0.3.9";
+  url = "https://plugins.dprint.dev/ruff-0.6.1.wasm";
+  version = "0.6.1";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "CSS, SCSS, Sass and Less formatter";
-  hash = "sha256-mFlhfqtglKtKNls96PO/2AWLL1fNC5msQCd9EgdKauE=";
+  hash = "sha256-IAIix6c9/GNDZsRk95T/rpvMh7HqFgBoq5KDVYHHOjU=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "malva";
@@ -14,6 +14,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-malva";
   updateUrl = "https://plugins.dprint.dev/g-plane/malva/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/malva-v0.11.2.wasm";
-  version = "0.11.2";
+  url = "https://plugins.dprint.dev/g-plane/malva-v0.14.3.wasm";
+  version = "0.14.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento formatter";
-  hash = "sha256-fCvurr8f79io/jIjwCfwr/WGjvcKZtptRrx9GFfytSI=";
+  hash = "sha256-TQxHIw5IXZwFA/WzIJ33ZckJNkHwW67lnh0cCGkgmrs=";
   initConfig = {
     configExcludes = [ ];
     configKey = "markup";
@@ -19,6 +19,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-markup_fmt";
   updateUrl = "https://plugins.dprint.dev/g-plane/markup_fmt/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.19.0.wasm";
-  version = "0.19.0";
+  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.24.0.wasm";
+  version = "0.24.0";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_graphql.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_graphql.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "GraphQL formatter";
-  hash = "sha256-PlQwpR0tMsghMrOX7is+anN57t9xa9weNtoWpc0E9ec=";
+  hash = "sha256-xEEBnmxxiIPNOePBDS2HG6lfAhR4l53w+QDF2mXdyzg=";
   initConfig = {
     configExcludes = [ ];
     configKey = "graphql";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-pretty_graphql";
   updateUrl = "https://plugins.dprint.dev/g-plane/pretty_graphql/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.1.wasm";
-  version = "0.2.1";
+  url = "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.3.wasm";
+  version = "0.2.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "YAML formatter";
-  hash = "sha256-6ua021G7ZW7Ciwy/OHXTA1Joj9PGEx3SZGtvaA//gzo=";
+  hash = "sha256-iSh5SRrjQB1hJoKkkup7R+Durcu+cxePa7GDVjwnexU=";
   initConfig = {
     configExcludes = [ ];
     configKey = "yaml";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-pretty_yaml";
   updateUrl = "https://plugins.dprint.dev/g-plane/pretty_yaml/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm";
-  version = "0.5.0";
+  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm";
+  version = "0.5.1";
 }

--- a/pkgs/by-name/dp/dprint/plugins/update-plugins.py
+++ b/pkgs/by-name/dp/dprint/plugins/update-plugins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python -p nix 'python3.withPackages (pp: [ pp.requests ])'
+#!nix-shell -i python3 -p nix 'python3.withPackages (ps: [ ps.requests ])'
 
 import json
 import os
@@ -138,7 +138,7 @@ def update_plugins():
             "updateUrl": update_url,
             "pname": pname,
             "version": e["version"],
-            "description": e["description"],
+            "description": e["description"].rstrip("."),
             "initConfig": {
                 "configKey": e["configKey"],
                 "configExcludes": e["configExcludes"],


### PR DESCRIPTION
There was an issue with the update script preventing some packages from getting updated. Fixed it and updated all the plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
