### PR TITLE
python3Packages.imageio: 2.37.0 -> 2.37.1

### DIFF
--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -44,28 +44,15 @@ in
 
 buildPythonPackage rec {
   pname = "imageio";
-  version = "2.37.0";
+  version = "2.37.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "imageio";
     repo = "imageio";
     tag = "v${version}";
-    hash = "sha256-/nxJxZrTYX7F2grafIWwx9SyfR47ZXyaUwPHMEOdKkI=";
+    hash = "sha256-eNS++8pD+m51IxRR23E98K0f3rwNez/UiByA+PSfUH8=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/imageio/imageio/issues/1139
-      # https://github.com/imageio/imageio/pull/1144
-      name = "fix-pyav-13-1-compat";
-      url = "https://github.com/imageio/imageio/commit/eadfc5906f5c2c3731f56a582536dbc763c3a7a9.patch";
-      excludes = [
-        "setup.py"
-      ];
-      hash = "sha256-ycsW1YXtiO3ZecIF1crYaX6vg/nRW4bF4So5uWCVzME=";
-    })
-  ];
 
   postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     substituteInPlace tests/test_core.py \


### PR DESCRIPTION
changelog: https://github.com/imageio/imageio/releases/tag/v2.37.1
diff: https://github.com/imageio/imageio/compare/v2.37.0...v2.37.1

Includes three major bugfixes:
* Add fsspec as freeimage dependency (https://github.com/imageio/imageio/pull/1145, 0f9692e)
* Fix plugin ffmpeg cannot load file with carets (https://github.com/imageio/imageio/pull/1135, 3009a96)
* Fix the error when time_base is set to null (https://github.com/imageio/imageio/pull/1144, eadfc59)

Removed the patch for 1144.

 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
