### PR TITLE
python3Packages.finetuning-scheduler: 2.5.3 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/finetuning-scheduler/default.nix
+++ b/pkgs/development/python-modules/finetuning-scheduler/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   setuptools,
@@ -13,34 +12,20 @@
   torch,
 
   # tests
-  pythonOlder,
-  pythonAtLeast,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "finetuning-scheduler";
-  version = "2.5.3";
+  version = "2.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "speediedan";
     repo = "finetuning-scheduler";
     tag = "v${version}";
-    hash = "sha256-6WRKDYug7eVaTSY2R2jBcj9o/984mqKZZi36XRT7KyI=";
+    hash = "sha256-xKaOVbsflqQI9e1Ezcgea2hZpLh6CY+vx2Jy7QPswHM=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/speediedan/finetuning-scheduler/commit/78e6e225f353d1ba95db05d7fc6ff541859ed6a2.patch";
-      hash = "sha256-7mbtsaHrnHph8lvuwhBGqxPQimbZcbGeyBYXzApFPn4=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools<77.0.0" "setuptools"
-  '';
 
   build-system = [ setuptools ];
 
@@ -58,23 +43,14 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
   enabledTestPaths = [ "tests" ];
-  disabledTests =
-    lib.optionals (pythonOlder "3.12") [
-      # torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
-      # LoweringException: ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler'
-      "test_fts_dynamo_enforce_p0"
-      "test_fts_dynamo_resume"
-      "test_fts_dynamo_intrafit"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.13") [
-      # RuntimeError: Dynamo is not supported on Python 3.13+
-      "test_fts_dynamo_enforce_p0"
-      "test_fts_dynamo_resume"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
-      # slightly exceeds numerical tolerance on aarch64-linux:
-      "test_fts_frozen_bn_track_running_stats"
-    ];
+  disabledTests = [
+    # AssertionError: assert 'lightning @ git+' in 'lightning>=2.5.0,<2.5.6'
+    "test_get_lightning_requirement"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
+    # slightly exceeds numerical tolerance on aarch64-linux:
+    "test_fts_frozen_bn_track_running_stats"
+  ];
 
   pythonImportsCheck = [ "finetuning_scheduler" ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/speediedan/finetuning-scheduler/compare/v2.5.3...v2.9.0
Changelog: https://github.com/speediedan/finetuning-scheduler/blob/v2.9.0/CHANGELOG.md

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc