### PR TITLE
pyrate-limiter: tests cleanup

### DIFF
--- a/pkgs/development/python-modules/pyrate-limiter/default.nix
+++ b/pkgs/development/python-modules/pyrate-limiter/default.nix
@@ -63,17 +63,19 @@ buildPythonPackage rec {
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  disabledTestPaths = [
-    # Slow: > 1.5 seconds/test run standalone on a fast machine
-    # (Apple M3 Max with highest performance settings and 36GB RAM)
-    # and/or hang under load
-    # https://github.com/vutran1710/PyrateLimiter/issues/245
-    # https://github.com/vutran1710/PyrateLimiter/issues/247
-    "tests/test_bucket_all.py"
-    "tests/test_bucket_factory.py"
-    "tests/test_limiter.py"
-    "tests/test_multiprocessing.py"
+  # https://github.com/vutran1710/PyrateLimiter/issues/245
+  # https://github.com/vutran1710/PyrateLimiter/issues/247
+  disabledTests = [
+    "test_limiter_01"
+    "test_limiter_async_factory_get"
+    "test_factory_leak"
+    "test_bucket_flush" # Part of "tests/test_bucket_all.py"
   ];
+
+  # Slow: > 1.5 seconds/test run standalone on a fast machine
+  # (Apple M3 Max with highest performance settings and 36GB RAM)
+  # and/or hang under load
+  disabledTestPaths = [ "tests/test_bucket_all.py" ];
 
   pythonImportsCheck = [ "pyrate_limiter" ];
 


### PR DESCRIPTION
~~Resolves #458830~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
