### PR TITLE
kaitai-struct-cpp-stl-runtime: init at 0.11

### DIFF
--- a/pkgs/by-name/ka/kaitai-struct-cpp-stl-runtime/package.nix
+++ b/pkgs/by-name/ka/kaitai-struct-cpp-stl-runtime/package.nix
@@ -1,0 +1,73 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gtest,
+  zlib,
+  copyPkgconfigItems,
+  makePkgconfigItem,
+  lib,
+  testers,
+  ctestCheckHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kaitai-struct-cpp-stl-runtime";
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    owner = "kaitai-io";
+    repo = "kaitai_struct_cpp_stl_runtime";
+    tag = finalAttrs.version;
+    sha256 = "sha256-2glGPf08bkzvnkLpQIaG2qiy/yO+bZ14hjIaCKou2vU=";
+  };
+
+  doCheck = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    copyPkgconfigItems
+    ctestCheckHook
+  ];
+
+  buildInputs = [
+    zlib
+    gtest
+  ];
+
+  strictDeps = true;
+
+  # https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/issues/82
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "kaitai-struct-cpp-stl-runtime";
+      inherit (finalAttrs) version;
+      cflags = [ "-I${variables.includedir}" ];
+      libs = [
+        "-L${variables.libdir}"
+        "-lkaitai_struct_cpp_stl_runtime"
+      ];
+      variables = {
+        includedir = "${placeholder "dev"}/include";
+        libdir = "${placeholder "out"}/lib";
+      };
+      inherit (finalAttrs.meta) description;
+    })
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    pkgConfigModules = [ "kaitai-struct-cpp-stl-runtime" ];
+    description = "Kaitai Struct C++ STL Runtime Library";
+    homepage = "https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fzakaria ];
+  };
+})


### PR DESCRIPTION
```bash
$ tree result
result
├── include
│   └── kaitai
│       ├── exceptions.h
│       ├── kaitaistream.h
│       └── kaitaistruct.h
└── lib
    ├── libkaitai_struct_cpp_stl_runtime.so
    └── pkgconfig
        └── kaitai-struct-cpp-stl-runtime.pc

5 directories, 5 files

$ cat result/lib/pkgconfig/kaitai-struct-cpp-stl-runtime.pc 
includedir=/nix/store/dqdm4x9xkrgf8h32fb835d77pb9n4shm-kaitai-struct-cpp-stl-runtime-0.11/include
libdir=/nix/store/dqdm4x9xkrgf8h32fb835d77pb9n4shm-kaitai-struct-cpp-stl-runtime-0.11/lib
prefix=/nix/store/dqdm4x9xkrgf8h32fb835d77pb9n4shm-kaitai-struct-cpp-stl-runtime-0.11

Cflags: -I/nix/store/dqdm4x9xkrgf8h32fb835d77pb9n4shm-kaitai-struct-cpp-stl-runtime-0.11/include
Description: Kaitai Struct C++ STL Runtime Library
Libs: -L/nix/store/dqdm4x9xkrgf8h32fb835d77pb9n4shm-kaitai-struct-cpp-stl-runtime-0.11/lib -lkaitai_struct_cpp_stl_runtime
Name: kaitai-struct-cpp-stl-runtime
Version: 0.11
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
