### PR TITLE
qdmr: 0.12.3 -> 0.13.1

### DIFF
--- a/pkgs/by-name/qd/qdmr/package.nix
+++ b/pkgs/by-name/qd/qdmr/package.nix
@@ -6,8 +6,9 @@
   cmake,
   libxslt,
   docbook_xsl_ns,
-  libsForQt5,
+  kdePackages,
   libusb1,
+  librsvg,
   yaml-cpp,
 }:
 
@@ -17,28 +18,30 @@ in
 
 stdenv.mkDerivation rec {
   pname = "qdmr";
-  version = "0.12.3";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "hmatuschek";
     repo = "qdmr";
     rev = "v${version}";
-    hash = "sha256-rb59zbYpIziqXWTjTApWXnkcpRiAUIqPiInEJdsYd48=";
+    hash = "sha256-Vz7di9VwrvtSCea3pipSCEw9pHfRv9lJn9jKzboyh6E=";
   };
 
   nativeBuildInputs = [
     cmake
-    libxslt
-    libsForQt5.wrapQtAppsHook
+    kdePackages.wrapQtAppsHook
     installShellFiles
   ];
 
   buildInputs = [
+    librsvg
     libusb1
-    libsForQt5.qtlocation
-    libsForQt5.qtserialport
-    libsForQt5.qttools
-    libsForQt5.qtbase
+    libxslt
+    kdePackages.qtlocation
+    kdePackages.qtserialport
+    kdePackages.qttools
+    kdePackages.qtbase
+    kdePackages.qtpositioning
     yaml-cpp
   ];
 
@@ -59,6 +62,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_MAN=ON"
     "-DCMAKE_INSTALL_FULL_MANDIR=share/man"
+    "-DDOCBOOK2MAN_XSLT=docbook_man.${if isLinux then "debian" else "macports"}.xsl"
     "-DINSTALL_UDEV_RULES=OFF"
   ];
 


### PR DESCRIPTION
part of #445447

- updated to latest release
- switched to qt6
- included upstream patch for building manpages
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
