### PR TITLE
llama-swap: 165 -> 172

### DIFF
--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -9,6 +9,7 @@
   callPackage,
 
   nixosTests,
+  nix-update-script,
 }:
 
 let
@@ -16,13 +17,18 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "llama-swap";
-  version = "165";
+  version = "172";
+
+  outputs = [
+    "out"
+    "wol" # wake on lan proxy
+  ];
 
   src = fetchFromGitHub {
     owner = "mostlygeek";
     repo = "llama-swap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3NlA4LnAJ1qCy1+Jcv6wrPg/7trQhpwx00Sk98V7ZdY=";
+    hash = "sha256-4yTcYYwFA+fDw9spzZhvAXETkmrmD5kMoe4d/fvk8D0=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -38,7 +44,6 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-5mmciFAGe8ZEIQvXejhYN+ocJL3wOVwevIieDuokhGU=";
 
   passthru.ui = callPackage ./ui.nix { llama-swap = finalAttrs.finalPackage; };
-  passthru.npmDepsHash = "sha256-F6izMZY4554M6PqPYjKcjNol3A6BZHHYA0CIcNrU5JA=";
 
   nativeBuildInputs = [
     versionCheckHook
@@ -108,14 +113,22 @@ buildGoModule (finalAttrs: {
     rm "$GOPATH/bin/simple-responder"
   '';
 
-  preInstall = ''
+  postInstall = ''
     install -Dm444 -t "$out/share/llama-swap" config.example.yaml
+    mkdir -p "$wol/bin"
+    mv "$out/bin/wol-proxy" "$wol/bin/"
   '';
 
   doInstallCheck = true;
   versionCheckProgramArg = "-version";
 
   passthru.tests.nixos = nixosTests.llama-swap;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "ui"
+    ];
+  };
 
   meta = {
     homepage = "https://github.com/mostlygeek/llama-swap";

--- a/pkgs/by-name/ll/llama-swap/ui.nix
+++ b/pkgs/by-name/ll/llama-swap/ui.nix
@@ -6,7 +6,8 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "${llama-swap.pname}-ui";
-  inherit (llama-swap) version src npmDepsHash;
+  inherit (llama-swap) version src;
+  npmDepsHash = "sha256-uxZn/VYrGHcDfNiudDPrV6dR7Z/ZDTj0MetpB/hoGWQ=";
 
   postPatch = ''
     substituteInPlace vite.config.ts \


### PR DESCRIPTION
- llama-swap: 165 -> 172
  - adds new utility for wake-on-lan, to be used on one machine to front and wake another larger machine
    - fairly niche so in it's own output
    - would warrant it's own module
  - new tls support
  - (adjusted update script)
- nixos/llama-swap: support new tls flags and listenAddress


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
