### PR TITLE
kubo: 0.36.0 -> 0.38.2

### DIFF
--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -330,8 +330,8 @@ in
     environment.variables.IPFS_PATH = fakeKuboRepo;
 
     # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
-    boot.kernel.sysctl."net.core.rmem_max" = lib.mkDefault 2500000;
-    boot.kernel.sysctl."net.core.wmem_max" = lib.mkDefault 2500000;
+    boot.kernel.sysctl."net.core.rmem_max" = lib.mkDefault 7500000;
+    boot.kernel.sysctl."net.core.wmem_max" = lib.mkDefault 7500000;
 
     programs.fuse = lib.mkIf cfg.autoMount {
       userAllowOther = true;

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -167,7 +167,7 @@ in
       autoMigrate = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = "Whether Kubo should try to run the fs-repo-migration at startup.";
+        description = "Whether Kubo should try to migrate its filesystem repository automatically.";
       };
 
       enableGC = lib.mkOption {
@@ -344,9 +344,6 @@ in
         createHome = false;
         uid = config.ids.uids.ipfs;
         description = "IPFS daemon user";
-        packages = [
-          pkgs.kubo-migrator
-        ];
       };
     };
 
@@ -377,6 +374,7 @@ in
       path = [
         "/run/wrappers"
         cfg.package
+        pkgs.kubo-fs-repo-migrations # Used by 'ipfs repo migrate --to=...'
       ];
       environment.IPFS_PATH = cfg.dataDir;
 
@@ -388,7 +386,7 @@ in
           rm -vf "$IPFS_PATH/api"
       ''
       + lib.optionalString cfg.autoMigrate ''
-        '${lib.getExe pkgs.kubo-migrator}' -to '${cfg.package.repoVersion}' -y
+        '${lib.getExe cfg.package}' repo migrate '--to=${cfg.package.repoVersion}' --allow-downgrade
       ''
       + ''
         fi
@@ -412,7 +410,7 @@ in
       serviceConfig = {
         ExecStart = [
           ""
-          "${cfg.package}/bin/ipfs daemon ${kuboFlags}"
+          "${lib.getExe cfg.package} daemon ${kuboFlags}"
         ];
         User = cfg.user;
         Group = cfg.group;

--- a/pkgs/by-name/ku/kubo-fs-repo-migrations/package.nix
+++ b/pkgs/by-name/ku/kubo-fs-repo-migrations/package.nix
@@ -258,7 +258,8 @@ symlinkJoin {
     longDescription = ''
       This package contains all the individual migrations in the bin directory.
       This is used by fs-repo-migrations and could also be used by Kubo itself
-      when starting it like this: ipfs daemon --migrate
+      when starting it like this: `ipfs daemon --migrate`
+      or when calling `ipfs repo migrate --to=16`.
     '';
   };
 }

--- a/pkgs/by-name/ku/kubo/package.nix
+++ b/pkgs/by-name/ku/kubo/package.nix
@@ -8,15 +8,15 @@
 
 buildGoModule rec {
   pname = "kubo";
-  version = "0.37.0"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.38.2"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
-  passthru.repoVersion = "17";
+  passthru.repoVersion = "18";
 
   # Kubo makes changes to its source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/kubo/releases/download/${rev}/kubo-source.tar.gz";
-    hash = "sha256-/7yWGxqqbiUajkWF5/YL/HUpH0/aevutQwy70VJuieA=";
+    hash = "sha256-A02edHUZoU2oQk4OyCmc/wMfk3k+EWkdO2RxPGlUrXg=";
   };
 
   # tarball contains multiple files/directories

--- a/pkgs/by-name/ku/kubo/package.nix
+++ b/pkgs/by-name/ku/kubo/package.nix
@@ -8,15 +8,15 @@
 
 buildGoModule rec {
   pname = "kubo";
-  version = "0.36.0"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.37.0"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
-  passthru.repoVersion = "16"; # Also update kubo-migrator when changing the repo version
+  passthru.repoVersion = "17";
 
   # Kubo makes changes to its source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/kubo/releases/download/${rev}/kubo-source.tar.gz";
-    hash = "sha256-JbWt6d1cX3F2lmivjszcxcyE+wKYk+Sy03xhb4E3oHw=";
+    hash = "sha256-/7yWGxqqbiUajkWF5/YL/HUpH0/aevutQwy70VJuieA=";
   };
 
   # tarball contains multiple files/directories


### PR DESCRIPTION
https://github.com/ipfs/kubo/releases/tag/v0.37.0
https://github.com/ipfs/kubo/releases/tag/v0.38.0
https://github.com/ipfs/kubo/releases/tag/v0.38.1
https://github.com/ipfs/kubo/releases/tag/v0.38.2

Kubo v0.37.0 embeds the repository migration from repo version v16 to v17 and the kubo-fs-repo-migrations package will not reveive any more updates.
I'll keep the `kubo-fs-repo-migrations` and `kubo-migrator` packages around for now until a future version of Kubo no longer supports calling the external migration binaries.
Since the (newest) migrations are now built into Kubo, the NixOS module now needs to call `ipfs repo migrate --to=xx --allow-downgrade` instead of `fs-repo-migrations --to xx -y`.
The `--allow-downgrade` flag is only there for the unlikely situation that someone downgrades their local Kubo version with an overlay, separate channel input or similar means. It does however not work for rolling back the NixOS generation after a Kubo upgrade which increases the repo version (not all Kubo upgrades increase the repo version). This is because the Kubo version of the previous NixOS generation doesn't have the code for upgrading to or downgrading from the newer repo version.
Since we only have one version of Kubo in Nixpkgs at a time, migrations cannot be tested automatically. I manually verified that `ipfs repo migrate` uses binaries like `fs-repo-15-to-16` provided by the `kubo-fs-repo-migrations` packages for older migrations. I also tested that the migration from v16 to v17 works on my machine using the NixOS module.


Also increase the maximum UDP buffer sizes to get rid of a warning.

Closes #444264.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
