### PR TITLE
top-level/all-packages: remove overwriting by-name callPackage

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -26,14 +26,14 @@
   libglvnd,
   libkrb5,
   openssl,
-
-  # Populate passthru.tests
-  tests,
+  ripgrep,
 
   # needed to fix "Save as Root"
   asar,
   bash,
+}:
 
+{
   # Attributes inherit from specific versions
   version,
   vscodeVersion ? version,
@@ -53,9 +53,11 @@
   vscodeServer ? null,
   sourceExecutableName ? executableName,
   useVSCodeRipgrep ? false,
-  ripgrep,
   hasVsceSign ? false,
   patchVSCodePath ? true,
+
+  # Populate passthru.tests
+  tests,
 }:
 
 stdenv.mkDerivation (

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   stdenvNoCC,
-  callPackage,
+  buildVscode,
   fetchurl,
   nixosTests,
   srcOnly,
@@ -51,7 +51,7 @@ let
   # This is used for VS Code - Remote SSH test
   rev = "7d842fb85a0275a4a8e4d7e040d2625abbf7f084";
 in
-callPackage ./generic.nix {
+buildVscode {
   pname = "vscode" + lib.optionalString isInsiders "-insiders";
 
   executableName = "code" + lib.optionalString isInsiders "-insiders";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  callPackage,
+  buildVscode,
   fetchurl,
   nixosTests,
   commandLineArgs ? "",
@@ -36,7 +36,7 @@ let
 
   sourceRoot = lib.optionalString (!stdenv.hostPlatform.isDarwin) ".";
 in
-callPackage ./generic.nix rec {
+buildVscode rec {
   inherit sourceRoot commandLineArgs useVSCodeRipgrep;
 
   # Please backport all compatible updates to the stable release.

--- a/pkgs/by-name/ae/aegisub/package.nix
+++ b/pkgs/by-name/ae/aegisub/package.nix
@@ -37,7 +37,11 @@
   pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   spellcheckSupport ? true,
   useBundledLuaJIT ? false,
-}:
+}@args:
+
+let
+  luajit = args.luajit.override { enable52Compat = true; };
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "aegisub";

--- a/pkgs/by-name/ak/akkoma-admin-fe/package.nix
+++ b/pkgs/by-name/ak/akkoma-admin-fe/package.nix
@@ -8,7 +8,7 @@
   yarn,
   nodejs,
   git,
-  python3,
+  python311,
   pkg-config,
   libsass,
   nix-update-script,
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     yarn
     nodejs
     pkg-config
-    python3
+    python311
     git
     libsass
   ]

--- a/pkgs/by-name/ak/akkoma/package.nix
+++ b/pkgs/by-name/ak/akkoma/package.nix
@@ -1,12 +1,23 @@
 {
   lib,
-  beamPackages,
+  beam_minimal,
   fetchFromGitea,
   cmake,
   file,
   nixosTests,
   nix-update-script,
 }:
+
+let
+  beamPackages = beam_minimal.packages.erlang_26.extend (
+    self: super: {
+      elixir = self.elixir_1_16;
+      rebar3 = self.rebar3WithPlugins {
+        plugins = with self; [ pc ];
+      };
+    }
+  );
+in
 
 beamPackages.mixRelease rec {
   pname = "akkoma";

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -13,7 +13,7 @@
   pciutils,
   procps,
   which,
-  fftw,
+  fftwFloat,
   pipewire,
   withPipewireLib ? true,
   symlinkJoin,
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     ncurses
     libsamplerate
-    fftw
+    fftwFloat
   ];
 
   configureFlags = [

--- a/pkgs/by-name/aq/aquamarine/package.nix
+++ b/pkgs/by-name/aq/aquamarine/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   cmake,
   fetchFromGitHub,
   hwdata,
@@ -21,7 +21,7 @@
   wayland-protocols,
   wayland-scanner,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "aquamarine";
   version = "0.9.5";
 

--- a/pkgs/by-name/ar/armips/package.nix
+++ b/pkgs/by-name/ar/armips/package.nix
@@ -1,11 +1,11 @@
 {
-  stdenv,
+  clangStdenv,
   lib,
   fetchFromGitHub,
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+clangStdenv.mkDerivation rec {
   pname = "armips";
   version = "0.11.0";
 

--- a/pkgs/by-name/ar/art/package.nix
+++ b/pkgs/by-name/ar/art/package.nix
@@ -22,7 +22,7 @@
   lcms2,
   libraw,
   libiptcdata,
-  fftw,
+  fftwSinglePrec,
   expat,
   pcre2,
   libsigcxx,
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     lcms2
     libraw
     libiptcdata
-    fftw
+    fftwSinglePrec
     expat
     pcre2
     libsigcxx

--- a/pkgs/by-name/at/atf/package.nix
+++ b/pkgs/by-name/at/atf/package.nix
@@ -6,7 +6,13 @@
   autoreconfHook,
   kyua,
   gitUpdater,
-}:
+  darwin,
+}@args:
+
+let
+  # atf is a dependency of libiconv. Avoid an infinite recursion with `pkgsStatic` by using a bootstrap stdenv.
+  stdenv = if args.stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else args.stdenv;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "atf";

--- a/pkgs/by-name/ba/basalt-monado/package.nix
+++ b/pkgs/by-name/ba/basalt-monado/package.nix
@@ -24,7 +24,12 @@
   xorg,
   cudaPackages,
   enableCuda ? config.cudaSupport,
-}:
+}@args:
+
+let
+  opencv = args.opencv.override { enableGtk3 = true; };
+in
+
 stdenv.mkDerivation {
   pname = "basalt-monado";
   version = "0-unstable-2025-09-25";

--- a/pkgs/by-name/ba/bazel_7/package.nix
+++ b/pkgs/by-name/ba/bazel_7/package.nix
@@ -10,9 +10,6 @@
   makeBinaryWrapper,
   autoPatchelfHook,
   buildFHSEnv,
-  # this package (through the fixpoint glass)
-  # TODO probably still need for tests at some point
-  bazel_self,
   # native build inputs
   runtimeShell,
   zip,

--- a/pkgs/by-name/ba/bazel_7/package.nix
+++ b/pkgs/by-name/ba/bazel_7/package.nix
@@ -34,8 +34,9 @@
   libtool,
   darwin,
   # Allow to independently override the jdks used to build and run respectively
-  buildJdk,
-  runJdk,
+  jdk21_headless,
+  buildJdk ? jdk21_headless,
+  runJdk ? jdk21_headless,
   # Toggle for hacks for running bazel under buildBazelPackage:
   # Always assume all markers valid (this is needed because we remove markers; they are non-deterministic).
   # Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).

--- a/pkgs/by-name/ba/bazel_7/package.nix
+++ b/pkgs/by-name/ba/bazel_7/package.nix
@@ -32,7 +32,7 @@
   # Apple dependencies
   cctools,
   libtool,
-  sigtool,
+  darwin,
   # Allow to independently override the jdks used to build and run respectively
   buildJdk,
   runJdk,
@@ -414,7 +414,7 @@ stdenv.mkDerivation rec {
         # don't use system installed Xcode to run clang, use Nix clang instead
         sed -i -E \
           -e "s;/usr/bin/xcrun (--sdk macosx )?clang;${stdenv.cc}/bin/clang $NIX_CFLAGS_COMPILE $(bazelLinkFlags) -framework CoreFoundation;g" \
-          -e "s;/usr/bin/codesign;CODESIGN_ALLOCATE=${cctools}/bin/${cctools.targetPrefix}codesign_allocate ${sigtool}/bin/codesign;" \
+          -e "s;/usr/bin/codesign;CODESIGN_ALLOCATE=${cctools}/bin/${cctools.targetPrefix}codesign_allocate ${darwin.sigtool}/bin/codesign;" \
           scripts/bootstrap/compile.sh \
           tools/osx/BUILD
 

--- a/pkgs/by-name/bi/biblioteca/package.nix
+++ b/pkgs/by-name/bi/biblioteca/package.nix
@@ -12,7 +12,7 @@
   gtk4,
   gobject-introspection,
   libadwaita,
-  webkitgtk,
+  webkitgtk_6_0,
   coreutils,
   makeShellWrapper,
   wrapGAppsHook4,
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     gtk4
     gobject-introspection
     libadwaita
-    webkitgtk
+    webkitgtk_6_0
     glib-networking
   ];
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
       gtk4.devdoc
       glib.devdoc
       libadwaita.devdoc
-      webkitgtk.devdoc
+      webkitgtk_6_0.devdoc
       gobject-introspection.devdoc
     ]
     ++ extraDocsPackage;

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -67,7 +67,7 @@
   pkg-config,
   potrace,
   pugixml,
-  python3Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
+  python311Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
   rocmPackages, # comes with a significantly larger closure size
   runCommand,
   shaderc,
@@ -94,6 +94,7 @@ let
     (!stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) || stdenv.hostPlatform.isDarwin;
   vulkanSupport = !stdenv.hostPlatform.isDarwin;
 
+  python3Packages = python311Packages;
   python3 = python3Packages.python;
   pyPkgsOpenusd = python3Packages.openusd.override (old: {
     opensubdiv = old.opensubdiv.override { inherit cudaSupport; };

--- a/pkgs/by-name/bl/bluespec/package.nix
+++ b/pkgs/by-name/bl/bluespec/package.nix
@@ -17,7 +17,7 @@
   yices, # bsc uses a patched version of yices
   zlib,
   ghc,
-  gmp-static,
+  gmp,
   iverilog,
   asciidoctor,
   texliveFull,
@@ -51,6 +51,8 @@ let
       split
     ])
   );
+
+  gmp-static = gmp.override { withStatic = true; };
 
 in
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/ca/cantata/package.nix
+++ b/pkgs/by-name/ca/cantata/package.nix
@@ -24,7 +24,7 @@
   withHttpStream ? true,
   gst_all_1,
   withReplaygain ? true,
-  ffmpeg,
+  ffmpeg_6,
   speex,
   mpg123,
   withMtp ? true,
@@ -91,7 +91,7 @@ let
       ];
       enable = withReplaygain;
       pkgs = [
-        ffmpeg
+        ffmpeg_6
         speex
         mpg123
       ];

--- a/pkgs/by-name/cl/clang-uml/package.nix
+++ b/pkgs/by-name/cl/clang-uml/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  stdenv,
+  clangStdenv,
   cmake,
   pkg-config,
   installShellFiles,
@@ -15,7 +15,7 @@
   enableLibcxx ? false,
   debug ? false,
 }:
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "clang-uml";
   version = "0.6.1";
 

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -8,7 +8,7 @@
   wrapGAppsHook3,
   v2ray-geoip,
   v2ray-domain-list-community,
-  libsoup,
+  libsoup_3,
 }:
 let
   pname = "clash-verge-rev";
@@ -50,7 +50,7 @@ let
       pnpm-hash
       vendor-hash
       meta
-      libsoup
+      libsoup_3
       ;
   };
 

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -20,7 +20,7 @@
   kdePackages,
   libayatana-appindicator,
   libsForQt5,
-  libsoup,
+  libsoup_3,
   openssl,
   webkitgtk_4_1,
 }:
