### PR TITLE
treewide: remove pre-21.05 migration code

### DIFF
--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -233,12 +233,6 @@ in
       group = group;
     };
 
-    systemd.tmpfiles.rules = [
-      # present since NixOS 19.09: remove old stateful symlink join directory,
-      # which has been replaced with the journalwatchConfigDir store path
-      "R ${dataDir}/config"
-    ];
-
     systemd.services.journalwatch = {
 
       environment = {

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -299,7 +299,6 @@ in
             if [ ! -f /var/lib/roundcube/des_key ]; then
               base64 /dev/urandom | head -c 24 > /var/lib/roundcube/des_key;
               # we need to log out everyone in case change the des_key
-              # from the default when upgrading from nixos 19.09
               ${psql} <<< 'TRUNCATE TABLE session;'
             fi
 

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -332,30 +332,26 @@ in
 
       path = [ "/run/wrappers" ] ++ cfg.extraPackages;
       preStart = ''
-        # pre 19.09 compatibility
-        if test -e "${runtimeDir}/db-created"; then
-          mv "${runtimeDir}/db-created" "${stateDir}/"
-        fi
-      ''
-      + optionalString pgsqlLocal ''
-        if ! test -e "${stateDir}/db-created"; then
-          cat ${cfg.package}/share/zabbix/database/postgresql/schema.sql | ${pgsql.package}/bin/psql ${cfg.database.name}
-          cat ${cfg.package}/share/zabbix/database/postgresql/images.sql | ${pgsql.package}/bin/psql ${cfg.database.name}
-          cat ${cfg.package}/share/zabbix/database/postgresql/data.sql | ${pgsql.package}/bin/psql ${cfg.database.name}
-          touch "${stateDir}/db-created"
-        fi
-      ''
-      + optionalString mysqlLocal ''
-        if ! test -e "${stateDir}/db-created"; then
-          cat ${cfg.package}/share/zabbix/database/mysql/schema.sql | ${mysql.package}/bin/mysql ${cfg.database.name}
-          cat ${cfg.package}/share/zabbix/database/mysql/images.sql | ${mysql.package}/bin/mysql ${cfg.database.name}
-          cat ${cfg.package}/share/zabbix/database/mysql/data.sql | ${mysql.package}/bin/mysql ${cfg.database.name}
-          touch "${stateDir}/db-created"
-        fi
-      ''
-      + optionalString (cfg.database.passwordFile != null) ''
-        # create a copy of the supplied password file in a format zabbix can consume
-        install -m 0600 <(echo "DBPassword = $(cat ${cfg.database.passwordFile})") ${passwordFile}
+        ${optionalString pgsqlLocal ''
+          if ! test -e "${stateDir}/db-created"; then
+            cat ${cfg.package}/share/zabbix/database/postgresql/schema.sql | ${pgsql.package}/bin/psql ${cfg.database.name}
+            cat ${cfg.package}/share/zabbix/database/postgresql/images.sql | ${pgsql.package}/bin/psql ${cfg.database.name}
+            cat ${cfg.package}/share/zabbix/database/postgresql/data.sql | ${pgsql.package}/bin/psql ${cfg.database.name}
+            touch "${stateDir}/db-created"
+          fi
+        ''}
+        ${optionalString mysqlLocal ''
+          if ! test -e "${stateDir}/db-created"; then
+            cat ${cfg.package}/share/zabbix/database/mysql/schema.sql | ${mysql.package}/bin/mysql ${cfg.database.name}
+            cat ${cfg.package}/share/zabbix/database/mysql/images.sql | ${mysql.package}/bin/mysql ${cfg.database.name}
+            cat ${cfg.package}/share/zabbix/database/mysql/data.sql | ${mysql.package}/bin/mysql ${cfg.database.name}
+            touch "${stateDir}/db-created"
+          fi
+        ''}
+        ${optionalString (cfg.database.passwordFile != null) ''
+          # create a copy of the supplied password file in a format zabbix can consume
+          install -m 0600 <(echo "DBPassword = $(cat ${cfg.database.passwordFile})") ${passwordFile}
+        ''}
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -749,25 +749,20 @@ in
         '';
       };
 
-      configDir =
-        let
-          cond = versionAtLeast config.system.stateVersion "19.03";
-        in
-        mkOption {
-          type = types.path;
-          description = ''
-            The path where the settings and keys will exist.
-          '';
-          default = cfg.dataDir + optionalString cond "/.config/syncthing";
-          defaultText = literalMD ''
-            * if `stateVersion >= 19.03`:
-
-                  config.${opt.dataDir} + "/.config/syncthing"
-            * otherwise:
-
-                  config.${opt.dataDir}
-          '';
-        };
+      configDir = mkOption {
+        type = types.path;
+        description = ''
+          The path where the settings and keys will exist.
+        '';
+        default =
+          cfg.dataDir
+          + optionalString (versionAtLeast config.system.stateVersion "19.03") "/.config/syncthing";
+        defaultText = literalExpression ''
+          if versionAtLeast config.system.stateVersion "19.03"
+          then "${opt.dataDir}/.config/syncthing"
+          else "${opt.dataDir}"
+        '';
+      };
 
       databaseDir = mkOption {
         type = types.path;

--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -187,19 +187,7 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    services.deluge.package = lib.mkDefault (
-      if lib.versionAtLeast config.system.stateVersion "20.09" then
-        pkgs.deluge-2_x
-      else
-        # deluge-1_x is no longer packaged and this will resolve to an error
-        # thanks to the alias for this name.  This is left here so that anyone
-        # using NixOS older than 20.09 receives that error when they upgrade
-        # and is forced to make an intentional choice to switch to deluge-2_x.
-        # That might be slightly inconvenient but there is no path to
-        # downgrade from 2.x to 1.x so NixOS should not automatically perform
-        # this state migration.
-        pkgs.deluge-1_x
-    );
+    services.deluge.package = lib.mkDefault pkgs.deluge-2_x;
 
     # Provide a default set of `extraPackages`.
     services.deluge.extraPackages = with pkgs; [

--- a/nixos/modules/services/web-apps/hedgedoc.nix
+++ b/nixos/modules/services/web-apps/hedgedoc.nix
@@ -10,11 +10,7 @@ let
 
   cfg = config.services.hedgedoc;
 
-  # 21.03 will not be an official release - it was instead 21.05.  This
-  # versionAtLeast statement remains set to 21.03 for backwards compatibility.
-  # See https://github.com/NixOS/nixpkgs/pull/108899 and
-  # https://github.com/NixOS/rfcs/blob/master/rfcs/0080-nixos-release-schedule.md.
-  name = if lib.versionAtLeast config.system.stateVersion "21.03" then "hedgedoc" else "codimd";
+  name = if lib.versionAtLeast config.system.stateVersion "21.05" then "hedgedoc" else "codimd";
 
   settingsFormat = pkgs.formats.json { };
 in
@@ -25,7 +21,9 @@ in
   ];
 
   imports = [
-    (lib.mkRenamedOptionModule [ "services" "codimd" ] [ "services" "hedgedoc" ])
+    (lib.mkRemovedOptionModule [ "services" "codimd" ] ''
+      This options group has been removed in favor of `services.hedgedoc`.
+    '')
     (lib.mkRenamedOptionModule
       [ "services" "hedgedoc" "configuration" ]
       [ "services" "hedgedoc" "settings" ]

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -785,10 +785,6 @@ in
       }
     ) vhostCertNames;
 
-    warnings = mapAttrsToList (name: hostOpts: ''
-      Using config.services.httpd.virtualHosts."${name}".servedFiles is deprecated and will become unsupported in a future release. Your configuration will continue to work as is but please migrate your configuration to config.services.httpd.virtualHosts."${name}".locations before the 20.09 release of NixOS.
-    '') (filterAttrs (name: hostOpts: hostOpts.servedFiles != [ ]) cfg.virtualHosts);
-
     users.users = optionalAttrs (cfg.user == "wwwrun") {
       wwwrun = {
         group = cfg.group;

--- a/nixos/modules/services/x11/desktop-managers/xterm.nix
+++ b/nixos/modules/services/x11/desktop-managers/xterm.nix
@@ -4,30 +4,28 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
-
   cfg = config.services.xserver.desktopManager.xterm;
   xSessionEnabled = config.services.xserver.enable;
-
+  inherit (lib)
+    mkOption
+    types
+    mkIf
+    singleton
+    literalExpression
+    ;
 in
-
 {
   options = {
-
     services.xserver.desktopManager.xterm.enable = mkOption {
       type = types.bool;
-      default = versionOlder config.system.stateVersion "19.09" && xSessionEnabled;
-      defaultText = literalExpression ''versionOlder config.system.stateVersion "19.09" && config.services.xserver.enable;'';
+      default = xSessionEnabled;
+      defaultText = literalExpression ''config.services.xserver.enable'';
       description = "Enable a xterm terminal as a desktop manager.";
     };
-
   };
 
   config = mkIf cfg.enable {
-
     services.xserver.desktopManager.session = singleton {
       name = "xterm";
       start = ''
@@ -35,9 +33,6 @@ in
         waitPID=$!
       '';
     };
-
     environment.systemPackages = [ pkgs.xterm ];
-
   };
-
 }

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -185,23 +185,6 @@ else
       inherit (ghc) version targetPrefix;
 
       hoogle = hoogleWithPackages';
-
-      # Inform users about backwards incompatibilities with <= 21.05
-      override =
-        _:
-        throw ''
-          The ghc.withPackages wrapper itself can now be overridden, but no longer
-          the result of calling it (as before). Consequently overrides need to be
-          adjusted: Instead of
-
-            (ghc.withPackages (p: [ p.my-package ])).override { withLLLVM = true; }
-
-          use
-
-            (ghc.withPackages.override { useLLVM = true; }) (p: [ p.my-package ])
-
-          Also note that withLLVM has been renamed to useLLVM for consistency with
-          the GHC Nix expressions.'';
     };
     pos = __curPos;
     meta = ghc.meta // {


### PR DESCRIPTION
Hard incompatibilities like new mysql and postgresql db locations were kept in place
I am fine with removing something from this pr



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
