### PR TITLE
python3Packages.aiolifx: fix build to work with click 8.2.x

### DIFF
--- a/pkgs/development/python-modules/aiolifx/default.nix
+++ b/pkgs/development/python-modules/aiolifx/default.nix
@@ -24,6 +24,8 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [ "click" ];
+
   dependencies = [
     async-timeout
     bitstring

--- a/pkgs/development/python-modules/aiolifx/default.nix
+++ b/pkgs/development/python-modules/aiolifx/default.nix
@@ -7,7 +7,6 @@
   fetchPypi,
   ifaddr,
   inquirerpy,
-  pythonOlder,
   setuptools,
 }:
 
@@ -15,8 +14,6 @@ buildPythonPackage rec {
   pname = "aiolifx";
   version = "1.2.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -38,12 +35,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiolifx" ];
 
-  meta = with lib; {
+  meta = {
     description = "Module for local communication with LIFX devices over a LAN";
     homepage = "https://github.com/aiolifx/aiolifx";
     changelog = "https://github.com/aiolifx/aiolifx/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ netixx ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ netixx ];
     mainProgram = "aiolifx";
   };
 }

--- a/pkgs/development/python-modules/aiolifx/default.nix
+++ b/pkgs/development/python-modules/aiolifx/default.nix
@@ -4,7 +4,7 @@
   bitstring,
   buildPythonPackage,
   click,
-  fetchPypi,
+  fetchFromGitHub,
   ifaddr,
   inquirerpy,
   setuptools,
@@ -15,9 +15,11 @@ buildPythonPackage rec {
   version = "1.2.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-h82KPrHcWUUrQFyMy3fY6BmQFA5a4DFJdhJ6zRnKMsc=";
+  src = fetchFromGitHub {
+    owner = "aiolifx";
+    repo = "aiolifx";
+    tag = version;
+    hash = "sha256-9FTsY/VFfzLlDEjF8ueBQxr30YasdQwei1/KfHiXwMo=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
1. Built from github source
2. Removed upper bound on python3Packages.click
3. Cleaned up `with lib;`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
