### PR TITLE
maintainers/README.md: change name to handle 

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -32,7 +32,7 @@ Commit access to the Nixpkgs repository is not required for that.
 In order to do so, add yourself to the [`maintainer-list.nix`](./maintainer-list.nix), and then to the desired package's `meta.maintainers` list, and send a PR with the changes.
 
 If you're adding yourself as a maintainer as part of another PR (in which you become a maintainer of a package, for example), make your change to
-`maintainer-list.nix` in a separate commit titled `maintainers: add <name>`.
+`maintainer-list.nix` in a separate commit titled `maintainers: add <handle>`.
 
 ### Losing maintainer status
 


### PR DESCRIPTION
As per the CONTRIBUTING.md docs the standard is to use the handle not the name, per refer to: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#commit-conventions

Updated to ensure the documentation aligns.