### PR TITLE
nixos/tailscale: warn about trustedInterfaces

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -141,6 +141,25 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings =
+      optional
+        (
+          config.networking.firewall.enable
+          && !(any (x: x == cfg.interfaceName) config.networking.firewall.trustedInterfaces)
+        )
+        ''
+          Since version 1.52.0 Tailscale creates a firewall rule that accepts
+          all incoming traffic on its interface. This effectively disables the
+          NixOS firewall on this interface.
+
+          To disable this warning explicitly add the Tailscale interface to the
+          firewall's trustedInterfaces:
+
+              networking.firewall.trustedInterfaces = [ config.services.tailscale.interfaceName ];
+
+          <https://github.com/tailscale/tailscale/commit/ba6ec42f6d5558d04b683755aca63f88b1f2d5fc>
+        '';
+
     environment.systemPackages = [ cfg.package ]; # for the CLI
     systemd.packages = [ cfg.package ];
     systemd.services.tailscaled = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the following warning:

> Since version 1.52.0 Tailscale creates a firewall rule that accepts all incoming traffic on its interface. This effectively disables the NixOS firewall on this interface.
>
> To disable this warning explicitly add the Tailscale interface to the firewall's trustedInterfaces:
>
> ```
> networking.firewall.trustedInterfaces = [ config.services.tailscale.interfaceName ];
> ```
>
> <https://github.com/tailscale/tailscale/commit/ba6ec42f6d5558d04b683755aca63f88b1f2d5fc>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
