### PR TITLE
chewing-editor: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/applications/misc/chewing-editor/default.nix
+++ b/pkgs/applications/misc/chewing-editor/default.nix
@@ -1,46 +1,53 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
+  gtest,
   cmake,
   pkg-config,
   libchewing,
+  qt5,
   qtbase,
   qttools,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "chewing-editor";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "chewing";
     repo = "chewing-editor";
-    rev = version;
-    sha256 = "0kc2hjx1gplm3s3p1r5sn0cyxw3k1q4gyv08q9r6rs4sg7xh2w7w";
+    tag = version;
+    hash = "sha256-gF3OotO/xb3Dc0YjVwAKIYnuEPIrgjpGR2tdjOBT4aI=";
   };
 
   doCheck = true;
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     pkg-config
+    qt5.wrapQtAppsHook
   ];
   buildInputs = [
+    gtest
     libchewing
     qtbase
     qttools
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Cross platform chewing user phrase editor";
     mainProgram = "chewing-editor";
     longDescription = ''
       chewing-editor is a cross platform chewing user phrase editor. It provides a easy way to manage user phrase. With it, user can customize their user phrase to increase input performance.
     '';
     homepage = "https://github.com/chewing/chewing-editor";
-    license = licenses.gpl2Plus;
-    maintainers = [ maintainers.ShamrockLee ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    platforms = lib.platforms.all;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447#issuecomment-3423962272

Changelog: https://github.com/chewing/chewing-editor/releases/tag/0.1.2
Diff: https://github.com/chewing/chewing-editor/compare/0.1.1...0.1.2
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
