### PR TITLE
msgpack-tools: Fix build

### DIFF
--- a/pkgs/by-name/ms/msgpack-tools/cmake-v4.patch
+++ b/pkgs/by-name/ms/msgpack-tools/cmake-v4.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt	2025-10-23 07:12:12.766221736 +0100
++++ b/CMakeLists.txt	2025-10-23 07:14:58.069499300 +0100
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 2.6...3.10)
+ 
+ include(GNUInstallDirs)
+ include(CheckCCompilerFlag)

--- a/pkgs/by-name/ms/msgpack-tools/package.nix
+++ b/pkgs/by-name/ms/msgpack-tools/package.nix
@@ -1,51 +1,62 @@
 {
   lib,
   stdenv,
-  fetchurl,
   fetchFromGitHub,
+  fetchurl,
   cmake,
+  rapidjson,
+  replaceVars,
+  libb64,
+  versionCheckHook,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "msgpack-tools";
   version = "0.6";
 
   src = fetchFromGitHub {
     owner = "ludocode";
     repo = "msgpack-tools";
-    rev = "v${version}";
-    sha256 = "1ygjk25zlpqjckxgqmahnz999704zy2bd9id6hp5jych1szkjgs5";
-  };
-
-  libb64 = fetchurl {
-    url = "mirror://sourceforge/libb64/libb64-1.2.1.zip";
-    sha256 = "1chlcc8qggzxnbpy5wrda533xyz38dk20w9wl4srrzawm45ny410";
-  };
-
-  rapidjson = fetchurl {
-    url = "https://github.com/miloyip/rapidjson/archive/99ba17bd66a85ec64a2f322b68c2b9c3b77a4391.tar.gz";
-    sha256 = "0jxgyy5n0lf9w36dycwwgz2wici4z9dnxlsn0z6m23zaa47g3wyw";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-RT85vw6QeVkuNC2mtoT/BJyU0rdQVfz6ZBJf+ouY8vk=";
   };
 
   mpack = fetchurl {
     url = "https://github.com/ludocode/mpack/archive/df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz";
-    sha256 = "1br8g3rf86h8z8wbqkd50aq40953862lgn0xk7cy68m07fhqc3pg";
+    hash = "sha256-hyiXygbAHnNgF4TIg+DemBvtdBnSgJ7fAhknVuL+T/c=";
   };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    rapidjson
+    libb64
+  ];
+
+  patches = [
+    ./cmake-v4.patch
+    (replaceVars ./use-nix-deps.patch {
+      rapidjson = "${rapidjson}";
+      libb64 = "${libb64}";
+    })
+  ];
 
   postUnpack = ''
     mkdir $sourceRoot/contrib
-    cp ${rapidjson} $sourceRoot/contrib/rapidjson-99ba17bd66a85ec64a2f322b68c2b9c3b77a4391.tar.gz
-    cp ${libb64} $sourceRoot/contrib/libb64-1.2.1.zip
-    cp ${mpack} $sourceRoot/contrib/mpack-df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz
+    cp ${finalAttrs.mpack} $sourceRoot/contrib/mpack-df17e83f0fa8571b9cd0d8ccf38144fa90e244d1.tar.gz
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/json2msgpack";
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Command-line tools for converting between MessagePack and JSON";
     homepage = "https://github.com/ludocode/msgpack-tools";
-    license = licenses.mit;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ deejayem ];
   };
-}
+})

