### PR TITLE
uv: fix CVE-2025-62518

### DIFF
--- a/pkgs/by-name/uv/uv/CVE-2025-62518.patch
+++ b/pkgs/by-name/uv/uv/CVE-2025-62518.patch
@@ -1,0 +1,25 @@
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -173,9 +173,9 @@
+ 
+ [[package]]
+ name = "astral-tokio-tar"
+-version = "0.5.2"
++version = "0.5.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1abb2bfba199d9ec4759b797115ba6ae435bdd920ce99783bb53aeff57ba919b"
++checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+ dependencies = [
+  "filetime",
+  "futures-core",
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -76,7 +76,7 @@
+ anyhow = { version = "1.0.89" }
+ arcstr = { version = "1.2.0" }
+ arrayvec = { version = "0.7.6" }
+-astral-tokio-tar = { version = "0.5.1" }
++astral-tokio-tar = { version = "0.5.6" }
+ async-channel = { version = "2.3.1" }
+ async-compression = { version = "0.4.12", features = ["bzip2", "gzip", "xz", "zstd"] }
+ async-trait = { version = "0.1.82" }

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -27,7 +27,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-949PYCKaZqaXFb2GFjTgpZr/b3R61Tf4lHSgGiZv0kA=";
   };
 
-  cargoHash = "sha256-ybhEzHlTuXoSV/3d1soA8Y7EpiphBEBXSlf2gWyiKnw=";
+  cargoPatches = [
+    ./CVE-2025-62518.patch
+  ];
+
+  cargoHash = "sha256-NxhOjfdfRPVAxpvK29NwFuKkXQkHOSNN0bVFOSSKQxs=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/development/python-modules/uv-build/default.nix
+++ b/pkgs/development/python-modules/uv-build/default.nix
@@ -13,6 +13,7 @@ buildPythonPackage {
   inherit (pkgs.uv)
     version
     src
+    patches
     cargoDeps
     cargoBuildFlags
     ;


### PR DESCRIPTION
Related to:
- GHSA-w476-p2h3-79g9
- GHSA-j5gw-2vrg-8fgx (CVE-2025-62518)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
