### PR TITLE
nixos/espanso: add espanso integration tests for x11 and wayland

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -513,6 +513,10 @@ in
   };
   ergo = runTest ./ergo.nix;
   ergochat = runTest ./ergochat.nix;
+  espanso = import ./espanso.nix {
+    inherit (pkgs) lib;
+    inherit runTest;
+  };
   esphome = runTest ./esphome.nix;
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./etcd/etcd.nix;

--- a/nixos/tests/espanso.nix
+++ b/nixos/tests/espanso.nix
@@ -1,0 +1,86 @@
+{ lib, runTest }:
+let
+  makeTest =
+    conf:
+    runTest {
+      name = "espanso";
+      meta.maintainers = with lib.maintainers; [ n8henrie ];
+
+      nodes.machine =
+        let
+          base =
+            { pkgs, config, ... }:
+            {
+              imports = [ ./common/user-account.nix ];
+              services.espanso.enable = true;
+              system.activationScripts.espanso-config = {
+                deps = [ "users" ];
+                text =
+                  let
+                    confdir = "${config.users.users.alice.home}/.config/espanso";
+                    espanso_conf =
+                      let
+                        settingsFormat = pkgs.formats.yaml { };
+                      in
+                      settingsFormat.generate "base.yaml" {
+                        matches = [
+                          {
+                            trigger = ":nixostest";
+                            replace = "My NixOS Test Passed!";
+                          }
+                        ];
+                      };
+                  in
+                  ''
+                    mkdir -p ${confdir}/{config,match}
+                    touch ${confdir}/config/default.yml
+                    cp ${espanso_conf} ${confdir}/match/base.yml
+                    chown -R ${config.users.users.alice.name} ${confdir}
+                  '';
+              };
+            };
+        in
+        lib.mkMerge [
+          base
+          conf
+        ];
+
+      enableOCR = true;
+      testScript = ''
+        machine.wait_for_unit("graphical.target")
+        machine.wait_for_text("Espanso is running!")
+        machine.send_chars(":nixostest")
+        machine.wait_for_text("My NixOS Test Passed!")
+      '';
+    };
+in
+{
+  x11 = makeTest {
+    imports = [ ./common/x11.nix ];
+    test-support.displayManager.auto.user = "alice";
+    users.users.alice.extraGroups = [ "input" ];
+  };
+  wayland = makeTest (
+    { pkgs, config, ... }:
+    {
+      programs.sway.enable = true;
+      services = {
+        greetd =
+          let
+            initial_session = {
+              user = config.users.users.alice.name;
+              command = lib.getExe pkgs.sway;
+            };
+          in
+          {
+            enable = true;
+            settings = {
+              inherit initial_session;
+              default_session = initial_session;
+            };
+          };
+        espanso.package = pkgs.espanso-wayland;
+      };
+    }
+  );
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
