### PR TITLE
lxqt.{libfm-qt,libqtxdg,lxqt-panel,lxqt-qtplugin,screengrab,xdg-desktop-portal-lxqt}: fix build against Qt >= 6.10

### DIFF
--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -20,23 +20,23 @@
   qtx11extras ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libfm-qt";
   inherit version;
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "libfm-qt";
-    rev = version;
+    tag = finalAttrs.version;
     hash =
       {
         "1.4.0" = "sha256-QxPYSA7537K+/dRTxIYyg+Q/kj75rZOdzlUsmSdQcn4=";
         "2.2.0" = "sha256-xLXHwrcMJ8PObZ2qWVZTf9FREcjUi5qtcCJgNHj391Q=";
       }
-      ."${version}";
+      ."${finalAttrs.version}";
   };
 
-  patches = lib.optionals (version == "2.2.0") [
+  patches = lib.optionals (finalAttrs.version == "2.2.0") [
     # fix build against Qt >= 6.10 (https://github.com/lxqt/libfm-qt/pull/1060)
     # TODO: drop when upgrading beyond version 2.2.0
     (fetchpatch {
@@ -63,15 +63,15 @@ stdenv.mkDerivation rec {
     lxqt-menu-data
     menu-cache
   ]
-  ++ (lib.optionals (lib.versionAtLeast "2.0.0" version) [ qtx11extras ]);
+  ++ (lib.optionals (lib.versionAtLeast "2.0.0" finalAttrs.version) [ qtx11extras ]);
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lxqt/libfm-qt";
     description = "Core library of PCManFM-Qt (Qt binding for libfm)";
-    license = licenses.lgpl21Plus;
-    platforms = with platforms; unix;
-    teams = [ teams.lxqt ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.lxqt ];
   };
-}
+})

--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   libXdmcp,
   libexif,
@@ -34,6 +35,16 @@ stdenv.mkDerivation rec {
       }
       ."${version}";
   };
+
+  patches = lib.optionals (version == "2.2.0") [
+    # fix build against Qt >= 6.10 (https://github.com/lxqt/libfm-qt/pull/1060)
+    # TODO: drop when upgrading beyond version 2.2.0
+    (fetchpatch {
+      name = "cmake-fix-build-with-Qt-6.10.patch";
+      url = "https://github.com/lxqt/libfm-qt/commit/3bcbae5831f5ce3d2f06dc370f0c2ad0026ae82a.patch";
+      hash = "sha256-nTuPXlkP7AzC8R4OHfQx6/kxPsDjaw7tGzQGyiYqQSQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   qtbase,
   qtsvg,
@@ -26,6 +27,16 @@ stdenv.mkDerivation rec {
       }
       ."${version}";
   };
+
+  patches = lib.optionals (version == "4.2.0") [
+    # fix build against Qt >= 6.10 (https://github.com/lxqt/libqtxdg/pull/313)
+    # TODO: drop when upgrading beyond version 4.2.0
+    (fetchpatch {
+      name = "cmake-fix-build-with-Qt-6.10.patch";
+      url = "https://github.com/lxqt/libqtxdg/commit/b01a024921acdfd5b0e97d5fda2933c726826e99.patch";
+      hash = "sha256-njpn6pU9BHlfYfkw/jEwh8w3Wo1F8MlRU8iQB+Tz2zU=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -12,23 +12,23 @@
   version ? "4.2.0",
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libqtxdg";
   inherit version;
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "libqtxdg";
-    rev = version;
+    tag = finalAttrs.version;
     hash =
       {
         "3.12.0" = "sha256-y+3noaHubZnwUUs8vbMVvZPk+6Fhv37QXUb//reedCU=";
         "4.2.0" = "sha256-TSyVYlWsmB/6gxJo+CjROBQaWsmYZAwkM8BwiWP+XBI=";
       }
-      ."${version}";
+      ."${finalAttrs.version}";
   };
 
-  patches = lib.optionals (version == "4.2.0") [
+  patches = lib.optionals (finalAttrs.version == "4.2.0") [
     # fix build against Qt >= 6.10 (https://github.com/lxqt/libqtxdg/pull/313)
     # TODO: drop when upgrading beyond version 4.2.0
     (fetchpatch {
@@ -59,11 +59,11 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lxqt/libqtxdg";
     description = "Qt implementation of freedesktop.org xdg specs";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    teams = [ teams.lxqt ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.lxqt ];
   };
-}
+})

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -34,14 +34,14 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lxqt-panel";
   version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-panel";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-ui+HD2igPiyIOgIKPbgfO4dnfm2rFP/R6oG2pH5g5VY=";
   };
 
@@ -91,12 +91,12 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lxqt/lxqt-panel";
     description = "LXQt desktop panel";
     mainProgram = "lxqt-panel";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    teams = [ teams.lxqt ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.lxqt ];
   };
-}
+})

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   alsa-lib,
@@ -43,6 +44,16 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-ui+HD2igPiyIOgIKPbgfO4dnfm2rFP/R6oG2pH5g5VY=";
   };