@@ -99,7 +99,7 @@ rustPlatform.buildRustPackage {
 
   buildInputs = [
     libayatana-appindicator
-    libsoup
+    libsoup_3
     openssl
     webkitgtk_4_1
   ];

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  callPackage,
-  vscode-generic,
+  buildVscode,
   fetchurl,
   appimageTools,
   undmg,
@@ -35,7 +34,7 @@ let
 
   source = sources.${hostPlatform.system};
 in
-(callPackage vscode-generic rec {
+(buildVscode rec {
   inherit useVSCodeRipgrep;
   commandLineArgs = finalCommandLineArgs;
 

--- a/pkgs/by-name/co/cope/package.nix
+++ b/pkgs/by-name/co/cope/package.nix
@@ -1,9 +1,12 @@
 {
   lib,
   fetchFromGitHub,
-  perl,
-  perlPackages,
+  perl538Packages,
 }:
+
+let
+  perlPackages = perl538Packages;
+in
 
 perlPackages.buildPerlPackage {
   pname = "cope";

--- a/pkgs/by-name/cp/cp2k/package.nix
+++ b/pkgs/by-name/cp/cp2k/package.nix
@@ -12,7 +12,7 @@
   fftw,
   libint,
   libvori,
-  libxc,
+  libxc_7,
   dftd4,
   simple-dftd3,
   tblite,
@@ -165,7 +165,7 @@ stdenv.mkDerivation rec {
     gsl
     libint
     libvori
-    libxc
+    libxc_7
     libxsmm
     mpi
     spglib

--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -53,7 +53,7 @@
   libtiff,
   libwebp,
   libxml2,
-  lua,
+  lua5_4,
   util-linux,
   openexr,
   openjpeg,
@@ -138,7 +138,7 @@ stdenv.mkDerivation rec {
     libtiff
     libwebp
     libxml2
-    lua
+    lua5_4
     openexr
     openjpeg
     osm-gps-map

--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -77,7 +77,11 @@
 
   versionCheckHook,
   gitUpdater,
-}:
+}@args:
+
+let
+  pugixml = args.pugixml.override { shared = true; };
+in
 
 stdenv.mkDerivation rec {
   version = "5.2.1";

--- a/pkgs/by-name/da/davis/package.nix
+++ b/pkgs/by-name/da/davis/package.nix
@@ -1,9 +1,14 @@
 {
   lib,
   fetchFromGitHub,
-  php,
+  php83,
   nixosTests,
 }:
+
+let
+  # https://github.com/tchapi/davis/issues/195
+  php = php83;
+in
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "davis";

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -7,7 +7,7 @@
   openjdk21,
   gnused,
   autoPatchelfHook,
-  autoSignDarwinBinariesHook,
+  darwin,
   wrapGAppsHook3,
   gtk3,
   glib,
@@ -54,7 +54,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
     undmg
-    autoSignDarwinBinariesHook
+    darwin.autoSignDarwinBinariesHook
   ];
 
   dontConfigure = true;
@@ -144,7 +144,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.asl20;
-    platforms = with lib.platforms; linux ++ darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [
       gepbird
       mkg20001

--- a/pkgs/by-name/db/dbqn/package.nix
+++ b/pkgs/by-name/db/dbqn/package.nix
@@ -1,13 +1,17 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
-  jdk,
+  jre,
   makeWrapper,
   buildNativeImage ? false,
 }:
 
-stdenv.mkDerivation rec {
+let
+  jdk = jre;
+in
+
+stdenvNoCC.mkDerivation rec {
   pname = "dbqn" + lib.optionalString buildNativeImage "-native";
   version = "0.2.2";
 
@@ -78,6 +82,6 @@ stdenv.mkDerivation rec {
       sternenseemann
     ];
     inherit (jdk.meta) platforms;
-    broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dbqn-native.x86_64-darwin
+    broken = stdenvNoCC.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dbqn-native.x86_64-darwin
   };
 }

--- a/pkgs/by-name/di/dillo/package.nix
+++ b/pkgs/by-name/di/dillo/package.nix
@@ -2,7 +2,7 @@
   lib,
   autoreconfHook,
   fetchFromGitHub,
-  fltk,
+  fltk13,
   libjpeg,
   libpng,
   libwebp,
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
-    fltk
+    fltk13
     which
   ];
 
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libwebp
     ssl
-    fltk
+    fltk13
   ];
 
   outputs = [

--- a/pkgs/by-name/dj/djv/package.nix
+++ b/pkgs/by-name/dj/djv/package.nix
@@ -18,7 +18,7 @@
   libpng,
   opencolorio_1,
   freetype,
-  openexr,
+  openexr_2,
 }:
 
 let
@@ -152,7 +152,7 @@ stdenv.mkDerivation {
     freetype
     opencolorio_1
     djv-deps
-    openexr
+    openexr_2
   ];
 
   postPatch = ''

--- a/pkgs/by-name/dw/dwl/package.nix
+++ b/pkgs/by-name/dw/dwl/package.nix
@@ -14,7 +14,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots,
+  wlroots_0_18,
   writeText,
   xcbutilwm,
   xwayland,
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     pixman
     wayland
     wayland-protocols
-    wlroots
+    wlroots_0_18
   ]
   ++ lib.optionals enableXWayland [
     libX11

--- a/pkgs/by-name/ef/eff/package.nix
+++ b/pkgs/by-name/ef/eff/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   fetchFromGitHub,
-  ocamlPackages,
+  ocaml-ng,
 }:
 
 let
-  inherit (ocamlPackages) buildDunePackage js_of_ocaml menhir;
+  inherit (ocaml-ng.ocamlPackages_5_2) buildDunePackage js_of_ocaml menhir;
 in
 
 buildDunePackage rec {

--- a/pkgs/by-name/el/element-web/package.nix
+++ b/pkgs/by-name/el/element-web/package.nix
@@ -3,7 +3,8 @@
   stdenv,
   jq,
   element-web-unwrapped,
-  conf ? { },
+  config,
+  conf ? config.element-web.conf or { },
 }:
 
 if (conf == { }) then

--- a/pkgs/by-name/eu/eudev/package.nix
+++ b/pkgs/by-name/eu/eudev/package.nix
@@ -6,7 +6,7 @@
   gperf,
   kmod,
   pkg-config,
-  util-linux,
+  util-linuxMinimal,
   testers,
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     kmod
-    util-linux
+    util-linuxMinimal
   ];
 
   configureFlags = [

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -16,7 +16,7 @@
   libxkbcommon,
   makeDesktopItem,
   makeWrapper,
-  releaseType,
+  releaseType ? "alpha",
   stdenv,
   wayland,
 

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -2,7 +2,7 @@
   lib,
   nixosTests,
   fetchFromGitHub,
-  beamPackages,
+  beam27Packages,
   gitMinimal,
   pnpm_9,
   nodejs,
@@ -12,7 +12,7 @@
   mixReleaseName ? "domain", # "domain" "web" or "api"
 }:
 
-beamPackages.mixRelease rec {
+beam27Packages.mixRelease rec {
   pname = "firezone-server-${mixReleaseName}";
   version = "0-unstable-2025-08-31";
 
@@ -67,7 +67,7 @@ beamPackages.mixRelease rec {
 
   inherit mixReleaseName;
 
-  mixFodDeps = beamPackages.fetchMixDeps {
+  mixFodDeps = beam27Packages.fetchMixDeps {
     pname = "mix-deps-${pname}-${version}";
     inherit src version;
     hash = "sha256-h3l7HK9dxNmkHWfJyCOCXmCvFOK+mZtmszhRv0zxqoo=";

--- a/pkgs/by-name/fr/freedv/package.nix
+++ b/pkgs/by-name/fr/freedv/package.nix
@@ -22,7 +22,7 @@
   dbus,
   apple-sdk_15,
   nix-update-script,
-}:
+}@args:
 
 let
   ebur128Src = fetchFromGitHub {
@@ -43,6 +43,7 @@ let
     rev = "2354cd2a4b3af60c7feb1c0d6b3d6dd7417c2ac9";
     hash = "sha256-yEr/OCXV83qXi89QHXMrUtQ2UwNOsijQMN35Or2JP+Y=";
   };
+  codec2 = args.codec2.override { freedvSupport = true; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "freedv";

--- a/pkgs/by-name/fr/freeimage/package.nix
+++ b/pkgs/by-name/fr/freeimage/package.nix
@@ -8,7 +8,7 @@
   zlib,
   libwebp,
   libraw,
-  openexr,
+  openexr_2,
   openjpeg,
   libjpeg,
   jxrlib,
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     libwebp
     libraw
-    openexr
+    openexr_2
     openjpeg
     libjpeg
     libjpeg.dev_private

--- a/pkgs/by-name/g-/g-wrap/package.nix
+++ b/pkgs/by-name/g-/g-wrap/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  guile,
+  guile_2_2,
   guile-lib,
   libffi,
   pkg-config,
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   # Note: Glib support is optional, but it's quite useful (e.g., it's used by
   # Guile-GNOME).
   buildInputs = [
-    guile
+    guile_2_2
     glib
     guile-lib
   ];

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -37,7 +37,7 @@
   makeBinaryWrapper,
   nix-update-script,
   enableExecutable ? true,
-  enableWsi ? true,
+  enableWsi ? false,
 }:
 let
   frogShaders = fetchFromGitHub {

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -29,7 +29,7 @@
   glslang,
   hwdata,
   stb,
-  wlroots,
+  wlroots_0_17,
   libdecor,
   lcms,
   lib,
@@ -138,7 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     vulkan-headers
   ]
   ++ lib.optionals enableExecutable (
-    wlroots.buildInputs
+    wlroots_0_17.buildInputs
     ++ [
       # gamescope uses a custom wlroots branch
       xorg.libXcomposite

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -74,317 +74,327 @@ let
       lib.meta.availableOn stdenv.hostPlatform libsystemtap;
 in
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "glib";
-  version = "2.84.4";
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    glib-untested = finalAttrs.finalPackage.overrideAttrs { doCheck = false; };
+    # break dependency cycles
+    # these things are only used for tests, they don't get into the closure
+    shared-mime-info = args.shared-mime-info.override { glib = glib-untested; };
+    desktop-file-utils = args.desktop-file-utils.override { glib = glib-untested; };
+  in
+  {
+    pname = "glib";
+    version = "2.84.4";
 
-  outputs = [
-    "bin"
-    "out"
-    "dev"
-    "devdoc"
-  ];
+    outputs = [
+      "bin"
+      "out"
+      "dev"
+      "devdoc"
+    ];
 
-  setupHook = ./setup-hook.sh;
+    setupHook = ./setup-hook.sh;
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ip6hCUPDb8EX4lP4DJHkd7ZzUlrkV2KUKFiu9XYxu5A=";
-  };
+    src = fetchurl {
+      url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
+      hash = "sha256-ip6hCUPDb8EX4lP4DJHkd7ZzUlrkV2KUKFiu9XYxu5A=";
+    };
 
-  patches =
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      ./darwin-compilation.patch
+    patches =
+      lib.optionals stdenv.hostPlatform.isDarwin [
+        ./darwin-compilation.patch
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isMusl [
+        ./quark_init_on_demand.patch
+        ./gobject_init_on_demand.patch
+      ]
+      ++ [
+        # This patch lets GLib's GDesktopAppInfo API watch and notice changes
+        # to the Nix user and system profiles.  That way, the list of available
+        # applications shown by the desktop environment is immediately updated
+        # when the user installs or removes any
+        # (see <https://issues.guix.gnu.org/35594>).
+
+        # It does so by monitoring /nix/var/nix/profiles (for changes to the system
+        # profile) and /nix/var/nix/profiles/per-user/USER (for changes to the user
+        # profile) as well as /etc/profiles/per-user (for chanes to the user
+        # environment profile) and crawling their share/applications sub-directory when
+        # changes happen.
+        ./glib-appinfo-watch.patch
+
+        ./schema-override-variable.patch
+
+        # Add support for Pantheon’s terminal emulator.
+        ./elementary-terminal-support.patch
+
+        # GLib contains many binaries used for different purposes;
+        # we will install them to different outputs:
+        # 1. Tools for desktop environment and introspection ($bin)
+        #    * gapplication (non-darwin)
+        #    * gdbus
+        #    * gi-compile-repository
+        #    * gi-decompile-typelib
+        #    * gi-inspect-typelib
+        #    * gio
+        #    * gio-launch-desktop (symlink to $out)
+        #    * gsettings
+        # 2. Development/build tools ($dev)
+        #    * gdbus-codegen
+        #    * gio-querymodules
+        #    * glib-compile-resources
+        #    * glib-compile-schemas
+        #    * glib-genmarshal
+        #    * glib-gettextize
+        #    * glib-mkenums
+        #    * gobject-query
+        #    * gresource
+        #    * gtester
+        #    * gtester-report
+        # 3. Tools for desktop environment that cannot go to $bin due to $out depending on them ($out)
+        #    * gio-launch-desktop
+        ./split-dev-programs.patch
+
+        # Tell Meson to install gdb scripts next to the lib
+        # GDB only looks there and in ${gdb}/share/gdb/auto-load,
+        # and by default meson installs in to $out/share/gdb/auto-load
+        # which does not help
+        ./gdb_script.patch
+      ];
+
+    strictDeps = true;
+
+    buildInputs = [
+      finalAttrs.setupHook
     ]
-    ++ lib.optionals stdenv.hostPlatform.isMusl [
-      ./quark_init_on_demand.patch
-      ./gobject_init_on_demand.patch
+    ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [
+      libsysprof-capture
     ]
     ++ [
-      # This patch lets GLib's GDesktopAppInfo API watch and notice changes
-      # to the Nix user and system profiles.  That way, the list of available
-      # applications shown by the desktop environment is immediately updated
-      # when the user installs or removes any
-      # (see <https://issues.guix.gnu.org/35594>).
-
-      # It does so by monitoring /nix/var/nix/profiles (for changes to the system
-      # profile) and /nix/var/nix/profiles/per-user/USER (for changes to the user
-      # profile) as well as /etc/profiles/per-user (for chanes to the user
-      # environment profile) and crawling their share/applications sub-directory when
-      # changes happen.
-      ./glib-appinfo-watch.patch
-
-      ./schema-override-variable.patch
-
-      # Add support for Pantheon’s terminal emulator.
-      ./elementary-terminal-support.patch
-
-      # GLib contains many binaries used for different purposes;
-      # we will install them to different outputs:
-      # 1. Tools for desktop environment and introspection ($bin)
-      #    * gapplication (non-darwin)
-      #    * gdbus
-      #    * gi-compile-repository
-      #    * gi-decompile-typelib
-      #    * gi-inspect-typelib
-      #    * gio
-      #    * gio-launch-desktop (symlink to $out)
-      #    * gsettings
-      # 2. Development/build tools ($dev)
-      #    * gdbus-codegen
-      #    * gio-querymodules
-      #    * glib-compile-resources
-      #    * glib-compile-schemas
-      #    * glib-genmarshal
-      #    * glib-gettextize
-      #    * glib-mkenums
-      #    * gobject-query
-      #    * gresource
-      #    * gtester
-      #    * gtester-report
-      # 3. Tools for desktop environment that cannot go to $bin due to $out depending on them ($out)
-      #    * gio-launch-desktop
-      ./split-dev-programs.patch
-
-      # Tell Meson to install gdb scripts next to the lib
-      # GDB only looks there and in ${gdb}/share/gdb/auto-load,
-      # and by default meson installs in to $out/share/gdb/auto-load
-      # which does not help
-      ./gdb_script.patch
+      pcre2
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
+      bash
+      gnum4 # install glib-gettextize and m4 macros for other apps to use
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
+      elfutils
+    ]
+    ++ lib.optionals withDtrace [
+      libsystemtap
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libselinux
+      util-linuxMinimal # for libmount
     ];
 
-  strictDeps = true;
-
-  buildInputs = [
-    finalAttrs.setupHook
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [
-    libsysprof-capture
-  ]
-  ++ [
-    pcre2
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-    bash
-    gnum4 # install glib-gettextize and m4 macros for other apps to use
-  ]
-  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
-    elfutils
-  ]
-  ++ lib.optionals withDtrace [
-    libsystemtap
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libselinux
-    util-linuxMinimal # for libmount
-  ];
-
-  depsBuildBuild = [
-    pkg-config # required to find native gi-docgen
-  ];
-
-  nativeBuildInputs = [
-    docutils # for rst2man, rst2html5
-    meson
-    ninja
-    pkg-config
-    perl
-    python3
-    python3Packages.packaging # mostly used to make meson happy
-    python3Packages.wrapPython # for patchPythonScript
-    gettext
-    libxslt
-  ]
-  ++ lib.optionals withIntrospection [
-    gi-docgen
-    gobject-introspection'
-  ]
-  ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    mesonEmulatorHook
-  ]
-  ++ lib.optionals withDtrace [
-    systemtap' # for dtrace
-  ];
-
-  propagatedBuildInputs = [
-    zlib
-    libffi
-    gettext
-    libiconv
-  ];
-
-  nativeCheckInputs = [
-    tzdata
-    desktop-file-utils
-    shared-mime-info
-  ];
-
-  mesonFlags = [
-    "-Dglib_debug=disabled" # https://gitlab.gnome.org/GNOME/glib/-/issues/3421#note_2206315
-    "-Ddocumentation=true" # gvariant specification can be built without gi-docgen
-    (lib.mesonEnable "dtrace" withDtrace)
-    (lib.mesonEnable "systemtap" withDtrace) # requires dtrace option to be enabled
-    "-Dnls=enabled"
-    "-Ddevbindir=${placeholder "dev"}/bin"
-    (lib.mesonEnable "introspection" withIntrospection)
-    # FIXME: Fails when linking target glib/tests/libconstructor-helper.so
-    # relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
-    "-Dtests=${lib.boolToString (!stdenv.hostPlatform.isStatic)}"
-  ]
-  ++ lib.optionals (!lib.meta.availableOn stdenv.hostPlatform elfutils) [
-    "-Dlibelf=disabled"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
-    "-Dxattr=false"
-    "-Dsysprof=disabled" # sysprof-capture does not build on FreeBSD
-  ];
-
-  env = {
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error=nonnull"
-      # Default for release buildtype but passed manually because
-      # we're using plain
-      "-DG_DISABLE_CAST_CHECKS"
+    depsBuildBuild = [
+      pkg-config # required to find native gi-docgen
     ];
-  };
 
-  postPatch = ''
-    patchShebangs glib/gen-unicode-tables.pl
-    patchShebangs glib/tests/gen-casefold-txt.py
-    patchShebangs glib/tests/gen-casemap-txt.py
-    patchShebangs tools/gen-visibility-macros.py
-    patchShebangs tests
+    nativeBuildInputs = [
+      docutils # for rst2man, rst2html5
+      meson
+      ninja
+      pkg-config
+      perl
+      python3
+      python3Packages.packaging # mostly used to make meson happy
+      python3Packages.wrapPython # for patchPythonScript
+      gettext
+      libxslt
+    ]
+    ++ lib.optionals withIntrospection [
+      gi-docgen
+      gobject-introspection'
+    ]
+    ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      mesonEmulatorHook
+    ]
+    ++ lib.optionals withDtrace [
+      systemtap' # for dtrace
+    ];
 
-    # Needs machine-id, comment the test
-    sed -e '/\/gdbus\/codegen-peer-to-peer/ s/^\/*/\/\//' -i gio/tests/gdbus-peer.c
-    sed -e '/g_test_add_func/ s/^\/*/\/\//' -i gio/tests/gdbus-address-get-session.c
-    # All gschemas fail to pass the test, upstream bug?
-    sed -e '/g_test_add_data_func/ s/^\/*/\/\//' -i gio/tests/gschema-compile.c
-    # Cannot reproduce the failing test_associations on hydra
-    sed -e '/\/appinfo\/associations/d' -i gio/tests/appinfo.c
-    # Needed because of libtool wrappers
-    sed -e '/g_subprocess_launcher_set_environ (launcher, envp);/a g_subprocess_launcher_setenv (launcher, "PATH", g_getenv("PATH"), TRUE);' -i gio/tests/gsubprocess.c
-  ''
-  + lib.optionalString stdenv.hostPlatform.isWindows ''
-    substituteInPlace gio/win32/meson.build \
-      --replace "libintl, " ""
-  '';
+    propagatedBuildInputs = [
+      zlib
+      libffi
+      gettext
+      libiconv
+    ];
 
-  postConfigure = ''
-    patchShebangs gio/gdbus-2.0/codegen/gdbus-codegen gobject/glib-{genmarshal,mkenums}
-  '';
+    nativeCheckInputs = [
+      tzdata
+      desktop-file-utils
+      shared-mime-info
+    ];
 
-  DETERMINISTIC_BUILD = 1;
+    mesonFlags = [
+      "-Dglib_debug=disabled" # https://gitlab.gnome.org/GNOME/glib/-/issues/3421#note_2206315
+      "-Ddocumentation=true" # gvariant specification can be built without gi-docgen
+      (lib.mesonEnable "dtrace" withDtrace)
+      (lib.mesonEnable "systemtap" withDtrace) # requires dtrace option to be enabled
+      "-Dnls=enabled"
+      "-Ddevbindir=${placeholder "dev"}/bin"
+      (lib.mesonEnable "introspection" withIntrospection)
+      # FIXME: Fails when linking target glib/tests/libconstructor-helper.so
+      # relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
+      "-Dtests=${lib.boolToString (!stdenv.hostPlatform.isStatic)}"
+    ]
+    ++ lib.optionals (!lib.meta.availableOn stdenv.hostPlatform elfutils) [
+      "-Dlibelf=disabled"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+      "-Dxattr=false"
+      "-Dsysprof=disabled" # sysprof-capture does not build on FreeBSD
+    ];
 
-  postInstall = ''
-    moveToOutput "share/glib-2.0" "$dev"
-    moveToOutput "share/glib-2.0/gdb" "$out"
-    substituteInPlace "$dev/bin/gdbus-codegen" --replace "$out" "$dev"
-    sed -i "$dev/bin/glib-gettextize" -e "s|^gettext_dir=.*|gettext_dir=$dev/share/glib-2.0/gettext|"
-
-    # This file is *included* in gtk3 and would introduce runtime reference via __FILE__.
-    sed '1i#line 1 "glib-${finalAttrs.version}/include/glib-2.0/gobject/gobjectnotifyqueue.c"' \
-      -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
-    for i in $bin/bin/*; do
-      moveToOutput "share/bash-completion/completions/''${i##*/}" "$bin"
-    done
-    for i in $dev/bin/*; do
-      moveToOutput "share/bash-completion/completions/''${i##*/}" "$dev"
-    done
-  '';
-
-  preFixup = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-    buildPythonPath ${python3Packages.packaging}
-    patchPythonScript "$dev/share/glib-2.0/codegen/utils.py"
-  '';
-
-  # Move man pages to the same output as their binaries (needs to be
-  # done after preFixupHooks which moves man pages too - in
-  # _multioutDocs)
-  postFixup = ''
-    for i in $dev/bin/*; do
-      moveToOutput "share/man/man1/''${i##*/}.1.*" "$dev"
-    done
-
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
-  # Conditional necessary to break infinite recursion with passthru.tests
-  preCheck = lib.optionalString finalAttrs.finalPackage.doCheck or config.doCheckByDefault or false ''
-    export LD_LIBRARY_PATH="$NIX_BUILD_TOP/glib-${finalAttrs.version}/glib/.libs''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
-    export TZDIR="${tzdata}/share/zoneinfo"
-    export XDG_CACHE_HOME="$TMP"
-    export XDG_RUNTIME_HOME="$TMP"
-    export HOME="$TMP"
-    export XDG_DATA_DIRS="${desktop-file-utils}/share:${shared-mime-info}/share"
-    export G_TEST_DBUS_DAEMON="${dbus}/bin/dbus-daemon"
-
-    # pkg_config_tests expects a PKG_CONFIG_PATH that points to meson-private, wrapped pkg-config
-    # tries to be clever and picks up the wrong glib at the end.
-    export PATH="${buildPackages.pkg-config-unwrapped}/bin:$PATH:$(pwd)/gobject"
-    echo "PATH=$PATH"
-
-    # Our gobject-introspection patches make the shared library paths absolute
-    # in the GIR files. When running tests, the library is not yet installed,
-    # though, so we need to replace the absolute path with a local one during build.
-    # We are using a symlink that we will delete before installation.
-    mkdir -p $out/lib
-    ln -s $PWD/gobject/libgobject-${librarySuffix} $out/lib/libgobject-${librarySuffix}
-    ln -s $PWD/gio/libgio-${librarySuffix} $out/lib/libgio-${librarySuffix}
-    ln -s $PWD/glib/libglib-${librarySuffix} $out/lib/libglib-${librarySuffix}
-  '';
-
-  postCheck = ''
-    rm $out/lib/libgobject-${librarySuffix}
-    rm $out/lib/libgio-${librarySuffix}
-    rm $out/lib/libglib-${librarySuffix}
-  '';
-
-  separateDebugInfo = stdenv.hostPlatform.isLinux;
-
-  passthru = rec {
-    gioModuleDir = "lib/gio/modules";
-
-    makeSchemaDataDirPath = dir: name: "${dir}/share/gsettings-schemas/${name}";
-    makeSchemaPath = dir: name: "${makeSchemaDataDirPath dir name}/glib-2.0/schemas";
-    getSchemaPath = pkg: makeSchemaPath pkg pkg.name;
-    getSchemaDataDirPath = pkg: makeSchemaDataDirPath pkg pkg.name;
-
-    tests = {
-      withChecks = finalAttrs.finalPackage.overrideAttrs (_: {
-        doCheck = true;
-      });
-      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    env = {
+      NIX_CFLAGS_COMPILE = toString [
+        "-Wno-error=nonnull"
+        # Default for release buildtype but passed manually because
+        # we're using plain
+        "-DG_DISABLE_CAST_CHECKS"
+      ];
     };
 
-    updateScript = gnome.updateScript {
-      packageName = "glib";
-      versionPolicy = "odd-unstable";
-    };
-  };
+    postPatch = ''
+      patchShebangs glib/gen-unicode-tables.pl
+      patchShebangs glib/tests/gen-casefold-txt.py
+      patchShebangs glib/tests/gen-casemap-txt.py
+      patchShebangs tools/gen-visibility-macros.py
+      patchShebangs tests
 
-  meta = with lib; {
-    description = "C library of programming buildings blocks";
-    homepage = "https://gitlab.gnome.org/GNOME/glib";
-    license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [
-      lovek323
-      raskin
-    ];
-    teams = [ teams.gnome ];
-    pkgConfigModules = [
-      "gio-2.0"
-      "gobject-2.0"
-      "gthread-2.0"
-    ];
-    platforms = platforms.unix ++ platforms.windows;
-
-    longDescription = ''
-      GLib provides the core application building blocks for libraries
-      and applications written in C.  It provides the core object
-      system used in GNOME, the main loop implementation, and a large
-      set of utility functions for strings and common data structures.
+      # Needs machine-id, comment the test
+      sed -e '/\/gdbus\/codegen-peer-to-peer/ s/^\/*/\/\//' -i gio/tests/gdbus-peer.c
+      sed -e '/g_test_add_func/ s/^\/*/\/\//' -i gio/tests/gdbus-address-get-session.c
+      # All gschemas fail to pass the test, upstream bug?
+      sed -e '/g_test_add_data_func/ s/^\/*/\/\//' -i gio/tests/gschema-compile.c
+      # Cannot reproduce the failing test_associations on hydra
+      sed -e '/\/appinfo\/associations/d' -i gio/tests/appinfo.c
+      # Needed because of libtool wrappers
+      sed -e '/g_subprocess_launcher_set_environ (launcher, envp);/a g_subprocess_launcher_setenv (launcher, "PATH", g_getenv("PATH"), TRUE);' -i gio/tests/gsubprocess.c
+    ''
+    + lib.optionalString stdenv.hostPlatform.isWindows ''
+      substituteInPlace gio/win32/meson.build \
+        --replace "libintl, " ""
     '';
-  };
-})
+
+    postConfigure = ''
+      patchShebangs gio/gdbus-2.0/codegen/gdbus-codegen gobject/glib-{genmarshal,mkenums}
+    '';
+
+    DETERMINISTIC_BUILD = 1;
+
+    postInstall = ''
+      moveToOutput "share/glib-2.0" "$dev"
+      moveToOutput "share/glib-2.0/gdb" "$out"
+      substituteInPlace "$dev/bin/gdbus-codegen" --replace "$out" "$dev"
+      sed -i "$dev/bin/glib-gettextize" -e "s|^gettext_dir=.*|gettext_dir=$dev/share/glib-2.0/gettext|"
+
+      # This file is *included* in gtk3 and would introduce runtime reference via __FILE__.
+      sed '1i#line 1 "glib-${finalAttrs.version}/include/glib-2.0/gobject/gobjectnotifyqueue.c"' \
+        -i "$dev"/include/glib-2.0/gobject/gobjectnotifyqueue.c
+      for i in $bin/bin/*; do
+        moveToOutput "share/bash-completion/completions/''${i##*/}" "$bin"
+      done
+      for i in $dev/bin/*; do
+        moveToOutput "share/bash-completion/completions/''${i##*/}" "$dev"
+      done
+    '';
+
+    preFixup = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+      buildPythonPath ${python3Packages.packaging}
+      patchPythonScript "$dev/share/glib-2.0/codegen/utils.py"
+    '';
+
+    # Move man pages to the same output as their binaries (needs to be
+    # done after preFixupHooks which moves man pages too - in
+    # _multioutDocs)
+    postFixup = ''
+      for i in $dev/bin/*; do
+        moveToOutput "share/man/man1/''${i##*/}.1.*" "$dev"
+      done
+
+      # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+      moveToOutput "share/doc" "$devdoc"
+    '';
+
+    # Conditional necessary to break infinite recursion with passthru.tests
+    preCheck = lib.optionalString finalAttrs.finalPackage.doCheck or config.doCheckByDefault or false ''
+      export LD_LIBRARY_PATH="$NIX_BUILD_TOP/glib-${finalAttrs.version}/glib/.libs''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+      export TZDIR="${tzdata}/share/zoneinfo"
+      export XDG_CACHE_HOME="$TMP"
+      export XDG_RUNTIME_HOME="$TMP"
+      export HOME="$TMP"
+      export XDG_DATA_DIRS="${desktop-file-utils}/share:${shared-mime-info}/share"
+      export G_TEST_DBUS_DAEMON="${dbus}/bin/dbus-daemon"
+
+      # pkg_config_tests expects a PKG_CONFIG_PATH that points to meson-private, wrapped pkg-config
+      # tries to be clever and picks up the wrong glib at the end.
+      export PATH="${buildPackages.pkg-config-unwrapped}/bin:$PATH:$(pwd)/gobject"
+      echo "PATH=$PATH"
+
+      # Our gobject-introspection patches make the shared library paths absolute
+      # in the GIR files. When running tests, the library is not yet installed,
+      # though, so we need to replace the absolute path with a local one during build.
+      # We are using a symlink that we will delete before installation.
+      mkdir -p $out/lib
+      ln -s $PWD/gobject/libgobject-${librarySuffix} $out/lib/libgobject-${librarySuffix}
+      ln -s $PWD/gio/libgio-${librarySuffix} $out/lib/libgio-${librarySuffix}
+      ln -s $PWD/glib/libglib-${librarySuffix} $out/lib/libglib-${librarySuffix}
+    '';
+
+    postCheck = ''
+      rm $out/lib/libgobject-${librarySuffix}
+      rm $out/lib/libgio-${librarySuffix}
+      rm $out/lib/libglib-${librarySuffix}
+    '';
+
+    separateDebugInfo = stdenv.hostPlatform.isLinux;
+
+    passthru = rec {
+      gioModuleDir = "lib/gio/modules";
+
+      makeSchemaDataDirPath = dir: name: "${dir}/share/gsettings-schemas/${name}";
+      makeSchemaPath = dir: name: "${makeSchemaDataDirPath dir name}/glib-2.0/schemas";
+      getSchemaPath = pkg: makeSchemaPath pkg pkg.name;
+      getSchemaDataDirPath = pkg: makeSchemaDataDirPath pkg pkg.name;
+
+      tests = {
+        withChecks = finalAttrs.finalPackage.overrideAttrs (_: {
+          doCheck = true;
+        });
+        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      };
+
+      updateScript = gnome.updateScript {
+        packageName = "glib";
+        versionPolicy = "odd-unstable";
+      };
+    };
+
+    meta = with lib; {
+      description = "C library of programming buildings blocks";
+      homepage = "https://gitlab.gnome.org/GNOME/glib";
+      license = licenses.lgpl21Plus;
+      maintainers = with maintainers; [
+        lovek323
+        raskin
+      ];
+      teams = [ teams.gnome ];
+      pkgConfigModules = [
+        "gio-2.0"
+        "gobject-2.0"
+        "gthread-2.0"
+      ];
+      platforms = platforms.unix ++ platforms.windows;
+
+      longDescription = ''
+        GLib provides the core application building blocks for libraries
+        and applications written in C.  It provides the core object
+        system used in GNOME, the main loop implementation, and a large
+        set of utility functions for strings and common data structures.
+      '';
+    };
+  }
+)

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -40,11 +40,13 @@
     stdenv.hostPlatform.emulatorAvailable buildPackages
     && lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.isLittleEndian == stdenv.buildPlatform.isLittleEndian,
