### PR TITLE
tandoor-recipes: 2.2.5 -> 2.3.3, fix build

### DIFF
--- a/pkgs/by-name/ta/tandoor-recipes/common.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/common.nix
@@ -1,12 +1,12 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "2.2.5";
+  version = "2.3.3";
 
   src = fetchFromGitHub {
     owner = "TandoorRecipes";
     repo = "recipes";
     tag = version;
-    hash = "sha256-N6d5T11fOAtPKAV/tqTWGdwMkWNY8rPpWT2TBSc0ybc=";
+    hash = "sha256-N9eHoQyNPbjf4XrdNvTuMKs866mO+jgn2zRkXLAMtb8=";
   };
 
   yarnHash = "sha256-1p79Bdsn6KDApYKz9BAwrA97svbB8ub+Wl49MTIumW8=";

--- a/pkgs/by-name/ta/tandoor-recipes/package.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/package.nix
@@ -4,7 +4,11 @@
   python3,
 }:
 let
-  python = python3;
+  python = python3.override {
+    packageOverrides = final: prev: {
+      django = final.django_5;
+    };
+  };
 
   common = callPackage ./common.nix { };
 

--- a/pkgs/by-name/ta/tandoor-recipes/pytest-xdist.patch
+++ b/pkgs/by-name/ta/tandoor-recipes/pytest-xdist.patch
@@ -11,4 +11,4 @@ index 2755dc99..4026b96e 100644
  # addopts = -n auto --junitxml=docs/reports/tests/pytest.xml --html=docs/reports/tests/tests.html
 -asyncio_default_fixture_loop_scope = fixture
 \ No newline at end of file
-+asyncio_default_fixture_loop_scope = fixture
++asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
Closes #453891 

https://github.com/TandoorRecipes/recipes/releases/tag/2.3.3
Diff: https://github.com/TandoorRecipes/recipes/compare/2.2.5...2.3.3

ZHF: #457852

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
