### PR TITLE
world-wall-clock: fix build and update

### DIFF
--- a/pkgs/by-name/wo/world-wall-clock/package.nix
+++ b/pkgs/by-name/wo/world-wall-clock/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "world-wall-clock";
-  version = "0.1.4";
+  version = "0.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ddelabru";
     repo = "world-wall-clock";
     tag = "v${version}";
-    hash = "sha256-OTBYSStCFBrZ8JutrhyyJpi7vRvBAUK0EKTtjvbi13I=";
+    hash = "sha256-gwJvoXSq8H+sMTyBEA1N+KxnkGxyt5Ev+V3awCBiILg=";
   };
 
   build-system = with python3.pkgs; [ poetry-core ];

--- a/pkgs/by-name/wo/world-wall-clock/package.nix
+++ b/pkgs/by-name/wo/world-wall-clock/package.nix
@@ -24,6 +24,10 @@ python3.pkgs.buildPythonApplication rec {
     xdg-base-dirs
   ];
 
+  pythonRelaxDeps = [
+    "urwid"
+  ];
+
   nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
 
   enabledTestPaths = [ "tests/*" ];


### PR DESCRIPTION
- **world-wall-clock: relax `urwid` to fix build**
- **world-wall-clock: 1.0.4 -> 1.0.5**

The build was failing due to urwid having a version 3.0.2 which didn't fit the requirements file.

I've run the build result and it seemed to work as expected.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
