### PR TITLE
nixos/firefox: remove deprecated options

### DIFF
--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -18,52 +18,32 @@ let
     given control of your browser, unless of course they also control your
     NixOS configuration.
   '';
-
-  # deprecated per-native-messaging-host options
-  nmhOptions = {
-    browserpass = {
-      name = "Browserpass";
-      package = pkgs.browserpass;
-    };
-    bukubrow = {
-      name = "Bukubrow";
-      package = pkgs.bukubrow;
-    };
-    euwebid = {
-      name = "Web eID";
-      package = pkgs.web-eid-app;
-    };
-    ff2mpv = {
-      name = "ff2mpv";
-      package = pkgs.ff2mpv;
-    };
-    fxCast = {
-      name = "fx_cast";
-      package = pkgs.fx-cast-bridge;
-    };
-    gsconnect = {
-      name = "GSConnect";
-      package = pkgs.gnomeExtensions.gsconnect;
-    };
-    jabref = {
-      name = "JabRef";
-      package = pkgs.jabref;
-    };
-    passff = {
-      name = "PassFF";
-      package = pkgs.passff-host;
-    };
-    tridactyl = {
-      name = "Tridactyl";
-      package = pkgs.tridactyl-native;
-    };
-    ugetIntegrator = {
-      name = "Uget Integrator";
-      package = pkgs.uget-integrator;
-    };
-  };
 in
 {
+  imports =
+    lib.mapAttrsToList
+      (
+        name: pkg:
+        lib.mkRemovedOptionModule [
+          "programs"
+          "firefox"
+          "nativeMessagingHosts"
+          name
+        ] "Use `programs.firefox.nativeMessagingHosts.packages = [ pkgs.${pkg} ]` instead"
+      )
+      {
+        browserpass = "browserpass";
+        bukubrow = "bukubrow";
+        euwebid = "web-eid-app";
+        ff2mpv = "ff2mpv";
+        fxCast = "fx-cast-bridge";
+        gsconnect = "gnomeExtensions.gsconnect";
+        jabref = "jabref";
+        passff = "passff-host";
+        tridactyl = "tridactyl-native";
+        ugetIntegrator = "uget-integrator";
+      };
+
   options.programs.firefox = {
     enable = lib.mkEnableOption "the Firefox web browser";
 
@@ -285,75 +265,55 @@ in
       '';
     };
 
-    nativeMessagingHosts = {
-      packages = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default = [ ];
-        description = ''
-          Additional packages containing native messaging hosts that should be made available to Firefox extensions.
-        '';
-      };
-    }
-    // (builtins.mapAttrs (k: v: lib.mkEnableOption "${v.name} support") nmhOptions);
+    nativeMessagingHosts.packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        Additional packages containing native messaging hosts that should be made available to Firefox extensions.
+      '';
+    };
   };
 
-  config =
-    let
-      forEachEnabledNmh =
-        fn:
-        lib.flatten (
-          lib.mapAttrsToList (k: v: lib.optional cfg.nativeMessagingHosts.${k} (fn k v)) nmhOptions
-        );
-    in
-    lib.mkIf cfg.enable {
-      warnings = forEachEnabledNmh (
-        k: v:
-        "The `programs.firefox.nativeMessagingHosts.${k}` option is deprecated, "
-        + "please add `${v.package.pname}` to `programs.firefox.nativeMessagingHosts.packages` instead."
-      );
-      programs.firefox.nativeMessagingHosts.packages = forEachEnabledNmh (_: v: v.package);
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      (cfg.package.override (old: {
+        extraPrefsFiles =
+          old.extraPrefsFiles
+          ++ cfg.autoConfigFiles
+          ++ [ (pkgs.writeText "firefox-autoconfig.js" cfg.autoConfig) ];
+        nativeMessagingHosts = old.nativeMessagingHosts ++ cfg.nativeMessagingHosts.packages;
+        cfg = old.cfg // cfg.wrapperConfig;
+      }))
+    ];
 
-      environment.systemPackages = [
-        (cfg.package.override (old: {
-          extraPrefsFiles =
-            old.extraPrefsFiles or [ ]
-            ++ cfg.autoConfigFiles
-            ++ [ (pkgs.writeText "firefox-autoconfig.js" cfg.autoConfig) ];
-          nativeMessagingHosts = lib.unique (
-            old.nativeMessagingHosts or [ ] ++ cfg.nativeMessagingHosts.packages
-          );
-          cfg = (old.cfg or { }) // cfg.wrapperConfig;
-        }))
-      ];
-
-      environment.etc =
-        let
-          policiesJSON = policyFormat.generate "firefox-policies.json" { inherit (cfg) policies; };
-        in
-        lib.mkIf (cfg.policies != { }) {
-          "firefox/policies/policies.json".source = "${policiesJSON}";
-        };
-
-      # Preferences are converted into a policy
-      programs.firefox.policies = {
-        DisableAppUpdate = true;
-        Preferences = (
-          builtins.mapAttrs (_: value: {
-            Value = value;
-            Status = cfg.preferencesStatus;
-          }) cfg.preferences
-        );
-        ExtensionSettings = builtins.listToAttrs (
-          builtins.map (
-            lang:
-            lib.attrsets.nameValuePair "langpack-${lang}@firefox.mozilla.org" {
-              installation_mode = "normal_installed";
-              install_url = "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
-            }
-          ) cfg.languagePacks
-        );
+    environment.etc =
+      let
+        policiesJSON = policyFormat.generate "firefox-policies.json" { inherit (cfg) policies; };
+      in
+      lib.mkIf (cfg.policies != { }) {
+        "firefox/policies/policies.json".source = "${policiesJSON}";
       };
+
+    # Preferences are converted into a policy
+    programs.firefox.policies = {
+      DisableAppUpdate = true;
+      Preferences = (
+        builtins.mapAttrs (_: value: {
+          Value = value;
+          Status = cfg.preferencesStatus;
+        }) cfg.preferences
+      );
+      ExtensionSettings = builtins.listToAttrs (
+        builtins.map (
+          lang:
+          lib.attrsets.nameValuePair "langpack-${lang}@firefox.mozilla.org" {
+            installation_mode = "normal_installed";
+            install_url = "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
+          }
+        ) cfg.languagePacks
+      );
     };
+  };
 
   meta.maintainers = with lib.maintainers; [
     danth


### PR DESCRIPTION
They were deprecated in #262623

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
