### PR TITLE
imagelol: fix darwin and use system libpng

### DIFF
--- a/pkgs/by-name/im/imagelol/use-system-libs.patch
+++ b/pkgs/by-name/im/imagelol/use-system-libs.patch
@@ -1,0 +1,32 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,26 +3,12 @@
+ project(ImageLOL VERSION 0.0)
+ set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_STANDARD_REQUIRED True)
+-include_directories("External/zlib" "External/libpng")
+ add_subdirectory("External/stb_image-cmake")
+
+-set(SKIP_INSTALL_ALL ON CACHE BOOL "")
+-add_subdirectory("External/zlib-no-examples")
+-
+-set(PNG_BUILD_ZLIB ON CACHE BOOL "")
+-link_libraries(zlibstatic)
+-get_target_property(ZLIB_INCLUDE_DIRECTORIES zlibstatic INCLUDE_DIRECTORIES)
+-include_directories(${ZLIB_INCLUDE_DIRECTORIES})
+-set(ZLIB_INCLUDE_DIR ${ZLIB_INCLUDE_DIRECTORIES} CACHE PATH "")
+-set(PNG_SHARED OFF CACHE BOOL "")
+-set(PNG_EXECUTABLES OFF CACHE BOOL "")
+-add_subdirectory("External/libpng")
+-add_dependencies(png_static zlibstatic zlib)
+-add_dependencies(genfiles zlibstatic)
+-unset(SKIP_INSTALL_ALL CACHE)
+-get_target_property(LIBPNG_INCLUDE_DIRECTORIES png_static INCLUDE_DIRECTORIES)
++find_package(PNG REQUIRED)
++set(LIBPNG_INCLUDE_DIRECTORIES ${PNG_INCLUDE_DIRS})
+
+ add_subdirectory("imagelol")
+ add_executable(ImageLOL main.cpp)
+ target_include_directories(ImageLOL PRIVATE ${LIBPNG_INCLUDE_DIRECTORIES})
+-target_link_libraries(ImageLOL PRIVATE stb_image png_static zlibstatic libimagelol)
++target_link_libraries(ImageLOL PRIVATE stb_image PNG::PNG libimagelol)


### PR DESCRIPTION
The bundled zlib failed to compile with clang 21.1.2 due to deprecated C syntax, and the bundled libpng failed due to missing fp.h header on macOS. Replace both with system libraries (zlib is already imported transitively via libpng) and remove the darwin broken flag.

Also remove the -std=gnu90 compiler flag which is no longer needed.

To be rebased after #454208


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
