### PR TITLE
openshift: 4.16.0 -> 4.19.0-202505210330

### DIFF
--- a/pkgs/by-name/op/openshift/package.nix
+++ b/pkgs/by-name/op/openshift/package.nix
@@ -5,10 +5,11 @@
   gpgme,
   installShellFiles,
   pkg-config,
-  testers,
-  openshift,
+  versionCheckHook,
+  nix-update-script,
 }:
-buildGoModule rec {
+
+buildGoModule (finalAttrs: {
   pname = "openshift";
   version = "4.19.0-202505210330";
   gitCommit = "8f1c8b5";
@@ -16,7 +17,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "openshift";
     repo = "oc";
-    tag = "openshift-clients-${version}";
+    tag = "openshift-clients-${finalAttrs.version}";
     hash = "sha256-EIsK73zSozqBOFZalURNcamk5FRDusUEhXtup60c2zQ=";
   };
 
@@ -32,8 +33,8 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/openshift/oc/pkg/version.commitFromGit=${gitCommit}"
-    "-X github.com/openshift/oc/pkg/version.versionFromGit=v${version}"
+    "-X github.com/openshift/oc/pkg/version.commitFromGit=${finalAttrs.gitCommit}"
+    "-X github.com/openshift/oc/pkg/version.versionFromGit=v${finalAttrs.version}"
   ];
 
   doCheck = false;
@@ -54,11 +55,11 @@ buildGoModule rec {
       --zsh <($out/bin/oc completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = openshift;
-    command = "oc version";
-    version = "v${version}";
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Build, deploy, and manage your applications with Docker and Kubernetes";
@@ -71,4 +72,4 @@ buildGoModule rec {
     ];
     mainProgram = "oc";
   };
-}
+})

--- a/pkgs/by-name/op/openshift/package.nix
+++ b/pkgs/by-name/op/openshift/package.nix
@@ -10,14 +10,14 @@
 }:
 buildGoModule rec {
   pname = "openshift";
-  version = "4.16.0";
-  gitCommit = "fa84651";
+  version = "4.19.0-202505210330";
+  gitCommit = "8f1c8b5";
 
   src = fetchFromGitHub {
     owner = "openshift";
     repo = "oc";
-    rev = "fa846511dbeb7e08cf77265056397283c6c896f9";
-    hash = "sha256-mGItCpZQqQOKoNm2amwpHrEIcZdVNirQFa7DGvmnR9s=";
+    tag = "openshift-clients-${version}";
+    hash = "sha256-EIsK73zSozqBOFZalURNcamk5FRDusUEhXtup60c2zQ=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
Resolves #453769

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