-}:
+}@args:
 
 assert stdenv.hostPlatform.isLinux -> util-linuxMinimal != null;
 
 let
+  dbus = args.dbus.override { enableSystemd = false; };
+
   gobject-introspection' = buildPackages.gobject-introspection.override {
     propagateFullGlib = false;
     # Avoid introducing cairo, which enables gobjectSupport by default.

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -5,8 +5,15 @@
   makeWrapper,
   ffmpeg,
   vlc,
+  x264,
   jq,
-}:
+}@args:
+
+let
+  vlc = args.vlc.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [ x264 ];
+  });
+in
 
 stdenv.mkDerivation {
   pname = "gopro-tool";

--- a/pkgs/by-name/gu/guile-xcb/package.nix
+++ b/pkgs/by-name/gu/guile-xcb/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  guile,
+  guile_2_2,
   pkg-config,
   texinfo,
 }:
@@ -24,13 +24,13 @@ stdenv.mkDerivation {
     pkg-config
   ];
   buildInputs = [
-    guile
+    guile_2_2
     texinfo
   ];
 
   configureFlags = [
-    "--with-guile-site-dir=$(out)/${guile.siteDir}"
-    "--with-guile-site-ccache-dir=$(out)/${guile.siteCcacheDir}"
+    "--with-guile-site-dir=$(out)/${guile_2_2.siteDir}"
+    "--with-guile-site-ccache-dir=$(out)/${guile_2_2.siteCcacheDir}"
   ];
 
   makeFlags = [
@@ -42,6 +42,6 @@ stdenv.mkDerivation {
     description = "XCB bindings for Guile";
     license = licenses.gpl3Plus;
     maintainers = [ ];
-    platforms = guile.meta.platforms;
+    platforms = guile_2_2.meta.platforms;
   };
 }

