### PR TITLE
jruby: 10.0.0.0 -> 10.0.2.0

### DIFF
--- a/pkgs/development/interpreters/jruby/default.nix
+++ b/pkgs/development/interpreters/jruby/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   callPackage,
   fetchurl,
+  fetchMavenArtifact,
   gitUpdater,
   mkRubyVersion,
   makeBinaryWrapper,
@@ -11,15 +12,15 @@
 
 let
   # The version number here is whatever is reported by the RUBY_VERSION string
-  rubyVersion = mkRubyVersion "3" "1" "4" "";
+  rubyVersion = mkRubyVersion "3" "4" "2" "";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jruby";
-  version = "10.0.0.0";
+  version = "10.0.2.0";
 
   src = fetchurl {
-    url = "https://s3.amazonaws.com/jruby.org/downloads/${finalAttrs.version}/jruby-bin-${finalAttrs.version}.tar.gz";
-    hash = "sha256-Qn2YJ+0j/mtNEf5hZlx13XR2ujagQ4N26zEM4qjSRzM=";
+    url = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/${finalAttrs.version}/jruby-dist-${finalAttrs.version}-bin.tar.gz";
+    hash = "sha256-uKAm84qphGGgTtCqCyCJHOJX7L5T4SRxnOnuW4BFJfE=";
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -27,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     mkdir -pv $out/share/jruby/docs
     mv * $out
-    rm $out/bin/*.{bat,dll,exe,sh}
+    rm $out/bin/*.{bat,dll,exe}
     mv $out/samples $out/share/jruby/
     mv $out/BSDL $out/COPYING $out/LEGAL $out/LICENSE* $out/share/jruby/docs/
 
@@ -35,8 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
       wrapProgram $i \
         --set JAVA_HOME ${jre.home}
     done
-
-    ln -s $out/bin/jruby $out/bin/ruby
 
     # Bundler tries to create this directory
     mkdir -pv $out/${finalAttrs.passthru.gemPath}


### PR DESCRIPTION
Fixes CVE-2025-46551.

Changes:
https://github.com/jruby/jruby/releases/tag/10.0.2.0
https://github.com/jruby/jruby/releases/tag/10.0.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 454328`
Commit: `3a506a348c44167f77caaccf02bf48174e805c7b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>jruby</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
