### PR TITLE
eq10q: fix build with cmake4

### DIFF
--- a/pkgs/by-name/eq/eq10q/package.nix
+++ b/pkgs/by-name/eq/eq10q/package.nix
@@ -45,13 +45,17 @@ stdenv.mkDerivation rec {
     # Fix build with lv2 1.18: https://sourceforge.net/p/eq10q/bugs/23/
     find . -type f -exec fgrep -q LV2UI_Descriptor {} \; \
       -exec sed -i {} -e 's/const _\?LV2UI_Descriptor/const LV2UI_Descriptor/' \;
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
   installFlags = [ "DESTDIR=$(out)" ];
 
   fixupPhase = ''
-    cp -r $out/var/empty/local/lib $out
-    rm -R $out/var
+    mkdir -p $out/lib
+    mv $out/usr/local/lib/* $out/lib/
+    rm -R $out/usr
   '';
 
   meta = {


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

I'm not familiar with this kind of package but it had this error:
```
cp: cannot stat '/nix/store/vpdx994y3qf47nwbp7hg4fbxn7x3yr48-eq10q-2.2/var/empty/local/lib': No such file or directory
```
So I made some changes to that part, now the result folder have:
lib/lv2/sapistaEQv2.lv2
with files:
```
bassup.so                 compressor_stereo.ttl  eq1qs.so   eq6qs.so         manifest.ttl
bassup.ttl                compressor.ttl         eq1qs.ttl  eq6qs.ttl        matrix_lr2ms.so
compressor_sc.so          eq10qm.so              eq4qm.so   gate.so          matrix_ms2lr.so
compressor_sc.ttl         eq10qm.ttl             eq4qm.ttl  gate_stereo.so   ms2lr.ttl
compressor.so             eq10qs.so              eq4qs.so   gate_stereo.ttl
compressor_stereo_sc.so   eq10qs.ttl             eq4qs.ttl  gate.ttl
compressor_stereo_sc.ttl  eq1qm.so               eq6qm.so   gui
compressor_stereo.so      eq1qm.ttl              eq6qm.ttl  lr2ms.ttl
```
Please let me know if adjustments are needed!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