--- a/pkgs/by-name/hy/hydra/package.nix
+++ b/pkgs/by-name/hy/hydra/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  nix,
+  nixVersions,
   perlPackages,
   buildEnv,
   makeWrapper,
@@ -50,6 +50,8 @@
 }:
 
 let
+  nix = nixVersions.nix_2_29;
+
   perlDeps = buildEnv {
     name = "hydra-perl-deps";
     paths =

--- a/pkgs/by-name/hy/hyprcursor/package.nix
+++ b/pkgs/by-name/hy/hyprcursor/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -12,7 +12,7 @@
   tomlplusplus,
   nix-update-script,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprcursor";
   version = "0.1.13";
 

--- a/pkgs/by-name/hy/hyprgraphics/package.nix
+++ b/pkgs/by-name/hy/hyprgraphics/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   nix-update-script,
   cmake,
@@ -17,7 +17,7 @@
   pixman,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprgraphics";
   version = "0.2.0";
 

--- a/pkgs/by-name/hy/hypridle/package.nix
+++ b/pkgs/by-name/hy/hypridle/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   pkg-config,
   cmake,
@@ -16,7 +16,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hypridle";
   version = "0.1.7";
 

--- a/pkgs/by-name/hy/hyprland-protocols/package.nix
+++ b/pkgs/by-name/hy/hyprland-protocols/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   meson,
   ninja,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland-protocols";
   version = "0.7.0";
 

--- a/pkgs/by-name/hy/hyprland-qt-support/package.nix
+++ b/pkgs/by-name/hy/hyprland-qt-support/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   ninja,
@@ -8,7 +8,7 @@
   pkg-config,
   hyprlang,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland-qt-support";
   version = "0.1.0";
 

--- a/pkgs/by-name/hy/hyprland-qtutils/package.nix
+++ b/pkgs/by-name/hy/hyprland-qtutils/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -12,7 +12,7 @@
 let
   inherit (lib.strings) makeBinPath;
 in
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland-qtutils";
   version = "0.1.5";
 

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   stdenvAdapters,
   fetchFromGitHub,
   pkg-config,
@@ -41,7 +41,7 @@
   xwayland,
   debug ? false,
   enableXWayland ? true,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  withSystemd ? lib.meta.availableOn gcc15Stdenv.hostPlatform systemd,
   wrapRuntimeDeps ? true,
   # deprecated flags
   nvidiaPatches ? false,
@@ -75,11 +75,11 @@ let
   # which would be controlled by the `debug` flag
   # Condition on darwin to avoid breaking eval for darwin in CI,
   # even though darwin is not supported anyway.
-  adapters = lib.optionals (!stdenv.targetPlatform.isDarwin) [
+  adapters = lib.optionals (!gcc15Stdenv.targetPlatform.isDarwin) [
     stdenvAdapters.useMoldLinker
   ];
 
-  customStdenv = foldl' (acc: adapter: adapter acc) stdenv adapters;
+  customStdenv = foldl' (acc: adapter: adapter acc) gcc15Stdenv adapters;
 in
 assert assertMsg (!nvidiaPatches) "The option `nvidiaPatches` has been removed.";
 assert assertMsg (!enableNvidiaPatches) "The option `enableNvidiaPatches` has been removed.";

--- a/pkgs/by-name/hy/hyprlang/package.nix
+++ b/pkgs/by-name/hy/hyprlang/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
   hyprutils,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlang";
   version = "0.6.4";
 

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -26,7 +26,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlock";
   version = "0.9.2";
 

--- a/pkgs/by-name/hy/hyprpaper/package.nix
+++ b/pkgs/by-name/hy/hyprpaper/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   cairo,
@@ -31,7 +31,7 @@
   hyprgraphics,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpaper";
   version = "0.7.6";
 
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     teams = [ lib.teams.hyprland ];
     inherit (wayland.meta) platforms;
-    broken = stdenv.hostPlatform.isDarwin;
+    broken = gcc15Stdenv.hostPlatform.isDarwin;
     mainProgram = "hyprpaper";
   };
 })

--- a/pkgs/by-name/hy/hyprpicker/package.nix
+++ b/pkgs/by-name/hy/hyprpicker/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   nix-update-script,
   pkg-config,
@@ -18,7 +18,7 @@
   libXdmcp,
   debug ? false,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpicker" + lib.optionalString debug "-debug";
   version = "0.4.5";
 

--- a/pkgs/by-name/hy/hyprpolkitagent/package.nix
+++ b/pkgs/by-name/hy/hyprpolkitagent/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   cmake,
   pkg-config,
   fetchFromGitHub,
@@ -10,7 +10,7 @@
   polkit,
   qt6,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpolkitagent";
   version = "0.1.3";
 

--- a/pkgs/by-name/hy/hyprsunset/package.nix
+++ b/pkgs/by-name/hy/hyprsunset/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   cmake,
   fetchFromGitHub,
   pkg-config,
@@ -13,7 +13,7 @@
   wayland-scanner,
   nix-update-script,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprsunset";
   version = "0.3.3";
 

--- a/pkgs/by-name/hy/hyprsysteminfo/package.nix
+++ b/pkgs/by-name/hy/hyprsysteminfo/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   qt6,
@@ -12,7 +12,7 @@
 let
   inherit (lib.strings) makeBinPath;
 in
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprsysteminfo";
   version = "0.1.3";
 

--- a/pkgs/by-name/hy/hyprutils/package.nix
+++ b/pkgs/by-name/hy/hyprutils/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   cmake,
   pkg-config,
   pixman,
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprutils";
   version = "0.10.0";
 

--- a/pkgs/by-name/hy/hyprwayland-scanner/package.nix
+++ b/pkgs/by-name/hy/hyprwayland-scanner/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  stdenv,
+  gcc15Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
   pugixml,
   nix-update-script,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprwayland-scanner";
   version = "0.4.5";
 

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -18,9 +18,21 @@
   isabelle-components,
   symlinkJoin,
   fetchhg,
-}:
+}@args:
 
 let
+  polyml = args.polyml.overrideAttrs {
+    pname = "polyml-for-isabelle";
+    version = "2025";
+    __intentionallyOverridingVersion = true; # avoid a warning, no src override
+    configureFlags = [
+      "--enable-intinf-as-int"
+      "--with-gmp"
+      "--disable-shared"
+    ];
+    buildFlags = [ "compiler" ];
+  };
+
   vampire' = vampire.overrideAttrs (_: {
     src = fetchFromGitHub {
       owner = "vprover";

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   coreutils,
   net-tools,
-  java,
+  openjdk21,
   scala_3,
   polyml,
   verit,
@@ -52,6 +52,8 @@ let
       cp libsha1.so $out/lib/
     '';
   };
+
+  java = openjdk21;
 
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ki/kiro/package.nix
+++ b/pkgs/by-name/ki/kiro/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  callPackage,
-  vscode-generic,
+  buildVscode,
   fetchurl,
   extraCommandLineArgs ? "",
   useVSCodeRipgrep ? stdenv.hostPlatform.isDarwin,
@@ -11,7 +10,7 @@
 let
   sources = (lib.importJSON ./sources.json).${stdenv.hostPlatform.system};
 in
-(callPackage vscode-generic {
+(buildVscode {
   inherit useVSCodeRipgrep;
   commandLineArgs = extraCommandLineArgs;
 

--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -43,7 +43,7 @@
   buildGo124Module,
   nix-update-script,
   makeBinaryWrapper,
-  autoSignDarwinBinariesHook,
+  darwin,
   cairo,
   fetchpatch,
 }:
@@ -117,7 +117,7 @@ buildPythonApplication rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     imagemagick
     libicns # For the png2icns tool.
-    autoSignDarwinBinariesHook
+    darwin.autoSignDarwinBinariesHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wayland-scanner

--- a/pkgs/by-name/li/libkazv/package.nix
+++ b/pkgs/by-name/li/libkazv/package.nix
@@ -8,7 +8,7 @@
   cryptopp,
   immer,
   lager,
-  libcpr,
+  libcpr_1_10_5,
   libhttpserver,
   libmicrohttpd,
   nlohmann_json,
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     cryptopp
     immer
     lager
-    libcpr
+    libcpr_1_10_5
     libhttpserver
     libmicrohttpd
     olm

--- a/pkgs/by-name/ma/marwaita-icons/package.nix
+++ b/pkgs/by-name/ma/marwaita-icons/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   gtk3,
-  breeze-icons,
+  kdePackages,
   hicolor-icon-theme,
   pantheon,
 }:
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
-    breeze-icons
+    kdePackages.breeze-icons
     hicolor-icon-theme
     pantheon.elementary-icon-theme
   ];

--- a/pkgs/by-name/ma/math-preview/package.nix
+++ b/pkgs/by-name/ma/math-preview/package.nix
@@ -3,8 +3,12 @@
   nix-update-script,
   fetchFromGitLab,
   buildNpmPackage,
-  nodejs,
+  nodejs_20,
 }:
+
+let
+  nodejs = nodejs_20;
+in
 
 buildNpmPackage rec {
   pname = "math-preview";

--- a/pkgs/by-name/me/meshlab-unstable/package.nix
+++ b/pkgs/by-name/me/meshlab-unstable/package.nix
@@ -24,9 +24,11 @@
   corto,
   openctm,
   structuresynth,
-}:
+}@args:
 
 let
+  stdenv = if args.stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else args.stdenv;
+
   tinygltf-src = fetchFromGitHub {
     owner = "syoyo";
     repo = "tinygltf";

--- a/pkgs/by-name/me/meshlab-unstable/package.nix
+++ b/pkgs/by-name/me/meshlab-unstable/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  llvmPackages,
+  llvmPackages_18,
   libsForQt5,
   libGLU,
   lib3ds,
@@ -90,7 +90,7 @@ stdenv.mkDerivation {
     structuresynth
   ]
   ++ lib.optionals stdenv.cc.isClang [
-    llvmPackages.openmp
+    llvmPackages_18.openmp
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -25,9 +25,11 @@
   corto,
   openctm,
   structuresynth,
-}:
+}@args:
 
 let
+  stdenv = if args.stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else args.stdenv;
+
   tinygltf-src = fetchFromGitHub {
     owner = "syoyo";
     repo = "tinygltf";

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  llvmPackages,
+  llvmPackages_18,
   libsForQt5,
   libGLU,
   lib3ds,
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     structuresynth
   ]
   ++ lib.optionals stdenv.cc.isClang [
-    llvmPackages.openmp
+    llvmPackages_18.openmp
   ];
 
   postPatch = ''

--- a/pkgs/by-name/mo/monado/package.nix
+++ b/pkgs/by-name/mo/monado/package.nix
@@ -13,8 +13,7 @@
   eigen,
   elfutils,
   glslang,
