### PR TITLE
copyq: 11.0.0 -> 13.0.0

### DIFF
--- a/pkgs/applications/misc/copyq/default.nix
+++ b/pkgs/applications/misc/copyq/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   ninja,
   qtbase,
@@ -19,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "CopyQ";
-  version = "11.0.0";
+  version = "13.0.0";
 
   src = fetchFromGitHub {
     owner = "hluk";
     repo = "CopyQ";
     rev = "v${version}";
-    hash = "sha256-/t+8YsqeX0tlxwQDDNTalttCDIgGhpLbzYe3UqY04xM=";
+    hash = "sha256-wxjUL5mGXAMNVGP+dAh1NrE9tw71cJW9zmLsaCVphTo=";
   };
 
   nativeBuildInputs = [
@@ -48,10 +49,19 @@ stdenv.mkDerivation rec {
     kdePackages.kconfig
     kdePackages.kstatusnotifieritem
     kdePackages.knotifications
+    kdePackages.kguiaddons
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_QT6" true)
+  ];
+
+  patches = [
+    # https://github.com/hluk/CopyQ/pull/3268
+    (fetchpatch2 {
+      url = "https://github.com/hluk/CopyQ/commit/103903593c37c9db5406d276e0097fbf18d2a8c4.patch?full_index=1";
+      hash = "sha256-zywE6ntMw+WvTyilXwvd4lfQRAAB9R/AGpwtwwPFZZE=";
+    })
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Release 13.0.0 · hluk/CopyQ](https://github.com/hluk/CopyQ/releases/tag/v13.0.0)

According to release notes, we should add `KGuiAddons` to the build, without it, the following error occurs:

```text
CMake Error at src/platform/x11/x11platform.cmake:56 (find_package):
  By not providing "FindKF6GuiAddons.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "KF6GuiAddons", but CMake did not find one.

  Could not find a package configuration file provided by "KF6GuiAddons" with
  any of the following names:

    KF6GuiAddonsConfig.cmake
    kf6guiaddons-config.cmake

  Add the installation prefix of "KF6GuiAddons" to CMAKE_PREFIX_PATH or set
  "KF6GuiAddons_DIR" to a directory containing one of the above files.  If
  "KF6GuiAddons" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  src/platform/platform.cmake:13 (include)
  src/CMakeLists.txt:25 (include)


-- Configuring incomplete, errors occurred!
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
