### PR TITLE
ocamlPackages.ocaml_gettext: fix for OCaml 5.4

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -4,27 +4,36 @@
   fetchpatch,
   applyPatches,
   buildDunePackage,
+  ocaml,
   cppo,
   gettext,
   fileutils,
   ounit2,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "gettext";
   version = "0.5.0";
 
   src = applyPatches {
     src = fetchurl {
-      url = "https://github.com/gildor478/ocaml-gettext/releases/download/v${version}/gettext-${version}.tbz";
+      url = "https://github.com/gildor478/ocaml-gettext/releases/download/v${finalAttrs.version}/gettext-${finalAttrs.version}.tbz";
       hash = "sha256-CN2d9Vsq8YOOIxK+S+lCtDddvBjCrtDKGSRIh1DjT10=";
     };
-    # Disable dune sites
-    # See https://github.com/gildor478/ocaml-gettext/pull/37
-    patches = fetchpatch {
-      url = "https://github.com/gildor478/ocaml-gettext/commit/5462396bee53cb13d8d6fde4c6d430412a17b64d.patch";
-      hash = "sha256-tOR+xgZTadvNeQpZnFTJEvZglK8P+ySvYnE3c1VWvKQ=";
-    };
+    patches = [
+      # Disable dune sites
+      # See https://github.com/gildor478/ocaml-gettext/pull/37
+      (fetchpatch {
+        url = "https://github.com/gildor478/ocaml-gettext/commit/5462396bee53cb13d8d6fde4c6d430412a17b64d.patch";
+        hash = "sha256-tOR+xgZTadvNeQpZnFTJEvZglK8P+ySvYnE3c1VWvKQ=";
+      })
+    ]
+    # Compatibility with OCaml ≥ 5.4
+    # See https://github.com/gildor478/ocaml-gettext/pull/41
+    ++ lib.optional (lib.versionAtLeast ocaml.version "5.4") (fetchpatch {
+      url = "https://github.com/gildor478/ocaml-gettext/commit/5d521981e39dcaeada6bbe7b15c5432d6de5d33c.patch";
+      hash = "sha256-82ajmpyXSd2RdVq/ND4lS8PIugRSkKe5oL8BL9CsLo4=";
+    });
   };
 
   nativeBuildInputs = [ cppo ];
@@ -46,4 +55,4 @@ buildDunePackage rec {
     maintainers = [ ];
     mainProgram = "ocaml-gettext";
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
