### PR TITLE
top-level/release-cuda: add gpuChecks behind a default-off parameter

### DIFF
--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -37,6 +37,9 @@ in
 
     __allowFileset = false;
   },
+
+  includePackages ? true,
+  includeGpuChecks ? false,
   ...
 }@args:
 
@@ -63,115 +66,131 @@ let
   # Derivations from these package sets are selected based on the value
   # of their meta.{hydraPlatforms,platforms,badPlatforms} attributes
   autoPackageSets = builtins.filter (lib.strings.hasPrefix "cudaPackages") (builtins.attrNames pkgs);
-  autoPackagePlatforms = lib.genAttrs autoPackageSets (pset: packagePlatforms pkgs.${pset});
+  autoPackagePlatforms = lib.optionalAttrs includePackages (
+    lib.genAttrs autoPackageSets (pset: packagePlatforms pkgs.${pset})
+  );
+
+  # TODO: automatic discovery
+  gpuChecks = lib.optionalAttrs includeGpuChecks {
+    blender.tests.tester-cudaAvailable.gpuCheck = linux;
+    cudaPackages.saxpy.gpuCheck = linux;
+    python3Packages.nvidia-ml-py.tests.tester-nvmlInit.gpuCheck = linux;
+    python3Packages.pytorch3d.tests.rotations-cuda.gpuCheck = linux;
+    python3Packages.torch.tests.tester-compileCpu.gpuCheck = linux;
+    python3Packages.torch.tests.tester-compileCuda.gpuCheck = linux;
+    python3Packages.torch.tests.tester-cudaAvailable.gpuCheck = linux;
+    python3Packages.triton.gpuCheck = linux;
+    python3Packages.triton.tests.axpy-cuda.gpuCheck = linux;
+  };
 
   # Explicitly select additional packages to also evaluate
   # The desired platforms must be set explicitly here
   explicitPackagePlatforms =
