### PR TITLE
nixos/kubo: add Mounts.FuseAllowOther setting for better documentation of the default value

### DIFF
--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -339,7 +339,7 @@ in
     boot.kernel.sysctl."net.core.rmem_max" = lib.mkDefault 2500000;
     boot.kernel.sysctl."net.core.wmem_max" = lib.mkDefault 2500000;
 
-    programs.fuse = lib.mkIf cfg.autoMount {
+    programs.fuse = lib.mkIf (cfg.autoMount && cfg.settings.Mounts.FuseAllowOther) {
       userAllowOther = true;
     };
 

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -242,6 +242,12 @@ in
               default = "/mfs";
               description = "Where to mount the MFS namespace to";
             };
+
+            Mounts.FuseAllowOther = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Allow all users to access the FUSE mount points";
+            };
           };
         };
         description = ''
@@ -368,10 +374,6 @@ in
     # The hardened systemd unit breaks the fuse-mount function according to documentation in the unit file itself
     systemd.packages =
       if cfg.autoMount then [ cfg.package.systemd_unit ] else [ cfg.package.systemd_unit_hardened ];
-
-    services.kubo.settings = lib.mkIf cfg.autoMount {
-      Mounts.FuseAllowOther = lib.mkDefault true;
-    };
 
     systemd.services.ipfs = {
       path = [


### PR DESCRIPTION
The `Mounts.FuseAllowOther` setting could be used before to override the default but it was not obvious that the default was `true`.

Since this option is irrelevant if the `--mount` flag isn't passed to the daemon (the `autoMount` NixOS option is set to false) the Kubo daemon ignores this setting in this case. This means enabling this option conditionally or not makes no difference in practice, so it might as well be enabled all the time.

Also only set programs.fuse.userAllowOther if required. If `services.kubo.settings.Mounts.FuseAllowOther` is set to `false`, we don't need to set `programs.fuse.userAllowOther` to `true`.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
