### PR TITLE
seagoat: disable broken tests under click 8.2.0

### DIFF
--- a/pkgs/by-name/se/seagoat/failing_tests.nix
+++ b/pkgs/by-name/se/seagoat/failing_tests.nix
@@ -51,4 +51,14 @@
   "test_file_change_many_times_is_first_result"
   "test_newer_change_can_beat_frequent_change_in_past"
   "test_commit_messages_with_three_or_more_colons"
+
+  # Compatibility issue with click 8.2
+  # https://github.com/kantord/SeaGOAT/issues/1021
+  "test_seagoat_warns_on_incomplete_accuracy[99]"
+  "test_seagoat_warns_on_incomplete_accuracy[100]"
+  "test_server_error_handling[File Not Found on Server-500]"
+  "test_server_error_handling[Database Connection Failed-503]"
+  "test_server_does_not_exist_error"
+  "test_no_network_to_update"
+  "test_server_shows_error_when_folder_is_not_a_git_repo"
 ]


### PR DESCRIPTION
Some tests started failing under click 8.2.0 with an unknown keyword. Disabled the tests and filed [an upstream bug](https://github.com/kantord/SeaGOAT/issues/1021).

https://click.palletsprojects.com/en/stable/changes/#version-8-2-0

See #448189


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
