### PR TITLE
various: move packages and modules to secshell maintainer

### DIFF
--- a/nixos/modules/services/networking/suricata/default.nix
+++ b/nixos/modules/services/networking/suricata/default.nix
@@ -22,7 +22,7 @@ let
     ;
 in
 {
-  meta.maintainers = with lib.maintainers; [ felbinger ];
+  meta.maintainers = lib.teams.secshell.members;
 
   options.services.suricata = {
     enable = mkEnableOption "Suricata";

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -17,7 +17,7 @@ let
     ;
 in
 {
-  meta.maintainers = with lib.maintainers; [ felbinger ];
+  meta.maintainers = lib.teams.secshell.members;
 
   options.services.part-db = {
     enable = mkEnableOption "PartDB";

--- a/nixos/tests/suricata.nix
+++ b/nixos/tests/suricata.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 {
   name = "suricata";
-  meta.maintainers = with lib.maintainers; [ felbinger ];
+  meta.maintainers = lib.teams.secshell.members;
 
   nodes = {
     ids = {

--- a/pkgs/by-name/od/odhcp6c/package.nix
+++ b/pkgs/by-name/od/odhcp6c/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     description = "Embedded DHCPv6-client for OpenWrt";
     homepage = "https://openwrt.org/packages/pkgdata/odhcp6c";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pa/part-db/package.nix
+++ b/pkgs/by-name/pa/part-db/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://docs.part-db.de/";
     changelog = "https://github.com/Part-DB/Part-DB-server/releases/tag/v${version}";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/development/python-modules/napalm/ros.nix
+++ b/pkgs/development/python-modules/napalm/ros.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/napalm-automation-community/napalm-ros/releases/tag/${src.tag}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-attachments/default.nix
+++ b/pkgs/development/python-modules/netbox-attachments/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/Kani999/netbox-attachments/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-bgp/default.nix
+++ b/pkgs/development/python-modules/netbox-bgp/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/netbox-community/netbox-bgp";
     changelog = "https://github.com/netbox-community/netbox-bgp/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-contextmenus/default.nix
+++ b/pkgs/development/python-modules/netbox-contextmenus/default.nix
@@ -28,6 +28,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/PieterL75/netbox_contextmenus/";
     changelog = "https://github.com/PieterL75/netbox_contextmenus/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-contract/default.nix
+++ b/pkgs/development/python-modules/netbox-contract/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/mlebreuil/netbox-contract/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-dns/default.nix
+++ b/pkgs/development/python-modules/netbox-dns/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/peteeckel/netbox-plugin-dns/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
+++ b/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/NetTech2001/netbox-interface-synchronization/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/netbox-community/netbox-napalm-plugin/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-qrcode/default.nix
+++ b/pkgs/development/python-modules/netbox-qrcode/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/netbox-community/netbox-qrcode/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }

--- a/pkgs/development/python-modules/netbox-topology-views/default.nix
+++ b/pkgs/development/python-modules/netbox-topology-views/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/netbox-community/netbox-topology-views/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ felbinger ];
+    teams = with lib.teams; [ secshell ];
   };
 }


### PR DESCRIPTION
For organizational reasons I'm going to move some of my packages to the team I created
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
