### PR TITLE
[Backport release-25.11] bcachefs-tools: 1.31.7 -> 1.31.11

### DIFF
--- a/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/kernel-module.nix
@@ -38,11 +38,12 @@ stdenv.mkDerivation {
 
     inherit (bcachefs-tools.meta)
       homepage
+      downloadPage
       license
       maintainers
       platforms
       ;
 
-    broken = !(lib.versionAtLeast kernel.version "6.16" && lib.versionOlder kernel.version "6.18");
+    broken = !(lib.versionAtLeast kernel.version "6.16" && lib.versionOlder kernel.version "6.19");
   };
 }

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bcachefs-tools";
-  version = "1.31.7";
+  version = "1.31.11";
 
   src = fetchFromGitHub {
     owner = "koverstreet";
     repo = "bcachefs-tools";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gKtOyaDN9hQo45Rk9hMabKRefOG+ooaCrtLBCPx0fT8=";
+    hash = "sha256-CnRB/iS1NZ0Ebsi12wXFvVb0qdv0V9q1oC3nLj13mqs=";
   };
 
   nativeBuildInputs = [
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-INnv9kRgM8RRMwBnC6Vwj9S5FfI5gMscU//aNzHF+8w=";
+    hash = "sha256-50xy1nqDctgz/lXd5JsfaU6yxDoRCQRtiYBwuEuiKFA=";
   };
 
   outputs = [

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -37,6 +37,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CnRB/iS1NZ0Ebsi12wXFvVb0qdv0V9q1oC3nLj13mqs=";
   };
 
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-50xy1nqDctgz/lXd5JsfaU6yxDoRCQRtiYBwuEuiKFA=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "target/release/bcachefs" "target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/bcachefs"
+  '';
+
   nativeBuildInputs = [
     pkg-config
     cargo
@@ -51,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     libaio
     keyutils
     lz4
-
     libsodium
     liburcu
     libuuid
@@ -61,16 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     udev
   ]
   ++ lib.optional fuseSupport fuse3;
-
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    src = finalAttrs.src;
-    hash = "sha256-50xy1nqDctgz/lXd5JsfaU6yxDoRCQRtiYBwuEuiKFA=";
-  };
-
-  outputs = [
-    "out"
-    "dkms"
-  ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
@@ -83,6 +82,9 @@ stdenv.mkDerivation (finalAttrs: {
     "PKGCONFIG_UDEVDIR=$(out)/lib/udev"
   ]
   ++ lib.optional fuseSupport "BCACHEFS_FUSE=1";
+
+  enableParallelBuilding = true;
+
   installFlags = [
     "install"
     "install_dkms"
@@ -96,6 +98,11 @@ stdenv.mkDerivation (finalAttrs: {
   # FIXME: Try enabling this once the default linux kernel is at least 6.7
   doCheck = false; # needs bcachefs module loaded on builder
 
+  preCheck = lib.optionalString (!fuseSupport) ''
+    rm tests/test_fuse.py
+  '';
+  checkFlags = [ "BCACHEFS_TEST_USE_VALGRIND=no" ];
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [
     udevCheckHook
@@ -103,22 +110,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   versionCheckProgramArg = "version";
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace-fail "target/release/bcachefs" "target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/bcachefs"
-  '';
-
-  preCheck = lib.optionalString (!fuseSupport) ''
-    rm tests/test_fuse.py
-  '';
-  checkFlags = [ "BCACHEFS_TEST_USE_VALGRIND=no" ];
-
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd bcachefs \
       --bash <($out/sbin/bcachefs completions bash) \
       --zsh  <($out/sbin/bcachefs completions zsh) \
       --fish <($out/sbin/bcachefs completions fish)
   '';
+
+  outputs = [
+    "out"
+    "dkms"
+  ];
 
   passthru = {
     # See NOTE in linux-kernels.nix
@@ -132,11 +134,10 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
   };
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Tool for managing bcachefs filesystems";
     homepage = "https://bcachefs.org/";
+    downloadPage = "https://github.com/koverstreet/bcachefs-tools";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       davidak

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -108,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     udevCheckHook
     versionCheckHook
   ];
+  versionCheckProgram = "${placeholder "out"}/bin/bcachefs";
   versionCheckProgramArg = "version";
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/452314

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
