### PR TITLE
prek: 0.2.4 -> 0.2.11

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.2.4";
+  version = "0.2.11";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XvNvVWEmJpsY2AxTYLT0/4IiJ2QTI4mWwDleMmZ2LgA=";
+    hash = "sha256-wzbvofNOAtqbjO5//ECu1FeZrS0FyDvFZPKxC0fOJnE=";
   };
 
-  cargoHash = "sha256-PDYCO1ggKwtMR9tnokY7JqVM03FWsO4c2L4GV+7TKu4=";
+  cargoHash = "sha256-KVGdAPyUlPCgcx1DpZbfNRNmALdJvzOcsv3WQy3Q7OI=";
 
   preBuild = ''
     version312_str=$(${python312}/bin/python -c 'import sys; print(sys.version_info[:3])')
@@ -38,6 +38,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export TMP=$TEMP
     export TMPDIR=$TEMP
     export PREK_INTERNAL__TEST_DIR=$TEMP
+
+    export UV_PROJECT_ENVIRONMENT="$(mktemp -d)"
+    cleanup() {
+        rm -rf "$UV_PROJECT_ENVIRONMENT"
+        rm -rf "$TEMP"
+    }
+    trap cleanup EXIT
   '';
 
   __darwinAllowLocalNetworking = true;
@@ -58,6 +65,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "node"
     "script"
     "check_useless_excludes_remote"
+    "run_worktree"
     # "meta_hooks"
     "reuse_env"
     "docker::docker"
@@ -99,8 +107,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "builtin_hooks_workspace_mode"
     "fix_byte_order_marker_hook"
     "fix_byte_order_marker"
+    "check_merge_conflict_hook"
+    "check_merge_conflict_without_assume_flag"
+    "check_symlinks_hook_unix"
+    "check_xml_hook"
+    "check_xml_with_features"
+    "detect_private_key_hook"
+    "no_commit_to_branch_hook"
+    "no_commit_to_branch_hook_with_custom_branches"
+    "no_commit_to_branch_hook_with_patterns"
     # does not properly use TMP
     "hook_impl"
+    # problems with environment
+    "try_repo_specific_hook"
+    "try_repo_specific_rev"
+    # lua path is hardcoded
+    "lua::additional_dependencies"
+    "lua::health_check"
+    "lua::hook_stderr"
+    "lua::lua_environment"
+    "lua::remote_hook"
+    # error message differs
+    "run_in_non_git_repo"
   ];
 
   meta = {


### PR DESCRIPTION
The link to changelogs is here:

- https://github.com/j178/prek/releases/tag/v0.2.11
- https://github.com/j178/prek/releases/tag/v0.2.10
- https://github.com/j178/prek/releases/tag/v0.2.9
- https://github.com/j178/prek/releases/tag/v0.2.8
- https://github.com/j178/prek/releases/tag/v0.2.5

This fixes the issue with prek raised in https://github.com/NixOS/nixpkgs/issues/455265.
The tarmagedon issue in prek was fixed with https://github.com/j178/prek/pull/952


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
