### PR TITLE
autoupnp: init at 0.5.1

### DIFF
--- a/pkgs/by-name/au/autoupnp/package.nix
+++ b/pkgs/by-name/au/autoupnp/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  miniupnpc,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "autoupnp";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "projg2";
+    repo = "autoupnp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QGFgHV5qF53YLXbg2chf/HeMf/rGAAg8A0TrXUEX9hU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [ miniupnpc ];
+
+  mesonFlags = [ "-Dlibnotify=disabled" ];
+
+  doCheck = true;
+
+  postInstall = ''
+    # 1) patch shebangs in installed scripts
+    patchShebangs "$out/bin"
+
+    # 2) teach the wrapper to LD_PRELOAD the absolute .so path
+    #    Only change the line that actually appends to LD_PRELOAD.
+    substituteInPlace "$out/bin/autoupnp" \
+      --replace-fail "set -- libautoupnp.so" "set -- $out/lib/libautoupnp.so"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Automatic UPnP/NAT-PMP port forwarder via LD_PRELOAD wrapper";
+    homepage = "https://github.com/projg2/autoupnp";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "autoupnp";
+    maintainers = with lib.maintainers; [ peigongdsd ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^


For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added https://github.com/projg2/autoupnp.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