-  gst-plugins-base,
-  gstreamer,
+  gst_all_1,
   hidapi,
   libbsd,
   libdrm,
@@ -104,8 +103,8 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     eigen
     elfutils
-    gst-plugins-base
-    gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
     hidapi
     libbsd
     libdrm

--- a/pkgs/by-name/my/mysql-workbench/package.nix
+++ b/pkgs/by-name/my/mysql-workbench/package.nix
@@ -20,7 +20,7 @@
   python3Packages,
 
   cairo,
-  mysql,
+  mysql80,
   libiodbc,
   proj,
 
@@ -38,9 +38,11 @@
   rapidjson,
   vsqlite,
   zstd,
-}:
+}@args:
 
 let
+  gdal = args.gdal.override { libmysqlclient = mysql80; };
+
   # for some reason the package doesn't build with swig 4.3.0
   swig_4_2 = swig.overrideAttrs (prevAttrs: {
     version = "4.2.1";
@@ -145,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
   );
 
   cmakeFlags = [
-    (lib.cmakeFeature "MySQL_CONFIG_PATH" (lib.getExe' mysql "mysql_config"))
+    (lib.cmakeFeature "MySQL_CONFIG_PATH" (lib.getExe' mysql80 "mysql_config"))
     (lib.cmakeFeature "IODBC_CONFIG_PATH" (lib.getExe' libiodbc "iodbc-config"))
     (lib.cmakeFeature "ANTLR_JAR_PATH" "${antlr4_13.jarLocation}")
     # mysql-workbench 8.0.21 depends on libmysqlconnectorcpp 1.1.8.

--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -5,7 +5,8 @@
   cmake,
   gettext,
   libuv,
-  lua,
+  lua5_1,
+  luajit,
   pkg-config,
   unibilium,
   utf8proc,
@@ -25,6 +26,11 @@
   fish ? null,
   python3 ? null,
 }:
+
+let
+  lua = if lib.meta.availableOn stdenv.hostPlatform luajit then luajit else lua5_1;
+in
+
 stdenv.mkDerivation (
   finalAttrs:
   let

--- a/pkgs/by-name/ne/netlify-cli/package.nix
+++ b/pkgs/by-name/ne/netlify-cli/package.nix
@@ -4,10 +4,14 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
-  nodejs,
+  nodejs_20,
   pkg-config,
   vips,
 }:
+
+let
+  nodejs = nodejs_20;
+in
 
 buildNpmPackage rec {
   pname = "netlify-cli";

--- a/pkgs/by-name/ns/nsxiv/package.nix
+++ b/pkgs/by-name/ns/nsxiv/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitea,
   giflib,
-  imlib2,
+  imlib2Full,
   libXft,
   libexif,
   libwebp,
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     giflib
-    imlib2
+    imlib2Full
     libXft
     libexif
     libwebp

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  llvmPackages,
+  llvmPackages_18,
   fetchFromGitHub,
   makeBinaryWrapper,
   which,
@@ -8,6 +8,7 @@
 }:
 
 let
+  llvmPackages = llvmPackages_18;
   inherit (llvmPackages) stdenv;
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/pe/pekwm/package.nix
+++ b/pkgs/by-name/pe/pekwm/package.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  awk,
+  gawk,
   cmake,
-  grep,
+  gnugrep,
   libXext,
   libXft,
   libXinerama,
@@ -14,7 +14,7 @@
   libpng,
   pkg-config,
   runtimeShell,
-  sed,
+  gnused,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,9 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   cmakeFlags = [
-    "-DAWK=${lib.getBin awk}/bin/awk"
-    "-DGREP=${lib.getBin grep}/bin/grep"
-    "-DSED=${lib.getBin sed}/bin/sed"
+    "-DAWK=${lib.getBin gawk}/bin/awk"
+    "-DGREP=${lib.getBin gnugrep}/bin/grep"
+    "-DSED=${lib.getBin gnused}/bin/sed"
     "-DSH=${runtimeShell}"
   ];
 

--- a/pkgs/by-name/pl/plausible/package.nix
+++ b/pkgs/by-name/pl/plausible/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
-  beamPackages,
+  beam27Packages,
+  elixir_1_18,
   buildNpmPackage,
   rustPlatform,
   fetchFromGitHub,
@@ -110,6 +111,8 @@ let
           ln -s "$lib" $out/mjml/priv/native/$base.so
         done
       '';
+
+  beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
 
 in
 beamPackages.mixRelease rec {

--- a/pkgs/by-name/pl/plfit/package.nix
+++ b/pkgs/by-name/pl/plfit/package.nix
@@ -3,10 +3,13 @@
   fetchFromGitHub,
   lib,
   llvmPackages,
+  withPython ? false,
   python ? null,
   stdenv,
   swig,
 }:
+
+assert withPython -> python != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "plfit";
@@ -19,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0JrPAq/4yzr7XbxvcnFj8CKmMyZT05PkSdGprNdAsJA=";
   };
 
-  postPatch = lib.optionalString (python != null) ''
+  postPatch = lib.optionalString withPython ''
     substituteInPlace src/CMakeLists.txt \
       --replace-fail ' ''${Python3_SITEARCH}' ' ${placeholder "out"}/${python.sitePackages}' \
       --replace-fail ' ''${Python3_SITELIB}' ' ${placeholder "out"}/${python.sitePackages}'
@@ -28,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
   ]
-  ++ lib.optionals (python != null) [
+  ++ lib.optionals withPython [
     python
     swig
   ];
@@ -36,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DPLFIT_USE_OPENMP=ON"
   ]
-  ++ lib.optionals (python != null) [
+  ++ lib.optionals withPython [
     "-DPLFIT_COMPILE_PYTHON_MODULE=ON"
   ];
 

--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
-  beamPackages,
+  beam27Packages,
+  elixir_1_17,
   stdenv,
   fetchurl,
   python3,
@@ -37,6 +38,8 @@ let
       systemd # for systemd unit activation check
     ]
   );
+
+  beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_17; });
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   makeWrapper,
-  nodejs,
+  nodejs_22,
   pnpm_10,
   python3,
   testers,
@@ -12,6 +12,10 @@
   nix-update-script,
   yq-go,
 }:
+
+let
+  nodejs = nodejs_22;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "renovate";

--- a/pkgs/by-name/re/renpy/package.nix
+++ b/pkgs/by-name/re/renpy/package.nix
@@ -12,7 +12,7 @@
   libpng,
   makeWrapper,
   pkg-config,
-  python3,
+  python312,
   SDL2,
   stdenv,
   versionCheckHook,
@@ -21,7 +21,7 @@
 }:
 
 let
-  python = python3;
+  python = python312;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "renpy";

--- a/pkgs/by-name/re/rescript-language-server/package.nix
+++ b/pkgs/by-name/re/rescript-language-server/package.nix
@@ -6,9 +6,11 @@
   esbuild,
   nix-update-script,
   versionCheckHook,
-  rescript-editor-analysis,
+  vscode-extensions,
 }:
 let
+  inherit (vscode-extensions.chenglou92.rescript-vscode) rescript-editor-analysis;
+
   platformDir =
     if stdenv.hostPlatform.isLinux then
       "linux"

--- a/pkgs/by-name/ri/ricochet-refresh/package.nix
+++ b/pkgs/by-name/ri/ricochet-refresh/package.nix
@@ -4,7 +4,8 @@
   fetchFromGitHub,
   qt5,
   openssl,
-  protobuf,
+  # https://github.com/blueprint-freespeech/ricochet-refresh/issues/178
+  protobuf_21,
   pkg-config,
   cmake,
 }:
@@ -35,12 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
     ])
     ++ [
       openssl
-      protobuf
+      protobuf_21
     ];
 
   nativeBuildInputs = [
     pkg-config
-    protobuf
+    protobuf_21
     cmake
     qt5.wrapQtAppsHook
   ];

--- a/pkgs/by-name/ru/rucio/package.nix
+++ b/pkgs/by-name/ru/rucio/package.nix
@@ -1,5 +1,7 @@
-{ python3Packages }:
+{ python312Packages }:
 
-with python3Packages;
+# Pinned to python 3.12 while python313Packages.future does not evaluate and
+# until https://github.com/CZ-NIC/pyoidc/issues/649 is resolved
+with python312Packages;
 
 toPythonApplication rucio

--- a/pkgs/by-name/ru/rustdesk-flutter/package.nix
+++ b/pkgs/by-name/ru/rustdesk-flutter/package.nix
@@ -4,7 +4,7 @@
   cargo,
   copyDesktopItems,
   fetchFromGitHub,
-  flutter,
+  flutter324,
   ffmpeg,
   gst_all_1,
   fuse3,
@@ -54,6 +54,8 @@ let
     ];
     doCheck = false;
   };
+
+  flutter = flutter324;
 
   ffigen = callPackage ./ffigen {
     inherit flutter;

--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   nixosTests,
   alsa-lib,
@@ -40,7 +40,8 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+# relies on std::sinf & co, which was broken in GCC until GCC 14: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79700
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
   version = "0.11.0";
 

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -12,8 +12,11 @@
   rustPlatform,
   luarocks,
 
+  # lua
+  luajit,
+  withLuaPackage ? luajit,
+
   # buildInputs
-  lua,
   harfbuzz,
   icu,
   fontconfig,
@@ -26,6 +29,10 @@
   runCommand,
   poppler-utils,
 }:
+
+let
+  lua = withLuaPackage;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sile";

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -34,8 +34,12 @@
   # enable internal X11 support via libssh2
   enableX11 ? true,
   enableNVML ? config.cudaSupport,
-  nvml,
+  cudaPackages,
 }:
+
+let
+  nvml = cudaPackages.cuda_nvml_dev;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "slurm";

--- a/pkgs/by-name/sm/smpq/package.nix
+++ b/pkgs/by-name/sm/smpq/package.nix
@@ -1,10 +1,23 @@
 {
   lib,
   cmake,
+  fetchFromGitHub,
   fetchurl,
   stdenv,
   stormlib,
 }:
+
+let
+  stormlib_9_22 = stormlib.overrideAttrs (old: {
+    version = "9.22";
+    src = fetchFromGitHub {
+      owner = "ladislav-zezula";
+      repo = "StormLib";
+      rev = "v9.22";
+      hash = "sha256-jFUfxLzuRHAvFE+q19i6HfGcL6GX4vKL1g7l7LOhjeU=";
+    };
+  });
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "smpq";
@@ -21,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ stormlib ];
+  buildInputs = [ stormlib_9_22 ];
 
   strictDeps = true;
 

--- a/pkgs/by-name/sw/sway-unwrapped/package.nix
+++ b/pkgs/by-name/sw/sway-unwrapped/package.nix
@@ -20,7 +20,7 @@
   libinput,
   gdk-pixbuf,
   librsvg,
-  wlroots,
+  wlroots_0_19,
   wayland-protocols,
   libdrm,
   nixosTests,
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     librsvg
     wayland-protocols
     libdrm
-    (wlroots.override { inherit (finalAttrs) enableXWayland; })
+    (wlroots_0_19.override { inherit (finalAttrs) enableXWayland; })
   ]
   ++ lib.optionals finalAttrs.enableXWayland [
     xorg.xcbutilwm

--- a/pkgs/by-name/th/the-powder-toy/package.nix
+++ b/pkgs/by-name/th/the-powder-toy/package.nix
@@ -8,7 +8,7 @@
   lib,
   libpng,
   libX11,
-  lua,
+  lua5_2,
   luajit,
   meson,
   ninja,
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     jsoncpp
     libpng
     libX11
-    lua
+    lua5_2
     luajit
     SDL2
     zlib

--- a/pkgs/by-name/to/tomb/package.nix
+++ b/pkgs/by-name/to/tomb/package.nix
@@ -15,7 +15,7 @@
   lsof,
   makeBinaryWrapper,
   nix-update-script,
-  pinentry,
+  pinentry-curses,
   stdenvNoCC,
   util-linuxMinimal,
   versionCheckHook,
@@ -36,7 +36,7 @@ let
     gnupg
     libargon2
     lsof
-    pinentry
+    pinentry-curses
     util-linuxMinimal
   ];
 
@@ -55,7 +55,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ makeBinaryWrapper ];
 
   buildInputs = [
-    pinentry
+    pinentry-curses
     zsh
   ];
 

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -24,7 +24,7 @@
   symlinkJoin,
   rsync,
 
-  appName,
+  appName ? "vanillatd",
   CMAKE_BUILD_TYPE ? "RelWithDebInfo", # "Choose the type of build, recommended options are: Debug Release RelWithDebInfo"
 }:
 assert lib.assertOneOf "appName" appName [

--- a/pkgs/by-name/vc/vcsh/package.nix
+++ b/pkgs/by-name/vc/vcsh/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   autoconf,
-  automake,
+  automake116x,
   makeWrapper,
   pkg-config,
   unzip,
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoconf
-    automake
+    automake116x
     makeWrapper
     pkg-config
     unzip

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   stdenv,
   nodejs,
-  pnpm,
+  pnpm_9,
   buildGoModule,
   mage,
   writeShellScriptBin,
@@ -28,7 +28,7 @@ let
     ];
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs)
         pname
         version
@@ -42,7 +42,7 @@ let
 
     nativeBuildInputs = [
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ];
 
     doCheck = true;

--- a/pkgs/by-name/vt/vtfedit/package.nix
+++ b/pkgs/by-name/vt/vtfedit/package.nix
@@ -7,9 +7,13 @@
 
   copyDesktopItems,
   makeWrapper,
-  wine,
+  wineWowPackages,
   winetricks,
 }:
