### PR TITLE
ci/eval/compare/maintainers: disable aliases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,6 +40,7 @@ jobs:
       - id: prepare
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          retries: 3
           script: |
             require('./ci/github-script/prepare.js')({
               github,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       - id: prepare
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          retries: 3
           script: |
             require('./ci/github-script/prepare.js')({
               github,

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -7,7 +7,13 @@
   removedattrs,
 }:
 let
-  pkgs = import ../../.. { system = "x86_64-linux"; };
+  pkgs = import ../../.. {
+    system = "x86_64-linux";
+    # We should never try to ping maintainers through package aliases, this can only lead to errors.
+    # One example case is, where an attribute is a throw alias, but then re-introduced in a PR.
+    # This would trigger the throw. By disabling aliases, we can fallback gracefully below.
+    config.allowAliases = false;
+  };
 
   changedpaths = lib.importJSON changedpathsjson;
 


### PR DESCRIPTION
We should never try to ping maintainers through package aliases, this can only lead to errors. One example case is, where an attribute is a throw alias, but then re-introduced in a PR. This would trigger the throw. By disabling aliases, we can fallback gracefully.

Should resolve https://github.com/NixOS/nixpkgs/pull/453264#issuecomment-3431434288.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
