### PR TITLE
bentopdf: init at 1.11.2, nixos/bentopdf: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -81,6 +81,8 @@
 
 - [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
 
+- [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available with [services.umami](#opt-services.umami.enable).
+
 - [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
 
 - [FirewallD](https://firewalld.org/), a firewall daemon with D-Bus interface providing a dynamic firewall. Available as [services.firewalld](#opt-services.firewalld.enable) and a [networking.firewall.backend](#opt-networking.firewall.backend).

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -24,6 +24,8 @@
 
 - [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable)
 
+- [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
+
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1581,6 +1581,7 @@
   ./services/web-apps/artalk.nix
   ./services/web-apps/audiobookshelf.nix
   ./services/web-apps/baikal.nix
+  ./services/web-apps/bentopdf.nix
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bluesky-pds.nix
   ./services/web-apps/bookstack.nix

--- a/nixos/modules/services/web-apps/bentopdf.nix
+++ b/nixos/modules/services/web-apps/bentopdf.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.bentopdf;
+in
+{
+  options.services.bentopdf = {
+    enable = lib.mkEnableOption "bentopdf Privacy First PDF Toolkit";
+
+    package = lib.mkPackageOption pkgs "bentopdf" {
+      extraDescription = ''
+        To use the "simple mode" variant of bentopdf, which removes all socials, marketing and explanatory texts, set this option to `pkgs.bentopdf.overrideAttrs { SIMPLE_MODE = true; }`.
+      '';
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "The host to listen on.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 4152;
+      description = "The port nginx is listening on for bentopdf.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the port nginx is listening on for bentopdf.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.nginx.enable = true;
+
+    # The nginx config is derived from: https://github.com/alam00000/bentopdf/blob/d9561d79b9eef5b0853dc8bfb3ef7cc9323a47c7/docs/self-hosting/nginx.md
+    services.nginx.virtualHosts."bentopdf" = {
+      listen = [
+        {
+          addr = cfg.host;
+          port = cfg.port;
+        }
+      ];
+
+      root = "${cfg.package}";
+
+      locations."/".extraConfig = ''
+        try_files $uri $uri/ /index.html;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+      '';
+
+      locations."~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$".extraConfig = ''
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+  };
+}

--- a/pkgs/by-name/be/bentopdf/package.nix
+++ b/pkgs/by-name/be/bentopdf/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage (finalAttrs: {
+  version = "1.11.2";
+  pname = "bentopdf";
+
+  src = fetchFromGitHub {
+    owner = "alam00000";
+    repo = "bentopdf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-br4My0Q4zoA+ZIrXM4o4oQjZ7IpSdwg+iKiAUdc2B/s=";
+  };
+  npmDepsHash = "sha256-UNNNYO7e7qdumI0/ka2ieFZzKURPl1V3981vHCPcVfY=";
+
+  npmBuildScript = "build";
+  npmBuildFlags = [
+    "--"
+    "--mode"
+    "production"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r dist/* $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Privacy-first PDF toolkit";
+    mainProgram = "bentopdf";
+    homepage = "https://bentopdf.com";
+    changelog = "https://github.com/alam00000/bentopdf/releases";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ charludo ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[bentopdf](https://bentopdf.com) is a privacy-first PDF toolkit running completely in-browser.  It is a rather recent project (`v1.0.0` was released yesterday, and literally while writing this I realized `v1.0.1` and `v1.0.2` had been released while working on the package, lol).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
