### PR TITLE
[25.05] nixseparatedebuginfod: 0.4.0 -> 0.4.1

### DIFF
--- a/nixos/tests/nixseparatedebuginfod.nix
+++ b/nixos/tests/nixseparatedebuginfod.nix
@@ -1,5 +1,9 @@
 import ./make-test-python.nix (
-  { pkgs, lib, ... }:
+  {
+    pkgs,
+    lib,
+    ...
+  }:
   let
     secret-key = "key-name:/COlMSRbehSh6YSruJWjL+R0JXQUKuPEn96fIb+pLokEJUjcK/2Gv8Ai96D7JGay5gDeUTx5wdpPgNvum9YtwA==";
     public-key = "key-name:BCVI3Cv9hr/AIveg+yRmsuYA3lE8ecHaT4Db7pvWLcA=";
@@ -16,8 +20,9 @@ import ./make-test-python.nix (
           openFirewall = true;
         };
         system.extraDependencies = [
-          pkgs.nix.debug
-          pkgs.nix.src
+          pkgs.gnumake.debug
+          pkgs.gnumake.src
+          pkgs.gnumake
           pkgs.sl
         ];
       };
@@ -32,11 +37,12 @@ import ./make-test-python.nix (
         trusted-public-keys = [ public-key ];
       };
       environment.systemPackages = [
+        pkgs.gnumake
         pkgs.valgrind
         pkgs.gdb
         (pkgs.writeShellScriptBin "wait_for_indexation" ''
           set -x
-          while debuginfod-find debuginfo /run/current-system/sw/bin/nix |& grep 'File too large'; do
+          while debuginfod-find debuginfo /run/current-system/sw/bin/make |& grep 'File too large'; do
             sleep 1;
           done
         '')
@@ -57,28 +63,26 @@ import ./make-test-python.nix (
 
       # nixseparatedebuginfod needs .drv to associate executable -> source
       # on regular systems this would be provided by nixos-rebuild
-      machine.succeed("nix-instantiate '<nixpkgs>' -A nix")
+      machine.succeed("nix-instantiate ${pkgs.path} -A gnumake")
 
       machine.succeed("timeout 600 wait_for_indexation")
 
       # test debuginfod-find
-      machine.succeed("debuginfod-find debuginfo /run/current-system/sw/bin/nix")
+      machine.succeed("debuginfod-find debuginfo /run/current-system/sw/bin/make")
 
       # test that gdb can fetch source
-      out = machine.succeed("gdb /run/current-system/sw/bin/nix --batch -x ${builtins.toFile "commands" ''
+      out = machine.succeed("gdb /run/current-system/sw/bin/make --batch -x ${builtins.toFile "commands" ''
         start
         l
       ''}")
       print(out)
-      assert 'int main(' in out
+      assert 'main (int argc, char **argv, char **envp)' in out
 
       # test that valgrind can display location information
-      # this relies on the fact that valgrind complains about nix
-      # libgc helps in this regard, and we also ask valgrind to show leak kinds
-      # which are usually false positives.
-      out = machine.succeed("valgrind --leak-check=full --show-leak-kinds=all nix-env --version 2>&1")
+      # we ask valgrind to show leak kinds which are usually false positives, so taht we get a source file report.
+      out = machine.succeed("valgrind --leak-check=full --show-leak-kinds=all make --version 2>&1")
       print(out)
-      assert 'main.cc' in out
+      assert 'main.c' in out
     '';
   }
 )

--- a/pkgs/by-name/ni/nixseparatedebuginfod/package.nix
+++ b/pkgs/by-name/ni/nixseparatedebuginfod/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nixseparatedebuginfod";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "symphorien";
     repo = "nixseparatedebuginfod";
     rev = "v${version}";
-    hash = "sha256-sVQ6UgQvSTEIxXPxISeTI9tqAdJlxQpLxq1h4I31r6k=";
+    hash = "sha256-z20KvspXUIr6PtVozcQDkiIzYvVAWQ9PGAZJM1eqrlY=";
   };
 
-  cargoHash = "sha256-vaCmRr1hXF0BSg/dl3LYyd7c1MdPKIv6KgDgGEzqqJQ=";
+  cargoHash = "sha256-XeeVgHlnVsRlZTx1fQz+r0ajuUZ9oOcvFio+agngDL8=";
 
   # tests need a working nix install with access to the internet
   doCheck = false;


### PR DESCRIPTION
Fixes CVE-2025-61557

This is not a backport from master. On master, I want to remove nixseparatedebuginfod and replace it with nixseparatedebuginfod2 instead. This is done in https://github.com/NixOS/nixpkgs/pull/452053


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