+
+let
+  wine = wineWowPackages.staging;
+in
 
 stdenv.mkDerivation rec {
   pname = "vtfedit";

--- a/pkgs/by-name/wa/waybox/package.nix
+++ b/pkgs/by-name/wa/waybox/package.nix
@@ -17,7 +17,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots,
+  wlroots_0_17,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     udev
     wayland
     wayland-protocols
-    wlroots
+    wlroots_0_17
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/wi/windsurf/package.nix
+++ b/pkgs/by-name/wi/windsurf/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  callPackage,
-  vscode-generic,
+  buildVscode,
   fetchurl,
   nixosTests,
   commandLineArgs ? "",
@@ -13,7 +12,7 @@ let
     (lib.importJSON ./info.json)."${stdenv.hostPlatform.system}"
       or (throw "windsurf: unsupported system ${stdenv.hostPlatform.system}");
 in
-callPackage vscode-generic {
+buildVscode {
   inherit commandLineArgs useVSCodeRipgrep;
 
   inherit (info) version vscodeVersion;

--- a/pkgs/by-name/wi/wio/package.nix
+++ b/pkgs/by-name/wi/wio/package.nix
@@ -16,7 +16,7 @@
   unstableGitUpdater,
   wayland,
   wayland-protocols,
-  wlroots,
+  wlroots_0_19,
   xwayland,
 }:
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     udev
     wayland
     wayland-protocols
-    wlroots
+    wlroots_0_19
     xwayland
   ];
 

--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -12,7 +12,6 @@
   lib,
   nodejs,
   nodePackages,
-  # needs to be static and built with MD2 support!
   openssl,
   pkg-config,
   qt5,
@@ -20,9 +19,14 @@
   stdenv,
   writeScript,
   x2t,
-}:
+}@args:
 
 let
+  openssl = args.openssl.override {
+    enableMD2 = true;
+    static = true;
+  };
+
   qmake = qt5.qmake;
   libv8 = nodejs.libv8;
   fixIcu = writeScript "fix-icu.sh" ''

--- a/pkgs/by-name/xc/xcbuild/package.nix
+++ b/pkgs/by-name/xc/xcbuild/package.nix
@@ -16,7 +16,7 @@
   xcodeVer ? null,
   sdkVer ? null,
   productBuildVer ? null,
-}:
+}@args:
 
 # TODO(@reckenrode) enable this warning after uses in nixpkgs have been fixed
 #let
@@ -42,6 +42,9 @@
 #'' true;
 
 let
+  # xcbuild is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
+  stdenv = if args.stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else args.stdenv;
+
   googletest = fetchFromGitHub {
     owner = "google";
     repo = "googletest";

--- a/pkgs/by-name/xf/xfe/package.nix
+++ b/pkgs/by-name/xf/xfe/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  fox,
+  fox_1_6,
   fontconfig,
   freetype,
   pkg-config,
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     intltool
   ];
   buildInputs = [
-    fox
+    fox_1_6
     gettext
     xcbutil
     gcc

--- a/pkgs/by-name/ze/zeroad-unwrapped/package.nix
+++ b/pkgs/by-name/ze/zeroad-unwrapped/package.nix
@@ -4,7 +4,7 @@
   perl,
   fetchurl,
   python3,
-  fmt,
+  fmt_9,
   libidn,
   pkg-config,
   spidermonkey_115,
@@ -34,7 +34,7 @@
   cxxtest,
   freetype,
   withEditor ? true,
-  wxGTK,
+  wxGTK32,
 }:
 
 # You can find more instructions on how to build 0ad here:
@@ -80,19 +80,19 @@ stdenv.mkDerivation rec {
     gloox
     nvidia-texture-tools
     libsodium
-    fmt
+    fmt_9
     freetype
     premake5
     cxxtest
   ]
-  ++ lib.optional withEditor wxGTK;
+  ++ lib.optional withEditor wxGTK32;
 
   env.NIX_CFLAGS_COMPILE = toString [
     "-I${xorgproto}/include"
     "-I${libX11.dev}/include"
     "-I${libXcursor.dev}/include"
     "-I${SDL2}/include/SDL2"
-    "-I${fmt.dev}/include"
+    "-I${fmt_9.dev}/include"
     "-I${nvidia-texture-tools.dev}/include"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7241,18 +7241,6 @@ with pkgs;
 
   grantlee = libsForQt5.callPackage ../development/libraries/grantlee { };
 
-  glib = callPackage ../by-name/gl/glib/package.nix (
-    let
-      glib-untested = glib.overrideAttrs { doCheck = false; };
-    in
-    {
-      # break dependency cycles
-      # these things are only used for tests, they don't get into the closure
-      shared-mime-info = shared-mime-info.override { glib = glib-untested; };
-      desktop-file-utils = desktop-file-utils.override { glib = glib-untested; };
-    }
-  );
-
   glibmm = callPackage ../development/libraries/glibmm { };
 
   glibmm_2_68 = callPackage ../development/libraries/glibmm/2.68.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6097,11 +6097,6 @@ with pkgs;
 
   bazel = bazel_7;
 
-  bazel_7 = callPackage ../by-name/ba/bazel_7/package.nix {
-    buildJdk = jdk21_headless;
-    runJdk = jdk21_headless;
-  };
-
   buildifier = bazel-buildtools;
   buildozer = bazel-buildtools;
   unused_deps = bazel-buildtools;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1408,10 +1408,6 @@ with pkgs;
 
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };
 
-  kitty = callPackage ../by-name/ki/kitty/package.nix {
-    inherit (darwin) autoSignDarwinBinariesHook;
-  };
-
   mlterm-wayland = mlterm.override {
     enableX11 = false;
   };
@@ -2072,10 +2068,6 @@ with pkgs;
   mobilizon = callPackage ../servers/mobilizon {
     beamPackages = beam.packages.erlang_26.extend (self: super: { elixir = self.elixir_1_15; });
     mobilizon-frontend = callPackage ../servers/mobilizon/frontend.nix { };
-  };
-
-  monado = callPackage ../by-name/mo/monado/package.nix {
-    inherit (gst_all_1) gstreamer gst-plugins-base;
   };
 
   mpd-sima = python3Packages.callPackage ../tools/audio/mpd-sima { };
@@ -6110,7 +6102,6 @@ with pkgs;
   bazel = bazel_7;
 
   bazel_7 = callPackage ../by-name/ba/bazel_7/package.nix {
-    inherit (darwin) sigtool;
     buildJdk = jdk21_headless;
     runJdk = jdk21_headless;
   };
@@ -6672,10 +6663,6 @@ with pkgs;
     replay-node-cli
     ;
 
-  rescript-language-server = callPackage ../by-name/re/rescript-language-server/package.nix {
-    rescript-editor-analysis = vscode-extensions.chenglou92.rescript-vscode.rescript-editor-analysis;
-  };
-
   rnginline = with python3Packages; toPythonApplication rnginline;
 
   rr = callPackage ../development/tools/analysis/rr { };
@@ -6715,10 +6702,6 @@ with pkgs;
   shellcheck-minimal = haskell.lib.compose.justStaticExecutables shellcheck.unwrapped;
 
   sloc = nodePackages.sloc;
-
-  slurm = callPackage ../by-name/sl/slurm/package.nix {
-    nvml = cudaPackages.cuda_nvml_dev;
-  };
 
   speedtest-cli = with python3Packages; toPythonApplication speedtest-cli;
 
@@ -8601,10 +8584,6 @@ with pkgs;
     gtkVersion = "4";
   };
 
-  vtfedit = callPackage ../by-name/vt/vtfedit/package.nix {
-    wine = wineWowPackages.staging;
-  };
-
   inherit (callPackage ../development/libraries/vtk { }) vtk_9_5;
 
   vtk = vtk_9_5;
@@ -10420,10 +10399,6 @@ with pkgs;
 
   maia-icon-theme = libsForQt5.callPackage ../data/icons/maia-icon-theme { };
 
