### PR TITLE
pyglossary: init at 5.1.1

### DIFF
--- a/pkgs/by-name/py/pyglossary-gui/package.nix
+++ b/pkgs/by-name/py/pyglossary-gui/package.nix
@@ -1,0 +1,9 @@
+{
+  python3,
+}:
+
+python3.pkgs.toPythonApplication (
+  python3.pkgs.pyglossary.override {
+    enableGui = true;
+  }
+)

--- a/pkgs/by-name/py/pyglossary/package.nix
+++ b/pkgs/by-name/py/pyglossary/package.nix
@@ -1,0 +1,5 @@
+{
+  python3,
+}:
+
+python3.pkgs.toPythonApplication python3.pkgs.pyglossary

--- a/pkgs/development/python-modules/pyglossary/default.nix
+++ b/pkgs/development/python-modules/pyglossary/default.nix
@@ -10,9 +10,17 @@
   # tests
   versionCheckHook,
 
+  # nativeBuildInputs for GUI
+  gobject-introspection,
+  wrapGAppsHook3,
+
   # dependencies (required for most functionality)
   pyicu,
   lxml,
+  enableGui ? false,
+  # for GUI only
+  pygobject3,
+  gtk3,
 }:
 
 buildPythonPackage rec {
@@ -38,11 +46,22 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
+  ]
+  ++ lib.optionals enableGui [
+    gobject-introspection
+    wrapGAppsHook3
   ];
 
   dependencies = [
     pyicu
     lxml
+  ]
+  ++ lib.optionals enableGui [
+    pygobject3
+  ];
+
+  buildInputs = lib.optionals enableGui [
+    gtk3
   ];
 
   # Many issues with the tests: They require `cd tests` in `preCheck`; Some of

--- a/pkgs/development/python-modules/pyglossary/default.nix
+++ b/pkgs/development/python-modules/pyglossary/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+
+  # build-system
+  setuptools,
+
+  # tests
+  versionCheckHook,
+
+  # dependencies (required for most functionality)
+  pyicu,
+  lxml,
+}:
+
+buildPythonPackage rec {
+  pname = "pyglossary";
+  version = "5.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ilius";
+    repo = "pyglossary";
+    tag = version;
+    hash = "sha256-OrySbbStVSz+WF8D+ODK++lKfYJOm9KCfOxDP3snuKY=";
+  };
+
+  patches = [
+    # Fixes a few install issues, can be removed in the next release. See:
+    # https://github.com/ilius/pyglossary/pull/684
+    (fetchpatch {
+      url = "https://github.com/ilius/pyglossary/commit/f86c91ed987579cd8a1c7f7f278452901ce725ac.patch";
+      hash = "sha256-ewYeNwD3/aSsNbMazgW/3tBpYAPBZdnVu9LCh7tQZjg=";
+    })
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pyicu
+    lxml
+  ];
+
+  # Many issues with the tests: They require `cd tests` in `preCheck`; Some of
+  # them depend upon files in `tests/deprecated`; Even with workarounds to
+  # these 2 issues, many tests require network access. We don't enable the
+  # tests by not adding pytestCheckHook to this list.
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+  env = {
+    # The default --help creates permission errors that may be confusing when
+    # observed in the build log.
+    versionCheckProgramArg = "--version";
+  };
+
+  pythonImportsCheck = [
+    "pyglossary"
+  ];
+
+  meta = {
+    description = "Tool for converting dictionary files aka glossaries. Mainly to help use our offline glossaries in any Open Source dictionary we like on any operating system / device";
+    homepage = "https://github.com/ilius/pyglossary";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "pyglossary";
+  };
+}

--- a/pkgs/development/python-modules/pyglossary/fix-install-issues.patch
+++ b/pkgs/development/python-modules/pyglossary/fix-install-issues.patch
@@ -1,0 +1,93 @@
+diff --git c/pyproject.toml w/pyproject.toml
+index abfb59ac..8f9c2121 100644
+--- c/pyproject.toml
++++ w/pyproject.toml
+@@ -416,11 +416,10 @@ version = "5.1.1"
+ description = "A tool for converting dictionary files aka glossaries."
+ readme = "README.md"
+ authors = [{ name = "Saeed Rasooli", email = "saeed.gnu@gmail.com" }]
+-license = { text = "GPLv3+" }
++license = "GPL-3.0-or-later"
+ keywords = ["dictionary", "glossary"]
+ classifiers = [
+ 	"Development Status :: 5 - Production/Stable",
+-	"License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+ 	"Operating System :: OS Independent",
+ 	"Typing :: Typed",
+ 	"Programming Language :: Python :: 3.11",
+@@ -430,6 +429,9 @@ classifiers = [
+ requires-python = ">= 3.11"
+ dependencies = []
+ 
++[project.scripts]
++pyglossary = "pyglossary.ui.main:main"
++
+ [project.optional-dependencies]
+ all = ["PyICU", "lxml", "beautifulsoup4"]
+ 
+diff --git c/setup.py w/setup.py
+index fd38a060..19df9ee3 100755
+--- c/setup.py
++++ w/setup.py
+@@ -8,8 +8,7 @@ import sys
+ from glob import glob
+ from os.path import dirname, exists, isdir, join
+ 
+-from setuptools import setup
+-from setuptools.command.install import install
++from setuptools import setup, find_packages
+ 
+ VERSION = "5.1.1"
+ log = logging.getLogger("root")
+@@ -46,29 +45,6 @@ def getPipSafeVersion() -> str:
+ 	return VERSION
+ 
+ 
+-class my_install(install):
+-	def run(self) -> None:
+-		install.run(self)
+-		if os.sep == "/":
+-			binPath = join(self.install_scripts, "pyglossary")
+-			log.info(f"creating script file {binPath!r}")
+-			if not exists(self.install_scripts):
+-				os.makedirs(self.install_scripts)
+-				# let it fail on wrong permissions.
+-			elif not isdir(self.install_scripts):
+-				raise OSError(
+-					"installation path already exists "
+-					f"but is not a directory: {self.install_scripts}",
+-				)
+-			open(binPath, "w", encoding="ascii").write("""#!/usr/bin/env -S python3 -O
+-import sys
+-from os.path import dirname
+-sys.path.insert(0, dirname(__file__))
+-from pyglossary.ui.main import main
+-main()""")
+-			os.chmod(binPath, 0o755)
+-
+-
+ root_data_file_names = [
+ 	"about",
+ 	"LICENSE",
+@@ -146,19 +122,14 @@ setup(
+ 	name="pyglossary",
+ 	version=getPipSafeVersion(),
+ 	python_requires=">=3.10.0",
+-	cmdclass={
+-		"install": my_install,
+-	},
+ 	description="A tool for converting dictionary files aka glossaries.",
+ 	long_description_content_type="text/markdown",
+ 	long_description=long_description,
+ 	author="Saeed Rasooli",
+ 	author_email="saeed.gnu@gmail.com",
+-	license="GPLv3+",
++	license="GPL-3.0-or-later",
+ 	url="https://github.com/ilius/pyglossary",
+-	packages=[
+-		"pyglossary",
+-	],
++	packages=find_packages(),
+ 	entry_points={
+ 		"console_scripts": [
+ 			"pyglossary = pyglossary.ui.main:main",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13124,6 +13124,8 @@ self: super: with self; {
 
   pyglm = callPackage ../development/python-modules/pyglm { };
 
+  pyglossary = callPackage ../development/python-modules/pyglossary { };
+
   pygls = callPackage ../development/python-modules/pygls { };
 
   pygltflib = callPackage ../development/python-modules/pygltflib { };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
