### PR TITLE
mysql80: 8.0.43 -> 8.0.44, mysql84: 8.4.6 -> 8.4.7

### DIFF
--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.4.6";
+  version = "8.4.7";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-oeUj3IvpbRilreEGmYZhKFygG29bRsCLJlQRDkDfL7c=";
+    hash = "sha256-wL8zqUzbkI8UmuoHl6/7GxOSYszw4Ll4ehckYgdULmk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.0.43";
+  version = "8.0.44";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-diUKgQFch49iUhz68w3/DqmyUJeNKx3/AHQIo5jV25M=";
+    hash = "sha256-YJUi7R/vzlqziN7CXg0bzhMjgtom4rd7aPB0HApkE1Y=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes:
* CVE-2025-53054
* CVE-2025-53053
* CVE-2025-53044
* CVE-2025-53045
* CVE-2025-53062
* CVE-2025-53069
* CVE-2025-53040
* CVE-2025-53042

https://www.oracle.com/security-alerts/cpuoct2025.html#AppendixMSQL

Changes:
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-7.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-44.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result (no new failures)

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 454338`
Commit: `9a28cade70d5a9fea018d794d9ce70eb3b276159`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>sympa</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 45 packages built:</summary>
  <ul>
    <li>exim</li>
    <li>libmysqlconnectorcpp</li>
    <li>longview</li>
    <li>mylvmbackup</li>
    <li>mysql-workbench</li>
    <li>mysql80</li>
    <li>mysql80.static</li>
    <li>mysql84</li>
    <li>mysql84.static</li>
    <li>opendmarc</li>
    <li>opendmarc.bin</li>
    <li>opendmarc.dev</li>
    <li>opendmarc.doc</li>
    <li>percona-toolkit</li>
    <li>percona-xtrabackup (percona-xtrabackup_8_4)</li>
    <li>percona-xtrabackup_8_0</li>
    <li>perl538Packages.DBDmysql</li>
    <li>perl538Packages.DBDmysql.devdoc</li>
    <li>perl538Packages.MinionBackendmysql</li>
    <li>perl538Packages.MinionBackendmysql.devdoc</li>
    <li>perl538Packages.Mojomysql</li>
    <li>perl538Packages.Mojomysql.devdoc</li>
    <li>perl538Packages.PerconaToolkit</li>
    <li>perl538Packages.Testmysqld</li>
    <li>perl538Packages.Testmysqld.devdoc</li>
    <li>perl538Packages.maatkit</li>
    <li>perlPackages.DBDmysql (perl540Packages.DBDmysql)</li>
    <li>perlPackages.DBDmysql.devdoc (perl540Packages.DBDmysql.devdoc)</li>
    <li>perlPackages.MinionBackendmysql (perl540Packages.MinionBackendmysql)</li>
    <li>perlPackages.MinionBackendmysql.devdoc (perl540Packages.MinionBackendmysql.devdoc)</li>
    <li>perlPackages.Mojomysql (perl540Packages.Mojomysql)</li>
    <li>perlPackages.Mojomysql.devdoc (perl540Packages.Mojomysql.devdoc)</li>
    <li>perlPackages.PerconaToolkit (perl540Packages.PerconaToolkit)</li>
    <li>perlPackages.Testmysqld (perl540Packages.Testmysqld)</li>
    <li>perlPackages.Testmysqld.devdoc (perl540Packages.Testmysqld.devdoc)</li>
    <li>perlPackages.maatkit (perl540Packages.maatkit)</li>
    <li>python312Packages.mysql-connector</li>
    <li>python312Packages.mysql-connector.dist</li>
    <li>python313Packages.mysql-connector</li>
    <li>python313Packages.mysql-connector.dist</li>
    <li>sqitchMysql</li>
    <li>sqlite3-to-mysql</li>
    <li>sqlite3-to-mysql.dist</li>
    <li>vep</li>
    <li>zoneminder</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>sympa</summary>
<pre>find: &#x27;po/sympa/add-lang.pl&#x27;: No such file or directory
applying patch /nix/store/npcmkdk30if0xgwkbcysvdlfkfn7sa0j-make-docs.patch
patching file doc/Makefile.am
Hunk #1 succeeded at 93 (offset 10 lines).
Running phase: autoreconfPhase
@nix { &quot;action&quot;: &quot;setPhase&quot;, &quot;phase&quot;: &quot;autoreconfPhase&quot; }
autoreconf: export WARNINGS=
autoreconf: Entering directory &#x27;.&#x27;
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force 
configure.ac:30: warning: macro &#x27;AM_PO_SUBDIRS&#x27; not found in library
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: /nix/store/0vbv3qlfrn930grhv1wc9a9xmwflmjca-autoconf-2.72/bin/autoconf --force
configure.ac:30: error: possibly undefined macro: AM_PO_SUBDIRS
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /nix/store/0vbv3qlfrn930grhv1wc9a9xmwflmjca-autoconf-2.72/bin/autoconf failed with exit status: 1</pre>
</details>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