-  marwaita-icons = callPackage ../by-name/ma/marwaita-icons/package.nix {
-    inherit (kdePackages) breeze-icons;
-  };
-
   mplus-outline-fonts = recurseIntoAttrs (callPackage ../data/fonts/mplus-outline-fonts { });
 
   noto-fonts-cjk-serif-static = callPackage ../by-name/no/noto-fonts-cjk-serif/package.nix {
@@ -10726,10 +10701,6 @@ with pkgs;
     callPackage ../tools/networking/dd-agent/integrations-core.nix {
       extraIntegrations = extras;
     };
-
-  dbeaver-bin = callPackage ../by-name/db/dbeaver-bin/package.nix {
-    inherit (darwin) autoSignDarwinBinariesHook;
-  };
 
   deadbeef = callPackage ../applications/audio/deadbeef { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1925,10 +1925,6 @@ with pkgs;
 
   easyocr = with python3.pkgs; toPythonApplication easyocr;
 
-  element-web = callPackage ../by-name/el/element-web/package.nix {
-    conf = config.element-web.conf or { };
-  };
-
   espanso-wayland = espanso.override {
     x11Support = false;
     waylandSupport = !stdenv.hostPlatform.isDarwin;
@@ -12961,8 +12957,6 @@ with pkgs;
 
   pmars-x11 = pmars.override { enableXwinGraphics = true; };
 
-  vanillatd = callPackage ../by-name/va/vanillatd/package.nix { appName = "vanillatd"; };
-
   vanillara = callPackage ../by-name/va/vanillatd/package.nix { appName = "vanillara"; };
 
   ### GAMES/DOOM-PORTS
@@ -13072,8 +13066,6 @@ with pkgs;
   fltrator = callPackage ../games/fltrator {
     fltk = fltk-minimal;
   };
-
-  factorio = callPackage ../by-name/fa/factorio/package.nix { releaseType = "alpha"; };
 
   factorio-experimental = factorio.override {
     releaseType = "alpha";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -282,10 +282,6 @@ with pkgs;
 
   cve = with python3Packages; toPythonApplication cvelib;
 
-  basalt-monado = callPackage ../by-name/ba/basalt-monado/package.nix {
-    opencv = opencv.override { enableGtk3 = true; };
-  };
-
   bloodhound-py = with python3Packages; toPythonApplication bloodhound-py;
 
   # Zip file format only allows times after year 1980, which makes e.g. Python
@@ -968,17 +964,6 @@ with pkgs;
 
   opnplug = adlplug.override { type = "OPN"; };
 
-  akkoma = callPackage ../by-name/ak/akkoma/package.nix {
-    beamPackages = beam_minimal.packages.erlang_26.extend (
-      self: super: {
-        elixir = self.elixir_1_16;
-        rebar3 = self.rebar3WithPlugins {
-          plugins = with self; [ pc ];
-        };
-      }
-    );
-  };
-
   acme-client = callPackage ../tools/networking/acme-client {
     stdenv = gccStdenv;
   };
@@ -1093,13 +1078,6 @@ with pkgs;
   winbox = winbox3;
   winbox3 = callPackage ../tools/admin/winbox {
     wine = wineWowPackages.stable;
-  };
-
-  x2t = callPackage ../by-name/x2/x2t/package.nix {
-    openssl = openssl.override {
-      enableMD2 = true;
-      static = true;
-    };
   };
 
   yabridge = callPackage ../tools/audio/yabridge {
@@ -1643,10 +1621,6 @@ with pkgs;
   kerf = kerf_1; # kerf2 is WIP
   kerf_1 = callPackage ../development/interpreters/kerf {
     stdenv = clangStdenv;
-  };
-
-  plausible = callPackage ../by-name/pl/plausible/package.nix {
-    beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
   };
 
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace { };
@@ -3838,18 +3812,6 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_12;
   };
 
-  smpq = callPackage ../by-name/sm/smpq/package.nix {
-    stormlib = stormlib.overrideAttrs (old: {
-      version = "9.22";
-      src = fetchFromGitHub {
-        owner = "ladislav-zezula";
-        repo = "StormLib";
-        rev = "v9.22";
-        hash = "sha256-jFUfxLzuRHAvFE+q19i6HfGcL6GX4vKL1g7l7LOhjeU=";
-      };
-    });
-  };
-
   snapcast = callPackage ../applications/audio/snapcast {
     pulseaudioSupport = config.pulseaudio or stdenv.hostPlatform.isLinux;
   };
@@ -4265,10 +4227,6 @@ with pkgs;
   binaryen = callPackage ../development/compilers/binaryen {
     nodejs = nodejs-slim;
     inherit (python3Packages) filecheck;
-  };
-
-  bluespec = callPackage ../by-name/bl/bluespec/package.nix {
-    gmp-static = gmp.override { withStatic = true; };
   };
 
   codon = callPackage ../development/compilers/codon {
@@ -4857,12 +4815,6 @@ with pkgs;
   inherit (haxePackages) hxcpp;
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix { });
-
-  gopro-tool = callPackage ../by-name/go/gopro-tool/package.nix {
-    vlc = vlc.overrideAttrs (old: {
-      buildInputs = old.buildInputs ++ [ x264 ];
-    });
-  };
 
   gwe = callPackage ../tools/misc/gwe {
     nvidia_x11 = linuxPackages.nvidia_x11;
@@ -7298,7 +7250,6 @@ with pkgs;
       # these things are only used for tests, they don't get into the closure
       shared-mime-info = shared-mime-info.override { glib = glib-untested; };
       desktop-file-utils = desktop-file-utils.override { glib = glib-untested; };
-      dbus = dbus.override { enableSystemd = false; };
     }
   );
 
@@ -9562,10 +9513,6 @@ with pkgs;
 
   qremotecontrol-server = libsForQt5.callPackage ../servers/misc/qremotecontrol-server { };
 
-  rabbitmq-server = callPackage ../by-name/ra/rabbitmq-server/package.nix {
-    beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_17; });
-  };
-
   rethinkdb = callPackage ../servers/nosql/rethinkdb {
     stdenv = clangStdenv;
     libtool = cctools;
@@ -10650,10 +10597,6 @@ with pkgs;
     haskell.lib.compose.justStaticExecutables haskellPackages.darcs
   );
 
-  darktable = callPackage ../by-name/da/darktable/package.nix {
-    pugixml = pugixml.override { shared = true; };
-  };
-
   datadog-agent = callPackage ../tools/networking/dd-agent/datadog-agent.nix {
     pythonPackages = datadog-integrations-core { };
   };
@@ -10959,12 +10902,6 @@ with pkgs;
     callPackage ../applications/editors/formiko {
       inherit buildPythonApplication;
     };
-
-  freedv = callPackage ../by-name/fr/freedv/package.nix {
-    codec2 = codec2.override {
-      freedvSupport = true;
-    };
-  };
 
   inherit
     ({
@@ -12454,9 +12391,6 @@ with pkgs;
   # so expect breakage. use wrapNeovim instead if you want a stable alternative
   wrapNeovimUnstable = callPackage ../applications/editors/neovim/wrapper.nix { };
   wrapNeovim = neovim-unwrapped: lib.makeOverridable (neovimUtils.legacyWrapper neovim-unwrapped);
-  neovim-unwrapped = callPackage ../by-name/ne/neovim-unwrapped/package.nix {
-    lua = if lib.meta.availableOn stdenv.hostPlatform luajit then luajit else lua5_1;
-  };
 
   neovimUtils = callPackage ../applications/editors/neovim/utils.nix {
     lua = lua5_1;
@@ -13699,19 +13633,6 @@ with pkgs;
 
   inherit (ocamlPackages) hol_light;
 
-  isabelle = callPackage ../by-name/is/isabelle/package.nix {
-    polyml = polyml.overrideAttrs {
-      pname = "polyml-for-isabelle";
-      version = "2025";
-      __intentionallyOverridingVersion = true; # avoid a warning, no src override
-      configureFlags = [
-        "--enable-intinf-as-int"
-        "--with-gmp"
-        "--disable-shared"
-      ];
-      buildFlags = [ "compiler" ];
-    };
-  };
   isabelle-components = recurseIntoAttrs (callPackage ../by-name/is/isabelle/components { });
 
   lean3 = lean;
@@ -14173,18 +14094,6 @@ with pkgs;
   );
 
   lice = python3Packages.callPackage ../tools/misc/lice { };
-
-  mysql-workbench = callPackage ../by-name/my/mysql-workbench/package.nix (
-    let
-      mysql = mysql80;
-    in
-    {
-      gdal = gdal.override {
-        libmysqlclient = mysql;
-      };
-      mysql = mysql;
-    }
-  );
 
   resp-app = libsForQt5.callPackage ../applications/misc/resp-app { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3781,13 +3781,6 @@ with pkgs;
 
   sasview = libsForQt5.callPackage ../applications/science/misc/sasview { };
 
-  saunafs = callPackage ../by-name/sa/saunafs/package.nix {
-    fmt = fmt_11;
-    spdlog = spdlog.override {
-      fmt = fmt_11;
-    };
-  };
-
   scfbuild = python3.pkgs.callPackage ../tools/misc/scfbuild { };
 
   segger-jlink-headless = callPackage ../by-name/se/segger-jlink/package.nix { headless = true; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12452,6 +12452,8 @@ with pkgs;
   vscode-fhs = vscode.fhs;
   vscode-fhsWithPackages = vscode.fhsWithPackages;
 
+  buildVscode = callPackage ../applications/editors/vscode/generic.nix { };
+
   vscode-with-extensions = callPackage ../applications/editors/vscode/with-extensions.nix { };
 
   vscode-utils = callPackage ../applications/editors/vscode/extensions/vscode-utils.nix { };
@@ -12466,23 +12468,13 @@ with pkgs;
   vscodium-fhs = vscodium.fhs;
   vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 
-  code-cursor = callPackage ../by-name/co/code-cursor/package.nix {
-    vscode-generic = ../applications/editors/vscode/generic.nix;
-  };
   code-cursor-fhs = code-cursor.fhs;
   code-cursor-fhsWithPackages = code-cursor.fhsWithPackages;
-
-  windsurf = callPackage ../by-name/wi/windsurf/package.nix {
-    vscode-generic = ../applications/editors/vscode/generic.nix;
-  };
 
   code-server = callPackage ../servers/code-server {
     nodejs = nodejs_20;
   };
 
-  kiro = callPackage ../by-name/ki/kiro/package.nix {
-    vscode-generic = ../applications/editors/vscode/generic.nix;
-  };
   kiro-fhs = kiro.fhs;
   kiro-fhsWithPackages = kiro.fhsWithPackages;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1034,14 +1034,6 @@ with pkgs;
     crate = "api";
   };
 
-  # This is to workaround gfal2-python broken against Python 3.12 or later.
-  # TODO: Remove these lines after solving the breakage.
-  gfal2-util = callPackage ../by-name/gf/gfal2-util/package.nix (
-    lib.optionalAttrs python3Packages.gfal2-python.meta.broken {
-      python3Packages = python311Packages;
-    }
-  );
-
   inherit (callPackages ../tools/networking/ivpn/default.nix { })
     ivpn
     ivpn-service

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11459,14 +11459,6 @@ with pkgs;
 
   mercurialFull = mercurial.override { fullBuild = true; };
 
-  meshlab = callPackage ../by-name/me/meshlab/package.nix {
-    stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
-  };
-
-  meshlab-unstable = callPackage ../by-name/me/meshlab-unstable/package.nix {
-    stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
-  };
-
   meshcentral = callPackage ../tools/admin/meshcentral { };
 
   michabo = libsForQt5.callPackage ../applications/misc/michabo { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -328,15 +328,6 @@ with pkgs;
 
   chef-cli = callPackage ../tools/misc/chef-cli { };
 
-  clang-uml = callPackage ../by-name/cl/clang-uml/package.nix {
-    stdenv = clangStdenv;
-  };
-
-  cope = callPackage ../by-name/co/cope/package.nix {
-    perl = perl538;
-    perlPackages = perl538Packages;
-  };
-
   coolercontrol = recurseIntoAttrs (callPackage ../applications/system/coolercontrol { });
 
   cup-docker-noserver = cup-docker.override { withServer = false; };
@@ -368,8 +359,6 @@ with pkgs;
   ebpf-verifier = callPackage ../tools/networking/ebpf-verifier {
     catch2 = catch2_3;
   };
-
-  eff = callPackage ../by-name/ef/eff/package.nix { ocamlPackages = ocaml-ng.ocamlPackages_5_2; };
 
   enochecker-test = with python3Packages; callPackage ../development/tools/enochecker-test { };
 
@@ -800,10 +789,6 @@ with pkgs;
     propagatedBuildInputs = [ dieHook ];
   } ../build-support/setup-hooks/shorten-perl-shebang.sh;
 
-  sile = callPackage ../by-name/si/sile/package.nix {
-    lua = luajit;
-  };
-
   singularity-tools = callPackage ../build-support/singularity-tools { };
 
   srcOnly = callPackage ../build-support/src-only { };
@@ -994,10 +979,6 @@ with pkgs;
     );
   };
 
-  akkoma-admin-fe = callPackage ../by-name/ak/akkoma-admin-fe/package.nix {
-    python3 = python311;
-  };
-
   aegisub = callPackage ../by-name/ae/aegisub/package.nix (
     {
       luajit = luajit.override { enable52Compat = true; };
@@ -1040,15 +1021,9 @@ with pkgs;
     libgamemode32 = pkgsi686Linux.gamemode.lib;
   };
 
-  gamescope = callPackage ../by-name/ga/gamescope/package.nix {
-    wlroots = wlroots_0_17;
-  };
-
   gamescope-wsi = callPackage ../by-name/ga/gamescope/package.nix {
     enableExecutable = false;
     enableWsi = true;
-
-    wlroots = wlroots_0_17;
   };
 
   font-v = with python3Packages; toPythonApplication font-v;
@@ -1379,11 +1354,6 @@ with pkgs;
     withWayland = true;
   };
 
-  shadps4 = callPackage ../by-name/sh/shadps4/package.nix {
-    # relies on std::sinf & co, which was broken in GCC until GCC 14: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79700
-    stdenv = gcc14Stdenv;
-  };
-
   winetricks = callPackage ../applications/emulators/wine/winetricks.nix { };
 
   zsnes = pkgsi686Linux.callPackage ../applications/emulators/zsnes { };
@@ -1428,10 +1398,6 @@ with pkgs;
   vifm-full = vifm.override {
     mediaSupport = true;
     inherit lib udisks2 python3;
-  };
-
-  xfe = callPackage ../by-name/xf/xfe/package.nix {
-    fox = fox_1_6;
   };
 
   johnny-reborn-engine = callPackage ../applications/misc/johnny-reborn { };
@@ -1880,10 +1846,6 @@ with pkgs;
 
   intel-oneapi = callPackage ../development/libraries/intel-oneapi { };
 
-  sway-unwrapped = callPackage ../by-name/sw/sway-unwrapped/package.nix {
-    wlroots = wlroots_0_19;
-  };
-
   cambrinary = python3Packages.callPackage ../applications/misc/cambrinary { };
 
   cplex = callPackage ../applications/science/math/cplex (config.cplex or { });
@@ -2041,74 +2003,6 @@ with pkgs;
     cairo = cairo.override { xcbSupport = true; };
   };
 
-  aquamarine = callPackage ../by-name/aq/aquamarine/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprcursor = callPackage ../by-name/hy/hyprcursor/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprgraphics = callPackage ../by-name/hy/hyprgraphics/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hypridle = callPackage ../by-name/hy/hypridle/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprland = callPackage ../by-name/hy/hyprland/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprland-protocols = callPackage ../by-name/hy/hyprland-protocols/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprland-qt-support = callPackage ../by-name/hy/hyprland-qt-support/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprland-qtutils = callPackage ../by-name/hy/hyprland-qtutils/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprlang = callPackage ../by-name/hy/hyprlang/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprlock = callPackage ../by-name/hy/hyprlock/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprpaper = callPackage ../by-name/hy/hyprpaper/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprpicker = callPackage ../by-name/hy/hyprpicker/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprpolkitagent = callPackage ../by-name/hy/hyprpolkitagent/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprsunset = callPackage ../by-name/hy/hyprsunset/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprsysteminfo = callPackage ../by-name/hy/hyprsysteminfo/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprutils = callPackage ../by-name/hy/hyprutils/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
-  hyprwayland-scanner = callPackage ../by-name/hy/hyprwayland-scanner/package.nix {
-    stdenv = gcc15Stdenv;
-  };
-
   hyprshade = python3Packages.callPackage ../applications/window-managers/hyprwm/hyprshade { };
 
   hyprlandPlugins = recurseIntoAttrs (
@@ -2221,8 +2115,6 @@ with pkgs;
   pyznap = python3Packages.callPackage ../tools/backup/pyznap { };
 
   psrecord = python3Packages.callPackage ../tools/misc/psrecord { };
-
-  renpy = callPackage ../by-name/re/renpy/package.nix { python3 = python312; };
 
   rmview = libsForQt5.callPackage ../applications/misc/remarkable/rmview { };
 
@@ -2740,10 +2632,6 @@ with pkgs;
   fcitx5-table-extra = callPackage ../tools/inputmethods/fcitx5/fcitx5-table-extra.nix { };
 
   fcitx5-table-other = callPackage ../tools/inputmethods/fcitx5/fcitx5-table-other.nix { };
-
-  firezone-server = callPackage ../by-name/fi/firezone-server/package.nix {
-    beamPackages = beam27Packages;
-  };
 
   flannel = callPackage ../tools/networking/flannel { };
   cni-plugin-flannel = callPackage ../tools/networking/flannel/plugin.nix { };
@@ -3524,10 +3412,6 @@ with pkgs;
     };
   });
 
-  netlify-cli = callPackage ../by-name/ne/netlify-cli/package.nix {
-    nodejs = nodejs_20;
-  };
-
   libnma-gtk4 = libnma.override { withGtk4 = true; };
 
   inherit (callPackages ../servers/nextcloud { })
@@ -3942,12 +3826,6 @@ with pkgs;
 
   rsibreak = libsForQt5.callPackage ../applications/misc/rsibreak { };
 
-  rucio = callPackage ../by-name/ru/rucio/package.nix {
-    # Pinned to python 3.12 while python313Packages.future does not evaluate and
-    # until https://github.com/CZ-NIC/pyoidc/issues/649 is resolved
-    python3Packages = python312Packages;
-  };
-
   rubocop = rubyPackages.rubocop;
 
   ruby-lsp = rubyPackages.ruby-lsp;
@@ -4171,8 +4049,6 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
-  vikunja = callPackage ../by-name/vi/vikunja/package.nix { pnpm = pnpm_9; };
-
   vimpager = callPackage ../tools/misc/vimpager { };
   vimpager-latest = callPackage ../tools/misc/vimpager/latest.nix { };
 
@@ -4295,10 +4171,6 @@ with pkgs;
 
   web-eid-app = libsForQt5.callPackage ../tools/security/web-eid-app { };
 
-  wio = callPackage ../by-name/wi/wio/package.nix {
-    wlroots = wlroots_0_19;
-  };
-
   wring = nodePackages.wring;
 
   wyrd = callPackage ../tools/misc/wyrd {
@@ -4420,10 +4292,6 @@ with pkgs;
 
   adaptivecppWithCuda = adaptivecpp.override { cudaSupport = true; };
   adaptivecppWithRocm = adaptivecpp.override { rocmSupport = true; };
-
-  armips = callPackage ../by-name/ar/armips/package.nix {
-    stdenv = clangStdenv;
-  };
 
   binaryen = callPackage ../development/compilers/binaryen {
     nodejs = nodejs-slim;
@@ -5650,14 +5518,9 @@ with pkgs;
     };
   };
 
