### PR TITLE
iio-niri: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28952,6 +28952,11 @@
     githubId = 1329212;
     name = "Andy Zhang";
   };
+  zhaithizaliel = {
+    name = "Zhaith Izaliel";
+    github = "Zhaith-Izaliel";
+    githubId = 39216756;
+  };
   zhaofengli = {
     email = "hello@zhaofeng.li";
     matrix = "@zhaofeng:zhaofeng.li";

--- a/nixos/doc/manual/release-notes/rl-2111.section.md
+++ b/nixos/doc/manual/release-notes/rl-2111.section.md
@@ -166,6 +166,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [twingate](https://docs.twingate.com/docs/linux), a high performance, easy to use zero trust solution that enables access to private resources from any device with better security than a VPN.
 
+- [iio-niri](https://github.com/Zhaith-Izaliel/iio-niri), a utils that listens to `iio-sensor-proxy` and updates Niri output orientation depending on the accelerometer orientation.
+
 ## Backward Incompatibilities {#sec-release-21.11-incompatibilities}
 
 - The NixOS VM test framework, `pkgs.nixosTest`/`make-test-python.nix` (`pkgs.testers.nixosTest` since 22.05), now requires detaching commands such as `succeed("foo &")` and `succeed("foo | xclip -i")` to close stdout.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -240,6 +240,7 @@
   ./programs/iay.nix
   ./programs/iftop.nix
   ./programs/iio-hyprland.nix
+  ./programs/iio-niri.nix
   ./programs/immersed.nix
   ./programs/iotop.nix
   ./programs/java.nix

--- a/nixos/modules/programs/iio-niri.nix
+++ b/nixos/modules/programs/iio-niri.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    mkIf
+    getExe
+    escapeShellArgs
+    mkDefault
+    ;
+  cfg = config.services.iio-niri;
+in
+{
+  options.services.iio-niri = {
+    enable = mkEnableOption "IIO-Niri";
+
+    package = mkPackageOption pkgs "iio-niri" { };
+
+    niriUnit = mkOption {
+      type = types.nonEmptyStr;
+      default = "niri.service";
+      description = "The Niri **user** service unit to bind IIO-Niri's **user** service unit to.";
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Extra arguments to pass to IIO-Niri.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    hardware.sensor.iio.enable = mkDefault true;
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.user.services.iio-niri = {
+      description = "IIO-Niri";
+      wantedBy = [ cfg.niriUnit ];
+      bindsTo = [ cfg.niriUnit ];
+      partOf = [ cfg.niriUnit ];
+      after = [ cfg.niriUnit ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${getExe cfg.package} ${escapeShellArgs cfg.extraArgs}";
+        Restart = "on-failure";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ zhaithizaliel ];
+}

--- a/pkgs/by-name/ii/iio-niri/package.nix
+++ b/pkgs/by-name/ii/iio-niri/package.nix
@@ -1,0 +1,37 @@
+{
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+  dbus,
+  pkg-config,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "iio-niri";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "Zhaith-Izaliel";
+    repo = "iio-niri";
+    tag = "v${version}";
+    hash = "sha256-IOMJ1xtjUkUoUgFZ9pxBf5XKdaUHu3WbUH5TlEiNRc4=";
+  };
+
+  cargoHash = "sha256-b05Jy+EKFAUcHR9+SdjHZUcIZG0Ta+ar/qc0GdRlJik=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+  ];
+
+  meta = {
+    description = "Listen to iio-sensor-proxy and updates Niri output orientation depending on the accelerometer orientation";
+    homepage = "https://github.com/Zhaith-Izaliel/iio-niri";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zhaithizaliel ];
+    mainProgram = "iio-niri";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [IIO-Niri](https://github.com/Zhaith-Izaliel/iio-niri), an utils that listens to iio-sensor-proxy and updates Niri output orientation depending on the accelerometer orientation. This PR adds a corresponding module to the package. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
