### PR TITLE
top-level/by-name-overlay: remove optimization TODO

### DIFF
--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -41,10 +41,6 @@ let
   # if the overlay has to be applied multiple times
   packageFiles = mergeAttrsList (mapAttrsToList namesForShard (readDir baseDirectory));
 in
-# TODO: Consider optimising this using `builtins.deepSeq packageFiles`,
-# which could free up the above thunks and reduce GC times.
-# Currently this would be hard to measure until we have more packages
-# and ideally https://github.com/NixOS/nix/pull/8895
 self: super:
 {
   # This attribute is necessary to allow CI to ensure that all packages defined in `pkgs/by-name`


### PR DESCRIPTION
This applies the TODO left open.

## Things done

- [x] Test performance.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
