### PR TITLE
ipopt: cleanup

### DIFF
--- a/pkgs/by-name/ip/ipopt/package.nix
+++ b/pkgs/by-name/ip/ipopt/package.nix
@@ -25,6 +25,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-85fUBMwQtG+RWQYk9YzdZYK3CYcDKgWroo4blhVWBzE=";
   };
 
+  outputs = [
+    "bin"
+    "dev"
+    "out"
+    "doc"
+  ];
+
   nativeBuildInputs = [
     pkg-config
     gfortran

--- a/pkgs/by-name/ip/ipopt/package.nix
+++ b/pkgs/by-name/ip/ipopt/package.nix
@@ -10,12 +10,12 @@
   libamplsolver,
   enableMUMPS ? true,
   mumps,
-  mpi,
   enableSPRAL ? true,
   spral,
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
+assert !mumps.mpiSupport;
 
 stdenv.mkDerivation rec {
   pname = "ipopt";
@@ -30,15 +30,13 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     lib.optionals enableAMPL [
-      "--with-asl-cflags=-I${libamplsolver}/include"
       "--with-asl-lflags=-lamplsolver"
     ]
     ++ lib.optionals enableMUMPS [
-      "--with-mumps-cflags=-I${mumps}/include"
+      "--with-mumps-cflags=-I${lib.getDev mumps}/include/mumps_seq"
       "--with-mumps-lflags=-ldmumps"
     ]
     ++ lib.optionals enableSPRAL [
-      "--with-spral-cflags=-I${spral}/include"
       "--with-spral-lflags=-lspral"
     ];
 
@@ -51,10 +49,7 @@ stdenv.mkDerivation rec {
     lapack
   ]
   ++ lib.optionals enableAMPL [ libamplsolver ]
-  ++ lib.optionals enableMUMPS [
-    mumps
-    mpi
-  ]
+  ++ lib.optionals enableMUMPS [ mumps ]
   ++ lib.optionals enableSPRAL [ spral ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ip/ipopt/package.nix
+++ b/pkgs/by-name/ip/ipopt/package.nix
@@ -6,12 +6,9 @@
   blas,
   lapack,
   gfortran,
-  enableAMPL ? true,
-  libamplsolver,
-  enableMUMPS ? true,
   mumps,
-  enableSPRAL ? true,
   spral,
+  libamplsolver,
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
@@ -28,29 +25,25 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-85fUBMwQtG+RWQYk9YzdZYK3CYcDKgWroo4blhVWBzE=";
   };
 
-  configureFlags =
-    lib.optionals enableAMPL [
-      "--with-asl-lflags=-lamplsolver"
-    ]
-    ++ lib.optionals enableMUMPS [
-      "--with-mumps-cflags=-I${lib.getDev mumps}/include/mumps_seq"
-      "--with-mumps-lflags=-ldmumps"
-    ]
-    ++ lib.optionals enableSPRAL [
-      "--with-spral-lflags=-lspral"
-    ];
-
   nativeBuildInputs = [
     pkg-config
     gfortran
   ];
+
   buildInputs = [
     blas
     lapack
-  ]
-  ++ lib.optionals enableAMPL [ libamplsolver ]
-  ++ lib.optionals enableMUMPS [ mumps ]
-  ++ lib.optionals enableSPRAL [ spral ];
+    mumps
+    spral
+    libamplsolver
+  ];
+
+  configureFlags = [
+    "--with-mumps-cflags=-I${lib.getDev mumps}/include/mumps_seq"
+    "--with-mumps-lflags=-ldmumps"
+    "--with-spral-lflags=-lspral"
+    "--with-asl-lflags=-lamplsolver"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ip/ipopt/package.nix
+++ b/pkgs/by-name/ip/ipopt/package.nix
@@ -28,12 +28,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-85fUBMwQtG+RWQYk9YzdZYK3CYcDKgWroo4blhVWBzE=";
   };
 
-  CXXDEFS = [
-    "-DHAVE_RAND"
-    "-DHAVE_CSTRING"
-    "-DHAVE_CSTDIO"
-  ];
-
   configureFlags =
     lib.optionals enableAMPL [
       "--with-asl-cflags=-I${libamplsolver}/include"

--- a/pkgs/by-name/ip/ipopt/package.nix
+++ b/pkgs/by-name/ip/ipopt/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Software package for large-scale nonlinear optimization";
     homepage = "https://projects.coin-or.org/Ipopt";
-    license = lib.licenses.epl10;
+    license = lib.licenses.epl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       nim65s


### PR DESCRIPTION
1. remove CXXDEFS (one can valid the outputs hash unchanged by running nix develop && genericBuild && nix hash path $out)
2. remove enable* flags
3. use mpi.h provided by mumps-seq
4. license: epl10 -> epl20
5. split outputs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
