### PR TITLE
nixosTests.limine.secureBoot: fix secure boot check

### DIFF
--- a/nixos/tests/limine/secure-boot.nix
+++ b/nixos/tests/limine/secure-boot.nix
@@ -26,10 +26,12 @@
       boot.loader.limine.secureBoot.enable = true;
       boot.loader.limine.secureBoot.createAndEnrollKeys = true;
       boot.loader.timeout = 0;
+
+      environment.systemPackages = [ pkgs.mokutil ];
     };
 
   testScript = ''
     machine.start()
-    assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
+    assert "SecureBoot enabled" in machine.succeed("mokutil --sb-state")
   '';
 }


### PR DESCRIPTION
An easier way to check if secureBoot is enabled is by running `mokutil --sb-state`. We have to do this way now because on systemd v258 `bootctl status` returns non 0 value if systemd-boot is not properly installed, which is to be expected when using Limine. 

See https://github.com/NixOS/nixpkgs/pull/453583#issuecomment-3432611135 and https://access.redhat.com/articles/5337691.

Thanks @dramforever for finding this!

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
