### PR TITLE
sigsum: init at 0.11.2

### DIFF
--- a/pkgs/by-name/si/sigsum/package.nix
+++ b/pkgs/by-name/si/sigsum/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sigsum";
+  version = "0.11.2";
+
+  src = fetchFromGitLab {
+    domain = "git.glasklar.is";
+    group = "sigsum";
+    owner = "core";
+    repo = "sigsum-go";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oaYquy0N8yHfKLoNEv8Vte3dpp/UQFZ74mZHin8dDzw=";
+  };
+
+  postPatch = ''
+    substituteInPlace internal/version/version.go \
+      --replace-fail "info.Main.Version" '"${finalAttrs.version}"'
+  '';
+
+  vendorHash = "sha256-8Tyhd13PRTO2dGOdhkgYmwsVzWfqwOpZ9XSsAtiCcyM=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  excludedPackages = [ "./test" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/sigsum-key";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "System for public and transparent logging of signed checksums";
+    homepage = "https://www.sigsum.org/";
+    downloadPage = "https://git.glasklar.is/sigsum/core/sigsum-go";
+    changelog = "https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/v${finalAttrs.version}/NEWS";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ defelo ];
+  };
+})


### PR DESCRIPTION
> System for public and transparent logging of signed checksums

https://www.sigsum.org/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
