### PR TITLE
buildPythonPackage: add fix-point argument support

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -420,7 +420,11 @@ lib.extendMkDerivation {
       // {
         updateScript = nix-update-script { };
       }
-      // attrs.passthru or { };
+      // attrs.passthru or { }
+      // lib.optionalAttrs (attrs ? stdenv) {
+        # Preserve requested stdenv for backwards compatibility
+        __stdenv = attrs.stdenv;
+      };
 
       meta = {
         # default to python's platforms

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -99,7 +99,11 @@ let
     "wheel"
   ];
 
-  cleanAttrs = flip removeAttrs [
+in
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
     "disabled"
     "checkPhase"
     "checkInputs"
@@ -114,93 +118,89 @@ let
     "build-system"
   ];
 
-in
-
-{
-  # Build-time dependencies for the package
-  nativeBuildInputs ? [ ],
-
-  # Run-time dependencies for the package
-  buildInputs ? [ ],
-
-  # Dependencies needed for running the checkPhase.
-  # These are added to buildInputs when doCheck = true.
-  checkInputs ? [ ],
-  nativeCheckInputs ? [ ],
-
-  # propagate build dependencies so in case we have A -> B -> C,
-  # C can import package A propagated by B
-  propagatedBuildInputs ? [ ],
-
-  # Python module dependencies.
-  # These are named after PEP-621.
-  dependencies ? [ ],
-  optional-dependencies ? { },
-
-  # Python PEP-517 build systems.
-  build-system ? [ ],
-
-  # DEPRECATED: use propagatedBuildInputs
-  pythonPath ? [ ],
-
-  # Enabled to detect some (native)BuildInputs mistakes
-  strictDeps ? true,
-
-  outputs ? [ "out" ],
-
-  # used to disable derivation, useful for specific python versions
-  disabled ? false,
-
-  # Raise an error if two packages are installed with the same name
-  # TODO: For cross we probably need a different PYTHONPATH, or not
-  # add the runtime deps until after buildPhase.
-  catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
-
-  # Additional arguments to pass to the makeWrapper function, which wraps
-  # generated binaries.
-  makeWrapperArgs ? [ ],
-
-  # Skip wrapping of python programs altogether
-  dontWrapPythonPrograms ? false,
-
-  # Don't use Pip to install a wheel
-  # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
-  # It's included here to prevent an infinite recursion.
-  dontUsePipInstall ? false,
-
-  # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
-  permitUserSite ? false,
-
-  # Remove bytecode from bin folder.
-  # When a Python script has the extension `.py`, bytecode is generated
-  # Typically, executables in bin have no extension, so no bytecode is generated.
-  # However, some packages do provide executables with extensions, and thus bytecode is generated.
-  removeBinBytecode ? true,
-
-  # pyproject = true <-> format = "pyproject"
-  # pyproject = false <-> format = "other"
-  # https://github.com/NixOS/nixpkgs/issues/253154
-  pyproject ? null,
-
-  # Several package formats are supported.
-  # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
-  # "wheel" : Install from a pre-compiled wheel.
-  # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
-  # "egg": Install a package from an egg.
-  # "other" : Provide your own buildPhase and installPhase.
-  format ? null,
-
-  meta ? { },
-
-  doCheck ? true,
-
-  ...
-}@attrs:
-
-let
-  # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-  self = stdenv.mkDerivation (
+  extendDrvArgs =
     finalAttrs:
