### PR TITLE
python3Packages.fenics-dolfinx: 0.9.0.post1 -> 0.10.0.post1

### DIFF
--- a/pkgs/by-name/do/dolfinx/package.nix
+++ b/pkgs/by-name/do/dolfinx/package.nix
@@ -12,6 +12,7 @@
   kahip,
   adios2,
   python3Packages,
+  darwinMinVersionHook,
   catch2_3,
   withParmetis ? false,
 }:
@@ -25,14 +26,14 @@ let
   );
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.9.0.post1";
+  version = "0.10.0.post1";
   pname = "dolfinx";
 
   src = fetchFromGitHub {
     owner = "fenics";
     repo = "dolfinx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4IIx7vUZeDwOGVdyC2PBvfhVjrmGZeVQKAwgDYScbY0=";
+    hash = "sha256-ZsaEcJdvsf3dxJ739/CU20+drjbAvuc/HkIGCfh9U5A=";
   };
 
   preConfigure = ''
@@ -48,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     dolfinxPackages.kahip
     dolfinxPackages.scotch
   ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin (darwinMinVersionHook "13.3")
   ++ lib.optional withParmetis dolfinxPackages.parmetis;
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/sl/slepc/package.nix
+++ b/pkgs/by-name/sl/slepc/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pythonImportsCheck = [ "slepc4py" ];
 
-  shellHook = ./setup-hook.sh;
+  setupHook = ./setup-hook.sh;
 
   meta = {
     description = "Scalable Library for Eigenvalue Problem Computations";

--- a/pkgs/development/python-modules/fenics-basix/default.nix
+++ b/pkgs/development/python-modules/fenics-basix/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "fenics-basix";
-  version = "0.9.0";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fenics";
     repo = "basix";
     tag = "v${version}";
-    hash = "sha256-jLQMDt6zdl+oixd5Qevn4bvxBsXpTNcbH2Os6TC9sRQ=";
+    hash = "sha256-atrfIMyLY9EAyw6eiVaC/boG2/a8PCrrv/7J0ntHgSo=";
   };
 
   dontUseCmakeConfigure = true;

--- a/pkgs/development/python-modules/fenics-dolfinx/default.nix
+++ b/pkgs/development/python-modules/fenics-dolfinx/default.nix
@@ -16,6 +16,7 @@
 
   # buildInputs
   dolfinx,
+  darwinMinVersionHook,
 
   # dependency
   numpy,
@@ -63,7 +64,6 @@ buildPythonPackage rec {
   pyproject = true;
 
   pythonRelaxDeps = [
-    "cffi"
     "fenics-ufl"
   ];
 
@@ -87,7 +87,8 @@ buildPythonPackage rec {
 
   buildInputs = [
     fenicsPackages.dolfinx
-  ];
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin (darwinMinVersionHook "13.3");
 
   dependencies = [
     numpy
@@ -102,8 +103,6 @@ buildPythonPackage rec {
     (mpi4py.override { inherit (fenicsPackages) mpi; })
   ];
 
-  doCheck = true;
-
   nativeCheckInputs = [
     scipy
     matplotlib
@@ -113,19 +112,11 @@ buildPythonPackage rec {
   ];
 
   preCheck = ''
-    rm -rf dolfinx
+    cd test
   '';
 
   pythonImportsCheck = [
     "dolfinx"
-  ];
-
-  disabledTests = [
-    # require cffi<1.17
-    "test_cffi_expression"
-    "test_hexahedron_mesh"
-    # https://github.com/FEniCS/dolfinx/issues/1104
-    "test_cube_distance"
   ];
 
   passthru = {

--- a/pkgs/development/python-modules/fenics-ffcx/default.nix
+++ b/pkgs/development/python-modules/fenics-ffcx/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -16,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "fenics-ffcx";
-  version = "0.9.0";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fenics";
     repo = "ffcx";
     tag = "v${version}";
-    hash = "sha256-eAV//RLbrxyhqgbZ2DiR7qML7xfgPn0/Seh+2no0x8w=";
+    hash = "sha256-i8fawnXWxIHfOvb0nK4/bzhrzfRJJACMCkFZKtdUwkU=";
   };
 
   pythonRelaxDeps = [
@@ -52,8 +51,6 @@ buildPythonPackage rec {
     pytestCheckHook
     addBinToPathHook
   ];
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=unused-command-line-argument";
 
   meta = {
     homepage = "https://fenicsproject.org";


### PR DESCRIPTION
Changelog: https://github.com/FEniCS/dolfinx/releases/tag/v0.10.0.post1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
