### PR TITLE
python3Packages.chipwhisperer: init at 5.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13933,6 +13933,14 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  krishnans2006 = {
+    email = "krishnans2006@gmail.com";
+    matrix = "@krishnans2006:matrix.org";
+    github = "krishnans2006";
+    githubId = 62958782;
+    name = "Krishnan Shankar";
+    keys = [ { fingerprint = "A30C 1843 F470 4843 5D54  3D68 29CB 06A8 40D0 E14A"; } ];
+  };
   kristian-brucaj = {
     email = "kbrucaj@gmail.com";
     github = "Flameslice";

--- a/pkgs/development/python-modules/chipwhisperer/default.nix
+++ b/pkgs/development/python-modules/chipwhisperer/default.nix
@@ -43,8 +43,6 @@ buildPythonPackage rec {
     hash = "sha256-C7QP044QEP7vmz1lMseLtMTYoKn5SoFV/q9URY7yQ6I=";
   };
 
-  # Build
-
   pyproject = true;
 
   build-system = [
@@ -70,8 +68,6 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  # Install
-
   nativeInstallCheckInputs = [
     udevCheckHook
   ];
@@ -89,8 +85,6 @@ buildPythonPackage rec {
     SUBSYSTEM=="tty", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", TAG+="uaccess", SYMLINK+="cw_bootloader%n"
     EOF
   '';
-
-  # Check
 
   pythonImportsCheck = [ "chipwhisperer" ];
 

--- a/pkgs/development/python-modules/chipwhisperer/default.nix
+++ b/pkgs/development/python-modules/chipwhisperer/default.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build
+  pythonAtLeast,
+  setuptools,
+  setuptools-scm,
+  cython,
+
+  # dependencies
+  colorama,
+  configobj,
+  ecpy,
+  fastdtw,
+  libusb1,
+  numpy,
+  pyserial,
+  tqdm,
+
+  # install
+  udevCheckHook,
+
+  # check
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+}:
+
+# Usage:
+# In NixOS, add the package to services.udev.packages for non-root plugdev
+# users to get device access permission:
+#    services.udev.packages = [ pkgs.python3Packages.chipwhisperer ];
+
+buildPythonPackage rec {
+  pname = "chipwhisperer";
+  version = "5.7.0";
+
+  src = fetchFromGitHub {
+    owner = "newaetech";
+    repo = "chipwhisperer";
+    tag = version;
+    hash = "sha256-C7QP044QEP7vmz1lMseLtMTYoKn5SoFV/q9URY7yQ6I=";
+  };
+
+  # Build
+
+  pyproject = true;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+
+  dependencies = [
+    colorama
+    configobj
+    ecpy
+    fastdtw
+    libusb1
+    pyserial
+    tqdm
+  ];
+
+  # Install
+
+  nativeInstallCheckInputs = [
+    udevCheckHook
+  ];
+
+  postInstall = ''
+    # Install udev rules
+    # The 50-newae.rules file from the repo isn't directly installed, since it
+    # installs to the chipwhisperer group (and not to uaccess)
+
+    mkdir -p $out/etc/udev/rules.d
+
+    cat <<EOF > $out/etc/udev/rules.d/50-newae.rules
+    SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="*", TAG+="uaccess"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="2b3e", ATTRS{idProduct}=="*", TAG+="uaccess", SYMLINK+="cw_serial%n"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", TAG+="uaccess", SYMLINK+="cw_bootloader%n"
+    EOF
+  '';
+
+  # Check
+
+  pythonImportsCheck = [ "chipwhisperer" ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    # All other tests require connected hardware
+    # Error: "Could not find ChipWhisperer. Is it connected?"
+    # See: https://chipwhisperer.readthedocs.io/en/latest/contributing.html#unit-tests
+    "tests/test_api.py"
+  ];
+
+  disabledTests = [ "TestCPA" ]; # Tries to open a tutorial project
+
+  meta = {
+    description = "Toolchain for side-channel power analysis and glitching attacks";
+    homepage = "https://github.com/newaetech/chipwhisperer";
+    changelog = "https://github.com/newaetech/chipwhisperer/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.krishnans2006 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2555,6 +2555,8 @@ self: super: with self; {
 
   chex = callPackage ../development/python-modules/chex { };
 
+  chipwhisperer = callPackage ../development/python-modules/chipwhisperer { };
+
   chirpstack-api = callPackage ../development/python-modules/chirpstack-api { };
 
   chispa = callPackage ../development/python-modules/chispa { };


### PR DESCRIPTION
This is a Python package for interfacing with ChipWhisperer FPGA boards, which perform side-channel analysis and voltage glitching on embedded devices.

[Homepage](https://chipwhisperer.readthedocs.io/en/latest/getting-started.html#getting-started)

Adapted from a flake I wrote [here](https://github.com/krishnans2006/csaw-esc-flake/blob/main/flake.nix) and udev rules I installed [here](https://github.com/krishnans2006/nixos-config/commit/2a53b50990febcd8663e5a965ce594e3a7b13809).

The package is quite popular in the cybersecurity community, so I'm surprised it isn't already packaged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
