### PR TITLE
nixos/virtualisation: ensure the VM Nix store supports `idmap` for nixos-containers

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -201,7 +201,10 @@ let
       --notify-ready=yes \
       --kill-signal=SIGRTMIN+3 \
       --bind-ro=/nix/store:/nix/store$NIX_BIND_OPT \
-      --bind-ro=/nix/var/nix/db:/nix/var/nix/db$NIX_BIND_OPT \
+      ${
+        optionalString (config.virtualisation.writableStore or true
+        ) "--bind-ro=/nix/var/nix/db:/nix/var/nix/db$NIX_BIND_OPT"
+      } \
       --bind-ro=/nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket$NIX_BIND_OPT \
       --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles$NIX_BIND_OPT" \
       --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots$NIX_BIND_OPT" \
@@ -1209,6 +1212,30 @@ in
           "tap"
           "tun"
         ];
+
+        # Ensure that the filesystem of the Nix store mounted inside the VM
+        # supports idmap via systemd.
+        # See https://github.com/NixOS/nixpkgs/issues/451167
+        virtualisation.vmVariant.virtualisation =
+          let
+            privateUserNamespaces = (
+              builtins.any (
+                container:
+                !(builtins.elem container.privateUsers [
+                  0
+                  "no"
+                  "identity"
+                ])
+              ) (builtins.attrValues config.containers)
+            );
+          in
+          lib.mkIf privateUserNamespaces {
+            # systemd seems unable to apply idmap to OverlayFS
+            # See https://github.com/systemd/systemd/issues/25886
+            writableStore = false;
+            # 9p mounts do not support idmap
+            useNixStoreImage = true;
+          };
       }
     ))
   ];


### PR DESCRIPTION
The nixos-containers module requires the filesystem of the Nix store to support `idmap` via systemd when private user namespaces are used. Currently, systemd does not support `idmap` on OverlayFS mounts.

Making the Nix store read-only inside the VM yields a raw 9p mount of the host's Nix store, but 9p also does not support idmap. Therefore, when private user namespaces are configured for nixos-containers, fall back to utilizing a read-only store image.

Because creating store images increases VM startup times and consumes considerably more disk space, do not apply this workaround if private user namespaces are not used.

Resolves #451167

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
