### PR TITLE
nixos/facter: add core library and system detection

### DIFF
--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -4,6 +4,10 @@
   ...
 }:
 {
+  imports = [
+    ./system.nix
+  ];
+
   meta.maintainers = with lib.maintainers; [ mic92 ];
 
   options.hardware.facter = with lib; {

--- a/nixos/modules/hardware/facter/lib.nix
+++ b/nixos/modules/hardware/facter/lib.nix
@@ -1,0 +1,59 @@
+# Internal library functions for hardware.facter modules
+# Eventually we can think about moving this under lib/
+# These are facter-specific helpers for querying nixos-facter reports
+lib:
+let
+
+  inherit (lib) assertMsg;
+
+  # Query if a facter report contains a CPU with the given vendor name
+  hasCpu =
+    name:
+    {
+      hardware ? { },
+      ...
+    }:
+    let
+      cpus = hardware.cpu or [ ];
+    in
+    assert assertMsg (hardware != { }) "no hardware entries found in the report";
+    assert assertMsg (cpus != [ ]) "no cpu entries found in the report";
+    builtins.any (
+      {
+        vendor_name ? null,
+        ...
+      }:
+      assert assertMsg (vendor_name != null) "detail.vendor_name not found in cpu entry";
+      vendor_name == name
+    ) cpus;
+
+  # Extract all driver_modules from a list of hardware entries
+  collectDrivers = list: lib.catAttrs "driver_modules" list;
+
+  # Convert number to zero-padded 4-digit hex string (for USB device IDs)
+  toZeroPaddedHex =
+    n:
+    let
+      hex = lib.toHexString n;
+      len = builtins.stringLength hex;
+    in
+    if len == 1 then
+      "000${hex}"
+    else if len == 2 then
+      "00${hex}"
+    else if len == 3 then
+      "0${hex}"
+    else
+      hex;
+in
+{
+  inherit
+    hasCpu
+    collectDrivers
+    toZeroPaddedHex
+    ;
+
+  hasAmdCpu = hasCpu "AuthenticAMD";
+  hasIntelCpu = hasCpu "GenuineIntel";
+
+}

--- a/nixos/modules/hardware/facter/system.nix
+++ b/nixos/modules/hardware/facter/system.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  options,
+  lib,
+  ...
+}:
+{
+  # Skip setting hostPlatform in test VMs where it's read-only
+  # Tests have virtualisation.test options and import read-only.nix
+  config.nixpkgs = lib.optionalAttrs (!(options ? virtualisation.test)) {
+    hostPlatform = lib.mkIf (
+      config.hardware.facter.report.system or null != null && !options.nixpkgs.pkgs.isDefined
+    ) (lib.mkDefault config.hardware.facter.report.system);
+  };
+}


### PR DESCRIPTION
This adds foundational functionality for nixos-facter hardware detection:

- lib.nix: Internal helper functions for querying facter reports
  - hasCpu/hasAmdCpu/hasIntelCpu: CPU vendor detection
  - collectDrivers: Extract driver_modules from hardware entries
  - toZeroPaddedHex: Format USB device IDs (for fingerprint matching)

- system.nix: Auto-detect nixpkgs.hostPlatform from facter report Automatically sets the correct platform (x86_64-linux, aarch64-linux, etc.) based on the hardware report, reducing manual configuration.

This builds on the base infrastructure added in PR #450303 and provides the foundation for upcoming hardware detection modules (boot, networking, graphics, etc.).

Part of the incremental upstreaming effort from:
https://github.com/nix-community/nixos-facter-modules


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
