### PR TITLE
valent: 1.0.0.alpha.46-unstable-2024-10-26 -> 1.0.0.alpha.48

### DIFF
--- a/pkgs/by-name/va/valent/package.nix
+++ b/pkgs/by-name/va/valent/package.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "valent";
-  version = "1.0.0.alpha.46-unstable-2024-10-26";
+  version = "1.0.0.alpha.48";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "valent";
-    rev = "165a2791d4bf3e7dee69e3dd7885dbe4948265b9";
-    hash = "sha256-7klvOvwyAg+Xno6zWo8UByjaS9OkOuCceuZcAIEgdyU=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-CB3Jb7N8vcNTLCWXKoDh/wQkPW1CH6WRlwXg4efU3GY=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Updates Valent to the latest alpha release (v1.0.0.alpha.48).

## Changelog
- Support connecting to devices by IP address
- Support compose mode and grab release for input remote  
- Support mounting specific SFTP volumes
- Async improvements for connections, transfers, and mDNS
- Various bug fixes

## Testing
Tested locally with `nix build .#valent`.

Release notes: https://github.com/andyholmes/valent/releases/tag/v1.0.0.alpha.48