### PR TITLE
prometheus-storagebox-exporter: 0-unstable-2025-07-28 -> 1.0.0

### DIFF
--- a/pkgs/by-name/pr/prometheus-storagebox-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-storagebox-exporter/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "prometheus-storagebox-exporter";
-  version = "0-unstable-2025-07-28";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "fleaz";
     repo = "prometheus-storagebox-exporter";
-    hash = "sha256-HGUAvoLIVXwZT/CJ1yj9H6ClNRwiJ8rjjluAQ6GdBME=";
-    rev = "e03cfd5f60f7847b74de2f6f47690bc03b7c157a";
+    hash = "sha256-sufxNnHAdOaYEzKj9vriDrJF6Tq4Eim3Z45FEuuG97Q=";
+    tag = "v${version}";
   };
 
-  vendorHash = "sha256-w2S8LWQyDLnUba7+YnTk7GhRXR/agbF5GFIeOPk8w64=";
+  vendorHash = "sha256-hWM7JnL0x+vsUrQsJZGM3z2jB3F1wtjKWmX8j+WnjKY=";
 
   meta = {
     description = "Prometheus exporter for Hetzner storage boxes";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated the package to 1.0.0. The code uses the official hcloud go-library now.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
