### PR TITLE
vecstore: init at 0.0.1

### DIFF
--- a/pkgs/by-name/ve/vecstore/package.nix
+++ b/pkgs/by-name/ve/vecstore/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, protobuf
+, stdenv
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "vecstore";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "PhilipJohnBasile";
+    repo = "vecstore";
+    rev = "v0.0.1";
+    hash = "sha256-fd94c51d68988ae3fe7e50e572978e10fdd5aba267e9a90cd136a0cb561c1412";
+  };
+
+  cargoHash = "sha256-REPLACE_WITH_ACTUAL_CARGO_HASH";
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ];
+
+  buildFeatures = [ "server" ];
+
+  # Build only the server binary
+  cargoBuildFlags = [ "--bin" "vecstore-server" ];
+
+  meta = with lib; {
+    description = "Embeddable vector database (alpha) with HNSW search and RAG tooling";
+    homepage = "https://github.com/PhilipJohnBasile/vecstore";
+    license = licenses.mit;
+    maintainers = with maintainers; [ philipjohnbasile ];
+    mainProgram = "vecstore-server";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
**Description:**

High-performance embeddable vector database with HNSW indexing, hybrid search, and comprehensive RAG toolkit.

**Features:**
- HNSW vector indexing
- Dense and sparse vector search
- Hybrid search with BM25
- Multi-language bindings (Rust, Python, JavaScript)
- Production-ready server mode

**Links:**
- Homepage: https://github.com/PhilipJohnBasile/vecstore
- Release: https://github.com/PhilipJohnBasile/vecstore/releases/tag/v0.0.1
- docs.rs: https://docs.rs/vecstore

**Testing:**
```bash
nix-build -A vecstore
./result/bin/vecstore-server --help
```

---
*Automated submission from GitHub Actions*