### PR TITLE
python3Packages.mat4py: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15296,6 +15296,12 @@
     githubId = 30698906;
     name = "Luna D Dragon";
   };
+  lunaticabs = {
+    name = "Anthony Liu";
+    github = "lunaticabs";
+    githubId = 77927794;
+    email = "lunaticabstraction@gmail.com";
+  };
   luNeder = {
     email = "luana@luana.dev.br";
     matrix = "@luana:catgirl.cloud";

--- a/pkgs/development/python-modules/mat4py/default.nix
+++ b/pkgs/development/python-modules/mat4py/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "mat4py";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nephics";
+    repo = "mat4py";
+    tag = "v${version}";
+    hash = "sha256-iG0ojfoaIZtEyHTuba1kEGazNKXQxOEGHjRc/YxJHr4=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [
+    "tests.py"
+  ];
+
+  meta = {
+    description = "Python module for loading and saving data in the Matlab (TM) MAT-file format";
+    homepage = "https://github.com/nephics/mat4py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lunaticabs ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9066,6 +9066,8 @@ self: super: with self; {
 
   mat2 = callPackage ../development/python-modules/mat2 { };
 
+  mat4py = callPackage ../development/python-modules/mat4py { };
+
   matchpy = callPackage ../development/python-modules/matchpy { };
 
   material-color-utilities = callPackage ../development/python-modules/material-color-utilities { };


### PR DESCRIPTION
I am submitting this PR to package mat4py. This package provides the mat4py library for reading and writing MAT files.

It is added for use in the open-mmlab ecosystem (e.g., mmpretrain).

Since I am the initial contributor, I have set maintainers = [ lib.maintainers.unmaintained ].
However, I would like to volunteer to become the official maintainer for this package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
