### PR TITLE
wox: fix hotkey-manager-linux's build failure with Clang 21

### DIFF
--- a/pkgs/development/compilers/dart/package-source-builders/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/default.nix
@@ -6,6 +6,7 @@
   flutter_secure_storage_linux = callPackage ./flutter-secure-storage-linux { };
   flutter_vodozemac = callPackage ./flutter_vodozemac { };
   flutter_volume_controller = callPackage ./flutter_volume_controller { };
+  hotkey_manager_linux = callPackage ./hotkey-manager-linux { };
   handy_window = callPackage ./handy-window { };
   matrix = callPackage ./matrix { };
   media_kit_libs_linux = callPackage ./media_kit_libs_linux { };

--- a/pkgs/development/compilers/dart/package-source-builders/hotkey-manager-linux/0001-fix-build-failure-with-Clang-21.patch
+++ b/pkgs/development/compilers/dart/package-source-builders/hotkey-manager-linux/0001-fix-build-failure-with-Clang-21.patch
@@ -1,0 +1,34 @@
+From 1b31e3ca4ab017ee72f54a7065b2073a88403d61 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gutyina=20Gerg=C5=91?= <gutyina.gergo.2@gmail.com>
+Date: Tue, 21 Oct 2025 11:19:13 +0200
+Subject: [PATCH] fix: build failure with Clang 21
+
+---
+ .../hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/packages/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc b/packages/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc
+index 74fabe2..72b962b 100644
+--- a/packages/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc
++++ b/packages/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc
+@@ -32,7 +32,7 @@ G_DEFINE_TYPE(HotkeyManagerLinuxPlugin,
+               g_object_get_type())
+ 
+ void handle_key_down(const char* keystring, void* user_data) {
+-  const char* identifier;
++  const char* identifier = "";
+ 
+   std::string val = keystring;
+   auto result = std::find_if(hotkey_id_map.begin(), hotkey_id_map.end(),
+@@ -103,7 +103,7 @@ static FlMethodResponse* hkm_unregister(_HotkeyManagerLinuxPlugin* self,
+                                         FlValue* args) {
+   const char* identifier =
+       fl_value_get_string(fl_value_lookup_string(args, "identifier"));
+-  const char* keystring;
++  const char* keystring = "";
+ 
+   std::string val = identifier;
+   auto result = std::find_if(hotkey_id_map.begin(), hotkey_id_map.end(),
+-- 
+2.51.0
+

--- a/pkgs/development/compilers/dart/package-source-builders/hotkey-manager-linux/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/hotkey-manager-linux/default.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+}:
+
+{ version, src, ... }:
+
+stdenv.mkDerivation {
+  pname = "hotkey-manager-linux";
+  inherit version src;
+  inherit (src) passthru;
+
+  prePatch = ''
+    # from a package like multipass, we get a src with the root hotkey_manager repo and need to cd into the linux package to apply the patch
+    # but from a package like wox, we get a src with the linux package already, I'm not sure why
+    if [[ -d packages/hotkey_manager_linux ]]; then
+      WAS_ROOT_DIRECTORY=1
+      pushd packages/hotkey_manager_linux
+    fi
+  '';
+
+  patches = [
+    ./0001-fix-build-failure-with-Clang-21.patch
+  ];
+
+  postPatch = ''
+    if [[ WAS_ROOT_DIRECTORY -eq 1 ]]; then
+      popd
+    fi
+  '';
+
+  patchFlags = [ "-p3" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r . $out
+
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://hydra.nixos.org/build/308944294

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