+    {
+      # Build-time dependencies for the package
+      nativeBuildInputs ? [ ],
+
+      # Run-time dependencies for the package
+      buildInputs ? [ ],
+
+      # Dependencies needed for running the checkPhase.
+      # These are added to buildInputs when doCheck = true.
+      checkInputs ? [ ],
+      nativeCheckInputs ? [ ],
+
+      # propagate build dependencies so in case we have A -> B -> C,
+      # C can import package A propagated by B
+      propagatedBuildInputs ? [ ],
+
+      # Python module dependencies.
+      # These are named after PEP-621.
+      dependencies ? [ ],
+      optional-dependencies ? { },
+
+      # Python PEP-517 build systems.
+      build-system ? [ ],
+
+      # DEPRECATED: use propagatedBuildInputs
+      pythonPath ? [ ],
+
+      # Enabled to detect some (native)BuildInputs mistakes
+      strictDeps ? true,
+
+      outputs ? [ "out" ],
+
+      # used to disable derivation, useful for specific python versions
+      disabled ? false,
+
+      # Raise an error if two packages are installed with the same name
+      # TODO: For cross we probably need a different PYTHONPATH, or not
+      # add the runtime deps until after buildPhase.
+      catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
+
+      # Additional arguments to pass to the makeWrapper function, which wraps
+      # generated binaries.
+      makeWrapperArgs ? [ ],
+
+      # Skip wrapping of python programs altogether
+      dontWrapPythonPrograms ? false,
+
+      # Don't use Pip to install a wheel
+      # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
+      # It's included here to prevent an infinite recursion.
+      dontUsePipInstall ? false,
+
+      # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
+      permitUserSite ? false,
+
+      # Remove bytecode from bin folder.
+      # When a Python script has the extension `.py`, bytecode is generated
+      # Typically, executables in bin have no extension, so no bytecode is generated.
+      # However, some packages do provide executables with extensions, and thus bytecode is generated.
+      removeBinBytecode ? true,
+
+      # pyproject = true <-> format = "pyproject"
+      # pyproject = false <-> format = "other"
+      # https://github.com/NixOS/nixpkgs/issues/253154
+      pyproject ? null,
+
+      # Several package formats are supported.
+      # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
+      # "wheel" : Install from a pre-compiled wheel.
+      # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
+      # "egg": Install a package from an egg.
+      # "other" : Provide your own buildPhase and installPhase.
+      format ? null,
+
+      meta ? { },
+
+      doCheck ? true,
+
+      ...
+    }@attrs:
+
     let
       getFinalPassthru =
         let
@@ -283,8 +283,7 @@ let
       name = namePrefix + attrs.name or "${finalAttrs.pname}-${finalAttrs.version}";
 
     in
-    (cleanAttrs attrs)
-    // {
+    {
       inherit name;
 
       inherit catchConflicts;
@@ -449,11 +448,8 @@ let
             "enabledTestPaths"
             "enabledTests"
           ] attrs
-        )
-  );
+        );
 
-  # This derivation transformation function must be independent to `attrs`
-  # for fixed-point arguments support in the future.
   transformDrv =
     let
       # Workaround to make the `lib.extendDerivation`-based disabled functionality
@@ -470,6 +466,4 @@ let
         };
     in
     drv: disablePythonPackage (toPythonModule drv);
-
-in
-transformDrv self
+}

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -37,16 +37,16 @@ let
 
   overrideStdenvCompat =
     f:
-    lib.setFunctionArgs (
+    lib.mirrorFunctionArgs f (
       args:
       if !(lib.isFunction args) && (args ? stdenv) then
         lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511) ''
           Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
             buildPythonPackage.override { stdenv = customStdenv; } { }
-        '' (f.override { stdenv = args.stdenv; } args)
+        '' (f.override { stdenv = args.stdenv; } (removeAttrs args [ "stdenv" ]))
       else
         f args
-    ) (removeAttrs (lib.functionArgs f) [ "stdenv" ])
+    )
     // {
       # Intentionally drop the effect of overrideStdenvCompat when calling `buildPython*.override`.
       inherit (f) override;

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -28,274 +28,294 @@
   eggInstallHook,
 }:
 
-{
-  name ? "${attrs.pname}-${attrs.version}",
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
 
-  # Build-time dependencies for the package
-  nativeBuildInputs ? [ ],
-
-  # Run-time dependencies for the package
-  buildInputs ? [ ],
-
-  # Dependencies needed for running the checkPhase.
-  # These are added to buildInputs when doCheck = true.
-  checkInputs ? [ ],
-  nativeCheckInputs ? [ ],
-
-  # propagate build dependencies so in case we have A -> B -> C,
-  # C can import package A propagated by B
-  propagatedBuildInputs ? [ ],
-
-  # DEPRECATED: use propagatedBuildInputs
-  pythonPath ? [ ],
-
-  # Enabled to detect some (native)BuildInputs mistakes
-  strictDeps ? true,
-
-  outputs ? [ "out" ],
-
-  # used to disable derivation, useful for specific python versions
-  disabled ? false,
-
-  # Raise an error if two packages are installed with the same name
-  # TODO: For cross we probably need a different PYTHONPATH, or not
-  # add the runtime deps until after buildPhase.
-  catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
-
-  # Additional arguments to pass to the makeWrapper function, which wraps
-  # generated binaries.
-  makeWrapperArgs ? [ ],
-
-  # Skip wrapping of python programs altogether
-  dontWrapPythonPrograms ? false,
-
-  # Don't use Pip to install a wheel
-  # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
-  # It's included here to prevent an infinite recursion.
-  dontUsePipInstall ? false,
-
-  # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
-  permitUserSite ? false,
-
-  # Remove bytecode from bin folder.
-  # When a Python script has the extension `.py`, bytecode is generated
-  # Typically, executables in bin have no extension, so no bytecode is generated.
-  # However, some packages do provide executables with extensions, and thus bytecode is generated.
-  removeBinBytecode ? true,
-
-  # Several package formats are supported.
-  # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
-  # "wheel" : Install from a pre-compiled wheel.
-  # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
-  # "egg": Install a package from an egg.
-  # "other" : Provide your own buildPhase and installPhase.
-  format ? "setuptools",
-
-  meta ? { },
-
-  passthru ? { },
-
-  doCheck ? true,
-
-  disabledTestPaths ? [ ],
-
-  ...
-}@attrs:
-
-let
-  withDistOutput = lib.elem format [
-    "pyproject"
-    "setuptools"
-    "wheel"
+  excludeDrvArgNames = [
+    "disabled"
+    "checkPhase"
+    "checkInputs"
+    "nativeCheckInputs"
+    "doCheck"
+    "doInstallCheck"
+    "dontWrapPythonPrograms"
+    "catchConflicts"
+    "format"
+    "disabledTestPaths"
+    "outputs"
   ];
 
-  name_ = name;
+  extendDrvArgs =
+    finalAttrs:
+    {
+      name ? "${attrs.pname}-${attrs.version}",
 
-  validatePythonMatches =
-    attrName:
+      # Build-time dependencies for the package
+      nativeBuildInputs ? [ ],
+
+      # Run-time dependencies for the package
+      buildInputs ? [ ],
+
+      # Dependencies needed for running the checkPhase.
+      # These are added to buildInputs when doCheck = true.
+      checkInputs ? [ ],
+      nativeCheckInputs ? [ ],
+
+      # propagate build dependencies so in case we have A -> B -> C,
+      # C can import package A propagated by B
+      propagatedBuildInputs ? [ ],
+
+      # DEPRECATED: use propagatedBuildInputs
+      pythonPath ? [ ],
+
+      # Enabled to detect some (native)BuildInputs mistakes
+      strictDeps ? true,
+
+      outputs ? [ "out" ],
+
+      # used to disable derivation, useful for specific python versions
+      disabled ? false,
+
+      # Raise an error if two packages are installed with the same name
+      # TODO: For cross we probably need a different PYTHONPATH, or not
+      # add the runtime deps until after buildPhase.
+      catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
+
+      # Additional arguments to pass to the makeWrapper function, which wraps
+      # generated binaries.
+      makeWrapperArgs ? [ ],
+
+      # Skip wrapping of python programs altogether
+      dontWrapPythonPrograms ? false,
+
+      # Don't use Pip to install a wheel
+      # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
+      # It's included here to prevent an infinite recursion.
+      dontUsePipInstall ? false,
+
+      # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
+      permitUserSite ? false,
+
+      # Remove bytecode from bin folder.
+      # When a Python script has the extension `.py`, bytecode is generated
+      # Typically, executables in bin have no extension, so no bytecode is generated.
+      # However, some packages do provide executables with extensions, and thus bytecode is generated.
+      removeBinBytecode ? true,
+
+      # Several package formats are supported.
+      # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
+      # "wheel" : Install from a pre-compiled wheel.
+      # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
+      # "egg": Install a package from an egg.
+      # "other" : Provide your own buildPhase and installPhase.
+      format ? "setuptools",
+
+      meta ? { },
+
+      passthru ? { },
+
+      doCheck ? true,
+
+      disabledTestPaths ? [ ],
+
+      ...
+    }@attrs:
+
     let
-      isPythonModule =
-        drv:
-        # all pythonModules have the pythonModule attribute
-        (drv ? "pythonModule")
-        # Some pythonModules are turned in to a pythonApplication by setting the field to false
-        && (!builtins.isBool drv.pythonModule);
-      isMismatchedPython = drv: drv.pythonModule != python;
+      withDistOutput = lib.elem format [
+        "pyproject"
+        "setuptools"
+        "wheel"
+      ];
 
-      optionalLocation =
+      name_ = name;
+
+      validatePythonMatches =
+        attrName:
         let
-          pos = builtins.unsafeGetAttrPos (if attrs ? "pname" then "pname" else "name") attrs;
+          isPythonModule =
+            drv:
+            # all pythonModules have the pythonModule attribute
+            (drv ? "pythonModule")
+            # Some pythonModules are turned in to a pythonApplication by setting the field to false
+            && (!builtins.isBool drv.pythonModule);
+          isMismatchedPython = drv: drv.pythonModule != python;
+
+          optionalLocation =
+            let
+              pos = builtins.unsafeGetAttrPos (if attrs ? "pname" then "pname" else "name") attrs;
+            in
+            lib.optionalString (pos != null) " at ${pos.file}:${toString pos.line}:${toString pos.column}";
+
+          leftPadName =
+            name: against:
+            let
+              len = lib.max (lib.stringLength name) (lib.stringLength against);
+            in
+            lib.strings.fixedWidthString len " " name;
+
+          throwMismatch =
+            drv:
+            let
+              myName = "'${namePrefix}${name}'";
+              theirName = "'${drv.name}'";
+            in
+            throw ''
+              Python version mismatch in ${myName}:
+
+              The Python derivation ${myName} depends on a Python derivation
+              named ${theirName}, but the two derivations use different versions
+              of Python:
+
+                  ${leftPadName myName theirName} uses ${python}
+                  ${leftPadName theirName myName} uses ${toString drv.pythonModule}
+
+              Possible solutions:
+
+                * If ${theirName} is a Python library, change the reference to ${theirName}
+                  in the ${attrName} of ${myName} to use a ${theirName} built from the same
+                  version of Python
+
+                * If ${theirName} is used as a tool during the build, move the reference to
+                  ${theirName} in ${myName} from ${attrName} to nativeBuildInputs
+
+                * If ${theirName} provides executables that are called at run time, pass its
+                  bin path to makeWrapperArgs:
+
+                      makeWrapperArgs = [ "--prefix PATH : ''${lib.makeBinPath [ ${lib.getName drv} ] }" ];
+
+              ${optionalLocation}
+            '';
+
+          checkDrv = drv: if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch drv else drv;
+
         in
-        lib.optionalString (pos != null) " at ${pos.file}:${toString pos.line}:${toString pos.column}";
-
-      leftPadName =
-        name: against:
-        let
-          len = lib.max (lib.stringLength name) (lib.stringLength against);
-        in
-        lib.strings.fixedWidthString len " " name;
-
-      throwMismatch =
-        drv:
-        let
-          myName = "'${namePrefix}${name}'";
-          theirName = "'${drv.name}'";
-        in
-        throw ''
-          Python version mismatch in ${myName}:
-
-          The Python derivation ${myName} depends on a Python derivation
-          named ${theirName}, but the two derivations use different versions
-          of Python:
-
-              ${leftPadName myName theirName} uses ${python}
-              ${leftPadName theirName myName} uses ${toString drv.pythonModule}
-
-          Possible solutions:
-
-            * If ${theirName} is a Python library, change the reference to ${theirName}
-              in the ${attrName} of ${myName} to use a ${theirName} built from the same
-              version of Python
-
-            * If ${theirName} is used as a tool during the build, move the reference to
-              ${theirName} in ${myName} from ${attrName} to nativeBuildInputs
-
-            * If ${theirName} provides executables that are called at run time, pass its
-              bin path to makeWrapperArgs:
-
-                  makeWrapperArgs = [ "--prefix PATH : ''${lib.makeBinPath [ ${lib.getName drv} ] }" ];
-
-          ${optionalLocation}
-        '';
-
-      checkDrv = drv: if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch drv else drv;
+        inputs: map checkDrv inputs;
 
     in
-    inputs: map checkDrv inputs;
+    {
 
-  # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-  self = toPythonModule (
-    stdenv.mkDerivation (
-      (removeAttrs attrs [
-        "disabled"
-        "checkPhase"
-        "checkInputs"
-        "nativeCheckInputs"
-        "doCheck"
-        "doInstallCheck"
-        "dontWrapPythonPrograms"
-        "catchConflicts"
-        "format"
-        "disabledTestPaths"
-        "outputs"
-      ])
-      // {
+      name = namePrefix + name_;
 
-        name = namePrefix + name_;
+      nativeBuildInputs = [
+        python
+        wrapPython
+        ensureNewerSourcesForZipFilesHook # move to wheel installer (pip) or builder (setuptools, ...)?
+        pythonRemoveTestsDirHook
+      ]
+      ++ lib.optionals catchConflicts [
+        pythonCatchConflictsHook
+      ]
+      ++ lib.optionals removeBinBytecode [
+        pythonRemoveBinBytecodeHook
+      ]
+      ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
+        unzip
+      ]
+      ++ lib.optionals (format == "setuptools") [
+        setuptoolsBuildHook
+      ]
+      ++ lib.optionals (format == "pyproject") [
+        pipBuildHook
+      ]
+      ++ lib.optionals (format == "wheel") [
+        wheelUnpackHook
+      ]
+      ++ lib.optionals (format == "egg") [
+        eggUnpackHook
+        eggBuildHook
+        eggInstallHook
+      ]
+      ++ lib.optionals (format != "other") [
+        pipInstallHook
+      ]
+      ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+        # This is a test, however, it should be ran independent of the checkPhase and checkInputs
+        pythonImportsCheckHook
+      ]
+      ++ lib.optionals withDistOutput [
+        pythonOutputDistHook
+      ]
+      ++ nativeBuildInputs;
 
-        nativeBuildInputs = [
+      buildInputs = validatePythonMatches "buildInputs" (buildInputs ++ pythonPath);
+
+      propagatedBuildInputs = validatePythonMatches "propagatedBuildInputs" (
+        propagatedBuildInputs
+        ++ [
+          # we propagate python even for packages transformed with 'toPythonApplication'
+          # this pollutes the PATH but avoids rebuilds
+          # see https://github.com/NixOS/nixpkgs/issues/170887 for more context
           python
-          wrapPython
-          ensureNewerSourcesForZipFilesHook # move to wheel installer (pip) or builder (setuptools, ...)?
-          pythonRemoveTestsDirHook
         ]
-        ++ lib.optionals catchConflicts [
-          pythonCatchConflictsHook
-        ]
-        ++ lib.optionals removeBinBytecode [
-          pythonRemoveBinBytecodeHook
-        ]
-        ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
-          unzip
-        ]
-        ++ lib.optionals (format == "setuptools") [
-          setuptoolsBuildHook
-        ]
-        ++ lib.optionals (format == "pyproject") [
-          pipBuildHook
-        ]
-        ++ lib.optionals (format == "wheel") [
-          wheelUnpackHook
-        ]
-        ++ lib.optionals (format == "egg") [
-          eggUnpackHook
-          eggBuildHook
-          eggInstallHook
-        ]
-        ++ lib.optionals (format != "other") [
-          pipInstallHook
-        ]
-        ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
-          # This is a test, however, it should be ran independent of the checkPhase and checkInputs
-          pythonImportsCheckHook
-        ]
-        ++ lib.optionals withDistOutput [
-          pythonOutputDistHook
-        ]
-        ++ nativeBuildInputs;
+      );
 
-        buildInputs = validatePythonMatches "buildInputs" (buildInputs ++ pythonPath);
+      inherit strictDeps;
 
-        propagatedBuildInputs = validatePythonMatches "propagatedBuildInputs" (
-          propagatedBuildInputs
-          ++ [
-            # we propagate python even for packages transformed with 'toPythonApplication'
-            # this pollutes the PATH but avoids rebuilds
-            # see https://github.com/NixOS/nixpkgs/issues/170887 for more context
-            python
-          ]
-        );
+      LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
 
-        inherit strictDeps;
+      # Python packages don't have a checkPhase, only an installCheckPhase
+      doCheck = false;
+      doInstallCheck = attrs.doCheck or true;
+      nativeInstallCheckInputs = nativeCheckInputs;
+      installCheckInputs = checkInputs;
 
-        LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
+      postFixup =
+        lib.optionalString (!dontWrapPythonPrograms) ''
+          wrapPythonPrograms
+        ''
+        + attrs.postFixup or "";
 
-        # Python packages don't have a checkPhase, only an installCheckPhase
-        doCheck = false;
-        doInstallCheck = attrs.doCheck or true;
-        nativeInstallCheckInputs = nativeCheckInputs;
-        installCheckInputs = checkInputs;
+      # Python packages built through cross-compilation are always for the host platform.
+      disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
+        python.pythonOnBuildForHost
+      ];
 
-        postFixup =
-          lib.optionalString (!dontWrapPythonPrograms) ''
-            wrapPythonPrograms
-          ''
-          + attrs.postFixup or "";
+      outputs = outputs ++ lib.optional withDistOutput "dist";
 
-        # Python packages built through cross-compilation are always for the host platform.
-        disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
-          python.pythonOnBuildForHost
-        ];
-
-        outputs = outputs ++ lib.optional withDistOutput "dist";
-
-        meta = {
-          # default to python's platforms
-          platforms = python.meta.platforms;
-          isBuildPythonPackage = python.meta.platforms;
-        }
-        // meta;
+      meta = {
+        # default to python's platforms
+        platforms = python.meta.platforms;
+        isBuildPythonPackage = python.meta.platforms;
       }
-      // lib.optionalAttrs (attrs ? checkPhase) {
-        # If given use the specified checkPhase, otherwise use the setup hook.
-        # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-        installCheckPhase = attrs.checkPhase;
-      }
-      // lib.optionalAttrs (disabledTestPaths != [ ]) {
-        disabledTestPaths = lib.escapeShellArgs disabledTestPaths;
-      }
-    )
-  );
+      // meta;
 
-  passthru.updateScript =
+      passthru = {
+        inherit disabled;
+        updateScript =
+          let
+            filename = builtins.head (lib.splitString ":" finalAttrs.finalPackage.meta.position);
+          in
+          [
+            update-python-libraries
+            filename
+          ];
+      }
+      // passthru;
+    }
+    // lib.optionalAttrs (attrs ? checkPhase) {
+      # If given use the specified checkPhase, otherwise use the setup hook.
+      # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
+      installCheckPhase = attrs.checkPhase;
+    }
+    // lib.optionalAttrs (disabledTestPaths != [ ]) {
+      disabledTestPaths = lib.escapeShellArgs disabledTestPaths;
+    };
+
+  transformDrv =
     let
-      filename = builtins.head (lib.splitString ":" self.meta.position);
+      # Workaround to make the `lib.extendDerivation`-based disabled functionality
+      # respect `<pkg>.overrideAttrs`
+      # It doesn't cover `<pkg>.<output>.overrideAttrs`.
+      disablePythonPackage =
+        drv:
+        lib.extendDerivation (
+          drv.disabled
+          -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
+        ) { } drv
+        // {
+          overrideAttrs = fdrv: disablePythonPackage (drv.overrideAttrs fdrv);
+        };
     in
-    attrs.passthru.updateScript or [
-      update-python-libraries
-      filename
-    ];
-in
-lib.extendDerivation (
-  disabled -> throw "${name} not supported for interpreter ${python.executable}"
-) passthru self
+    drv: disablePythonPackage (toPythonModule drv);
+}

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -291,7 +291,11 @@ lib.extendMkDerivation {
             filename
           ];
       }
-      // passthru;
+      // passthru
+      // lib.optionalAttrs (attrs ? stdenv) {
+        # Preserve requested stdenv for backwards compatibility
+        __stdenv = attrs.stdenv;
+      };
     }
     // lib.optionalAttrs (attrs ? checkPhase) {
       # If given use the specified checkPhase, otherwise use the setup hook.

--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -19,11 +19,8 @@
   tree-sitter-grammars,
   versionCheckHook,
 }:
-let
+buildPythonPackage (finalAttrs: {
   version = "0.22.1";
-in
-buildPythonPackage {
-  inherit version;
   pname = "keymap-drawer";
   pyproject = true;
   disabled = pythonOlder "3.12";
@@ -31,7 +28,7 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "caksoylar";
     repo = "keymap-drawer";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-X3O5yspEdey03YQ6JsYN/DE9NUiq148u1W6LQpUQ3ns=";
   };
 
@@ -72,7 +69,7 @@ buildPythonPackage {
   meta = {
     description = "Module and CLI tool to help parse and draw keyboard layouts";
     homepage = "https://github.com/caksoylar/keymap-drawer";
-    changelog = "https://github.com/caksoylar/keymap-drawer/releases/tag/v${version}";
+    changelog = "https://github.com/caksoylar/keymap-drawer/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       MattSturgeon
@@ -84,4 +81,4 @@ buildPythonPackage {
     # incompatibility, thanks to a Python override
     broken = lib.versionAtLeast tree-sitter.version "0.25.0";
   };
-}
+})


### PR DESCRIPTION
Draft PR adding `finalAttrs`-style fix-point argument support to python's `buildPythonPackage`.

This PR's diff is largely indentation changes, so an "ignore whitespace" diff may be helpful.

> [!NOTE]
> The "final attrs" in the fix-point are the attrs passed _by_ `buildPythonPackage` _to_ the underlying `mkDerivation` invocation, **NOT** the attrs passed by the user to `buildPythonPackage`. I.e. _after_ `buildPythonPackage`'s transformations.
>
> This is consistent with other derivation helpers that use `lib.extendMkDerivation`.
>
> This may be confusing, since `buildPythonPackage` makes a number of unintuitive changes under the hood, principally mapping everything `checkPhase`-related to `installCheckPhase` equivalents.

TODO:
- [ ] Get feedback
- [ ] Fix or deprecate custom stdenv support?
- [ ] Run tests (which ones?)
- [ ] Investigate rebuilds
- [ ] Update documentation

<details><summary>Current rebuilds</summary>
<p>

- [opensplatWithCuda](https://search.nixos.org/packages?channel=unstable&show=opensplatWithCuda&from=0&size=50&sort=relevance&type=packages&query=opensplatWithCuda)
- [python312Packages.cupy](https://search.nixos.org/packages?channel=unstable&show=python312Packages.cupy&from=0&size=50&sort=relevance&type=packages&query=python312Packages.cupy)
- [python312Packages.dmt-core](https://search.nixos.org/packages?channel=unstable&show=python312Packages.dmt-core&from=0&size=50&sort=relevance&type=packages&query=python312Packages.dmt-core)
- [python312Packages.torchWithCuda](https://search.nixos.org/packages?channel=unstable&show=python312Packages.torchWithCuda&from=0&size=50&sort=relevance&type=packages&query=python312Packages.torchWithCuda)
- [python312Packages.verilogae](https://search.nixos.org/packages?channel=unstable&show=python312Packages.verilogae&from=0&size=50&sort=relevance&type=packages&query=python312Packages.verilogae)
- [python313Packages.cupy](https://search.nixos.org/packages?channel=unstable&show=python313Packages.cupy&from=0&size=50&sort=relevance&type=packages&query=python313Packages.cupy)
- [python313Packages.dmt-core](https://search.nixos.org/packages?channel=unstable&show=python313Packages.dmt-core&from=0&size=50&sort=relevance&type=packages&query=python313Packages.dmt-core)
- [python313Packages.torchWithCuda](https://search.nixos.org/packages?channel=unstable&show=python313Packages.torchWithCuda&from=0&size=50&sort=relevance&type=packages&query=python313Packages.torchWithCuda)
- [python313Packages.verilogae](https://search.nixos.org/packages?channel=unstable&show=python313Packages.verilogae&from=0&size=50&sort=relevance&type=packages&query=python313Packages.verilogae)
- [webmacs](https://search.nixos.org/packages?channel=unstable&show=webmacs&from=0&size=50&sort=relevance&type=packages&query=webmacs)
- [xpraWithNvenc](https://search.nixos.org/packages?channel=unstable&show=xpraWithNvenc&from=0&size=50&sort=relevance&type=packages&query=xpraWithNvenc)</details>


</p>
</details> 

Future work:
- [ ] Add "overlay extension function" support to `overridePythonAttrs` (matching `overrideAttrs`)
- [ ] Provide access to the "final python attrs" passed to `buildPythonPackage` or `overridePythonAttrs` (maybe via a passthru?)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

So far I've only spot-tested locally, by verifying specific packages are not rebuilt.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
