### PR TITLE
speedcrunch: migrate to `qt6`

### DIFF
--- a/pkgs/by-name/sp/speedcrunch/01-fix-qt6-build.patch
+++ b/pkgs/by-name/sp/speedcrunch/01-fix-qt6-build.patch
@@ -1,0 +1,38 @@
+# Sourced from https://bitbucket.org/heldercorreia/speedcrunch/pull-requests/140/commits
+
+diff --git a/cmake/QtWin32Deploy.cmake b/cmake/QtWin32Deploy.cmake
+
+--- a/cmake/QtWin32Deploy.cmake
++++ b/cmake/QtWin32Deploy.cmake
+@@ -15,7 +15,7 @@ set(qtwin32_QMLPLUGIN_SUFFIX_DEBUG "plugin${qtwin32_DLL_SUFFIX_DEBUG}")
+ 
+ # Determine the Qt minor version (so '6.4' or '6.5') for version checking. There's unlikely to be enough changes in
+ # patch releases to make it worth distinguishing based on those.
+-string(REGEX MATCH "[0-9]+[.][0-9]+" qtwin32_QT_MINOR_VERSION ${Qt6Core_VERSION_STRING})
++string(REGEX MATCH "[0-9]+[.][0-9]+" qtwin32_QT_MINOR_VERSION "${Qt6Core_VERSION}")
+ 
+ 
+ # qtwin32_check_qt_version([STRICT] <version>...)
+diff --git a/math/rational.h b/math/rational.h
+--- a/math/rational.h
++++ b/math/rational.h
+@@ -19,6 +19,8 @@
+ #ifndef RATIONAL_H
+ #define RATIONAL_H
+ 
++#include <QHash>
++
+ class HNumber;
+ class QString;
+ 
+@@ -64,6 +66,10 @@ public:
+     QString toString() const;
+     HNumber toHNumber( )const;
+     double toDouble() const;
++
++    friend size_t qHash(const Rational &r, size_t seed = 0) {
++        return qHashMulti(seed, r.m_num, r.m_denom, r.m_valid);
++    }
+ };
+ 
+ #endif // RATIONAL_H

--- a/pkgs/by-name/sp/speedcrunch/package.nix
+++ b/pkgs/by-name/sp/speedcrunch/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromBitbucket,
   cmake,
-  libsForQt5,
+  qt6,
 }:
 
 stdenv.mkDerivation {
@@ -13,39 +13,44 @@ stdenv.mkDerivation {
   src = fetchFromBitbucket {
     owner = "heldercorreia";
     repo = "speedcrunch";
-    rev = "db51fc5e547aa83834761d874d3518c06d0fec9e";
-    hash = "sha256-rnl4z/HU3lAF9Y1JvdM8LZWIV1NGfR4q5gOMxlNU2EA=";
+    rev = "3c1b4c18ccb275eb2891f9d8ff36a9205c0f566b";
+    hash = "sha256-9/id5h+5aBntlcsEUGkyEzMJf7we7hMslnkqKDcbaNY=";
   };
 
   sourceRoot = "source/src";
 
-  buildInputs = with libsForQt5; [
-    qtbase
-    qttools
+  patches = [
+    ./01-fix-qt6-build.patch
   ];
 
   nativeBuildInputs = [
     cmake
-  ]
-  ++ [
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qttools
   ];
 
   meta = {
     homepage = "https://speedcrunch.org";
     license = lib.licenses.gpl2Plus;
-    description = "Fast power user calculator";
+    description = "High-precision scientific calculator";
     mainProgram = "speedcrunch";
     longDescription = ''
-      SpeedCrunch is a fast, high precision and powerful desktop calculator.
-      Among its distinctive features are a scrollable display, up to 50 decimal
-      precisions, unlimited variable storage, intelligent automatic completion
-      full keyboard-friendly and more than 15 built-in math function.
+      SpeedCrunch is a high-precision scientific calculator.
+      Among its distinctive features are a syntax-highlighted scrollable display,
+      up to 50 decimal places of precision, complex number support, various
+      numeric bases, unit conversions, intelligent automatic completion of functions
+      and variables, integrated formula book, over 150 built-in scientific constants,
+      fully keyboard-driven interface, over 80 built-in mathematical functions and
+      support for user-defined functions.
     '';
     maintainers = with lib.maintainers; [
       j0hax
     ];
-    inherit (libsForQt5.qtbase.meta) platforms;
+    inherit (qt6.qtbase.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
### Migrate `speedcrunch` to `Qt6`.

- This update migrates `speedcrunch` to support `Qt6`, aligning with upstream changes.

- The commit reference has been updated. Previously, the unstable version was pinned to the penultimate upstream commit due to `Qt6` enforcement in the latest one.

- The `meta.description` and `meta.longDescription` fields have been revised to better reflect the current upstream documentation.

- General reformatting.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