-    # This comment prevents nixfmt from changing the indentation level, lol
-    {
-      blas = linux;
-      blender = linux;
-      faiss = linux;
-      lapack = linux;
-      magma = linux;
-      mpich = linux;
-      openmpi = linux;
-      ucx = linux;
-
-      opencv = linux;
-      cctag = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
-
-      cholmod-extra = linux;
-      colmap = linux;
-      ctranslate2 = linux;
-      ffmpeg-full = linux;
-      firefox = linux;
-      firefox-unwrapped = linux;
-      firefox-beta = linux;
-      firefox-beta-unwrapped = linux;
-      firefox-devedition = linux;
-      firefox-devedition-unwrapped = linux;
-      gimp = linux;
-      gimp3 = linux;
-      gpu-screen-recorder = linux;
-      gst_all_1.gst-plugins-bad = linux;
-      jellyfin-ffmpeg = linux;
-      kdePackages.kdenlive = linux;
-      lightgbm = linux;
-      llama-cpp = linux;
-      meshlab = linux;
-      mistral-rs = linux;
-      monado = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
-      noisetorch = linux;
-      obs-studio-plugins.obs-backgroundremoval = linux;
-      octave = linux; # because depend on SuiteSparse which need rebuild when cuda enabled
-      ollama = linux;
-      onnxruntime = linux;
-      openmvg = linux;
-      openmvs = linux;
-      opentrack = linux;
-      openvino = linux;
-      pixinsight = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
-      qgis = linux;
-      rtabmap = linux;
-      saga = linux;
-      suitesparse = linux;
-      sunshine = linux;
-      thunderbird = linux;
-      thunderbird-unwrapped = linux;
-      truecrack-cuda = linux;
-      tts = linux;
-      ueberzugpp = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
-      wyoming-faster-whisper = linux;
-      xgboost = linux;
-
-      python3Packages = {
-        catboost = linux;
-        cupy = linux;
+    lib.optionalAttrs includePackages
+      # This comment prevents nixfmt from changing the indentation level, lol
+      {
+        blas = linux;
+        blender = linux;
         faiss = linux;
-        faster-whisper = linux;
-        flashinfer = linux;
-        flax = linux;
-        gpt-2-simple = linux;
-        grad-cam = linux;
-        jaxlib = linux;
-        jax = linux;
-        keras = linux;
-        kornia = linux;
-        mmcv = linux;
-        mxnet = linux;
-        numpy = linux; # Only affected by MKL?
-        onnx = linux;
-        triton = linux;
-        openai-whisper = linux;
-        opencv4 = linux;
-        opensfm = linux;
-        pycuda = linux;
-        pymc = linux;
-        pyrealsense2WithCuda = linux;
-        pytorch-lightning = linux;
-        scikit-image = linux;
-        scikit-learn = linux; # Only affected by MKL?
-        scipy = linux; # Only affected by MKL?
-        spacy-transformers = linux;
-        tensorflow = linux;
-        tensorflow-probability = linux;
-        tesserocr = linux;
-        tiny-cuda-nn = linux;
-        torchaudio = linux;
-        torch = linux;
-        torchvision = linux;
-        transformers = linux;
-        ttstokenizer = linux;
-        vidstab = linux;
-        vllm = linux;
+        lapack = linux;
+        magma = linux;
+        mpich = linux;
+        openmpi = linux;
+        ucx = linux;
+
+        opencv = linux;
+        cctag = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+
+        cholmod-extra = linux;
+        colmap = linux;
+        ctranslate2 = linux;
+        ffmpeg-full = linux;
+        firefox = linux;
+        firefox-unwrapped = linux;
+        firefox-beta = linux;
+        firefox-beta-unwrapped = linux;
+        firefox-devedition = linux;
+        firefox-devedition-unwrapped = linux;
+        gimp = linux;
+        gimp3 = linux;
+        gpu-screen-recorder = linux;
+        gst_all_1.gst-plugins-bad = linux;
+        jellyfin-ffmpeg = linux;
+        kdePackages.kdenlive = linux;
+        lightgbm = linux;
+        llama-cpp = linux;
+        meshlab = linux;
+        mistral-rs = linux;
+        monado = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+        noisetorch = linux;
+        obs-studio-plugins.obs-backgroundremoval = linux;
+        octave = linux; # because depend on SuiteSparse which need rebuild when cuda enabled
+        ollama = linux;
+        onnxruntime = linux;
+        openmvg = linux;
+        openmvs = linux;
+        opentrack = linux;
+        openvino = linux;
+        pixinsight = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+        qgis = linux;
+        rtabmap = linux;
+        saga = linux;
+        suitesparse = linux;
+        sunshine = linux;
+        thunderbird = linux;
+        thunderbird-unwrapped = linux;
+        truecrack-cuda = linux;
+        tts = linux;
+        ueberzugpp = linux; # Failed in https://github.com/NixOS/nixpkgs/pull/233581
+        wyoming-faster-whisper = linux;
+        xgboost = linux;
+
+        python3Packages = {
+          catboost = linux;
+          cupy = linux;
+          faiss = linux;
+          faster-whisper = linux;
+          flashinfer = linux;
+          flax = linux;
+          gpt-2-simple = linux;
+          grad-cam = linux;
+          jaxlib = linux;
+          jax = linux;
+          keras = linux;
+          kornia = linux;
+          mmcv = linux;
+          mxnet = linux;
+          numpy = linux; # Only affected by MKL?
+          onnx = linux;
+          triton = linux;
+          openai-whisper = linux;
+          opencv4 = linux;
+          opensfm = linux;
+          pycuda = linux;
+          pymc = linux;
+          pyrealsense2WithCuda = linux;
+          pytorch-lightning = linux;
+          scikit-image = linux;
+          scikit-learn = linux; # Only affected by MKL?
+          scipy = linux; # Only affected by MKL?
+          spacy-transformers = linux;
+          tensorflow = linux;
+          tensorflow-probability = linux;
+          tesserocr = linux;
+          tiny-cuda-nn = linux;
+          torchaudio = linux;
+          torch = linux;
+          torchvision = linux;
+          transformers = linux;
+          ttstokenizer = linux;
+          vidstab = linux;
+          vllm = linux;
+        };
       };
-    };
 
   # Explicitly specified platforms take precedence over the platforms
   # automatically inferred in autoPackagePlatforms
-  allPackagePlatforms = lib.recursiveUpdate autoPackagePlatforms explicitPackagePlatforms;
+  allPackagePlatforms = lib.recursiveUpdate (lib.recursiveUpdate autoPackagePlatforms explicitPackagePlatforms) gpuChecks;
   jobs = mapTestOn allPackagePlatforms;
 in
 jobs


### PR DESCRIPTION
## Things done

cc @ConnorBaker @SomeoneSerge

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
