### PR TITLE
cachix: 1.7.9 -> 1.9.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -4034,16 +4034,17 @@ with haskellLib;
   }
 )
 
-# cachix: manually maintained
+# Cachix packages
+# Manually maintained
 // (
   let
-    version = "1.7.9";
+    version = "1.9.1";
 
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
       tag = "v${version}";
-      hash = "sha256-R0W7uAg+BLoHjMRMQ8+oiSbTq8nkGz5RDpQ+ZfxxP3A=";
+      hash = "sha256-IwnNtbNVrlZIHh7h4Wz6VP0Furxg9Hh0ycighvL5cZc=";
     };
   in
   {
@@ -4057,12 +4058,9 @@ with haskellLib;
         inherit version;
         src = src + "/cachix";
       })
-      # Fix ambiguous 'show' reference: https://github.com/cachix/cachix/pull/704
-      (overrideCabal (_: {
-        postPatch = ''
-          sed -i 's/<> show i/<> Protolude.show i/' src/Cachix/Client/NixVersion.hs
-        '';
-      }))
+      (addBuildDepends [
+        self.pqueue
+      ])
       (
         drv:
         drv.override {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -747,43 +747,6 @@ with haskellLib;
   # https://github.com/illia-shkroba/pfile/issues/2
   pfile = doJailbreak super.pfile;
 
-  # Manually maintained
-  cachix-api = overrideCabal (drv: {
-    # FIXME: should use overrideSrc
-    version = "1.7.9";
-    src = pkgs.fetchFromGitHub {
-      owner = "cachix";
-      repo = "cachix";
-      tag = "v1.7.9";
-      hash = "sha256-R0W7uAg+BLoHjMRMQ8+oiSbTq8nkGz5RDpQ+ZfxxP3A=";
-    };
-    postUnpack = "sourceRoot=$sourceRoot/cachix-api";
-  }) super.cachix-api;
-  cachix = (
-    overrideCabal
-      (drv: {
-        # FIXME: should use overrideSrc
-        version = "1.7.9";
-        src = pkgs.fetchFromGitHub {
-          owner = "cachix";
-          repo = "cachix";
-          tag = "v1.7.9";
-          hash = "sha256-R0W7uAg+BLoHjMRMQ8+oiSbTq8nkGz5RDpQ+ZfxxP3A=";
-        };
-        postUnpack = "sourceRoot=$sourceRoot/cachix";
-        # Fix ambiguous 'show' reference: https://github.com/cachix/cachix/pull/704
-        postPatch = ''
-          sed -i 's/<> show i/<> Protolude.show i/' src/Cachix/Client/NixVersion.hs
-        '';
-      })
-      (
-        super.cachix.override {
-          nix = self.hercules-ci-cnix-store.nixPackage;
-          hnix-store-core = self.hnix-store-core_0_8_0_0;
-        }
-      )
-  );
-
   # Overly strict bounds on postgresql-simple (< 0.7), tasty (< 1.5) and tasty-quickcheck (< 0.11)
   # https://github.com/tdammers/migrant/pull/5
   migrant-core = doJailbreak super.migrant-core;
@@ -4068,5 +4031,45 @@ with haskellLib;
     amazonka-test = warnAfterVersion "2.0" (
       setAmazonkaSourceRoot "lib/amazonka-test" (doJailbreak super.amazonka-test)
     );
+  }
+)
+
+# cachix: manually maintained
+// (
+  let
+    version = "1.7.9";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "cachix";
+      repo = "cachix";
+      tag = "v${version}";
+      hash = "sha256-R0W7uAg+BLoHjMRMQ8+oiSbTq8nkGz5RDpQ+ZfxxP3A=";
+    };
+  in
+  {
+    cachix-api = overrideSrc {
+      inherit version;
+      src = src + "/cachix-api";
+    } super.cachix-api;
+
+    cachix = lib.pipe super.cachix [
+      (overrideSrc {
+        inherit version;
+        src = src + "/cachix";
+      })
+      # Fix ambiguous 'show' reference: https://github.com/cachix/cachix/pull/704
+      (overrideCabal (_: {
+        postPatch = ''
+          sed -i 's/<> show i/<> Protolude.show i/' src/Cachix/Client/NixVersion.hs
+        '';
+      }))
+      (
+        drv:
+        drv.override {
+          nix = self.hercules-ci-cnix-store.nixPackage;
+          hnix-store-core = self.hnix-store-core_0_8_0_0;
+        }
+      )
+    ];
   }
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates Cachix to v1.9.1.

Release notes: https://github.com/cachix/cachix/blob/c5bfd933d1033672f51a863c47303fc0e093c2d2/cachix/CHANGELOG.md

I've also [refactored the package definitions](https://github.com/NixOS/nixpkgs/commit/1d1668a995abb6ea578c8f3c70f8e5d3618fc94d), addressing the notes left by the Haskell maintainers.

cc @domenkozar 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
