### PR TITLE
cruiser: init at 5.7.1

### DIFF
--- a/pkgs/by-name/cr/cruiser/package.nix
+++ b/pkgs/by-name/cr/cruiser/package.nix
@@ -1,0 +1,72 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  jre,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cruiser";
+  version = "5.7.1";
+
+  src = fetchzip {
+    url = "https://github.com/devemux86/cruiser/releases/download/${finalAttrs.version}/cruiser-${finalAttrs.version}.zip";
+    hash = "sha256-nwT/0Vu3X0CktWytSaZRM00D45JzGU+jpYT/SDHfcWc=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Cruiser";
+      exec = "cruiser";
+      icon = "cruiser";
+      desktopName = "Cruiser";
+      genericName = "Map and Navigation";
+      categories = [
+        "Application"
+        "Maps"
+      ];
+      comment = "Map and navigation application using offline vector maps";
+      startupWMClass = "Cruiser";
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/java
+
+    cp -r $src/lib $src/cruiser.jar $out/share/java
+
+    makeWrapper ${lib.getExe jre} $out/bin/cruiser \
+      --add-flags "-jar $out/share/java/cruiser.jar"
+
+    # install icon
+    mkdir -p $out/share/icons/hicolor/512x512/apps/
+    cp $src/cruiser.png $out/share/icons/hicolor/512x512
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Offline route planning and navigation application";
+    homepage = "https://github.com/devemux86/cruiser";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ kilianar ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cruiser";
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+})


### PR DESCRIPTION
This pull request adds the package for Cruiser, an offline route planning and navigation application. The software is proprietary but distributed free of charge.

Since this is a Java application provided as a pre-built binary, this package downloads the .jar file and uses a wrapper to execute it with the appropriate Java runtime environment

https://github.com/devemux86/cruiser/releases/tag/5.7.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
