### PR TITLE
live-server: 0.10.1 -> 0.11.0

### DIFF
--- a/pkgs/by-name/li/live-server/package.nix
+++ b/pkgs/by-name/li/live-server/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "live-server";
-  version = "0.10.1";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "lomirus";
     repo = "live-server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0IP7F8+Vdl/h4+zcghRqowvzz6zjQYDTjMSZPuGOOj4=";
+    hash = "sha256-FKX1rbRKWkWsxzJZDicVAUqrHBwEe2o7EXIouK74UMA=";
   };
 
-  cargoHash = "sha256-MMeeUoj3vYd1lv15N3+qjHbn991IVMhIUCMd0isCNhk=";
+  cargoHash = "sha256-gaBYnhljcMqSEPViaOPMtuHjoDP8iY64UizlfK+fcQA=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/li/live-server/package.nix
+++ b/pkgs/by-name/li/live-server/package.nix
@@ -33,7 +33,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/lomirus/live-server/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "live-server";
-    maintainers = [ lib.maintainers.philiptaron ];
+    maintainers = with lib.maintainers; [
+      philiptaron
+      doronbehar
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/live-server/package.nix
+++ b/pkgs/by-name/li/live-server/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lomirus";
     repo = "live-server";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0IP7F8+Vdl/h4+zcghRqowvzz6zjQYDTjMSZPuGOOj4=";
   };
 
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Local network server with live reload feature for static pages";
     downloadPage = "https://github.com/lomirus/live-server/releases";
     homepage = "https://github.com/lomirus/live-server";
-    changelog = "https://github.com/lomirus/live-server/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/lomirus/live-server/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "live-server";
     maintainers = [ lib.maintainers.philiptaron ];


### PR DESCRIPTION
## Description of changes

https://github.com/lomirus/live-server/releases/tag/v0.11.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
