### PR TITLE
nixos/nylon-wg: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24606,6 +24606,12 @@
     githubId = 12636891;
     name = "Akhil Indurti";
   };
+  smephite = {
+    email = "nix@kai.run";
+    github = "Smephite";
+    githubId = 2955065;
+    name = "Kai Berszin";
+  };
   smironov = {
     email = "grrwlf@gmail.com";
     github = "sergei-mironov";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -38,6 +38,8 @@
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
+- [Nylon](https://github.com/encodeous/nylon/), a Resilient Overlay Network built from WireGuard, designed to be performant, secure, reliable, and most importantly, easy to use available as [services.networking.nylon-wg](#opt-services.nylon-wg.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1309,6 +1309,7 @@
   ./services/networking/ntp/ntpd.nix
   ./services/networking/ntp/openntpd.nix
   ./services/networking/nullidentdmod.nix
+  ./services/networking/nylon-wg.nix
   ./services/networking/nylon.nix
   ./services/networking/ocserv.nix
   ./services/networking/ofono.nix

--- a/nixos/modules/services/networking/nylon-wg.nix
+++ b/nixos/modules/services/networking/nylon-wg.nix
@@ -1,0 +1,129 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.nylon-wg;
+  # Is there a better way? lib.isPath does not work
+  keyIsPath = builtins.match "^/.+" cfg.node.key != null;
+  nodeBaseCfg = pkgs.writeText "node_base.yml" (
+    ''
+      id: "${cfg.node.id}"
+      port: ${builtins.toString cfg.node.port}
+      interfacename: "${cfg.node.interface}"
+      logpath: "${builtins.toString cfg.node.logPath}"
+      nonetconfigure: ${lib.boolToString cfg.node.noNetConfigure}
+      usesystemrouting: ${lib.boolToString cfg.node.useSystemRouting}
+      disablerouting: ${lib.boolToString cfg.node.disableRouting}
+    ''
+    + lib.optionalString (!keyIsPath) ''
+      key: ${cfg.node.key}
+    ''
+  );
+in
+{
+  options = {
+    services.nylon-wg = {
+      enable = lib.mkEnableOption "Nylon - Resilient Overlay Network built from WireGuard";
+
+      centralConfig = lib.mkOption {
+        type = with lib.types; path;
+        description = "Path to nylon central config.";
+      };
+
+      node = {
+        key = lib.mkOption {
+          type = with lib.types; either path str;
+          description = ''
+            Node key as string or path to node key
+            A path is preferred as else the key will be commited to the nix-store.
+          '';
+        };
+        port = lib.mkOption {
+          type = with lib.types; int;
+          default = 57175;
+          description = "Port for nylon to listen on.";
+        };
+        interface = lib.mkOption {
+          type = with lib.types; str;
+          default = "nylon";
+          description = "Interface for nylon to listen on.";
+        };
+        id = lib.mkOption {
+          type = with lib.types; str;
+          description = "Nylon node id";
+        };
+        logPath = lib.mkOption {
+          type = with lib.types; nullOr path;
+          default = null;
+          description = "Log to this file";
+        };
+        noNetConfigure = lib.mkOption {
+          type = with lib.types; bool;
+          default = false;
+          description = "Do not configure the system network settings.";
+        };
+        useSystemRouting = lib.mkOption {
+          type = with lib.types; bool;
+          default = false;
+          description = "Use the system route table to forward packets";
+        };
+        disableRouting = lib.mkOption {
+          type = with lib.types; bool;
+          default = false;
+          description = "Do not route traffic through this node";
+        };
+      };
+      openFirewall = lib.mkOption {
+        type = with lib.types; bool;
+        default = true;
+        description = "Configure firewall to trust nylon port and interface";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedUDPPorts = [ cfg.node.port ];
+      trustedInterfaces = [ cfg.node.interface ];
+    };
+
+    boot.kernel.sysctl = lib.mkIf cfg.node.useSystemRouting {
+      "net.ipv4.conf.all.forwarding" = lib.mkOverride 97 true;
+      "net.ipv6.conf.all.forwarding" = lib.mkOverride 97 true;
+    };
+
+    systemd.services.nylon-wg = {
+      description = "Nylon - Resilient Overlay Network built from WireGuard";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig =
+        let
+          sh = lib.getExe' pkgs.bash "sh";
+          cat = lib.getExe' pkgs.coreutils "cat";
+          echo = lib.getExe' pkgs.coreutils "echo";
+          rm = lib.getExe' pkgs.coreutils "rm";
+          nylon-wg = lib.getExe pkgs.nylon-wg;
+          keyLine = ''${echo} -en "\nkey: " && ${cat} ${cfg.node.key}'';
+        in
+        {
+          RuntimeDirectory = "nylon-wg";
+          WorkingDirectory = "%t/nylon-wg";
+          RuntimeDirectoryMode = "0640";
+          UMask = "0007";
+          ExecStartPre = "${sh} -c '{ ${cat} ${nodeBaseCfg} ${
+            lib.optionalString keyIsPath ("&& " + keyLine)
+          } ;} > node.yaml'";
+          ExecStart = "${nylon-wg} run -c ${cfg.centralConfig} -n node.yaml";
+          ExecStop = "-${rm} -f node.yaml";
+          Restart = "always";
+          RestartSec = "10s";
+        };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ smephite ];
+}

--- a/pkgs/by-name/ny/nylon-wg/package.nix
+++ b/pkgs/by-name/ny/nylon-wg/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  darwin,
+  fetchFromGitHub,
+  installShellFiles,
+  iproute2,
+  stdenv,
+}:
+buildGoModule rec {
+  pname = "nylon-wg";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "encodeous";
+    repo = "nylon";
+    tag = "v${version}";
+    hash = "sha256-l2tSBTdfCmfG8zf/J6b9i7oJyj4FPhABwEj6PNbwsik=";
+  };
+
+  vendorHash = "sha256-az1Qf01x7Mx7lFdp1zNNCELXQf+7/uWMTKGxSK+TRGE=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postPatch =
+    # Replace `Exec("ip"` on linux with absolute path
+    lib.optionalString stdenv.isLinux ''
+      substituteInPlace core/sys_linux.go \
+          --replace-fail "Exec(\"ip\"" "Exec(\"${iproute2}/bin/ip\""
+    ''
+    +
+      # Replace "/sbin/ifconfig" and "/sbin/route" with absolute path
+      lib.optionalString stdenv.isDarwin ''
+        substituteInPlace core/sys_darwin.go \
+            --replace-fail "/sbin/route" "${darwin.network_cmds}/bin/route"
+        substituteInPlace core/sys_darwin.go \
+            --replace-fail "/sbin/ifconfig" "${darwin.network_cmds}/bin/ifconfig"
+      '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd nylon \
+      --bash <($out/bin/nylon completion bash) \
+      --fish <($out/bin/nylon completion fish) \
+      --zsh <($out/bin/nylon completion zsh)
+  '';
+
+  meta = {
+    homepage = "https://github.com/encodeous/nylon";
+    description = "Resilient Overlay Network built from WireGuard";
+    license = lib.licenses.mit;
+    mainProgram = "nylon";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ smephite ];
+  };
+}


### PR DESCRIPTION
Adding [nylon](https://github.com/encodeous/nylon/) v0.3.2 - a  [Resilient Overlay Network](https://dl.acm.org/doi/10.1145/502034.502048) built from WireGuard.

Due to the pname `nylon` being taken and the wireguard heritage, I chose `nylon-wg` as the package name.  
Please let me know if you have opinions about the name.

They themselves also [stumbled across this](https://github.com/encodeous/nylon/issues/29) issue, but will still keep the project name the same 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
