### PR TITLE
python3Packages.llm, python3Packages.symbex: disable tests that fail due to click 8.2.0

### DIFF
--- a/pkgs/development/python-modules/llm/default.nix
+++ b/pkgs/development/python-modules/llm/default.nix
@@ -228,6 +228,17 @@ let
       "tests/"
     ];
 
+    disabledTests = [
+      # AssertionError: The following responses are mocked but not requested:
+      # - Match POST request on https://api.openai.com/v1/chat/completions
+      # https://github.com/simonw/llm/issues/1292
+      "test_gpt4o_mini_sync_and_async"
+
+      # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr
+      # https://github.com/simonw/llm/issues/1293
+      "test_embed_multi_files_encoding"
+    ];
+
     pythonImportsCheck = [ "llm" ];
 
     passthru = {

--- a/pkgs/development/python-modules/symbex/default.nix
+++ b/pkgs/development/python-modules/symbex/default.nix
@@ -35,6 +35,15 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  disabledTests = [
+    # Broken due to click 8.2.0 update
+    # https://github.com/simonw/symbex/issues/48
+    "test_output"
+    "test_replace"
+    "test_replace_errors"
+    "test_errors"
+  ];
+
   meta = {
     description = "Find the Python code for specified symbols";
     homepage = "https://github.com/simonw/symbex";


### PR DESCRIPTION
Filed:
https://github.com/simonw/llm/issues/1292
https://github.com/simonw/llm/issues/1293
https://github.com/simonw/symbex/issues/48

Disabled the affected tests that need migrating to newer APIs.

See #448189

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
