### PR TITLE
jigmo: 20230816 -> 20250912

### DIFF
--- a/pkgs/by-name/ji/jigmo/package.nix
+++ b/pkgs/by-name/ji/jigmo/package.nix
@@ -6,11 +6,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "jigmo";
-  version = "20230816";
+  version = "20250912";
 
   src = fetchzip {
     url = "https://kamichikoichi.github.io/jigmo/Jigmo-${version}.zip";
-    hash = "sha256-wBec7IiUneqCEyY704Wi6F6WG0Z1KK7gBGcJhRjrRDc=";
+    hash = "sha256-Z9WYPqNjHqnYjRndxtHsQ9XhFshMR50hVkQsXgUMKE8=";
+    stripRoot = false;
   };
 
   installPhase = ''

--- a/pkgs/by-name/ji/jigmo/package.nix
+++ b/pkgs/by-name/ji/jigmo/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jigmo";
   version = "20250912";
 
   src = fetchzip {
-    url = "https://kamichikoichi.github.io/jigmo/Jigmo-${version}.zip";
+    url = "https://kamichikoichi.github.io/jigmo/Jigmo-${finalAttrs.version}.zip";
     hash = "sha256-Z9WYPqNjHqnYjRndxtHsQ9XhFshMR50hVkQsXgUMKE8=";
     stripRoot = false;
   };
@@ -17,16 +17,16 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 *.ttf -t $out/share/fonts/truetype/
+    install -Dm644 *.ttf --target-directory=$out/share/fonts/truetype
 
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Japanese Kanji font set which is the official successor to Hanazono Mincho";
     homepage = "https://kamichikoichi.github.io/jigmo/";
-    license = licenses.cc0;
+    license = lib.licenses.cc0;
     maintainers = [ ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Resolves #454094

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
