### PR TITLE
lib/trivial: add abs and rem; rewrite mod from integer modulus to mathematical modulus

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -152,6 +152,7 @@ let
         oldestSupportedReleaseIsAtLeast
         mod
         rem
+        abs
         compare
         splitByAndCompare
         seq

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -151,6 +151,7 @@ let
         isInOldestRelease
         oldestSupportedReleaseIsAtLeast
         mod
+        rem
         compare
         splitByAndCompare
         seq

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -586,6 +586,51 @@ in
   */
   mod = base: int: base - (int * (builtins.div base int));
 
+  /**
+    C-style remainder
+
+    # Inputs
+
+    `dividend`
+
+    : The number to be divided
+
+    `divisor`
+
+    : The number by which to divide
+
+    # Examples
+    :::{.example}
+    ## `lib.trivial.rem` usage example
+
+    ```nix
+    rem 11 10
+    # => 1
+    rem 1 10
+    # => 1
+    rem (-1) 10
+    # => -1
+    rem 10 (-3)
+    # => 1
+    rem 5.5 2
+    # => 1.5
+    rem (-3.7) 2.5
+    # => -1.2
+    ```
+
+    :::
+  */
+  rem =
+    dividend: divisor:
+    let
+      quotient =
+        if dividend >= 0 then
+          builtins.floor (dividend / divisor)
+        else
+          -builtins.floor (-dividend / divisor);
+    in
+    dividend - quotient * divisor;
+
   ## Comparisons
 
   /**

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -631,6 +631,32 @@ in
     in
     dividend - quotient * divisor;
 
+  /**
+    Absolute value
+
+    # Inputs
+
+    `n`
+
+    : A number
+
+    # Examples
+    :::{.example}
+    ## `lib.trivial.abs` usage example
+
+    ```nix
+    abs 1
+    # => 1
+    abs -1
+    # => 1
+    abs -12.34
+    # => 12.34
+    ```
+
+    :::
+  */
+  abs = n: if n < 0 then -n else n;
+
   ## Comparisons
 
   /**

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -559,17 +559,17 @@ in
   max = x: y: if x > y then x else y;
 
   /**
-    Integer modulus
+    Mathematical modulus
 
     # Inputs
 
-    `base`
+    `dividend`
 
-    : 1\. Function argument
+    : The number to be divided
 
-    `int`
+    `divisor`
 
-    : 2\. Function argument
+    : The number by which to divide
 
     # Examples
     :::{.example}
@@ -580,11 +580,25 @@ in
     => 1
     mod 1 10
     => 1
+    mod (-1) 10
+    => 9
+    mod 10 (-3)
+    => 1
+    mod 5.5 2
+    => 1.5
+    mod (-3.7) 2.5
+    => 1.3
     ```
 
     :::
   */
-  mod = base: int: base - (int * (builtins.div base int));
+  mod =
+    dividend: divisor:
+    let
+      quotient = builtins.floor (dividend / divisor);
+      remainder = dividend - quotient * divisor;
+    in
+    if remainder < 0 then remainder + lib.abs divisor else remainder;
 
   /**
     C-style remainder


### PR DESCRIPTION
I don't see any reason for `lib.mod` (mathematical modulus) to be limited to integer values. It's just misleading

I also added `lib.rem` (C-style remainder) for related semantics and `lib.abs` because a basic absolute value function was missing, is often implemented manually, and is used by `lib.mod`.

~~I don't think this rewrite of `lib.mod` will break anything because it only removes the restriction to integer values.~~

The new `lib.mod` does not behave the same as the old `lib.mod` for negative dividends, because the **old `lib.mod` is a C-style remainder (`lib.rem`)**. I am not sure what the best approach is in this case, as it could break someone's code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