+
+  patches = [
+    # fix build against Qt >= 6.10 (https://github.com/lxqt/lxqt-panel/pull/2306)
+    # TODO: drop when upgrading beyond version 2.2.2
+    (fetchpatch {
+      name = "cmake-fix-build-with-Qt-6.10.patch";
+      url = "https://github.com/lxqt/lxqt-panel/commit/fce8cd99a1de0e637e8539c4d8ac68832a40fa6d.patch";
+      hash = "sha256-KXxV6SZqdpvZSn+zbBZ32Qs6XKfFXEej1F4qBt+MzxA=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
@@ -15,14 +15,14 @@
   wrapQtAppsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lxqt-qtplugin";
   version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "lxqt-qtplugin";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-qXadz9JBk4TURAWj6ByP/lGV1u0Z6rNJ/VraBh5zY+Q=";
   };
 
@@ -58,11 +58,11 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lxqt/lxqt-qtplugin";
     description = "LXQt Qt platform integration plugin";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    teams = [ teams.lxqt ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.lxqt ];
   };
-}
+})

--- a/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   libdbusmenu-lxqt,
   libfm-qt,
@@ -24,6 +25,16 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-qXadz9JBk4TURAWj6ByP/lGV1u0Z6rNJ/VraBh5zY+Q=";
   };
+
+  patches = [
+    # fix build against Qt >= 6.10 (https://github.com/lxqt/lxqt-qtplugin/pull/100)
+    # TODO: drop when upgrading beyond version 2.2.0
+    (fetchpatch {
+      name = "cmake-fix-build-with-Qt-6.10.patch";
+      url = "https://github.com/lxqt/lxqt-qtplugin/commit/90473945206dbf21816a00dfba27426a5b5a9e25.patch";
+      hash = "sha256-cCghOJHsveR5IYisEFv3h8WreRDi0kuyj/2YBD+ATsc=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/screengrab/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   autoPatchelfHook,
   gitUpdater,
@@ -30,6 +31,16 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-6cGj3Ijv4DsAdJjcHKUg5et+yYc5miIHHZOTD2D9ASk=";
   };
+
+  patches = [
+    # fix build against Qt >= 6.10 (https://github.com/lxqt/screengrab/pull/434)
+    # TODO: drop when upgrading beyond version 3.0.0
+    (fetchpatch {
+      name = "cmake-fix-build-with-Qt-6.10.patch";
+      url = "https://github.com/lxqt/screengrab/commit/1621ef5df9461cdd1dcef3faee36e9419f1ca08c.patch";
+      hash = "sha256-+rpCDLnHmgy/1PME3QaN+978W+jR6PDmiZ/5hAx8Djg=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/desktops/lxqt/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/screengrab/default.nix
@@ -21,14 +21,14 @@
   wrapQtAppsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "screengrab";
   version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "screengrab";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-6cGj3Ijv4DsAdJjcHKUg5et+yYc5miIHHZOTD2D9ASk=";
   };
 
@@ -65,12 +65,12 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lxqt/screengrab";
     description = "Crossplatform tool for fast making screenshots";
     mainProgram = "screengrab";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    teams = [ teams.lxqt ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.lxqt ];
   };
-}
+})

--- a/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
+++ b/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
@@ -15,14 +15,14 @@
   extraQtStyles ? [ ],
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-lxqt";
   version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "xdg-desktop-portal-lxqt";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-y3VqDuFagKcG8O5m5qjRGtlUZXfIXV0tclvZLChhWkg=";
   };
 
@@ -53,11 +53,11 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gitUpdater { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lxqt/xdg-desktop-portal-lxqt";
     description = "Backend implementation for xdg-desktop-portal that is using Qt/KF5/libfm-qt";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ romildo ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.romildo ];
   };
-}
+})

--- a/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
+++ b/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   kwindowsystem,
   libexif,
@@ -24,6 +25,16 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-y3VqDuFagKcG8O5m5qjRGtlUZXfIXV0tclvZLChhWkg=";
   };
+
+  patches = [
+    # fix build against Qt >= 6.10 (https://github.com/lxqt/xdg-desktop-portal-lxqt/pull/50)
+    # TODO: drop when upgrading beyond version 1.2.0
+    (fetchpatch {
+      name = "cmake-fix-build-with-Qt-6.10.patch";
+      url = "https://github.com/lxqt/xdg-desktop-portal-lxqt/commit/15fae3c57a8e8149ef19a8c919f5728016390e3f.patch";
+      hash = "sha256-oReYMEr+tBDHtnFDZahBwTtzgtL/BABZO64yob9tem4=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `ea9f4739b60e933dee0d02972cdbdda94b12b856`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 24 packages built:</summary>
  <ul>
    <li>lxqt.libfm-qt</li>
    <li>lxqt.liblxqt</li>
    <li>lxqt.libqtxdg</li>
    <li>lxqt.lximage-qt</li>
    <li>lxqt.lxqt-about</li>
    <li>lxqt.lxqt-admin</li>
    <li>lxqt.lxqt-archiver</li>
    <li>lxqt.lxqt-config</li>
    <li>lxqt.lxqt-globalkeys</li>
    <li>lxqt.lxqt-notificationd</li>
    <li>lxqt.lxqt-openssh-askpass</li>
    <li>lxqt.lxqt-panel</li>
    <li>lxqt.lxqt-policykit</li>
    <li>lxqt.lxqt-powermanagement</li>
    <li>lxqt.lxqt-qtplugin</li>
    <li>lxqt.lxqt-runner</li>
    <li>lxqt.lxqt-session</li>
    <li>lxqt.lxqt-sudo</li>
    <li>lxqt.lxqt-wayland-session</li>
    <li>lxqt.pcmanfm-qt</li>
    <li>lxqt.qps</li>
    <li>lxqt.qtxdg-tools</li>
    <li>lxqt.screengrab</li>
    <li>lxqt.xdg-desktop-portal-lxqt</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc