### PR TITLE
Revert "nixos/tests: More temporary uaccess fixes"

### DIFF
--- a/nixos/tests/budgie.nix
+++ b/nixos/tests/budgie.nix
@@ -54,8 +54,7 @@
           machine.succeed("xauth merge ${user.home}/.Xauthority")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if Budgie session components actually start"):
           for i in ["budgie-daemon", "budgie-panel", "budgie-wm", "budgie-desktop-view", "gsd-media-keys"]:

--- a/nixos/tests/cinnamon-wayland.nix
+++ b/nixos/tests/cinnamon-wayland.nix
@@ -42,8 +42,7 @@
           machine.wait_for_file("/run/user/${toString user.uid}/wayland-0")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Wait for the Cinnamon shell"):
           # Correct output should be (true, '2')

--- a/nixos/tests/cinnamon.nix
+++ b/nixos/tests/cinnamon.nix
@@ -53,8 +53,7 @@
           machine.succeed("xauth merge ${user.home}/.Xauthority")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Wait for the Cinnamon shell"):
           # Correct output should be (true, '2')

--- a/nixos/tests/enlightenment.nix
+++ b/nixos/tests/enlightenment.nix
@@ -42,8 +42,7 @@
           machine.succeed("xauth merge ${user.home}/.Xauthority")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("First time wizard"):
           machine.wait_for_text("Default")  # Language

--- a/nixos/tests/gnome-extensions.nix
+++ b/nixos/tests/gnome-extensions.nix
@@ -105,8 +105,7 @@
           # wait for alice to be logged in
           machine.wait_for_unit("default.target", "${user.name}")
           # check that logging in has given the user ownership of devices
-          # Change back to /dev/snd/timer after systemd-258.1
-          assert "alice" in machine.succeed("getfacl -p /dev/dri/card0")
+          assert "alice" in machine.succeed("getfacl -p /dev/snd/timer")
 
       with subtest("Wait for GNOME Shell"):
           # correct output should be (true, 'false')

--- a/nixos/tests/gnome-flashback.nix
+++ b/nixos/tests/gnome-flashback.nix
@@ -46,8 +46,7 @@
           machine.wait_for_file("${xauthority}")
           machine.succeed("xauth merge ${xauthority}")
           # Check that logging in has given the user ownership of devices
-          # Change back to /dev/snd/timer after systemd-258.1
-          assert "alice" in machine.succeed("getfacl -p /dev/dri/card0")
+          assert "alice" in machine.succeed("getfacl -p /dev/snd/timer")
 
       with subtest("Wait for Metacity"):
           machine.wait_until_succeeds("pgrep metacity")

--- a/nixos/tests/gnome-xorg.nix
+++ b/nixos/tests/gnome-xorg.nix
@@ -83,8 +83,7 @@
           machine.wait_for_file("${xauthority}")
           machine.succeed("xauth merge ${xauthority}")
           # Check that logging in has given the user ownership of devices
-          # Change back to /dev/snd/timer after systemd-258.1
-          assert "alice" in machine.succeed("getfacl -p /dev/dri/card0")
+          assert "alice" in machine.succeed("getfacl -p /dev/snd/timer")
 
       with subtest("Wait for GNOME Shell"):
           # correct output should be (true, 'false')

--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -76,8 +76,7 @@
           # wait for alice to be logged in
           machine.wait_for_unit("default.target", "${user.name}")
           # check that logging in has given the user ownership of devices
-          # Change back to /dev/snd/timer after systemd-258.1
-          assert "alice" in machine.succeed("getfacl -p /dev/dri/card0")
+          assert "alice" in machine.succeed("getfacl -p /dev/snd/timer")
 
       with subtest("Wait for GNOME Shell"):
           # correct output should be (true, 'false')

--- a/nixos/tests/lxqt.nix
+++ b/nixos/tests/lxqt.nix
@@ -42,8 +42,7 @@
           machine.succeed("su - ${user.name} -c 'xauth merge /tmp/xauth_*'")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if LXQt components actually start"):
           for i in ["openbox", "lxqt-session", "pcmanfm-qt", "lxqt-panel", "lxqt-runner"]:

--- a/nixos/tests/mate.nix
+++ b/nixos/tests/mate.nix
@@ -41,8 +41,7 @@
           machine.succeed("xauth merge ${user.home}/.Xauthority")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if MATE session components actually start"):
           machine.wait_until_succeeds("pgrep marco")

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -72,8 +72,7 @@
           machine.wait_for_file("/run/user/${toString user.uid}/wayland-0")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-          # Change back to /dev/snd/timer after systemd-258.1
-          machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+          machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if Pantheon components actually start"):
           pgrep_list = [

--- a/nixos/tests/xfce-wayland.nix
+++ b/nixos/tests/xfce-wayland.nix
@@ -39,8 +39,7 @@
         machine.wait_for_file("/run/user/${toString user.uid}/wayland-0")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-        # Change back to /dev/snd/timer after systemd-258.1
-        machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+        machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if Xfce components actually start"):
         for p in ["labwc", "xfdesktop", "xfce4-notifyd", "xfconfd", "xfce4-panel"]:

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -38,8 +38,7 @@
         machine.succeed("xauth merge ${user.home}/.Xauthority")
 
       with subtest("Check that logging in has given the user ownership of devices"):
-        # Change back to /dev/snd/timer after systemd-258.1
-        machine.succeed("getfacl -p /dev/dri/card0 | grep -q ${user.name}")
+        machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
       with subtest("Check if Xfce components actually start"):
         machine.wait_for_window("xfce4-panel")


### PR DESCRIPTION
This reverts commit df2e6853205ca30bb6a7726e751bb9ba1d9333e6.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