-  dbqn = callPackage ../by-name/db/dbqn/package.nix {
-    jdk = jre;
-    stdenv = stdenvNoCC;
-  };
-
   dbqn-native = dbqn.override {
     buildNativeImage = true;
-    jdk = graalvmPackages.graalvm-ce;
+    jre = graalvmPackages.graalvm-ce;
   };
 
   clojupyter = callPackage ../applications/editors/jupyter-kernels/clojupyter {
@@ -6102,10 +5965,6 @@ with pkgs;
 
   guile = guile_3_0;
 
-  guile-xcb = callPackage ../by-name/gu/guile-xcb/package.nix {
-    guile = guile_2_2;
-  };
-
   msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
 
   msp430Newlib = callPackage ../development/misc/msp430/newlib.nix { };
@@ -6118,10 +5977,6 @@ with pkgs;
   vc4-newlib = callPackage ../development/misc/vc4/newlib.nix { };
 
   or1k-newlib = callPackage ../development/misc/or1k/newlib.nix { };
-
-  vcsh = callPackage ../by-name/vc/vcsh/package.nix {
-    automake = automake116x;
-  };
 
   ### DEVELOPMENT / TOOLS
 
@@ -6610,9 +6465,6 @@ with pkgs;
   griffe = with python3Packages; toPythonApplication griffe;
 
   gwrap = g-wrap;
-  g-wrap = callPackage ../by-name/g-/g-wrap/package.nix {
-    guile = guile_2_2;
-  };
 
   hadolint =
     # TODO: Erroneous references to GHC on aarch64-darwin: https://github.com/NixOS/nixpkgs/issues/318013
@@ -7245,10 +7097,6 @@ with pkgs;
   fplll = callPackage ../development/libraries/fplll { };
   fplll_20160331 = callPackage ../development/libraries/fplll/20160331.nix { };
 
-  freeimage = callPackage ../by-name/fr/freeimage/package.nix {
-    openexr = openexr_2;
-  };
-
   freeipa = callPackage ../os-specific/linux/freeipa {
     # NOTE: freeipa and sssd need to be built with the same version of python
     kerberos = krb5.override {
@@ -7619,8 +7467,6 @@ with pkgs;
     lib.warn "hunspellWithDicts is deprecated, please use hunspell.withDicts instead."
       hunspell.withDicts
       (_: dicts);
-
-  hydra = callPackage ../by-name/hy/hydra/package.nix { nix = nixVersions.nix_2_29; };
 
   icu-versions = callPackages ../development/libraries/icu { };
   inherit (icu-versions)
@@ -8514,10 +8360,6 @@ with pkgs;
 
   librdf_redland = callPackage ../development/libraries/librdf/redland.nix { };
   redland = librdf_redland; # added 2018-04-25
-
-  renovate = callPackage ../by-name/re/renovate/package.nix {
-    nodejs = nodejs_22;
-  };
 
   qadwaitadecorations-qt6 = callPackage ../by-name/qa/qadwaitadecorations/package.nix {
     useQt6 = true;
@@ -9909,10 +9751,6 @@ with pkgs;
 
   alfred = callPackage ../os-specific/linux/batman-adv/alfred.nix { };
 
-  alsa-utils = callPackage ../by-name/al/alsa-utils/package.nix {
-    fftw = fftwFloat;
-  };
-
   arm-trusted-firmware = callPackage ../misc/arm-trusted-firmware { };
   inherit (arm-trusted-firmware)
     buildArmTrustedFirmware
@@ -10205,10 +10043,6 @@ with pkgs;
 
   open-vm-tools-headless = open-vm-tools.override { withX = false; };
 
-  odin = callPackage ../by-name/od/odin/package.nix {
-    llvmPackages = llvmPackages_18;
-  };
-
   pam =
     if stdenv.hostPlatform.isLinux then
       linux-pam
@@ -10414,10 +10248,6 @@ with pkgs;
     ubootVisionFive2
     ubootWandboard
     ;
-
-  eudev = callPackage ../by-name/eu/eudev/package.nix {
-    util-linux = util-linuxMinimal;
-  };
 
   udisks2 = callPackage ../os-specific/linux/udisks/2-default.nix { };
   udisks = udisks2;
@@ -10651,10 +10481,6 @@ with pkgs;
 
   qogir-kde = libsForQt5.callPackage ../data/themes/qogir-kde { };
 
-  ricochet-refresh = callPackage ../by-name/ri/ricochet-refresh/package.nix {
-    protobuf = protobuf_21; # https://github.com/blueprint-freespeech/ricochet-refresh/issues/178
-  };
-
   shaderc = callPackage ../development/compilers/shaderc {
     inherit (darwin) autoSignDarwinBinariesHook;
   };
@@ -10816,10 +10642,6 @@ with pkgs;
     pinentry = pinentry-curses;
   };
 
-  blender = callPackage ../by-name/bl/blender/package.nix {
-    python3Packages = python311Packages;
-  };
-
   blender-hip = blender.override { hipSupport = true; };
 
   blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
@@ -10896,7 +10718,6 @@ with pkgs;
   );
 
   darktable = callPackage ../by-name/da/darktable/package.nix {
-    lua = lua5_4;
     pugixml = pugixml.override { shared = true; };
   };
 
@@ -10934,8 +10755,6 @@ with pkgs;
 
   dfasma = libsForQt5.callPackage ../applications/audio/dfasma { };
 
-  djv = callPackage ../by-name/dj/djv/package.nix { openexr = openexr_2; };
-
   djview4 = djview;
 
   dmenu-rs-enable-plugins = dmenu-rs.override { enablePlugins = true; };
@@ -10971,10 +10790,6 @@ with pkgs;
   drawterm-wayland = callPackage ../by-name/dr/drawterm/package.nix { withWayland = true; };
 
   droopy = python3Packages.callPackage ../applications/networking/droopy { };
-
-  dwl = callPackage ../by-name/dw/dwl/package.nix {
-    wlroots = wlroots_0_18;
-  };
 
   evilwm = callPackage ../applications/window-managers/evilwm {
     patches = config.evilwm.patches or [ ];
@@ -11452,10 +11267,6 @@ with pkgs;
 
   kitti3 = python3.pkgs.callPackage ../applications/window-managers/i3/kitti3.nix { };
 
-  waybox = callPackage ../by-name/wa/waybox/package.nix {
-    wlroots = wlroots_0_17;
-  };
-
   workstyle = callPackage ../applications/window-managers/i3/workstyle.nix { };
 
   wmfocus = callPackage ../applications/window-managers/i3/wmfocus.nix { };
@@ -11796,12 +11607,10 @@ with pkgs;
 
   meshlab = callPackage ../by-name/me/meshlab/package.nix {
     stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
-    llvmPackages = llvmPackages_18;
   };
 
   meshlab-unstable = callPackage ../by-name/me/meshlab-unstable/package.nix {
     stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
-    llvmPackages = llvmPackages_18;
   };
 
   meshcentral = callPackage ../tools/admin/meshcentral { };
@@ -12107,12 +11916,6 @@ with pkgs;
 
   parsec-bin = callPackage ../applications/misc/parsec/bin.nix { };
 
-  pekwm = callPackage ../by-name/pe/pekwm/package.nix {
-    awk = gawk;
-    grep = gnugrep;
-    sed = gnused;
-  };
-
   petrifoo = callPackage ../applications/audio/petrifoo {
     inherit (gnome2) libgnomecanvas;
   };
@@ -12379,10 +12182,6 @@ with pkgs;
   );
 
   sxiv = callPackage ../applications/graphics/sxiv {
-    imlib2 = imlib2Full;
-  };
-
-  nsxiv = callPackage ../by-name/ns/nsxiv/package.nix {
     imlib2 = imlib2Full;
   };
 
@@ -13198,10 +12997,6 @@ with pkgs;
   anki-bin = callPackage ../games/anki/bin.nix { };
   anki-sync-server = callPackage ../games/anki/sync-server.nix { };
 
-  art = callPackage ../by-name/ar/art/package.nix {
-    fftw = fftwSinglePrec;
-  };
-
   arx-libertatis = libsForQt5.callPackage ../games/arx-libertatis { };
 
   asc = callPackage ../games/asc {
@@ -13522,10 +13317,6 @@ with pkgs;
 
   synthv1 = libsForQt5.callPackage ../applications/audio/synthv1 { };
 
-  the-powder-toy = callPackage ../by-name/th/the-powder-toy/package.nix {
-    lua = lua5_2;
-  };
-
   tbe = libsForQt5.callPackage ../games/the-butterfly-effect { };
 
   teeworlds-server = teeworlds.override { buildClient = false; };
@@ -13591,11 +13382,6 @@ with pkgs;
     yquake2-the-reckoning
     yquake2-all-games
     ;
-
-  zeroad-unwrapped = callPackage ../by-name/ze/zeroad-unwrapped/package.nix {
-    wxGTK = wxGTK32;
-    fmt = fmt_9;
-  };
 
   ### DESKTOP ENVIRONMENTS
 
@@ -13729,10 +13515,6 @@ with pkgs;
 
   siesta-mpi = callPackage ../applications/science/chemistry/siesta { useMpi = true; };
 
-  cp2k = callPackage ../by-name/cp/cp2k/package.nix {
-    libxc = pkgs.libxc_7;
-  };
-
   ### SCIENCE/GEOMETRY
 
   ### SCIENCE/BENCHMARK
@@ -13815,10 +13597,6 @@ with pkgs;
   mathematica-webdoc-cuda = mathematica.override {
     webdoc = true;
     cudaSupport = true;
-  };
-
-  math-preview = callPackage ../by-name/ma/math-preview/package.nix {
-    nodejs = nodejs_20;
   };
 
   p4est-sc-dbg = p4est-sc.override { debug = true; };
@@ -14008,8 +13786,6 @@ with pkgs;
       ];
       buildFlags = [ "compiler" ];
     };
-
-    java = openjdk21;
   };
   isabelle-components = recurseIntoAttrs (callPackage ../by-name/is/isabelle/components { });
 
@@ -14673,10 +14449,6 @@ with pkgs;
     qt6Packages.callPackage ../applications/networking/instant-messengers/discord-screenaudio
       { };
 
-  tomb = callPackage ../by-name/to/tomb/package.nix {
-    pinentry = pinentry-curses;
-  };
-
   tora = libsForQt5.callPackage ../development/tools/tora { };
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
@@ -14773,35 +14545,8 @@ with pkgs;
 
   yaziPlugins = recurseIntoAttrs (callPackage ../by-name/ya/yazi/plugins { });
 
-  dillo = callPackage ../by-name/di/dillo/package.nix {
-    fltk = fltk13;
-  };
-
-  cantata = callPackage ../by-name/ca/cantata/package.nix {
-    ffmpeg = ffmpeg_6;
-  };
-
-  libkazv = callPackage ../by-name/li/libkazv/package.nix {
-    libcpr = libcpr_1_10_5;
-  };
-
-  biblioteca = callPackage ../by-name/bi/biblioteca/package.nix {
-    webkitgtk = webkitgtk_6_0;
-  };
-
   libpostalWithData = callPackage ../by-name/li/libpostal/package.nix {
     withData = true;
   };
 
-  clash-verge-rev = callPackage ../by-name/cl/clash-verge-rev/package.nix {
-    libsoup = libsoup_3;
-  };
-
-  rustdesk-flutter = callPackage ../by-name/ru/rustdesk-flutter/package.nix {
-    flutter = flutter324;
-  };
-
-  davis = callPackage ../by-name/da/davis/package.nix {
-    php = php83; # https://github.com/tchapi/davis/issues/195
-  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6763,12 +6763,6 @@ with pkgs;
 
   watson-ruby = callPackage ../development/tools/misc/watson-ruby { };
 
-  xcbuild = callPackage ../by-name/xc/xcbuild/package.nix {
-    stdenv =
-      # xcbuild is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
-      if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-  };
-
   xcbuildHook = makeSetupHook {
     name = "xcbuild-hook";
     propagatedBuildInputs = [ xcbuild ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1041,9 +1041,6 @@ with pkgs;
   };
 
   gamescope = callPackage ../by-name/ga/gamescope/package.nix {
-    enableExecutable = true;
-    enableWsi = false;
-
     wlroots = wlroots_0_17;
   };
 
@@ -2659,7 +2656,6 @@ with pkgs;
 
   tsm-client-withGui = callPackage ../by-name/ts/tsm-client/package.nix { enableGui = true; };
 
-  tracy = callPackage ../by-name/tr/tracy/package.nix { withWayland = stdenv.hostPlatform.isLinux; };
   tracy-glfw = callPackage ../by-name/tr/tracy/package.nix { withWayland = false; };
   tracy-wayland = callPackage ../by-name/tr/tracy/package.nix { withWayland = true; };
 
@@ -5655,7 +5651,6 @@ with pkgs;
   };
 
   dbqn = callPackage ../by-name/db/dbqn/package.nix {
-    buildNativeImage = false;
     jdk = jre;
     stdenv = stdenvNoCC;
   };
@@ -6267,7 +6262,6 @@ with pkgs;
     inherit (darwin) sigtool;
     buildJdk = jdk21_headless;
     runJdk = jdk21_headless;
-    bazel_self = bazel_7;
   };
 
   buildifier = bazel-buildtools;
@@ -13313,12 +13307,6 @@ with pkgs;
   };
 
   factorio-utils = callPackage ../by-name/fa/factorio/utils.nix { };
-
-  freeciv = callPackage ../by-name/fr/freeciv/package.nix {
-    sdl2Client = false;
-    gtkClient = true;
-    qtClient = false;
-  };
 
   freeciv_sdl2 = freeciv.override {
     sdl2Client = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8681,14 +8681,6 @@ with pkgs;
       };
     } ../os-specific/darwin/darwin-min-version-hook/setup-hook.sh;
 
-  ### DEVELOPMENT / TESTING TOOLS
-
-  atf = callPackage ../by-name/at/atf/package.nix {
-    stdenv =
-      # atf is a dependency of libiconv. Avoid an infinite recursion with `pkgsStatic` by using a bootstrap stdenv.
-      if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-  };
-
   ### DEVELOPMENT / LIBRARIES / AGDA
 
   agdaPackages = recurseIntoAttrs (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -979,13 +979,6 @@ with pkgs;
     );
   };
 
-  aegisub = callPackage ../by-name/ae/aegisub/package.nix (
-    {
-      luajit = luajit.override { enable52Compat = true; };
-    }
-    // (config.aegisub or { })
-  );
-
   acme-client = callPackage ../tools/networking/acme-client {
     stdenv = gccStdenv;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3684,10 +3684,6 @@ with pkgs;
     beamPackages = beam.packages.erlang_26.extend (self: super: { elixir = elixir_1_17; });
   };
 
-  plfit = callPackage ../by-name/pl/plfit/package.nix {
-    python = null;
-  };
-
   inherit (callPackage ../development/tools/pnpm { })
     pnpm_8
     pnpm_9

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11947,7 +11947,12 @@ self: super: with self; {
 
   plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
 
-  plfit = toPythonModule (pkgs.plfit.override { inherit (self) python; });
+  plfit = toPythonModule (
+    pkgs.plfit.override {
+      withPython = true;
+      inherit (self) python;
+    }
+  );
 
   plink = callPackage ../development/python-modules/plink { };
 


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/444420, we changed the approach regarding the override interface for packages in by-name. This allows us to move a lot more packages to by-name - and also to get rid of `callPackage` in `all-packages.nix` for by-name packages.

This PR removes all cases where a by-name package was *overwritten*, aka with the same name. There are still plenty of `callPackage` into by-name folders in `all-packages.nix`, but these introduce *new attributes*.

This first step will allow us to disallow overwriting these by-name attributes and then simplify nixpkgs-vet accordingly.

## Things done

- [x] Ensure 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
