### PR TITLE
nixos/plymouth: refresh

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -331,6 +331,8 @@
 
 - `services.dnscrypt-proxy` gains a `package` option to specify dnscrypt-proxy package to use.
 
+- `boot.plymouth` now has a [`package`](#opt-boot.plymouth.package) option to specify the package used in the module.
+
 - `services.limesurvey` now supports nginx as reverse-proxy. Available through [services.limesurvey.webserver](#opt-services.limesurvey.webserver).
 
 - `services.nextcloud.configureRedis` now defaults to `true` in accordance with upstream recommendations to have caching for file locking. See the [upstream doc](https://docs.nextcloud.com/server/31/admin_manual/configuration_files/files_locking_transactional.html) for further details.

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -6,9 +6,20 @@
   ...
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    optional
+    mkIf
+    mkBefore
+    mkAfter
+    literalExpression
+    types
+    literalMD
+    getBin
+    escapeShellArg
+    ;
 
   plymouth = pkgs.plymouth.override {
     systemd = config.boot.initrd.systemd.package;
@@ -109,7 +120,7 @@ in
       };
 
       themePackages = mkOption {
-        default = lib.optional (cfg.theme == "breeze") nixosBreezePlymouth;
+        default = optional (cfg.theme == "breeze") nixosBreezePlymouth;
         defaultText = literalMD ''
           A NixOS branded variant of the breeze theme when
           `config.${opt.theme} == "breeze"`, otherwise
@@ -202,7 +213,7 @@ in
     boot.initrd.systemd = {
       extraBin.plymouth = "${plymouth}/bin/plymouth"; # for the recovery shell
       storePaths = [
-        "${lib.getBin config.boot.initrd.systemd.package}/bin/systemd-tty-ask-password-agent"
+        "${getBin config.boot.initrd.systemd.package}/bin/systemd-tty-ask-password-agent"
         "${plymouth}/bin/plymouthd"
         "${plymouth}/sbin/plymouthd"
       ];
@@ -306,7 +317,7 @@ in
       '')
     ];
 
-    boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (
+    boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) (
       ''
         copy_bin_and_libs ${plymouth}/bin/plymouth
         copy_bin_and_libs ${plymouth}/bin/plymouthd

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -17,7 +17,7 @@ let
     literalExpression
     types
     literalMD
-    getBin
+    getExe'
     escapeShellArg
     ;
 
@@ -92,7 +92,7 @@ let
   preStartQuitFixup = {
     serviceConfig.ExecStartPre = [
       ""
-      "${cfg.package}/bin/plymouth quit --wait"
+      "${getExe' cfg.package "plymouth"} quit --wait"
     ];
   };
 
@@ -220,10 +220,10 @@ in
     systemd.services.emergency = preStartQuitFixup;
 
     boot.initrd.systemd = {
-      extraBin.plymouth = "${cfg.package}/bin/plymouth"; # for the recovery shell
+      extraBin.plymouth = getExe' cfg.package "plymouth"; # for the recovery shell
       storePaths = [
-        "${getBin config.boot.initrd.systemd.package}/bin/systemd-tty-ask-password-agent"
-        "${cfg.package}/bin/plymouthd"
+        (getExe' config.boot.initrd.systemd.package "systemd-tty-ask-password-agent")
+        (getExe' cfg.package "plymouthd")
         "${cfg.package}/sbin/plymouthd"
       ];
       packages = [ cfg.package ]; # systemd units
@@ -328,8 +328,8 @@ in
 
     boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) (
       ''
-        copy_bin_and_libs ${cfg.package}/bin/plymouth
-        copy_bin_and_libs ${cfg.package}/bin/plymouthd
+        copy_bin_and_libs ${getExe' cfg.package "plymouth"}
+        copy_bin_and_libs ${getExe' cfg.package "plymouthd"}
 
       ''
       + checkIfThemeExists


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
