### PR TITLE
orbbec-sdk: init at 1.10.27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14225,6 +14225,12 @@
     github = "lachrymaLF";
     githubId = 13716477;
   };
+  lachstec = {
+    email = "git@1ux.dev";
+    name = "Lachstec";
+    github = "Lachstec";
+    githubId = 52079984;
+  };
   lactose = {
     name = "lactose";
     email = "lactose@allthingslinux.com";

--- a/pkgs/by-name/or/orbbec-sdk/package.nix
+++ b/pkgs/by-name/or/orbbec-sdk/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  gcc,
+  libGL,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "OrbbecSDK";
+  version = "1.10.27";
+
+  src = fetchFromGitHub {
+    owner = "orbbec";
+    repo = "OrbbecSDK";
+    tag = "v${version}";
+    hash = "sha256-e4dVlMkjQ5GNMO02RiIcV/IPhwqf5o9wTTPTds9qzL0=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    stdenv.cc.cc
+    (lib.getLib stdenv.cc.cc)
+    libGL
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/udev/rules.d $out/include
+    cp -r include/* $out/include
+    cp -r lib/linux_x64/* $out/lib
+    cp misc/scripts/99-obsensor-libusb.rules $out/lib/udev/rules.d/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Orbbec SDK v1&v2 Pre-Compiled";
+    homepage = "https://github.com/orbbec/OrbbecSDK";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lachstec ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds the C/C++ SDK for [3D-Sensors manufactured from Orbbec](https://github.com/orbbec/OrbbecSDK/tree/v1.10.27) as package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
