### PR TITLE
fparser: 0-unstable-2015-09-25 -> 0-unstable-2025-06-23, csxcad, qcsxcad, openems, appcsxcad: fix for CMake v4

### DIFF
--- a/pkgs/by-name/ap/appcsxcad/package.nix
+++ b/pkgs/by-name/ap/appcsxcad/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   csxcad,
   qcsxcad,
@@ -24,6 +25,20 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-KrsnCnRZRTbkgEH3hOETrYhseg5mCHPqhAbYyHlS3sk=";
   };
+
+  patches = [
+    # ref. https://github.com/thliebig/AppCSXCAD/pull/14 merged upstream
+    (fetchpatch {
+      name = "update-minimum-cmake-required.patch";
+      url = "https://github.com/thliebig/AppCSXCAD/commit/9585207eb08195c3f1c47dc9d6a80b563a3272e0.patch";
+      hash = "sha256-2+C3cqQMU3UL12h0f7EdBZVqeJVSPhDVbMOcqbOY0gg=";
+    })
+    (fetchpatch {
+      name = "remove-cmp0020-policy.patch";
+      url = "https://github.com/thliebig/AppCSXCAD/commit/688c07cd847f463a2a42f01d41751374b4f787c8.patch";
+      hash = "sha256-pa6imzrUoVA3Ebc4UGPACJ6qjYiHOjB5aQ9FN/CUpVM=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/cs/csxcad/package.nix
+++ b/pkgs/by-name/cs/csxcad/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   fparser,
   tinyxml,
@@ -13,18 +14,26 @@
   mpfr,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "csxcad";
   version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "thliebig";
     repo = "CSXCAD";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-SSV5ulx3rCJg99I/oOQbqe+gOSs+BfcCo6UkWHVhnSs=";
   };
 
-  patches = [ ./searchPath.patch ];
+  patches = [
+    ./searchPath.patch
+    # ref. https://github.com/thliebig/CSXCAD/pull/62 merged upstream
+    (fetchpatch {
+      name = "update-cmake-minimum-required.patch";
+      url = "https://github.com/thliebig/CSXCAD/commit/b8ea64e11320910109a49b6da5352e1a1a18a736.patch";
+      hash = "sha256-mpQmpvrEDjOKgEAZ5laIIepG+PWqSr637tOY7FQst2s=";
+    })
+  ];
 
   buildInputs = [
     cgal
@@ -39,11 +48,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  meta = {
     description = "C++ library to describe geometrical objects";
     homepage = "https://github.com/thliebig/CSXCAD";
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ matthuszagh ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ matthuszagh ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/fp/fparser/package.nix
+++ b/pkgs/by-name/fp/fparser/package.nix
@@ -7,22 +7,22 @@
 
 stdenv.mkDerivation {
   pname = "fparser";
-  version = "0-unstable-2015-09-25";
+  version = "0-unstable-2025-06-23";
 
   src = fetchFromGitHub {
     owner = "thliebig";
     repo = "fparser";
-    rev = "a59e1f51e32096bfe2a0a2640d5dffc7ae6ba37b";
-    sha256 = "0wayml1mlyi922gp6am3fsidhzsilziksdn5kbnpcln01h8555ad";
+    rev = "ee15c675514e53b37304179b4a91319d44ba9a85";
+    hash = "sha256-YlkaJlZ60EAsaejdyaV7OK3zF7pnkhyr+PssuToFplA=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  meta = {
     description = "C++ Library for Evaluating Mathematical Functions";
     homepage = "https://github.com/thliebig/fparser";
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ matthuszagh ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ matthuszagh ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/op/openems/package.nix
+++ b/pkgs/by-name/op/openems/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   csxcad,
   fparser,
   tinyxml,
@@ -19,16 +20,31 @@
   hyp2mat,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openems";
   version = "0.0.36";
 
   src = fetchFromGitHub {
     owner = "thliebig";
     repo = "openEMS";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-wdH+Zw7G2ZigzBMX8p3GKdFVx/AhbTNL+P3w+YjI/dc=";
   };
+
+  patches = [
+    # ref. https://github.com/thliebig/openEMS/pull/183 merged upstream
+    (fetchpatch {
+      name = "update-cmake-minimum-required.patch";
+      url = "https://github.com/thliebig/openEMS/commit/0fa7ba3aebc8ee531077973cfa136ead8e887872.patch";
+      hash = "sha256-q/ax7MZHwqSKAjx22uyV13YO/TXZa4bwikoQyItMB7E=";
+    })
+    # ref. https://github.com/thliebig/openEMS/pull/184 merged upstream
+    (fetchpatch {
+      name = "update-nf2ff-cmake-minimum-required.patch";
+      url = "https://github.com/thliebig/openEMS/commit/e02e2a8414355482145240e4c2b2464d7a26dd9e.patch";
+      hash = "sha256-y3pvim/8XUKF5k7shj0D+8P6tdfSZ3E/gxTogbRtxdo=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -60,11 +76,11 @@ stdenv.mkDerivation rec {
       -o $out/share/openEMS/matlab/h5readatt_octave.oct
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Open Source Electromagnetic Field Solver";
     homepage = "https://wiki.openems.de/index.php/Main_Page.html";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ matthuszagh ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ matthuszagh ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/qc/qcsxcad/package.nix
+++ b/pkgs/by-name/qc/qcsxcad/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   csxcad,
   tinyxml,
@@ -19,6 +20,20 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-bX6e3ugHJynU9tP70BV8TadnoGg1VO7SAYJueMkMAyo=";
   };
+
+  patches = [
+    # ref. https://github.com/thliebig/QCSXCAD/pull/18 merged upstream
+    (fetchpatch {
+      name = "fix-cmake-40-issues.patch";
+      url = "https://github.com/thliebig/QCSXCAD/commit/200c9c211ee1401d6dce2bcbf2543089cdc67208.patch";
+      hash = "sha256-OVihvjBRTQ87l0bBq2J8aWC7WdFCPqy5CtU4S5a11Xw=";
+    })
+    (fetchpatch {
+      name = "update-cmake-minimum-required.patch";
+      url = "https://github.com/thliebig/QCSXCAD/commit/64a4bdc13511690499756e6602076c1e70cf4ee7.patch";
+      hash = "sha256-rzVj9YdAJVxhTatTO5MxZJInb1RB0qqmPFAkI2nxpQ0=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
fix for CMake v4
Part of https://github.com/NixOS/nixpkgs/issues/445447


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