--- a/pkgs/by-name/ms/msgpack-tools/use-nix-deps.patch
+++ b/pkgs/by-name/ms/msgpack-tools/use-nix-deps.patch
@@ -1,0 +1,67 @@
+--- a/CMakeLists.txt	2017-01-22 19:51:41.000000000 +0000
++++ b/CMakeLists.txt	2025-10-04 14:08:24.934041902 +0100
+@@ -83,57 +83,21 @@
+ 
+ # rapidjson
+ 
+-set(RAPIDJSON_FILE "rapidjson-${RAPIDJSON_COMMIT}.tar.gz")
+-set(RAPIDJSON_DIR "${CONTRIB_DIR}/rapidjson-${RAPIDJSON_COMMIT}")
+-set(RAPIDJSON_URL "https://github.com/miloyip/rapidjson/archive/${RAPIDJSON_COMMIT}.tar.gz")
+-
+-if(EXISTS "${CMAKE_SOURCE_DIR}/contrib/${RAPIDJSON_FILE}")
+-    message(STATUS "Found package: ${RAPIDJSON_FILE}")
+-else()
+-    message(STATUS "Downloading: ${RAPIDJSON_FILE}")
+-    file(DOWNLOAD ${RAPIDJSON_URL} "${CMAKE_SOURCE_DIR}/contrib/${RAPIDJSON_FILE}")
+-    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/contrib/${RAPIDJSON_FILE}")
+-        message(FATAL_ERROR "\nFailed to download source file: ${RAPIDJSON_FILE}\nFrom: ${RAPIDJSON_URL}")
+-    endif()
+-endif()
+-
+-execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_SOURCE_DIR}/contrib/${RAPIDJSON_FILE} WORKING_DIRECTORY ${CONTRIB_DIR})
+-
+-include_directories(SYSTEM ${RAPIDJSON_DIR}/include)
++include_directories(SYSTEM @rapidjson@/include)
+ 
+ 
+ # libb64
+ 
+-set(LIBB64_FILE "libb64-${LIBB64_VERSION}.zip")
+-set(LIBB64_DIR "${CONTRIB_DIR}/libb64-${LIBB64_VERSION}")
+-set(LIBB64_URL "http://downloads.sourceforge.net/project/libb64/libb64/libb64/${LIBB64_FILE}?use_mirror=autoselect")
+-
+-if(EXISTS "${CMAKE_SOURCE_DIR}/contrib/${LIBB64_FILE}")
+-    message(STATUS "Found package: ${LIBB64_FILE}")
+-else()
+-    message(STATUS "Downloading: ${LIBB64_FILE}")
+-    file(DOWNLOAD ${LIBB64_URL} "${CMAKE_SOURCE_DIR}/contrib/${LIBB64_FILE}")
+-    if(NOT EXISTS "${CMAKE_SOURCE_DIR}/contrib/${LIBB64_FILE}")
+-        message(FATAL_ERROR "\nFailed to download source file: ${LIBB64_FILE}\nFrom: ${LIBB64_URL}")
+-    endif()
+-endif()
+-
+-execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_SOURCE_DIR}/contrib/${LIBB64_FILE}" WORKING_DIRECTORY "${CONTRIB_DIR}")
+-
+-# Remove libb64's newlines
+-set(LIBB64_CENCODE_FILE ${LIBB64_DIR}/src/cencode.c)
+-file(READ ${LIBB64_CENCODE_FILE} LIBB64_CENCODE)
+-string(REPLACE "*codechar++ = '\\n';" "/* *codechar++ = '\\n'; */" LIBB64_CENCODE "${LIBB64_CENCODE}")
+-file(WRITE ${LIBB64_CENCODE_FILE} "${LIBB64_CENCODE}")
+-
+-file(GLOB_RECURSE LIBB64_SRCS ${LIBB64_DIR}/src/*.c)
+-include_directories(SYSTEM ${LIBB64_DIR}/include)
++include_directories(SYSTEM @libb64@/include)
+ 
+ 
+ # executable targets
+ 
+-add_executable(msgpack2json src/msgpack2json.cpp ${MPACK_SRCS} ${LIBB64_SRCS})
+-add_executable(json2msgpack src/json2msgpack.cpp ${MPACK_SRCS} ${LIBB64_SRCS})
++add_executable(msgpack2json src/msgpack2json.cpp ${MPACK_SRCS})
++add_executable(json2msgpack src/json2msgpack.cpp ${MPACK_SRCS})
++
++target_link_libraries(msgpack2json b64)
++target_link_libraries(json2msgpack b64)
+ 
+ install(TARGETS msgpack2json json2msgpack DESTINATION bin)
+ 


### PR DESCRIPTION
Currently, msgpack-tools fails to build for two reasons.

Firstly, it's specifying a cmake version that's too old, so we get an error about `Compatibility with CMake < 3.5 has been removed from CMake.`

Secondly, it fetches and tries to build a version of rapidjson that fails to compile.

This PR fixes those issues, and some other issues:
- it includes some modernisations to the derivation from https://github.com/NixOS/nixpkgs/pull/436281
- there was no maintainer, so I've added myself
- instead of fetching tarballs of rapidjson and libb64, we use the versions from nixpkgs. It still fetches mpack, because this is unrelated to the mpack in nixpkgs, and since it's written by the author of msgpack-tools, it probably isn't used by much else

Note that the build scripts expect to find a tarball of mpack in a certain location, hence we still use fetchurl instead of fetchFromGitHub, as the latter unpacks it (and it seemed pointless to re-tar it, or to modify the upstream build scripts any more than I already have).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
