### PR TITLE
rocmPackages.rocblas: move tests and benchmarks to passthru.tests

### DIFF
--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -134,10 +134,7 @@ let
           ;
       };
 
-      rocblas = self.callPackage ./rocblas {
-        buildTests = true;
-        buildBenchmarks = true;
-      };
+      rocblas = self.callPackage ./rocblas { };
 
       rocsolver = self.callPackage ./rocsolver { };
 

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -25,8 +25,8 @@
   rocm-smi,
   pkg-config,
   buildTensile ? true,
-  buildTests ? true,
-  buildBenchmarks ? true,
+  buildTests ? false,
+  buildBenchmarks ? false,
   tensileSepArch ? true,
   tensileLazyLib ? true,
   withHipBlasLt ? true,
@@ -130,8 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "Tensile_LAZY_LIBRARY_LOADING" tensileLazyLib)
   ];
 
-  passthru.amdgpu_targets = gpuTargets';
-
   patches = [
     (fetchpatch {
       name = "Extend-rocBLAS-HIP-ISA-compatibility.patch";
@@ -150,10 +148,17 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '0.10' '1.0'
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+  passthru = {
+    amdgpu_targets = gpuTargets';
+    tests.rocblas-tests = finalAttrs.finalPackage.override {
+      buildBenchmarks = true;
+      buildTests = true;
+    };
+    updateScript = rocmUpdateScript {
+      name = finalAttrs.pname;
+      inherit (finalAttrs.src) owner;
+      inherit (finalAttrs.src) repo;
+    };
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fixes #454079. Test and bench data bloated rocblas' closure size by around 1.1G.

Before:

```log
$ nix path-info --size -h github:nixos/nixpkgs/master#rocmPackages.rocblas
/nix/store/smy4a23mx4zzyvhrwfksdp2p8ffqh3qf-rocblas-6.4.3          1.7G
$ nix path-info --closure-size -h github:nixos/nixpkgs/master#llama-cpp-rocm
/nix/store/hz1dz57qwq9dzmlwmsvy163ay64j66lc-llama-cpp-6782         4.2G
```

After:

```shell
$ nix path-info --size -h .#rocmPackages.rocblas
/nix/store/nhr7h2fc5qj4p546yl5gc274nwxgdrkr-rocblas-6.4.3        677.5M
$ nix path-info --closure-size -h .#llama-cpp-rocm
/nix/store/pjyiwpi84jj9nljmk3nwhkmr887dcvig-llama-cpp-6782         3.1G
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Tested langle mangle inference on gfx90a (MI210)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
