### PR TITLE
mgmt: unstable-2022-10-24 -> 1.0.1

### DIFF
--- a/pkgs/by-name/mg/mgmt/package.nix
+++ b/pkgs/by-name/mg/mgmt/package.nix
@@ -10,16 +10,19 @@
   pkg-config,
   ragel,
 }:
-buildGoModule rec {
+
+buildGoModule (finalAttrs: {
   pname = "mgmt";
   version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "purpleidea";
     repo = "mgmt";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Qi9KkWzFOqmUp5CSHxzQabQ8bVnBbxxKS/W6aLBTv6k=";
   };
+
+  vendorHash = "sha256-XZTDqN5nQqze41Y/jOhT3mFHXeR2oPjXpz7CJuPOi8k=";
 
   buildInputs = [
     augeas
@@ -38,18 +41,16 @@ buildGoModule rec {
     "-s"
     "-w"
     "-X main.program=mgmt"
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
   ];
 
   subPackages = [ "." ];
 
-  vendorHash = "sha256-XZTDqN5nQqze41Y/jOhT3mFHXeR2oPjXpz7CJuPOi8k=";
-
-  meta = with lib; {
+  meta = {
     description = "Next generation distributed, event-driven, parallel config management";
     homepage = "https://mgmtconfig.com";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ urandom ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ urandom ];
     mainProgram = "mgmt";
   };
-}
+})

--- a/pkgs/by-name/mg/mgmt/package.nix
+++ b/pkgs/by-name/mg/mgmt/package.nix
@@ -12,27 +12,14 @@
 }:
 buildGoModule rec {
   pname = "mgmt";
-  version = "unstable-2022-10-24";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "purpleidea";
     repo = "mgmt";
-    rev = "d8820fa1855668d9e0f7a7829d9dd0d122b2c5a9";
-    hash = "sha256-jurZvEtiaTjWeDkmCJDIFlTzR5EVglfoDxkFgOilo8s=";
+    tag = version;
+    hash = "sha256-Qi9KkWzFOqmUp5CSHxzQabQ8bVnBbxxKS/W6aLBTv6k=";
   };
-
-  # patching must be done in prebuild, so it is shared with goModules
-  # see https://github.com/NixOS/nixpkgs/issues/208036
-  preBuild = ''
-    for file in `find -name Makefile -type f`; do
-      substituteInPlace $file --replace "/usr/bin/env " ""
-    done
-
-    substituteInPlace lang/types/Makefile \
-      --replace "unset GOCACHE && " ""
-    patchShebangs misc/header.sh
-    make lang funcgen
-  '';
 
   buildInputs = [
     augeas
@@ -56,7 +43,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  vendorHash = "sha256-Dtqy4TILN+7JXiHKHDdjzRTsT8jZYG5sPudxhd8znXY=";
+  vendorHash = "sha256-XZTDqN5nQqze41Y/jOhT3mFHXeR2oPjXpz7CJuPOi8k=";
 
   meta = with lib; {
     description = "Next generation distributed, event-driven, parallel config management";


### PR DESCRIPTION
Resolves #453975

Doesn't build yet.
Upstream issue: https://github.com/purpleidea/mgmt/issues/826
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
