### PR TITLE
gt: 0-unstable-2022-05-08 -> 0-unstable-2025-06-26

### DIFF
--- a/pkgs/by-name/gt/gt/package.nix
+++ b/pkgs/by-name/gt/gt/package.nix
@@ -11,19 +11,25 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "gt";
-  version = "0-unstable-2022-05-08";
+  version = "0-unstable-2025-06-26";
 
   src = fetchFromGitHub {
     owner = "linux-usb-gadgets";
     repo = "gt";
-    rev = "7f9c45d98425a27444e49606ce3cf375e6164e8e";
-    sha256 = "sha256-km4U+t4Id2AZx6GpH24p2WNmvV5RVjJ14sy8tWLCQsk=";
+    rev = "8ebbf3eb6fb77a53d6ace0eebf4f5debb779b576";
+    sha256 = "sha256-f/1nYnpAJ22ilWeyGtGcz9ZynL8a4UQoiKW+K/97iRI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/source";
 
   preConfigure = ''
     cmakeFlagsArray+=("-DBASH_COMPLETION_COMPLETIONSDIR=$out/share/bash-completions/completions")
+  '';
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 2.8)' \
+      'cmake_minimum_required(VERSION ${cmake.version})'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gt/gt/package.nix
+++ b/pkgs/by-name/gt/gt/package.nix
@@ -8,7 +8,9 @@
   libconfig,
   asciidoc,
   libusbgx,
+  nix-update-script,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "gt";
   version = "0-unstable-2025-06-26";
@@ -17,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "linux-usb-gadgets";
     repo = "gt";
     rev = "8ebbf3eb6fb77a53d6ace0eebf4f5debb779b576";
-    sha256 = "sha256-f/1nYnpAJ22ilWeyGtGcz9ZynL8a4UQoiKW+K/97iRI=";
+    hash = "sha256-f/1nYnpAJ22ilWeyGtGcz9ZynL8a4UQoiKW+K/97iRI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/source";
@@ -32,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
       'cmake_minimum_required(VERSION ${cmake.version})'
   '';
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -44,8 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
     libusbgx
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    description = "Linux command line tool for setting up USB gadgets using configfs";
+    description = "CLI tool for setting up USB gadgets using configfs";
     mainProgram = "gt";
     license = with lib.licenses; [ asl20 ];
     maintainers = [ ];

--- a/pkgs/by-name/li/libusbgx/package.nix
+++ b/pkgs/by-name/li/libusbgx/package.nix
@@ -5,21 +5,31 @@
   pkg-config,
   libconfig,
   autoreconfHook,
+  nix-update-script,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "libusbgx";
   version = "0.3.0";
+
   src = fetchFromGitHub {
     owner = "linux-usb-gadgets";
     repo = "libusbgx";
     tag = "libusbgx-v${finalAttrs.version}";
-    sha256 = "sha256-cG9hSv9TEs9+nfVtMrh88Gsg3P45aH+dr0d98hzqo0I=";
+    hash = "sha256-cG9hSv9TEs9+nfVtMrh88Gsg3P45aH+dr0d98hzqo0I=";
   };
+
+  strictDeps = true;
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
   ];
+
   buildInputs = [ libconfig ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "C library encapsulating the kernel USB gadget-configfs userspace API functionality";
     license = with lib.licenses; [

--- a/pkgs/by-name/li/libusbgx/package.nix
+++ b/pkgs/by-name/li/libusbgx/package.nix
@@ -6,14 +6,14 @@
   libconfig,
   autoreconfHook,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libusbgx";
-  version = "unstable-2021-10-31";
+  version = "0.3.0";
   src = fetchFromGitHub {
     owner = "linux-usb-gadgets";
     repo = "libusbgx";
-    rev = "060784424609d5a4e3bce8355f788c93f09802a5";
-    sha256 = "172qh8gva17jr18ldhf9zi960w2bqzmp030w6apxq57c9nv6d8k7";
+    tag = "libusbgx-v${finalAttrs.version}";
+    sha256 = "sha256-cG9hSv9TEs9+nfVtMrh88Gsg3P45aH+dr0d98hzqo0I=";
   };
   nativeBuildInputs = [
     autoreconfHook
@@ -29,4 +29,4 @@ stdenv.mkDerivation {
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Resolves #453940

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
