### PR TITLE
treewide: remove deprecated lib functions that had warning for more than 2 years

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -342,15 +342,31 @@
 
 ### Breaking changes {#sec-nixpkgs-release-25.11-lib-breaking}
 
+- `lib.literalExample` has been removed, use `lib.literalExpression` instead, or use `lib.literalMD` for a non-Nix description.
+
+- `lib.replaceChars` has been removed, it was a deprecated alias of `lib.replaceStrings`.
+
+- `lib.readPathsFromFile` has been removed, use a list instead
+
 - `lib.mapAttrsFlatten` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.mapAttrsToList` instead.
 
+- `lib.strings.isCoercibleToString` has been in favor of either `lib.strings.isStringLike` or `lib.strings.isConvertibleWithToString`. Only use the latter if it needs to return true for null, numbers, booleans, or a list of those.
+
+- `lib.types.string` has been removed. See [this pull request](https://github.com/NixOS/nixpkgs/pull/66346) for better alternative types like `lib.types.str`.
+
+- `lib.modules.defaultPriority` has been removed, please use `lib.modules.defaultOverridePriority` instead.
+
 - `lib.attrsets.cartesianProductOfSets` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.cartesianProduct` instead.
+
+- `lib.sources.pathType`, `lib.sources.pathIsDirectory` and `lib.sources.pathIsRegularFile` have been replaced by `lib.filesystem.pathType`, `lib.filesystem.pathIsDirectory` and `lib.filesystem.pathIsRegularFile` respectively.
 
 - `lib.attrsets.zip` has been removed, following its deprecation in 2013. Use `lib.attrsets.zipAttrsWith` instead.
 
 - `lib.attrsets.zipWithNames` has been removed, following its deprecation in 2009. Use `lib.attrsets.zipAttrsWithNames` instead.
 
 - `lib.options.mkPackageOptionMD` has been removed, following its deprecation in NixOS 24.11. Use `lib.options.mkPackageOption` instead.
+
+- `haskell.lib.addOptparseApplicativeCompletionScripts` has been removed, use `haskellPackages.generateOptparseApplicativeCompletions` instead.
 
 - The `buildPythonPackage` and `buildPythonApplication` functions now require
   an explicit `format` attribute. Previously the default format used setuptools

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -22,7 +22,6 @@ let
     filterAttrs
     optionalString
     flip
-    pathIsDirectory
     head
     pipe
     isDerivation

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -344,7 +344,6 @@ let
         escapeRegex
         escapeURL
         escapeXML
-        replaceChars
         lowerChars
         upperChars
         toLower
@@ -377,7 +376,6 @@ let
         fixedWidthNumber
         toInt
         toIntBase10
-        readPathsFromFile
         fileContents
         ;
       inherit (self.stringsWithDeps)
@@ -495,7 +493,6 @@ let
         optionAttrSetToDocList'
         scrubOptionValue
         literalExpression
-        literalExample
         showOption
         showOptionWithDefLocs
         showFiles

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1468,11 +1468,6 @@ let
   mkForce = mkOverride 50;
   mkVMOverride = mkOverride 10; # used by ‘nixos-rebuild build-vm’
 
