### PR TITLE
stellarium, qt6Packages.qxlsx: fix build and migrate stellarium to pkgs/by-name

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   perl,
   wrapGAppsHook3,
@@ -36,6 +37,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-9uQ6u1+dSszmKG8eY6kSXhqsCPRGw6tulCTCrLByIxc=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/stellarium/-/raw/ab559b6e9349569278f83c2dfc83990e971a8cb2/qt-6.10.patch";
+      hash = "sha256-a7zC9IQOj93VnPy8Bj/fLe4oJux7I4Edgj5OaKI4TZU=";
+    })
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/by-name/st/stellarium/package.nix
+++ b/pkgs/by-name/st/stellarium/package.nix
@@ -6,19 +6,11 @@
   cmake,
   perl,
   wrapGAppsHook3,
-  wrapQtAppsHook,
-  qtbase,
-  qtcharts,
-  qtpositioning,
-  qtmultimedia,
-  qtserialport,
-  qtwayland,
-  qtwebengine,
+  qt6,
+  qt6Packages,
   calcmysky,
-  qxlsx,
   indilib,
   libnova,
-  qttools,
   exiv2,
   nlopt,
   testers,
@@ -50,26 +42,26 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'SET(CMAKE_INSTALL_PREFIX "''${PROJECT_BINARY_DIR}/Stellarium.app/Contents")' \
                 'SET(CMAKE_INSTALL_PREFIX "${placeholder "out"}/Applications/Stellarium.app/Contents")'
     substituteInPlace src/CMakeLists.txt \
-      --replace-fail "\''${_qt_bin_dir}/../" "${qtmultimedia}/lib/qt-6/"
+      --replace-fail "\''${_qt_bin_dir}/../" "${qt6.qtmultimedia}/lib/qt-6/"
   '';
 
   nativeBuildInputs = [
     cmake
     perl
     wrapGAppsHook3
-    wrapQtAppsHook
-    qttools
+    qt6.wrapQtAppsHook
+    qt6.qttools
   ];
 
   buildInputs = [
-    qtbase
-    qtcharts
-    qtpositioning
-    qtmultimedia
-    qtserialport
-    qtwebengine
+    qt6.qtbase
+    qt6.qtcharts
+    qt6.qtpositioning
+    qt6.qtmultimedia
+    qt6.qtserialport
+    qt6.qtwebengine
     calcmysky
-    qxlsx
+    qt6Packages.qxlsx
     indilib
     libnova
     exiv2
@@ -77,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     nlopt
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    qtwayland
+    qt6.qtwayland
   ];
 
   preConfigure = ''
@@ -88,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # fatal error: 'QtSerialPort/QSerialPortInfo' file not found
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-F${qtserialport}/lib";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-F${qt6.qtserialport}/lib";
 
   dontWrapGApps = true;
 

--- a/pkgs/development/libraries/qxlsx/default.nix
+++ b/pkgs/development/libraries/qxlsx/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   qtbase,
 }:
@@ -16,6 +17,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-twOlAiLE0v7+9nWo/Gd+oiKT1umL3UnG1Xa0zDG7u7s=";
   };
+
+  patches = [
+    # Fix for Qt 6.10, can likely be removed when version bump passes v1.5.0.
+    (fetchpatch {
+      url = "https://github.com/QtExcel/QXlsx/commit/90d762625750c6b2c73f6cd96b633e9158aed72e.patch";
+      hash = "sha256-/0xLrkjuJGZRocK1EyBhuaUmg0usueQz2F340DkQhb0=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qtbase ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14232,8 +14232,6 @@ with pkgs;
 
   spyder = with python3.pkgs; toPythonApplication spyder;
 
-  stellarium = qt6Packages.callPackage ../applications/science/astronomy/stellarium { };
-
   tulip = libsForQt5.callPackage ../applications/science/misc/tulip {
     python3 = python312; # fails to build otherwise
   };


### PR DESCRIPTION
# For Stellarium

Migrated `stellarium` from `pkgs/applications/science/astronomy/stellarium` to `pkgs/by-name/st/stellarium`.

Added a patch so that `Qt6.GuiPrivate` is available when using `qxlsx` when `qt` version 6.10 is used, else the build fails, see [Hydra](https://hydra.nixos.org/build/310745998).

# For qt6Packages.qxlsx

Add fix for `qt` version 6.10.

`qxlsx` is failing to build, with this error (see [Hydra](https://hydra.nixos.org/build/309892575/nixlog/1)):

> qxlsx> CMake Error at CMakeLists.txt:167 (target_link_libraries):
> qxlsx>   Target "QXlsx" links to:
> qxlsx>
> qxlsx>     Qt6::GuiPrivate
> qxlsx>
> qxlsx>   but the target was not found.

The upstream `qxlsx` has been patched to fix this, but as a new upstream version has not been released, this fix is not present in `nixpkgs` even though `nixpkgs` has now bumped `qt6` to version 6.10.0 in PR 449572.

Thus, directly apply the patch made in this commit:
https://github.com/QtExcel/QXlsx/commit/90d762625750c6b2c73f6cd96b633e9158aed72e

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
