### PR TITLE
hunspellDicts: Clean up package set, use fixed-point helpers (finalAttrs)

### DIFF
--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -64,16 +64,16 @@ let
         rev = "v${version}";
         sha256 = "sha256-oGnxOGHzDogzUMZESydIxRTbq9Dmd03flwHx16AK1yk=";
       };
-      meta = with lib; {
+      meta = {
         description = "Hunspell dictionary for ${shortDescription} from rla";
         homepage = "https://github.com/sbosio/rla-es";
-        license = with licenses; [
+        license = with lib.licenses; [
           gpl3
           lgpl3
           mpl11
         ];
-        maintainers = with maintainers; [ renzo ];
-        platforms = platforms.all;
+        maintainers = with lib.maintainers; [ renzo ];
+        platforms = lib.platforms.all;
       };
       nativeBuildInputs = [
         bash
@@ -116,15 +116,15 @@ let
         url = "https://extensions.libreoffice.org/extensions/swedish-spelling-dictionary-den-stora-svenska-ordlistan/${version}/@@download/file/${_name}.oxt";
         sha256 = "b982881cc75f5c4af1199535bd4735ee476bdc48edf63e3f05fb4f715654a7bc";
       };
-      meta = with lib; {
+      meta = {
         longDescription = ''
           Svensk ordlista baserad på DSSO (den stora svenska ordlistan) och Göran
           Anderssons (goran@init.se) arbete med denna. Ordlistan hämtas från
           LibreOffice då dsso.se inte längre verkar vara med oss.
         '';
         description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
-        license = licenses.lgpl3;
-        platforms = platforms.all;
+        license = lib.licenses.lgpl3;
+        platforms = lib.platforms.all;
       };
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
@@ -163,13 +163,13 @@ let
         url = "http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip";
         sha256 = "0ca7084jm7zb1ikwzh1frvpb97jn27i7a5d48288h2qlfp068ik0";
       };
-      meta = with lib; {
+      meta = {
         inherit longDescription;
         description = "Hunspell dictionary for ${shortDescription} from Dicollecte";
         homepage = "https://www.dicollecte.org/home.php?prj=fr";
-        license = licenses.mpl20;
-        maintainers = with maintainers; [ renzo ];
-        platforms = platforms.all;
+        license = lib.licenses.mpl20;
+        maintainers = with lib.maintainers; [ renzo ];
+        platforms = lib.platforms.all;
       };
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
@@ -198,12 +198,12 @@ let
       pname = "hunspell-dict-${shortName}-wordlist";
       srcReadmeFile = "README_" + srcFileName + ".txt";
       readmeFile = "README_" + dictFileName + ".txt";
-      meta = with lib; {
+      meta = {
         description = "Hunspell dictionary for ${shortDescription} from Wordlist";
         homepage = "http://wordlist.aspell.net/";
-        license = licenses.bsd3;
-        maintainers = with maintainers; [ renzo ];
-        platforms = platforms.all;
+        license = lib.licenses.bsd3;
+        maintainers = with lib.maintainers; [ renzo ];
+        platforms = lib.platforms.all;
       };
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
@@ -229,12 +229,12 @@ let
       version = "2.4";
       pname = "hunspell-dict-${shortName}-linguistico";
       readmeFile = dictFileName + "_README.txt";
-      meta = with lib; {
+      meta = {
         description = "Hunspell dictionary for ${shortDescription}";
         homepage = "https://sourceforge.net/projects/linguistico/";
-        license = licenses.gpl3;
-        maintainers = with maintainers; [ renzo ];
-        platforms = platforms.all;
+        license = lib.licenses.gpl3;
+        maintainers = with lib.maintainers; [ renzo ];
+        platforms = lib.platforms.all;
       };
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
@@ -275,13 +275,13 @@ let
         ln -sv "$out/share/hunspell/${dictFileName}.aff" "$out/share/myspell/dicts/"
       '';
 
-      meta = with lib; {
+      meta = {
         homepage = "https://xuxen.eus/";
         description = shortDescription;
         longDescription = longDescription;
-        license = licenses.gpl2;
-        maintainers = with maintainers; [ zalakain ];
-        platforms = platforms.all;
+        license = lib.licenses.gpl2;
+        maintainers = with lib.maintainers; [ zalakain ];
+        platforms = lib.platforms.all;
       };
     };
 
@@ -321,15 +321,15 @@ let
         ln -sv "$out/share/hunspell/${dictFileName}.aff" "$out/share/myspell/dicts/"
       '';
 
-      meta = with lib; {
+      meta = {
         homepage = "https://www.j3e.de/ispell/igerman98/index_en.html";
         description = shortDescription;
-        license = with licenses; [
+        license = with lib.licenses; [
           gpl2
           gpl3
         ];
-        maintainers = with maintainers; [ timor ];
-        platforms = platforms.all;
+        maintainers = with lib.maintainers; [ timor ];
+        platforms = lib.platforms.all;
       };
     };
 
@@ -355,12 +355,12 @@ let
       buildPhase = ''
         cp -a ${sourceRoot}/* .
       '';
-      meta = with lib; {
+      meta = {
         homepage = "https://wiki.documentfoundation.org/Development/Dictionaries";
         description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
         license = license;
-        maintainers = with maintainers; [ vlaci ];
-        platforms = platforms.all;
+        maintainers = with lib.maintainers; [ vlaci ];
+        platforms = lib.platforms.all;
       };
     };
 
@@ -812,12 +812,12 @@ rec {
       unzip $src ${dictFileName}/{${dictFileName}.dic,${dictFileName}.aff,${readmeFile}}
     '';
 
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Ukrainian (Ukraine) from LibreOffice";
       homepage = "https://extensions.libreoffice.org/extensions/ukrainian-spelling-dictionary-and-thesaurus/";
-      license = licenses.mpl20;
-      maintainers = with maintainers; [ dywedir ];
-      platforms = platforms.all;
+      license = lib.licenses.mpl20;
+      maintainers = with lib.maintainers; [ dywedir ];
+      platforms = lib.platforms.all;
     };
   };
 
@@ -908,7 +908,7 @@ rec {
       unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile} -d ${dictFileName}
     '';
 
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Danish (Denmark) from Stavekontrolden";
       homepage = "https://github.com/jeppebundsgaard/stavekontrolden";
       license = with lib.licenses; [
@@ -916,7 +916,7 @@ rec {
         lgpl21Only
         mpl11
       ];
-      maintainers = with maintainers; [ louisdk1 ];
+      maintainers = with lib.maintainers; [ louisdk1 ];
     };
   };
 
@@ -942,14 +942,14 @@ rec {
     dictFileName = "nl_NL";
     readmeFile = "README.md";
 
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Dutch (Netherlands) from OpenTaal";
       homepage = "https://www.opentaal.org/";
-      license = with licenses; [
+      license = with lib.licenses; [
         bsd3 # or
         cc-by-30
       ];
-      maintainers = with maintainers; [ artturin ];
+      maintainers = with lib.maintainers; [ artturin ];
     };
   };
 
@@ -978,12 +978,12 @@ rec {
       rev = "419eb32115b936da9c949e35b35c29b8187f6c93";
       sha256 = "sha256-aXjof5dcEoCmep3PtvVkBhcgcd2NtqUpUEu37wsi1Uk=";
     };
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Central Thai (Thailand)";
       homepage = "https://github.com/SyafiqHadzir/Hunspell-TH";
-      license = with licenses; [ gpl3 ];
-      maintainers = with maintainers; [ toastal ]; # looking for a native speaker
-      platforms = platforms.all;
+      license = with lib.licenses; [ gpl3 ];
+      maintainers = with lib.maintainers; [ toastal ]; # looking for a native speaker
+      platforms = lib.platforms.all;
     };
   };
 
@@ -1054,7 +1054,7 @@ rec {
 
     dontBuild = true;
 
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Toki Pona";
       homepage = "https://github.com/somasis/hunspell-tok";
       license = with lib.licenses; [
@@ -1063,8 +1063,8 @@ rec {
         cc-by-sa-30
         cc-by-sa-40
       ];
-      maintainers = with maintainers; [ somasis ];
-      platforms = platforms.all;
+      maintainers = with lib.maintainers; [ somasis ];
+      platforms = lib.platforms.all;
     };
   };
 
@@ -1134,12 +1134,12 @@ rec {
       sed -i 's/^\(## *File Version[^,]*\),.*/\1/' fa-IR.aff
       runHook postBuild
     '';
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Persian (Iran)";
       homepage = "https://github.com/b00f/lilak";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ nix-julia ];
-      platforms = platforms.all;
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ nix-julia ];
+      platforms = lib.platforms.all;
     };
   };
 
@@ -1188,12 +1188,12 @@ rec {
     dictFileName = "tr_TR";
     readmeFile = "README.md";
 
-    meta = with lib; {
+    meta = {
       description = "Hunspell dictionary for Turkish (Turkey) from tdd-ai";
       homepage = "https://github.com/tdd-ai/hunspell-tr/";
-      license = licenses.mpl20;
-      maintainers = with maintainers; [ samemrecebi ];
-      platforms = platforms.all;
+      license = lib.licenses.mpl20;
+      maintainers = with lib.maintainers; [ samemrecebi ];
+      platforms = lib.platforms.all;
     };
   };
 

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -299,40 +299,48 @@ let
       };
   };
 
-  mkDictFromLinguistico =
-    {
-      shortName,
-      shortDescription,
-      dictFileName,
-      src,
-    }:
-    mkDict (finalAttrs: {
-      inherit src dictFileName;
-      pname = "hunspell-dict-${shortName}-linguistico";
-      version = "2.4";
+  mkDictFromLinguistico = lib.extendMkDerivation {
+    constructDrv = mkDict;
 
-      readmeFile = finalAttrs.dictFileName + "_README.txt";
+    excludeDrvArgNames = [
+      "shortName"
+      "shortDescription"
+    ];
 
-      unpackCmd = ''
-        unzip $curSrc ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
-      '';
-      sourceRoot = ".";
+    extendDrvArgs =
+      finalAttrs:
+      {
+        shortName,
+        shortDescription,
+        ...
+      }@args:
+      {
+        pname = "hunspell-dict-${shortName}-linguistico";
+        version = "2.4";
 
-      prePatch = ''
-        # Fix dic file empty lines (FS#22275)
-        sed '/^\/$/d' -i ${finalAttrs.dictFileName}.dic
-      '';
+        readmeFile = finalAttrs.dictFileName + "_README.txt";
 
-      depsBuildBuild = [ unzip ];
+        unpackCmd = ''
+          unzip $curSrc ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
+        '';
+        sourceRoot = ".";
 
-      meta = {
-        description = "Hunspell dictionary for ${shortDescription}";
-        homepage = "https://sourceforge.net/projects/linguistico/";
-        license = lib.licenses.gpl3;
-        maintainers = with lib.maintainers; [ renzo ];
-        platforms = lib.platforms.all;
+        prePatch = ''
+          # Fix dic file empty lines (FS#22275)
+          sed '/^\/$/d' -i ${finalAttrs.dictFileName}.dic
+        '';
+
+        depsBuildBuild = [ unzip ];
+
+        meta = {
+          description = "Hunspell dictionary for ${shortDescription}";
+          homepage = "https://sourceforge.net/projects/linguistico/";
+          license = lib.licenses.gpl3;
+          maintainers = with lib.maintainers; [ renzo ];
+          platforms = lib.platforms.all;
+        };
       };
-    });
+  };
 
   mkDictFromXuxen = lib.extendMkDerivation {
     constructDrv = stdenvNoCC.mkDerivation;

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -251,43 +251,53 @@ let
       };
   };
 
-  mkDictFromWordlist =
-    {
-      shortName,
-      shortDescription,
-      srcFileName,
-      dictFileName,
-      src,
-    }:
-    mkDict (finalAttrs: {
-      inherit src srcFileName dictFileName;
-      pname = "hunspell-dict-${shortName}-wordlist";
-      version = "2018.04.16";
+  mkDictFromWordlist = lib.extendMkDerivation {
+    constructDrv = mkDict;
 
-      srcReadmeFile = "README_" + finalAttrs.srcFileName + ".txt";
-      readmeFile = "README_" + finalAttrs.dictFileName + ".txt";
+    excludeDrvArgNames = [
+      "shortName"
+      "shortDescription"
+      "srcFileName"
+    ];
 
-      unpackCmd = ''
-        unzip $curSrc ${finalAttrs.srcFileName}.dic ${finalAttrs.srcFileName}.aff ${finalAttrs.srcReadmeFile}
-      '';
-      sourceRoot = ".";
+    extendDrvArgs =
+      finalAttrs:
+      {
+        shortName,
+        shortDescription,
+        srcFileName,
+        ...
+      }@args:
+      {
+        inherit srcFileName;
+        pname = "hunspell-dict-${shortName}-wordlist";
+        version = "2018.04.16";
 
-      postUnpack = ''
-        mv ${finalAttrs.srcFileName}.dic ${finalAttrs.dictFileName}.dic || true
-        mv ${finalAttrs.srcFileName}.aff ${finalAttrs.dictFileName}.aff || true
-        mv ${finalAttrs.srcReadmeFile} ${finalAttrs.readmeFile}         || true
-      '';
+        srcReadmeFile = "README_" + srcFileName + ".txt";
+        readmeFile = "README_" + finalAttrs.dictFileName + ".txt";
 
-      depsBuildBuild = [ unzip ];
+        unpackCmd = ''
+          unzip $curSrc ${srcFileName}.dic ${srcFileName}.aff "$srcReadmeFile"
+        '';
+        sourceRoot = ".";
 
-      meta = {
-        description = "Hunspell dictionary for ${shortDescription} from Wordlist";
-        homepage = "http://wordlist.aspell.net/";
-        license = lib.licenses.bsd3;
-        maintainers = with lib.maintainers; [ renzo ];
-        platforms = lib.platforms.all;
+        postUnpack = ''
+          mv ${srcFileName}.dic ${finalAttrs.dictFileName}.dic || true
+          mv ${srcFileName}.aff ${finalAttrs.dictFileName}.aff || true
+          mv "$srcReadmeFile" "${finalAttrs.readmeFile}" || true
+        '';
+
+        depsBuildBuild = [ unzip ];
+
+        meta = {
+          description = "Hunspell dictionary for ${shortDescription} from Wordlist";
+          homepage = "http://wordlist.aspell.net/";
+          license = lib.licenses.bsd3;
+          maintainers = with lib.maintainers; [ renzo ];
+          platforms = lib.platforms.all;
+        };
       };
-    });
+  };
 
   mkDictFromLinguistico =
     {

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -126,66 +126,75 @@ let
       };
   };
 
-  mkDictFromDSSO =
-    {
-      shortName,
-      shortDescription,
-      dictFileName,
-    }:
-    mkDict (finalAttrs: {
-      inherit dictFileName;
-      pname = "hunspell-dict-${shortName}-dsso";
-      version = "2.40";
+  mkDictFromDSSO = lib.extendMkDerivation {
+    constructDrv = mkDict;
 
-      # Should really use a string function or something
-      _version = "2-40";
-      _name = "ooo_swedish_dict_${finalAttrs._version}";
+    excludeDrvArgNames = [
+      "shortName"
+      "shortDescription"
+    ];
 
-      readmeFile = "LICENSE_en_US.txt";
+    extendDrvArgs =
+      finalAttrs:
+      {
+        shortName,
+        shortDescription,
+        ...
+      }@args:
+      {
+        pname = "hunspell-dict-${shortName}-dsso";
+        version = "2.40";
 
-      src = fetchurl {
-        url = "https://extensions.libreoffice.org/extensions/swedish-spelling-dictionary-den-stora-svenska-ordlistan/${finalAttrs.version}/@@download/file/${finalAttrs._name}.oxt";
-        hash = "sha256-uYKIHMdfXErxGZU1vUc17kdr3Ejt9j4/BftPcVZUp7w=";
-      };
+        # Should really use a string function or something
+        _version = "2-40";
+        _name = "ooo_swedish_dict_${finalAttrs._version}";
 
-      unpackCmd = ''
-        unzip $curSrc dictionaries/${finalAttrs.dictFileName}.dic dictionaries/${finalAttrs.dictFileName}.aff $readmeFile
-      '';
-      sourceRoot = ".";
+        readmeFile = "LICENSE_en_US.txt";
 
-      depsBuildBuild = [ unzip ];
+        src = fetchurl {
+          url = "https://extensions.libreoffice.org/extensions/swedish-spelling-dictionary-den-stora-svenska-ordlistan/${finalAttrs.version}/@@download/file/${finalAttrs._name}.oxt";
+          hash = "sha256-uYKIHMdfXErxGZU1vUc17kdr3Ejt9j4/BftPcVZUp7w=";
+        };
 
-      installPhase = ''
-        runHook preInstall
-
-        # hunspell dicts
-        install -dm755 "$out/share/hunspell"
-        install -m644 dictionaries/${finalAttrs.dictFileName}.dic "$out/share/hunspell/"
-        install -m644 dictionaries/${finalAttrs.dictFileName}.aff "$out/share/hunspell/"
-
-        # myspell dicts symlinks
-        install -dm755 "$out/share/myspell/dicts"
-        ln -sv "$out/share/hunspell/${finalAttrs.dictFileName}.dic" "$out/share/myspell/dicts/"
-        ln -sv "$out/share/hunspell/${finalAttrs.dictFileName}.aff" "$out/share/myspell/dicts/"
-
-        # docs
-        install -dm755 "$out/share/doc"
-        install -m644 ${finalAttrs.readmeFile} $out/share/doc/${finalAttrs.pname}.txt
-
-        runHook postInstall
-      '';
-
-      meta = {
-        longDescription = ''
-          Svensk ordlista baserad på DSSO (den stora svenska ordlistan) och Göran
-          Anderssons (goran@init.se) arbete med denna. Ordlistan hämtas från
-          LibreOffice då dsso.se inte längre verkar vara med oss.
+        unpackCmd = ''
+          unzip $curSrc dictionaries/${finalAttrs.dictFileName}.dic dictionaries/${finalAttrs.dictFileName}.aff $readmeFile
         '';
-        description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
-        license = lib.licenses.lgpl3;
-        platforms = lib.platforms.all;
+        sourceRoot = ".";
+
+        depsBuildBuild = [ unzip ];
+
+        installPhase = ''
+          runHook preInstall
+
+          # hunspell dicts
+          install -dm755 "$out/share/hunspell"
+          install -m644 dictionaries/${finalAttrs.dictFileName}.dic "$out/share/hunspell/"
+          install -m644 dictionaries/${finalAttrs.dictFileName}.aff "$out/share/hunspell/"
+
+          # myspell dicts symlinks
+          install -dm755 "$out/share/myspell/dicts"
+          ln -sv "$out/share/hunspell/${finalAttrs.dictFileName}.dic" "$out/share/myspell/dicts/"
+          ln -sv "$out/share/hunspell/${finalAttrs.dictFileName}.aff" "$out/share/myspell/dicts/"
+
+          # docs
+          install -dm755 "$out/share/doc"
+          install -m644 ${finalAttrs.readmeFile} $out/share/doc/${finalAttrs.pname}.txt
+
+          runHook postInstall
+        '';
+
+        meta = {
+          longDescription = ''
+            Svensk ordlista baserad på DSSO (den stora svenska ordlistan) och Göran
+            Anderssons (goran@init.se) arbete med denna. Ordlistan hämtas från
+            LibreOffice då dsso.se inte längre verkar vara med oss.
+          '';
+          description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
+          license = lib.licenses.lgpl3;
+          platforms = lib.platforms.all;
+        };
       };
-    });
+  };
 
   mkDictFromDicollecte =
     {

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -3,6 +3,7 @@
 {
   lib,
   stdenvNoCC,
+  pkgsBuildBuild,
   fetchurl,
   fetchzip,
   fetchFromGitHub,
@@ -1323,7 +1324,7 @@ rec {
     dictFileName = "ko_KR";
     readmeFile = "README.md";
 
-    nativeBuildInputs = [ (python3.withPackages (ps: [ ps.pyyaml ])) ];
+    nativeBuildInputs = [ (pkgsBuildBuild.python3.withPackages (ps: [ ps.pyyaml ])) ];
 
     preInstall = ''
       mv ko.aff ko_KR.aff

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -465,39 +465,52 @@ let
       };
   };
 
-  mkDictFromLibreOffice =
-    {
-      shortName,
-      shortDescription,
-      dictFileName,
-      license,
-      readmeFile ? "README_${dictFileName}.txt",
-      sourceRoot ? dictFileName,
-    }:
-    mkDict (finalAttrs: {
-      inherit dictFileName readmeFile;
-      pname = "hunspell-dict-${shortName}-libreoffice";
-      version = "6.3.0.4";
+  mkDictFromLibreOffice = lib.extendMkDerivation {
+    constructDrv = mkDict;
 
-      src = fetchFromGitHub {
-        owner = "LibreOffice";
-        repo = "dictionaries";
-        rev = "libreoffice-${finalAttrs.version}";
-        hash = "sha256-w/iD26CfTLCMnYPxN1awkN911WOG6qMTRZwdmx9Y5JM=";
+    excludeDrvArgNames = [
+      "shortName"
+      "shortDescription"
+      "license"
+      "sourceRoot"
+    ];
+
+    extendDrvArgs =
+      finalAttrs:
+      {
+        shortName,
+        shortDescription,
+        dictFileName,
+        license,
+        readmeFile ? "README_${finalAttrs.dictFileName}.txt",
+        sourceRoot ? dictFileName,
+        ...
+      }@args:
+      {
+        inherit readmeFile;
+        pname = "hunspell-dict-${shortName}-libreoffice";
+        version = "6.3.0.4";
+
+        src = fetchFromGitHub {
+          owner = "LibreOffice";
+          repo = "dictionaries";
+          rev = "libreoffice-${finalAttrs.version}";
+          hash = "sha256-w/iD26CfTLCMnYPxN1awkN911WOG6qMTRZwdmx9Y5JM=";
+        };
+
+        buildPhase = ''
+          cp -a ${sourceRoot}/* .
+        '';
+
+        meta = {
+          inherit license;
+          homepage = "https://wiki.documentfoundation.org/Development/Dictionaries";
+          description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
+          maintainers = with lib.maintainers; [ vlaci ];
+          platforms = lib.platforms.all;
+        };
       };
-
-      buildPhase = ''
-        cp -a ${sourceRoot}/* .
-      '';
-
-      meta = {
-        homepage = "https://wiki.documentfoundation.org/Development/Dictionaries";
-        description = "Hunspell dictionary for ${shortDescription} from LibreOffice";
-        license = license;
-        maintainers = with lib.maintainers; [ vlaci ];
-        platforms = lib.platforms.all;
-      };
-    });
+  };
 
 in
 rec {

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -61,7 +61,7 @@ let
       shortDescription,
       dictFileName,
     }:
-    mkDict rec {
+    mkDict (finalAttrs: {
       inherit dictFileName;
       version = "2.5";
       pname = "hunspell-dict-${shortName}-rla";
@@ -69,8 +69,8 @@ let
       src = fetchFromGitHub {
         owner = "sbosio";
         repo = "rla-es";
-        rev = "v${version}";
-        sha256 = "sha256-oGnxOGHzDogzUMZESydIxRTbq9Dmd03flwHx16AK1yk=";
+        rev = "v${finalAttrs.version}";
+        hash = "sha256-oGnxOGHzDogzUMZESydIxRTbq9Dmd03flwHx16AK1yk=";
       };
       meta = {
         description = "Hunspell dictionary for ${shortDescription} from rla";
@@ -100,11 +100,11 @@ let
       '';
       buildPhase = ''
         cd ortograf/herramientas
-        bash -x ./make_dict.sh -l ${dictFileName} -2
-        unzip ${dictFileName}.zip \
-          ${dictFileName}.dic ${dictFileName}.aff ${readmeFile}
+        bash -x ./make_dict.sh -l ${finalAttrs.dictFileName} -2
+        unzip ${finalAttrs.dictFileName}.zip \
+          ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
       '';
-    };
+    });
 
   mkDictFromDSSO =
     {
@@ -112,17 +112,17 @@ let
       shortDescription,
       dictFileName,
     }:
-    mkDict rec {
+    mkDict (finalAttrs: {
       inherit dictFileName;
       version = "2.40";
       # Should really use a string function or something
       _version = "2-40";
       pname = "hunspell-dict-${shortName}-dsso";
-      _name = "ooo_swedish_dict_${_version}";
+      _name = "ooo_swedish_dict_${finalAttrs._version}";
       readmeFile = "LICENSE_en_US.txt";
       src = fetchurl {
-        url = "https://extensions.libreoffice.org/extensions/swedish-spelling-dictionary-den-stora-svenska-ordlistan/${version}/@@download/file/${_name}.oxt";
-        sha256 = "b982881cc75f5c4af1199535bd4735ee476bdc48edf63e3f05fb4f715654a7bc";
+        url = "https://extensions.libreoffice.org/extensions/swedish-spelling-dictionary-den-stora-svenska-ordlistan/${finalAttrs.version}/@@download/file/${finalAttrs._name}.oxt";
+        hash = "sha256-uYKIHMdfXErxGZU1vUc17kdr3Ejt9j4/BftPcVZUp7w=";
       };
       meta = {
         longDescription = ''
@@ -137,22 +137,22 @@ let
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src dictionaries/${dictFileName}.dic dictionaries/${dictFileName}.aff $readmeFile
+        unzip $src dictionaries/${finalAttrs.dictFileName}.dic dictionaries/${finalAttrs.dictFileName}.aff $readmeFile
       '';
       installPhase = ''
         # hunspell dicts
         install -dm755 "$out/share/hunspell"
-        install -m644 dictionaries/${dictFileName}.dic "$out/share/hunspell/"
-        install -m644 dictionaries/${dictFileName}.aff "$out/share/hunspell/"
+        install -m644 dictionaries/${finalAttrs.dictFileName}.dic "$out/share/hunspell/"
+        install -m644 dictionaries/${finalAttrs.dictFileName}.aff "$out/share/hunspell/"
         # myspell dicts symlinks
         install -dm755 "$out/share/myspell/dicts"
-        ln -sv "$out/share/hunspell/${dictFileName}.dic" "$out/share/myspell/dicts/"
-        ln -sv "$out/share/hunspell/${dictFileName}.aff" "$out/share/myspell/dicts/"
+        ln -sv "$out/share/hunspell/${finalAttrs.dictFileName}.dic" "$out/share/myspell/dicts/"
+        ln -sv "$out/share/hunspell/${finalAttrs.dictFileName}.aff" "$out/share/myspell/dicts/"
         # docs
         install -dm755 "$out/share/doc"
-        install -m644 ${readmeFile} $out/share/doc/${pname}.txt
+        install -m644 ${finalAttrs.readmeFile} $out/share/doc/${finalAttrs.pname}.txt
       '';
-    };
+    });
 
   mkDictFromDicollecte =
     {
@@ -162,14 +162,14 @@ let
       dictFileName,
       isDefault ? false,
     }:
-    mkDict rec {
+    mkDict (finalAttrs: {
       inherit dictFileName;
       version = "5.3";
       pname = "hunspell-dict-${shortName}-dicollecte";
       readmeFile = "README_dict_fr.txt";
       src = fetchurl {
-        url = "http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${version}.zip";
-        sha256 = "0ca7084jm7zb1ikwzh1frvpb97jn27i7a5d48288h2qlfp068ik0";
+        url = "http://www.dicollecte.org/download/fr/hunspell-french-dictionaries-v${finalAttrs.version}.zip";
+        hash = "sha256-YEZkwHUUC4iQQKQVdeIRVp607s4uwM9nDOufKgkCRzE=";
       };
       meta = {
         inherit longDescription;
@@ -182,15 +182,15 @@ let
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile}
+        unzip $src ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
       '';
       postInstall = lib.optionalString isDefault ''
         for ext in aff dic; do
-          ln -sv $out/share/hunspell/${dictFileName}.$ext $out/share/hunspell/fr_FR.$ext
-          ln -sv $out/share/myspell/dicts/${dictFileName}.$ext $out/share/myspell/dicts/fr_FR.$ext
+          ln -sv $out/share/hunspell/${finalAttrs.dictFileName}.$ext $out/share/hunspell/fr_FR.$ext
+          ln -sv $out/share/myspell/dicts/${finalAttrs.dictFileName}.$ext $out/share/myspell/dicts/fr_FR.$ext
         done
       '';
-    };
+    });
 
   mkDictFromWordlist =
     {
@@ -200,12 +200,12 @@ let
       dictFileName,
       src,
     }:
-    mkDict rec {
+    mkDict (finalAttrs: {
       inherit src srcFileName dictFileName;
       version = "2018.04.16";
       pname = "hunspell-dict-${shortName}-wordlist";
-      srcReadmeFile = "README_" + srcFileName + ".txt";
-      readmeFile = "README_" + dictFileName + ".txt";
+      srcReadmeFile = "README_" + finalAttrs.srcFileName + ".txt";
+      readmeFile = "README_" + finalAttrs.dictFileName + ".txt";
       meta = {
         description = "Hunspell dictionary for ${shortDescription} from Wordlist";
         homepage = "http://wordlist.aspell.net/";
@@ -216,14 +216,14 @@ let
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src ${srcFileName}.dic ${srcFileName}.aff ${srcReadmeFile}
+        unzip $src ${finalAttrs.srcFileName}.dic ${finalAttrs.srcFileName}.aff ${finalAttrs.srcReadmeFile}
       '';
       postUnpack = ''
-        mv ${srcFileName}.dic ${dictFileName}.dic || true
-        mv ${srcFileName}.aff ${dictFileName}.aff || true
-        mv ${srcReadmeFile} ${readmeFile}         || true
+        mv ${finalAttrs.srcFileName}.dic ${finalAttrs.dictFileName}.dic || true
+        mv ${finalAttrs.srcFileName}.aff ${finalAttrs.dictFileName}.aff || true
+        mv ${finalAttrs.srcReadmeFile} ${finalAttrs.readmeFile}         || true
       '';
-    };
+    });
 
   mkDictFromLinguistico =
     {
@@ -232,11 +232,11 @@ let
       dictFileName,
       src,
     }:
-    mkDict rec {
+    mkDict (finalAttrs: {
       inherit src dictFileName;
       version = "2.4";
       pname = "hunspell-dict-${shortName}-linguistico";
-      readmeFile = dictFileName + "_README.txt";
+      readmeFile = finalAttrs.dictFileName + "_README.txt";
       meta = {
         description = "Hunspell dictionary for ${shortDescription}";
         homepage = "https://sourceforge.net/projects/linguistico/";
@@ -248,12 +248,12 @@ let
       sourceRoot = ".";
       prePatch = ''
         # Fix dic file empty lines (FS#22275)
-        sed '/^\/$/d' -i ${dictFileName}.dic
+        sed '/^\/$/d' -i ${finalAttrs.dictFileName}.dic
       '';
       unpackCmd = ''
-        unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile}
+        unzip $src ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
       '';
-    };
+    });
 
   mkDictFromXuxen =
     {
@@ -350,15 +350,15 @@ let
       readmeFile ? "README_${dictFileName}.txt",
       sourceRoot ? dictFileName,
     }:
-    mkDict rec {
+    mkDict (finalAttrs: {
       pname = "hunspell-dict-${shortName}-libreoffice";
       version = "6.3.0.4";
       inherit dictFileName readmeFile;
       src = fetchFromGitHub {
         owner = "LibreOffice";
         repo = "dictionaries";
-        rev = "libreoffice-${version}";
-        sha256 = "14z4b0grn7cw8l9s7sl6cgapbpwhn1b3gwc3kn6b0k4zl3dq7y63";
+        rev = "libreoffice-${finalAttrs.version}";
+        hash = "sha256-w/iD26CfTLCMnYPxN1awkN911WOG6qMTRZwdmx9Y5JM=";
       };
       buildPhase = ''
         cp -a ${sourceRoot}/* .
@@ -370,7 +370,7 @@ let
         maintainers = with lib.maintainers; [ vlaci ];
         platforms = lib.platforms.all;
       };
-    };
+    });
 
 in
 rec {
@@ -758,24 +758,23 @@ rec {
   # ESTONIAN
 
   et_EE = et-ee;
-  et-ee = mkDict rec {
+  et-ee = mkDict (finalAttrs: {
     pname = "hunspell-dict-et-ee";
-    name = pname;
     version = "20030606";
 
     src = fetchzip {
-      url = "http://www.meso.ee/~jjpp/speller/ispell-et_${version}.tar.gz";
-      sha256 = "sha256-MVfKekzq2RKZONsz2Ey/xSRlh2bln46YO5UdGNkFdxk=";
+      url = "http://www.meso.ee/~jjpp/speller/ispell-et_${finalAttrs.version}.tar.gz";
+      hash = "sha256-MVfKekzq2RKZONsz2Ey/xSRlh2bln46YO5UdGNkFdxk=";
     };
 
     dictFileName = "et_EE";
     readmeFile = "README";
 
     preInstall = ''
-      mv latin-1/${dictFileName}.dic ./
-      mv latin-1/${dictFileName}.aff ./
+      mv latin-1/${finalAttrs.dictFileName}.dic ./
+      mv latin-1/${finalAttrs.dictFileName}.aff ./
     '';
-  };
+  });
 
   # GERMAN
 
@@ -803,13 +802,13 @@ rec {
   # UKRAINIAN
 
   uk_UA = uk-ua;
-  uk-ua = mkDict rec {
+  uk-ua = mkDict (finalAttrs: {
     pname = "hunspell-dict-uk-ua";
     version = "6.5.3";
     _version = "1727974630";
 
     src = fetchurl {
-      url = "https://extensions.libreoffice.org/assets/downloads/521/${_version}/dict-uk_UA-${version}.oxt";
+      url = "https://extensions.libreoffice.org/assets/downloads/521/${finalAttrs._version}/dict-uk_UA-${finalAttrs.version}.oxt";
       hash = "sha256-c957WHJqaf/M2QrE2H3aIDAWGoQDnDl0na7sd+kUXNI=";
     };
 
@@ -817,7 +816,7 @@ rec {
     readmeFile = "README_uk_UA.txt";
     nativeBuildInputs = [ unzip ];
     unpackCmd = ''
-      unzip $src ${dictFileName}/{${dictFileName}.dic,${dictFileName}.aff,${readmeFile}}
+      unzip $src ${finalAttrs.dictFileName}/{${finalAttrs.dictFileName}.dic,${finalAttrs.dictFileName}.aff,${finalAttrs.readmeFile}}
     '';
 
     meta = {
@@ -827,18 +826,18 @@ rec {
       maintainers = with lib.maintainers; [ dywedir ];
       platforms = lib.platforms.all;
     };
-  };
+  });
 
   # UZBEK
   uz_UZ = uz-uz;
-  uz-uz = mkDict rec {
+  uz-uz = mkDict (finalAttrs: {
     pname = "hunspell-dict-uz-uz";
     version = "0.1.0";
 
     src = fetchFromGitHub {
       owner = "uzbek-net";
       repo = "uz-hunspell";
-      tag = version;
+      tag = finalAttrs.version;
       hash = "sha256-EUYhnUWUy45AYGH+HoxaFFCBVnotsIm4GlpMBgnHxdo=";
     };
 
@@ -854,7 +853,7 @@ rec {
       ];
       teams = [ lib.teams.uzinfocom ];
     };
-  };
+  });
 
   # RUSSIAN
 
@@ -898,13 +897,13 @@ rec {
   # DANISH
 
   da_DK = da-dk;
-  da-dk = mkDict rec {
+  da-dk = mkDict (finalAttrs: {
     pname = "hunspell-dict-da-dk";
     version = "2.5.189";
 
     src = fetchurl {
-      url = "https://stavekontrolden.dk/dictionaries/da_DK/da_DK-${version}.oxt";
-      sha256 = "sha256:0i1cw0nfg24b0sg2yc3q7315ng5vc5245nvh0l1cndkn2c9z4978";
+      url = "https://stavekontrolden.dk/dictionaries/da_DK/da_DK-${finalAttrs.version}.oxt";
+      hash = "sha256-6CTyExN2NssCBXDbQkRhuzxbwjh4MC+eBouI5yzgLEQ=";
     };
 
     shortName = "da-dk";
@@ -913,7 +912,7 @@ rec {
     readmeFile = "README_da_DK.txt";
     nativeBuildInputs = [ unzip ];
     unpackCmd = ''
-      unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile} -d ${dictFileName}
+      unzip $src ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
     '';
 
     meta = {
@@ -926,20 +925,20 @@ rec {
       ];
       maintainers = with lib.maintainers; [ louisdk1 ];
     };
-  };
+  });
 
   # DUTCH
 
   nl_NL = nl_nl;
-  nl_nl = mkDict rec {
+  nl_nl = mkDict (finalAttrs: {
     pname = "hunspell-dict-nl-nl";
     version = "2.20.19";
 
     src = fetchFromGitHub {
       owner = "OpenTaal";
       repo = "opentaal-hunspell";
-      rev = version;
-      sha256 = "0jma8mmrncyzd77kxliyngs4z6z4769g3nh0a7xn2pd4s5y2xdpy";
+      rev = finalAttrs.version;
+      hash = "sha256-/rYufNGkXWH7UQDa8ZI55JtP9LM+0j7Pad8zm2tFqko=";
     };
 
     preInstall = ''
@@ -959,7 +958,7 @@ rec {
       ];
       maintainers = with lib.maintainers; [ artturin ];
     };
-  };
+  });
 
   # HEBREW
 
@@ -1049,15 +1048,15 @@ rec {
 
   # TOKI PONA
 
-  tok = mkDict rec {
+  tok = mkDict (finalAttrs: {
     pname = "hunspell-dict-tok";
     version = "20220829";
     dictFileName = "tok";
     readmeFile = "README.en.adoc";
 
     src = fetchzip {
-      url = "https://github.com/somasis/hunspell-tok/releases/download/${version}/hunspell-tok-${version}.tar.gz";
-      sha256 = "sha256-RiAODKXPUeIcf8IFcU6Tacehq5S8GYuPTuxEiN2CXD0=";
+      url = "https://github.com/somasis/hunspell-tok/releases/download/${finalAttrs.version}/hunspell-tok-${finalAttrs.version}.tar.gz";
+      hash = "sha256-RiAODKXPUeIcf8IFcU6Tacehq5S8GYuPTuxEiN2CXD0=";
     };
 
     dontBuild = true;
@@ -1074,7 +1073,7 @@ rec {
       maintainers = with lib.maintainers; [ somasis ];
       platforms = lib.platforms.all;
     };
-  };
+  });
 
   # POLISH
 
@@ -1153,32 +1152,32 @@ rec {
 
   # ROMANIAN
   ro_RO = ro-ro;
-  ro-ro = mkDict rec {
+  ro-ro = mkDict (finalAttrs: {
     pname = "hunspell-dict-ro-ro";
     version = "3.3.10";
     shortName = "ro-ro";
     dictFileName = "ro_RO";
-    fileName = "${dictFileName}.${version}.zip";
+    fileName = "${finalAttrs.dictFileName}.${finalAttrs.version}.zip";
     shortDescription = "Romanian (Romania)";
     readmeFile = "README";
 
     src = fetchurl {
-      url = "mirror://sourceforge/rospell/${fileName}";
+      url = "mirror://sourceforge/rospell/${finalAttrs.fileName}";
       hash = "sha256-fxKNZOoGyeZxHDCxGMCv7vsBTY8zyS2szfRVq6LQRRk=";
     };
 
     nativeBuildInputs = [ unzip ];
     unpackCmd = ''
-      unzip $src ${dictFileName}.aff ${dictFileName}.dic ${readmeFile} -d ${dictFileName}
+      unzip $src ${finalAttrs.dictFileName}.aff ${finalAttrs.dictFileName}.dic ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
     '';
 
     meta = {
-      description = "Hunspell dictionary for ${shortDescription} from rospell";
+      description = "Hunspell dictionary for ${finalAttrs.shortDescription} from rospell";
       homepage = "https://sourceforge.net/projects/rospell/";
       license = with lib.licenses; [ gpl2Only ];
       maintainers = with lib.maintainers; [ Andy3153 ];
     };
-  };
+  });
 
   # Turkish
   tr_TR = tr-tr;
@@ -1222,14 +1221,14 @@ rec {
 
   # KOREAN
   ko_KR = ko-kr;
-  ko-kr = mkDict rec {
+  ko-kr = mkDict (finalAttrs: {
     pname = "hunspell-dict-ko-kr";
     version = "0.7.94";
 
     src = fetchFromGitHub {
       owner = "spellcheck-ko";
       repo = "hunspell-dict-ko";
-      rev = version;
+      rev = finalAttrs.version;
       hash = "sha256-eHuNppqB536wHXftzDghpB3cM9CNFKW1z8f0SNkEiD8=";
     };
 
@@ -1253,5 +1252,5 @@ rec {
       ];
       maintainers = with lib.maintainers; [ honnip ];
     };
-  };
+  });
 }

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -83,7 +83,7 @@ let
         src = fetchFromGitHub {
           owner = "sbosio";
           repo = "rla-es";
-          rev = "v${finalAttrs.version}";
+          tag = "v${finalAttrs.version}";
           hash = "sha256-oGnxOGHzDogzUMZESydIxRTbq9Dmd03flwHx16AK1yk=";
         };
 
@@ -494,7 +494,7 @@ let
         src = fetchFromGitHub {
           owner = "LibreOffice";
           repo = "dictionaries";
-          rev = "libreoffice-${finalAttrs.version}";
+          tag = "libreoffice-${finalAttrs.version}";
           hash = "sha256-w/iD26CfTLCMnYPxN1awkN911WOG6qMTRZwdmx9Y5JM=";
         };
 
@@ -1077,7 +1077,7 @@ rec {
     src = fetchFromGitHub {
       owner = "OpenTaal";
       repo = "opentaal-hunspell";
-      rev = finalAttrs.version;
+      tag = finalAttrs.version;
       hash = "sha256-/rYufNGkXWH7UQDa8ZI55JtP9LM+0j7Pad8zm2tFqko=";
     };
 
@@ -1368,7 +1368,7 @@ rec {
     src = fetchFromGitHub {
       owner = "spellcheck-ko";
       repo = "hunspell-dict-ko";
-      rev = finalAttrs.version;
+      tag = finalAttrs.version;
       hash = "sha256-eHuNppqB536wHXftzDghpB3cM9CNFKW1z8f0SNkEiD8=";
     };
 

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -136,7 +136,7 @@ let
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src dictionaries/${finalAttrs.dictFileName}.dic dictionaries/${finalAttrs.dictFileName}.aff $readmeFile
+        unzip $curSrc dictionaries/${finalAttrs.dictFileName}.dic dictionaries/${finalAttrs.dictFileName}.aff $readmeFile
       '';
       installPhase = ''
         # hunspell dicts
@@ -181,7 +181,7 @@ let
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
+        unzip $curSrc ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
       '';
       postInstall = lib.optionalString isDefault ''
         for ext in aff dic; do
@@ -215,7 +215,7 @@ let
       nativeBuildInputs = [ unzip ];
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src ${finalAttrs.srcFileName}.dic ${finalAttrs.srcFileName}.aff ${finalAttrs.srcReadmeFile}
+        unzip $curSrc ${finalAttrs.srcFileName}.dic ${finalAttrs.srcFileName}.aff ${finalAttrs.srcReadmeFile}
       '';
       postUnpack = ''
         mv ${finalAttrs.srcFileName}.dic ${finalAttrs.dictFileName}.dic || true
@@ -250,7 +250,7 @@ let
         sed '/^\/$/d' -i ${finalAttrs.dictFileName}.dic
       '';
       unpackCmd = ''
-        unzip $src ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
+        unzip $curSrc ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile}
       '';
     });
 
@@ -852,7 +852,7 @@ rec {
     readmeFile = "README_uk_UA.txt";
     nativeBuildInputs = [ unzip ];
     unpackCmd = ''
-      unzip $src ${finalAttrs.dictFileName}/{${finalAttrs.dictFileName}.dic,${finalAttrs.dictFileName}.aff,${finalAttrs.readmeFile}}
+      unzip $curSrc ${finalAttrs.dictFileName}/{${finalAttrs.dictFileName}.dic,${finalAttrs.dictFileName}.aff,${finalAttrs.readmeFile}}
     '';
 
     meta = {
@@ -948,7 +948,7 @@ rec {
     readmeFile = "README_da_DK.txt";
     nativeBuildInputs = [ unzip ];
     unpackCmd = ''
-      unzip $src ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
+      unzip $curSrc ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
     '';
 
     meta = {
@@ -1204,7 +1204,7 @@ rec {
 
     nativeBuildInputs = [ unzip ];
     unpackCmd = ''
-      unzip $src ${finalAttrs.dictFileName}.aff ${finalAttrs.dictFileName}.dic ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
+      unzip $curSrc ${finalAttrs.dictFileName}.aff ${finalAttrs.dictFileName}.dic ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
     '';
 
     meta = {

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -523,6 +523,7 @@ rec {
     shortDescription = "English (United States)";
     srcFileName = "en_US";
     dictFileName = "en_US";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_US-2018.04.16.zip";
       sha256 = "18hbncvqnckzqarrmnzk58plymjqyi93k4qj98fac5mr71jbmzaf";
@@ -535,6 +536,7 @@ rec {
     shortDescription = "English (United States) Large";
     srcFileName = "en_US-large";
     dictFileName = "en_US";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_US-large-2018.04.16.zip";
       sha256 = "1xm9jgqbivp5cb78ykjxg47vzq1yqj82l7r4q5cjpivrv99s49qc";
@@ -547,6 +549,7 @@ rec {
     shortDescription = "English (Canada)";
     srcFileName = "en_CA";
     dictFileName = "en_CA";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_CA-2018.04.16.zip";
       sha256 = "06yf3s7y1215jmikbs18cn4j8a13csp4763w3jfgah8zlim6vc47";
@@ -559,6 +562,7 @@ rec {
     shortDescription = "English (Canada) Large";
     srcFileName = "en_CA-large";
     dictFileName = "en_CA";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_CA-large-2018.04.16.zip";
       sha256 = "1200xxyvv6ni8nk52v3059c367817vnrkm0cdh38rhiigb5flfha";
@@ -571,6 +575,7 @@ rec {
     shortDescription = "English (Australia)";
     srcFileName = "en_AU";
     dictFileName = "en_AU";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_AU-2018.04.16.zip";
       sha256 = "1kp06npl1kd05mm9r52cg2iwc13x02zwqgpibdw15b6x43agg6f5";
@@ -583,6 +588,7 @@ rec {
     shortDescription = "English (Australia) Large";
     srcFileName = "en_AU-large";
     dictFileName = "en_AU";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_AU-large-2018.04.16.zip";
       sha256 = "14l1w4dpk0k1js2wwq5ilfil89ni8cigph95n1rh6xi4lzxj7h6g";
@@ -595,6 +601,7 @@ rec {
     shortDescription = "English (United Kingdom, 'ise' ending)";
     srcFileName = "en_GB-ise";
     dictFileName = "en_GB";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-ise-2018.04.16.zip";
       sha256 = "0ylg1zvfvsawamymcc9ivrqcb9qhlpgpnizm076xc56jz554xc2l";
@@ -607,6 +614,7 @@ rec {
     shortDescription = "English (United Kingdom, 'ize' ending)";
     srcFileName = "en_GB-ize";
     dictFileName = "en_GB";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-ize-2018.04.16.zip";
       sha256 = "1rmwy6sxmd400cwjf58az6g14sq28p18f5mlq8ybg8y33q9m42ps";
@@ -619,6 +627,7 @@ rec {
     shortDescription = "English (United Kingdom) Large";
     srcFileName = "en_GB-large";
     dictFileName = "en_GB";
+
     src = fetchurl {
       url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-large-2018.04.16.zip";
       sha256 = "1y4d7x5vvi1qh1s3i09m0vvqrpdzzqhsdngr8nsh7hc5bnlm37mi";
@@ -945,16 +954,17 @@ rec {
   uk-ua = mkDict (finalAttrs: {
     pname = "hunspell-dict-uk-ua";
     version = "6.5.3";
+
     _version = "1727974630";
+    dictFileName = "uk_UA";
+    readmeFile = "README_uk_UA.txt";
 
     src = fetchurl {
       url = "https://extensions.libreoffice.org/assets/downloads/521/${finalAttrs._version}/dict-uk_UA-${finalAttrs.version}.oxt";
       hash = "sha256-c957WHJqaf/M2QrE2H3aIDAWGoQDnDl0na7sd+kUXNI=";
     };
 
-    dictFileName = "uk_UA";
-    readmeFile = "README_uk_UA.txt";
-    nativeBuildInputs = [ unzip ];
+    depsBuildBuild = [ unzip ];
     unpackCmd = ''
       unzip $curSrc ${finalAttrs.dictFileName}/{${finalAttrs.dictFileName}.dic,${finalAttrs.dictFileName}.aff,${finalAttrs.readmeFile}}
     '';
@@ -974,16 +984,16 @@ rec {
     pname = "hunspell-dict-uz-uz";
     version = "0.1.0";
 
+    shortName = "uz-uz";
+    dictFileName = "uz_UZ";
+    readmeFile = "README.md";
+
     src = fetchFromGitHub {
       owner = "uzbek-net";
       repo = "uz-hunspell";
       tag = finalAttrs.version;
       hash = "sha256-EUYhnUWUy45AYGH+HoxaFFCBVnotsIm4GlpMBgnHxdo=";
     };
-
-    shortName = "uz-uz";
-    dictFileName = "uz_UZ";
-    readmeFile = "README.md";
 
     meta = {
       description = "Hunspell dictionary for Uzbek";
@@ -1041,16 +1051,17 @@ rec {
     pname = "hunspell-dict-da-dk";
     version = "2.5.189";
 
+    shortName = "da-dk";
+    shortDescription = "Danish (Danmark)";
+    dictFileName = "da_DK";
+    readmeFile = "README_da_DK.txt";
+
     src = fetchurl {
       url = "https://stavekontrolden.dk/dictionaries/da_DK/da_DK-${finalAttrs.version}.oxt";
       hash = "sha256-6CTyExN2NssCBXDbQkRhuzxbwjh4MC+eBouI5yzgLEQ=";
     };
 
-    shortName = "da-dk";
-    shortDescription = "Danish (Danmark)";
-    dictFileName = "da_DK";
-    readmeFile = "README_da_DK.txt";
-    nativeBuildInputs = [ unzip ];
+    depsBuildBuild = [ unzip ];
     unpackCmd = ''
       unzip $curSrc ${finalAttrs.dictFileName}.dic ${finalAttrs.dictFileName}.aff ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
     '';
@@ -1074,6 +1085,9 @@ rec {
     pname = "hunspell-dict-nl-nl";
     version = "2.20.19";
 
+    dictFileName = "nl_NL";
+    readmeFile = "README.md";
+
     src = fetchFromGitHub {
       owner = "OpenTaal";
       repo = "opentaal-hunspell";
@@ -1085,9 +1099,6 @@ rec {
       mv nl.aff nl_NL.aff
       mv nl.dic nl_NL.dic
     '';
-
-    dictFileName = "nl_NL";
-    readmeFile = "README.md";
 
     meta = {
       description = "Hunspell dictionary for Dutch (Netherlands) from OpenTaal";
@@ -1117,14 +1128,17 @@ rec {
   th-th = mkDict {
     pname = "hunspell-dict-th-th";
     version = "experimental-2024-04-15";
+
     dictFileName = "th_TH";
     readmeFile = "README.md";
+
     src = fetchFromGitHub {
       owner = "SyafiqHadzir";
       repo = "Hunspell-TH";
       rev = "419eb32115b936da9c949e35b35c29b8187f6c93";
       sha256 = "sha256-aXjof5dcEoCmep3PtvVkBhcgcd2NtqUpUEu37wsi1Uk=";
     };
+
     meta = {
       description = "Hunspell dictionary for Central Thai (Thailand)";
       homepage = "https://github.com/SyafiqHadzir/Hunspell-TH";
@@ -1140,9 +1154,11 @@ rec {
   id_id = mkDictFromLibreOffice {
     shortName = "id-id";
     dictFileName = "id_ID";
-    sourceRoot = "id";
-    shortDescription = "Bahasa Indonesia (Indonesia)";
     readmeFile = "README-dict.md";
+    shortDescription = "Bahasa Indonesia (Indonesia)";
+
+    sourceRoot = "id";
+
     license = with lib.licenses; [
       lgpl21Only
       lgpl3Only
@@ -1157,6 +1173,7 @@ rec {
     dictFileName = "hr_HR";
     shortDescription = "Croatian (Croatia)";
     readmeFile = "README_hr_HR.txt";
+
     license = with lib.licenses; [
       gpl2Only
       lgpl21Only
@@ -1170,9 +1187,11 @@ rec {
   nb-no = mkDictFromLibreOffice {
     shortName = "nb-no";
     dictFileName = "nb_NO";
-    sourceRoot = "no";
     readmeFile = "README_hyph_NO.txt";
     shortDescription = "Norwegian Bokmål (Norway)";
+
+    sourceRoot = "no";
+
     license = with lib.licenses; [ gpl2Only ];
   };
 
@@ -1180,9 +1199,11 @@ rec {
   nn-no = mkDictFromLibreOffice {
     shortName = "nn-no";
     dictFileName = "nn_NO";
-    sourceRoot = "no";
     readmeFile = "README_hyph_NO.txt";
     shortDescription = "Norwegian Nynorsk (Norway)";
+
+    sourceRoot = "no";
+
     license = with lib.licenses; [ gpl2Only ];
   };
 
@@ -1191,6 +1212,7 @@ rec {
   tok = mkDict (finalAttrs: {
     pname = "hunspell-dict-tok";
     version = "20220829";
+
     dictFileName = "tok";
     readmeFile = "README.en.adoc";
 
@@ -1223,6 +1245,7 @@ rec {
     dictFileName = "pl_PL";
     shortDescription = "Polish (Poland)";
     readmeFile = "README_en.txt";
+
     # the README doesn't specify versions of licenses :/
     license = with lib.licenses; [
       gpl2Plus
@@ -1241,6 +1264,7 @@ rec {
     dictFileName = "pt_BR";
     shortDescription = "Portuguese (Brazil)";
     readmeFile = "README_pt_BR.txt";
+
     license = with lib.licenses; [ lgpl3 ];
   };
 
@@ -1250,6 +1274,7 @@ rec {
     dictFileName = "pt_PT";
     shortDescription = "Portuguese (Portugal)";
     readmeFile = "README_pt_PT.txt";
+
     license = with lib.licenses; [
       gpl2
       lgpl21
@@ -1263,24 +1288,34 @@ rec {
   fa-ir = mkDict {
     pname = "hunspell-dict-fa-ir";
     version = "experimental-2022-09-04";
+
     dictFileName = "fa-IR";
     readmeFile = "README.md";
+
     src = fetchFromGitHub {
       owner = "b00f";
       repo = "lilak";
       rev = "1a80a8e5c9377ac424d29ef20be894e250bc9765";
       hash = "sha256-xonnrclzgFEHdQ9g8ijm0bo9r5a5Y0va52NoJR5d8mo=";
     };
+
     nativeBuildInputs = [ python3 ];
+
     buildPhase = ''
       runHook preBuild
+
       mkdir build
+
       (cd src && python3 lilak.py)
+
       mv build/* ./
+
       # remove timestamp from file
       sed -i 's/^\(## *File Version[^,]*\),.*/\1/' fa-IR.aff
+
       runHook postBuild
     '';
+
     meta = {
       description = "Hunspell dictionary for Persian (Iran)";
       homepage = "https://github.com/b00f/lilak";
@@ -1295,18 +1330,18 @@ rec {
   ro-ro = mkDict (finalAttrs: {
     pname = "hunspell-dict-ro-ro";
     version = "3.3.10";
-    shortName = "ro-ro";
+
     dictFileName = "ro_RO";
-    fileName = "${finalAttrs.dictFileName}.${finalAttrs.version}.zip";
+
     shortDescription = "Romanian (Romania)";
     readmeFile = "README";
 
     src = fetchurl {
-      url = "mirror://sourceforge/rospell/${finalAttrs.fileName}";
+      url = "mirror://sourceforge/rospell/${finalAttrs.dictFileName}.${finalAttrs.version}.zip";
       hash = "sha256-fxKNZOoGyeZxHDCxGMCv7vsBTY8zyS2szfRVq6LQRRk=";
     };
 
-    nativeBuildInputs = [ unzip ];
+    depsBuildBuild = [ unzip ];
     unpackCmd = ''
       unzip $curSrc ${finalAttrs.dictFileName}.aff ${finalAttrs.dictFileName}.dic ${finalAttrs.readmeFile} -d ${finalAttrs.dictFileName}
     '';
@@ -1325,15 +1360,15 @@ rec {
     pname = "hunspell-dict-tr-tr";
     version = "1.1.1";
 
+    dictFileName = "tr_TR";
+    readmeFile = "README.md";
+
     src = fetchFromGitHub {
       owner = "tdd-ai";
       repo = "hunspell-tr";
       rev = "7302eca5f3652fe7ae3d3ec06c44697c97342b4e";
       hash = "sha256-r/I5T/1e7gcp2XZ4UvnpFmWMTsNqLZSCbkqPcgC13PE=";
     };
-
-    dictFileName = "tr_TR";
-    readmeFile = "README.md";
 
     meta = {
       description = "Hunspell dictionary for Turkish (Turkey) from tdd-ai";
@@ -1352,6 +1387,7 @@ rec {
     dictFileName = "el_GR";
     shortDescription = "Greek (Greece)";
     readmeFile = "README_el_GR.txt";
+
     license = with lib.licenses; [
       mpl11
       gpl2


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This is best reviewed commit-by-commit

1. Remove all legacy sha256 hashes, only use SRI hashes
2. Remove all instances of `with lib;`
3. Convert `mkDict` to a fixed-point helper with `lib.extendMkDerivation`
4. Convert all uses of `mkDict` from `rec` to `finalAttrs`
5. Convert mkDictFromJ3e to fixed-point helper
6. Convert mkDictFromXuxen to fixed-point helper
7. Change all `unpackCmd` definitions to use `$curSrc`
8. mkDictFromRla to fixed-point helper
9. Fix cross-compilation with some invalid splicing stuff
10. mkDictFromDSSO to fixed-point helper
11. mkDictFromDicollecte to fixed-point helper
12. mkDictFromWorldlist to fixed-point helper
13. mkDictFromLinguistico to fixed-point helper
14. mkDictFromLibreOffice to fixed-point helper
15. Remove all `rev = version` uses and replace with `tag`
16. Try to declutter the derivations
17. mkDictFromChromium to fixed-point helper


Built by running `nom build -f . hunspellDicts`, `nom build -f. hunspellDictsChromium`, and `nom build -f. pkgsCross.aarch64-multiplatform.hunspellDicts`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