-  defaultPriority =
-    warnIf (oldestSupportedReleaseIsAtLeast 2305)
-      "lib.modules.defaultPriority is deprecated, please use lib.modules.defaultOverridePriority instead."
-      defaultOverridePriority;
-
   mkFixStrictness = warn "lib.mkFixStrictness has no effect and will be removed. It returns its argument unmodified, so you can just remove any calls." id;
 
   mkOrder = priority: content: {
@@ -2162,7 +2157,6 @@ private
   inherit
     defaultOrderPriority
     defaultOverridePriority
-    defaultPriority
     doRename
     evalModules
     evalOptionValue # for use by lib.types

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -684,8 +684,6 @@ rec {
         inherit text;
       };
 
-  literalExample = lib.warn "lib.literalExample is deprecated, use lib.literalExpression instead, or use lib.literalMD for a non-Nix description." literalExpression;
-
   /**
     For use in the `defaultText` and `example` option attributes. Causes the
     given MD text to be inserted verbatim in the documentation, for when

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -509,22 +509,6 @@ let
 
 in
 {
-
-  pathType =
-    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
-      "lib.sources.pathType has been moved to lib.filesystem.pathType."
-      lib.filesystem.pathType;
-
-  pathIsDirectory =
-    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
-      "lib.sources.pathIsDirectory has been moved to lib.filesystem.pathIsDirectory."
-      lib.filesystem.pathIsDirectory;
-
-  pathIsRegularFile =
-    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
-      "lib.sources.pathIsRegularFile has been moved to lib.filesystem.pathIsRegularFile."
-      lib.filesystem.pathIsRegularFile;
-
   inherit
     pathIsGitRepo
     commitIdFromGitRepo

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1467,9 +1467,6 @@ rec {
       [ "\"" "'" "<" ">" "&" ]
       [ "&quot;" "&apos;" "&lt;" "&gt;" "&amp;" ];
 
-  # warning added 12-12-2022
-  replaceChars = lib.warn "lib.replaceChars is a deprecated alias of lib.replaceStrings." builtins.replaceStrings;
-
   # Case conversion utilities.
   lowerChars = stringToCharacters "abcdefghijklmnopqrstuvwxyz";
   upperChars = stringToCharacters "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -2579,30 +2576,6 @@ rec {
     lib.warnIf (!precise) "Imprecise conversion from float to string ${result}" result;
 
   /**
-    Check whether a value `val` can be coerced to a string.
-
-    :::{.warning}
-    Soft-deprecated function. While the original implementation is available as
-    `isConvertibleWithToString`, consider using `isStringLike` instead, if suitable.
-    :::
-
-    # Inputs
-
-    `val`
-    : 1\. Function argument
-
-    # Type
-
-    ```
-    isCoercibleToString :: a -> bool
-    ```
-  */
-  isCoercibleToString =
-    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2305)
-      "lib.strings.isCoercibleToString is deprecated in favor of either isStringLike or isConvertibleWithToString. Only use the latter if it needs to return true for null, numbers, booleans and list of similarly coercibles."
-      isConvertibleWithToString;
-
-  /**
     Check whether a list or other value `x` can be passed to toString.
 
     Many types of value are coercible to string this way, including `int`, `float`,
@@ -2841,60 +2814,6 @@ rec {
     # Return result.
     else
       parsedInput;
-
-  /**
-    Read a list of paths from `file`, relative to the `rootPath`.
-    Lines beginning with `#` are treated as comments and ignored.
-    Whitespace is significant.
-
-    :::{.warning}
-    This function is deprecated and should be avoided.
-    :::
-
-    :::{.note}
-    This function is not performant and should be avoided.
-    :::
-
-    # Inputs
-
-    `rootPath`
-    : 1\. Function argument
-
-    `file`
-    : 2\. Function argument
-
-    # Type
-
-    ```
-    readPathsFromFile :: string -> string -> [string]
-    ```
-
-    # Examples
-    :::{.example}
-    ## `lib.strings.readPathsFromFile` usage example
-
-    ```nix
-    readPathsFromFile /prefix
-      ./pkgs/development/libraries/qt-5/5.4/qtbase/series
-    => [ "/prefix/dlopen-resolv.patch" "/prefix/tzdir.patch"
-         "/prefix/dlopen-libXcursor.patch" "/prefix/dlopen-openssl.patch"
-         "/prefix/dlopen-dbus.patch" "/prefix/xdg-config-dirs.patch"
-         "/prefix/nix-profiles-library-paths.patch"
-         "/prefix/compose-search-path.patch" ]
-    ```
-
-    :::
-  */
-  readPathsFromFile = lib.warn "lib.readPathsFromFile is deprecated, use a list instead." (
-    rootPath: file:
-    let
-      lines = lib.splitString "\n" (readFile file);
-      removeComments = lib.filter (line: line != "" && !(lib.hasPrefix "#" line));
-      relativePaths = removeComments lines;
-      absolutePaths = map (path: rootPath + "/${path}") relativePaths;
-    in
-    absolutePaths
-  );
 
   /**
     Read the contents of a file removing the trailing \n

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -380,7 +380,7 @@ in
       assert (pathWith { absolute = null; }).description == "path";
       assert (pathWith { inStore = false; }).description == "path not in the Nix store";
       assert (pathWith { inStore = null; }).description == "path";
-      assert (separatedString "").description == "Concatenated string";
+      assert (separatedString "").description == "strings concatenated with \"\"";
       assert (separatedString ",").description == "strings concatenated with \",\"";
       assert (separatedString "\n").description == ''strings concatenated with "\n"'';
       assert (separatedString ":").description == "strings concatenated with \":\"";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -559,11 +559,7 @@ let
         sep:
         mkOptionType rec {
           name = "separatedString";
-          description =
-            if sep == "" then
-              "Concatenated string" # for types.string.
-            else
-              "strings concatenated with ${builtins.toJSON sep}";
+          description = "strings concatenated with ${builtins.toJSON sep}";
           descriptionClass = "noun";
           check = isString;
           merge = loc: defs: concatStringsSep sep (getValues defs);
@@ -577,19 +573,6 @@ let
       lines = separatedString "\n";
       commas = separatedString ",";
       envVar = separatedString ":";
-
-      # Deprecated; should not be used because it quietly concatenates
-      # strings, which is usually not what you want.
-      # We use a lib.warn because `deprecationMessage` doesn't trigger in nested types such as `attrsOf string`
-      string =
-        lib.warn
-          "The type `types.string` is deprecated. See https://github.com/NixOS/nixpkgs/pull/66346 for better alternative types."
-          (
-            separatedString ""
-            // {
-              name = "string";
-            }
-          );
 
       passwdEntry =
         entryType:

--- a/nixos/modules/programs/pay-respects.nix
+++ b/nixos/modules/programs/pay-respects.nix
@@ -16,7 +16,7 @@ let
     mkOption
     mkPackageOption
     optionalString
-    replaceChars
+    replaceStrings
     substring
     toLower
     types
@@ -142,7 +142,7 @@ in
               description = "The model used by `pay-respects` to generate command corrections.";
             };
             locale = mkOption {
-              default = toLower (replaceChars [ "_" ] [ "-" ] (substring 0 5 config.i18n.defaultLocale));
+              default = toLower (replaceStrings [ "_" ] [ "-" ] (substring 0 5 config.i18n.defaultLocale));
               example = "nl-be";
               type = str;
               description = ''

--- a/pkgs/development/haskell-modules/lib/default.nix
+++ b/pkgs/development/haskell-modules/lib/default.nix
@@ -339,12 +339,6 @@ rec {
   # packagesFromDirectory : { directory : Directory, ... } -> HaskellPackageOverrideSet
   packagesFromDirectory = compose.packagesFromDirectory;
 
-  addOptparseApplicativeCompletionScripts =
-    exeName: pkg:
-    lib.warn "addOptparseApplicativeCompletionScripts is deprecated in favor of haskellPackages.generateOptparseApplicativeCompletions. Please change ${pkg.name} to use the latter and make sure it uses its matching haskell.packages set!" (
-      compose.__generateOptparseApplicativeCompletion exeName pkg
-    );
-
   /*
     Modify a Haskell package to add shell completion scripts for the
     given executable produced by it. These completion scripts will be


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
