### PR TITLE
nlohmann_json: add patch to fix implicit conversion of optional values

### DIFF
--- a/pkgs/by-name/nl/nlohmann_json/package.nix
+++ b/pkgs/by-name/nl/nlohmann_json/package.nix
@@ -9,7 +9,7 @@ let
   testData = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json_test_data";
-    rev = "v3.1.0";
+    tag = "v3.1.0";
     hash = "sha256-bG34W63ew7haLnC82A3lS7bviPDnApLipaBjJAjLcVk=";
   };
 in
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-cECvDOLxgX7Q9R3IE86Hj9JJUxraDQvhoyPDF03B2CY=";
   };
 
@@ -54,11 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = "rm -rf $out/lib64";
 
-  meta = with lib; {
+  meta = {
     description = "JSON for Modern C++";
     homepage = "https://json.nlohmann.me";
     changelog = "https://github.com/nlohmann/json/blob/develop/ChangeLog.md";
-    license = licenses.mit;
-    platforms = platforms.all;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/nl/nlohmann_json/package.nix
+++ b/pkgs/by-name/nl/nlohmann_json/package.nix
@@ -24,7 +24,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-cECvDOLxgX7Q9R3IE86Hj9JJUxraDQvhoyPDF03B2CY=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
+    # https://github.com/nlohmann/json/pull/4771
+    # Fixes build failure in python3Packages.docling-parse, et. al.
+    (fetchpatch {
+      url = "https://github.com/nlohmann/json/commit/96c1b52f1cc4742a00ee02b34e043f61bbffa6ae.patch";
+      hash = "sha256-Reum5a3W6V+OIyyFcStoY4NJB3ZzdAyA/TDt1i07fg4=";
+    })
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMusl [
     # Musl does not support LC_NUMERIC, causing a test failure.
     # Turn the error into a warning to make the test succeed.
     # https://github.com/nlohmann/json/pull/4770
@@ -33,6 +41,11 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-gOZfRyDRI6USdUIY+sH7cygPrSIKGIo8AWcjqc/GQNI=";
     })
   ];
+
+  # TODO Remove when 3.12.1 is released
+  postPatch = ''
+    rm tests/src/unit-class_parser.cpp
+  '';
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
### DO NOT MERGE -- WORK IN PROGRESS

`python3Packages.docling-parse` fails during compilation with an error in `nlohmann_json`. See https://github.com/docling-project/docling-parse/issues/172 

A feature that should have been enabled in `nlohmann_json` was disabled by accident. This is a fixed issue  -- see https://github.com/nlohmann/json/issues/4864 -- and we're waiting for release 3.12.1.

In the meantime, we can add the patch to fix the compilation issue.


### Changes

1. Apply https://github.com/nlohmann/json/pull/4742 as a patch.
2. Minor cleanup: `rev` -> `tag`, remove `with lib;`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
