### PR TITLE
hyprlandPlugins.hypr-darkwindow: init at 0.51.1

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -37,6 +37,7 @@ let
 
   plugins = lib.mergeAttrsList [
     { hy3 = import ./hy3.nix; }
+    { hypr-darkwindow = import ./hypr-darkwindow.nix; }
     { hypr-dynamic-cursors = import ./hypr-dynamic-cursors.nix; }
     { hyprfocus = import ./hyprfocus.nix; }
     { hyprgrass = import ./hyprgrass.nix; }

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-darkwindow.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-darkwindow.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  mkHyprlandPlugin,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+mkHyprlandPlugin (finalAttrs: {
+  pluginName = "hypr-darkwindow";
+  version = "0.51.1";
+
+  src = fetchFromGitHub {
+    owner = "micha4w";
+    repo = "Hypr-DarkWindow";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jq5j459gCVuBOpuGEvXe+9/O+HAineFxQI4sIcEPi/c=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv out/hypr-darkwindow.so $out/lib/libhypr-darkwindow.so
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Hyprland Plugin to invert Colors of specific Windows!";
+    homepage = "https://github.com/micha4w/Hypr-DarkWindow";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anninzy ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hyprland Plugin to invert Colors of specific Windows!
https://github.com/micha4w/Hypr-DarkWindow/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
