### PR TITLE
maintainers: drop ttuegel

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -265,15 +265,15 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /lib/licenses.nix @alyssais @emilazy @jopejoe1
 
 # Qt
-/pkgs/development/libraries/qt-5 @K900 @NickCao @SuperSandro2000 @ttuegel
-/pkgs/development/libraries/qt-6 @K900 @NickCao @SuperSandro2000 @ttuegel
+/pkgs/development/libraries/qt-5 @K900 @NickCao @SuperSandro2000
+/pkgs/development/libraries/qt-6 @K900 @NickCao @SuperSandro2000
 
 # KDE Frameworks 5
-/pkgs/development/libraries/kde-frameworks @K900 @NickCao @SuperSandro2000 @ttuegel
+/pkgs/development/libraries/kde-frameworks @K900 @NickCao @SuperSandro2000
 
 # KDE / Plasma 6
-/pkgs/kde @K900 @NickCao @SuperSandro2000 @ttuegel
-/maintainers/scripts/kde @K900 @NickCao @SuperSandro2000 @ttuegel
+/pkgs/kde @K900 @NickCao @SuperSandro2000
+/maintainers/scripts/kde @K900 @NickCao @SuperSandro2000
 
 # PostgreSQL and related stuff
 /pkgs/by-name/po/postgresqlTestHook @NixOS/postgres

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26660,12 +26660,6 @@
     githubId = 77488956;
     name = "Timothy Tschnitzel";
   };
-  ttuegel = {
-    email = "ttuegel@mailbox.org";
-    github = "ttuegel";
-    githubId = 563054;
-    name = "Thomas Tuegel";
-  };
   tu-maurice = {
     email = "valentin.gehrke+nixpkgs@zom.bi";
     github = "tu-maurice";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1104,7 +1104,6 @@ with lib.maintainers;
       mjm
       nickcao
       SuperSandro2000
-      ttuegel
     ];
     github = "qt-kde";
     scope = "Maintain the Qt framework, KDE application suite, Plasma desktop environment and related projects.";

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -34,8 +34,8 @@
     { lib, ... }:
     {
       name = "sddm-autologin";
-      meta = with lib.maintainers; {
-        maintainers = [ ttuegel ];
+      meta = {
+        maintainers = [ ];
       };
 
       nodes.machine = {

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -152,6 +152,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     mainProgram = "clementine";
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/applications/display-managers/sddm/unwrapped.nix
+++ b/pkgs/applications/display-managers/sddm/unwrapped.nix
@@ -112,7 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "QML based X11 display manager";
     homepage = "https://github.com/sddm/sddm";
     maintainers = with maintainers; [
-      ttuegel
       k900
     ];
     platforms = platforms.linux;

--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -131,7 +131,7 @@ buildFHSEnv {
     description = "Online stored folders (daemon version)";
     homepage = "https://www.dropbox.com/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -121,7 +121,7 @@ in
       as WeeChat, but graphical (based on Qt4/KDE4 or Qt5/KF5).
     '';
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     mainProgram =
       if monolithic then
         "quassel"

--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -93,7 +93,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Collection of Fortran77 subroutines to solve large scale eigenvalue problems";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      ttuegel
       dotlambda
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/at/ats2/package.nix
+++ b/pkgs/by-name/at/ats2/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [
       thoughtpolice
-      ttuegel
       bbarker
     ];
   };

--- a/pkgs/by-name/au/audacious-bare/package.nix
+++ b/pkgs/by-name/au/audacious-bare/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     mainProgram = "audacious";
     maintainers = with lib.maintainers; [
       ramkromberg
-      ttuegel
       thiagokokada
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/bi/biber/package.nix
+++ b/pkgs/by-name/bi/biber/package.nix
@@ -69,7 +69,7 @@ perlPackages.buildPerlModule {
     description = "Backend for BibLaTeX";
     license = biberSource.meta.license;
     platforms = platforms.unix;
-    maintainers = [ maintainers.ttuegel ];
+    maintainers = [ ];
     mainProgram = "biber";
   };
 }

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -206,7 +206,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://cmake.org/cmake/help/v${lib.versions.majorMinor finalAttrs.version}/release/${lib.versions.majorMinor finalAttrs.version}.html";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      ttuegel
       lnl7
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/es/es/package.nix
+++ b/pkgs/by-name/es/es/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
     license = licenses.publicDomain;
     maintainers = with maintainers; [
       sjmackenzie
-      ttuegel
     ];
     platforms = platforms.all;
   };

--- a/pkgs/by-name/fr/freetype/package.nix
+++ b/pkgs/by-name/fr/freetype/package.nix
@@ -142,6 +142,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl2Plus; # or the FreeType License (BSD + advertising clause)
     platforms = platforms.all;
     pkgConfigModules = [ "freetype2" ];
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/hp/hplip/package.nix
+++ b/pkgs/by-name/hp/hplip/package.nix
@@ -356,6 +356,6 @@ python3Packages.buildPythonApplication {
           gpl2Plus
         ];
     platforms = lib.attrNames hplipPlatforms;
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/io/iosevka/package.nix
+++ b/pkgs/by-name/io/iosevka/package.nix
@@ -147,7 +147,6 @@ buildNpmPackage rec {
     license = licenses.ofl;
     platforms = platforms.all;
     maintainers = with maintainers; [
-      ttuegel
       lunik1
     ];
   };

--- a/pkgs/by-name/ip/ipe/package.nix
+++ b/pkgs/by-name/ip/ipe/package.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
       It supports making small figures for inclusion into LaTeX-documents
       as well as presentations in PDF.
     '';
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/js/jsoncpp/package.nix
+++ b/pkgs/by-name/js/jsoncpp/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/open-source-parsers/jsoncpp";
     description = "C++ library for interacting with JSON";
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/by-name/li/libfm/package.nix
+++ b/pkgs/by-name/li/libfm/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://blog.lxde.org/category/pcmanfm/";
     license = lib.licenses.lgpl21Plus;
     description = "Glib-based library for file management";
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/li/libxkbcommon_8/package.nix
+++ b/pkgs/by-name/li/libxkbcommon_8/package.nix
@@ -96,9 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://xkbcommon.org";
     changelog = "https://github.com/xkbcommon/libxkbcommon/blob/xkbcommon-${finalAttrs.version}/NEWS.md";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      ttuegel
-    ];
+    maintainers = [ ];
     mainProgram = "xkbcli";
     platforms = with platforms; unix;
     pkgConfigModules = [

--- a/pkgs/by-name/me/media-player-info/package.nix
+++ b/pkgs/by-name/me/media-player-info/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     description = "Repository of data files describing media player capabilities";
     homepage = "https://www.freedesktop.org/wiki/Software/media-player-info/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/by-name/me/menu-cache/package.nix
+++ b/pkgs/by-name/me/menu-cache/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library to read freedesktop.org menu files";
     homepage = "https://blog.lxde.org/tag/menu-cache/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/op/openlibm/package.nix
+++ b/pkgs/by-name/op/openlibm/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "High quality system independent, portable, open source libm implementation";
     homepage = "https://openlibm.org/";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/op/openslp/package.nix
+++ b/pkgs/by-name/op/openslp/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.openslp.org/";
     description = "Open-source implementation of the IETF Service Location Protocol";
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     license = licenses.bsd3;
     platforms = platforms.all;
     # never built on aarch64-darwin since first introduction in nixpkgs

--- a/pkgs/by-name/op/openspecfun/package.nix
+++ b/pkgs/by-name/op/openspecfun/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "Collection of special mathematical functions";
     homepage = "https://github.com/JuliaLang/openspecfun";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ot/otfcc/package.nix
+++ b/pkgs/by-name/ot/otfcc/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/caryll/otfcc";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     # Build fails on all platforms with
     #        > configure flags: gmake
     #   > ** Warning: action 'xcode4' sets 'os' field, which is deprecated, use 'targetos' instead.

--- a/pkgs/by-name/pc/pcmanfm/package.nix
+++ b/pkgs/by-name/pc/pcmanfm/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://blog.lxde.org/category/pcmanfm/";
     license = lib.licenses.gpl2Plus;
     description = "File manager with GTK interface";
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "pcmanfm";
   };

--- a/pkgs/by-name/po/postiats-utilities/package.nix
+++ b/pkgs/by-name/po/postiats-utilities/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Hibou57/PostiATS-Utilities";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.ttuegel ];
+    maintainers = [ ];
   };
 
   buildInputs = [

--- a/pkgs/by-name/ru/rubber/package.nix
+++ b/pkgs/by-name/ru/rubber/package.nix
@@ -58,7 +58,6 @@ pypkgs.buildPythonApplication rec {
     license = licenses.gpl2Plus;
     homepage = "https://gitlab.com/latex-rubber/rubber";
     maintainers = with maintainers; [
-      ttuegel
       peterhoeg
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/so/source-sans-pro/package.nix
+++ b/pkgs/by-name/so/source-sans-pro/package.nix
@@ -33,6 +33,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Sans serif font family for user interface environments (version of Source Sans before being renamed)";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/so/source-sans/package.nix
+++ b/pkgs/by-name/so/source-sans/package.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Sans serif font family for user interface environments";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/so/source-serif-pro/package.nix
+++ b/pkgs/by-name/so/source-serif-pro/package.nix
@@ -33,6 +33,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Typeface for setting text in many sizes, weights, and languages. Designed to complement Source Sans";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/so/source-serif/package.nix
+++ b/pkgs/by-name/so/source-serif/package.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Typeface for setting text in many sizes, weights, and languages. Designed to complement Source Sans";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ta/taglib/package.nix
+++ b/pkgs/by-name/ta/taglib/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21Only
       mpl11
     ];
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     pkgConfigModules = [
       "taglib"
       "taglib_c"

--- a/pkgs/by-name/ta/taglib_1/package.nix
+++ b/pkgs/by-name/ta/taglib_1/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21Only
       mpl11
     ];
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     pkgConfigModules = [
       "taglib"
       "taglib_c"

--- a/pkgs/by-name/ua/ua/package.nix
+++ b/pkgs/by-name/ua/ua/package.nix
@@ -35,6 +35,6 @@ buildGoModule {
     homepage = "https://github.com/sloonz/ua";
     license = licenses.isc;
     description = "Universal Aggregator";
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/vc/vcsh/package.nix
+++ b/pkgs/by-name/vc/vcsh/package.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/RichiH/vcsh/blob/v${finalAttrs.version}/changelog";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      ttuegel
       alerque
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/vo/vobsub2srt/package.nix
+++ b/pkgs/by-name/vo/vobsub2srt/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     description = "Converts VobSub subtitles into SRT subtitles";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
     mainProgram = "vobsub2srt";
   };
 }

--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -177,7 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       thoughtpolice
-      ttuegel
       numinit
     ];
     pkgConfigModules = lib.optionals useCmakeBuild [ "z3" ];

--- a/pkgs/data/fonts/lohit-fonts/default.nix
+++ b/pkgs/data/fonts/lohit-fonts/default.nix
@@ -131,7 +131,6 @@ let
         homepage = "https://pagure.io/lohit";
         maintainers = [
           lib.maintainers.mathnerd314
-          lib.maintainers.ttuegel
         ];
         # Set a non-zero priority to allow easy overriding of the
         # fontconfig configuration files.

--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -144,6 +144,6 @@ buildPackages.stdenv.mkDerivation (finalAttrs: {
     description = "Local Hoogle database";
     platforms = ghc.meta.platforms;
     hydraPlatforms = with lib.platforms; none;
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/libraries/grantlee/5/default.nix
+++ b/pkgs/development/libraries/grantlee/5/default.nix
@@ -61,7 +61,7 @@ mkDerivation rec {
       and the design of Django is reused in Grantlee.'';
 
     homepage = "https://github.com/steveire/grantlee";
-    maintainers = [ maintainers.ttuegel ];
+    maintainers = [ ];
     license = licenses.lgpl21;
     inherit (qtbase.meta) platforms;
   };

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -155,7 +155,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = platforms.unix;
     maintainers = with maintainers; [
-      ttuegel
       matthewbauer
     ];
   };

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -31,7 +31,6 @@
 
 let
   maintainers = with lib.maintainers; [
-    ttuegel
     nyanloutre
   ];
   license = with lib.licenses; [

--- a/pkgs/development/libraries/kdiagram/default.nix
+++ b/pkgs/development/libraries/kdiagram/default.nix
@@ -30,6 +30,6 @@ mkDerivation rec {
     description = "Libraries for creating business diagrams";
     license = lib.licenses.gpl2;
     platforms = qtbase.meta.platforms;
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/kdsoap/default.nix
+++ b/pkgs/development/libraries/kdsoap/default.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation rec {
       gpl3
       lgpl21
     ];
-    maintainers = [ maintainers.ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.pcre.org/";
     description = "Perl Compatible Regular Expressions";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = platforms.all;
     pkgConfigModules = [
       "libpcre2-posix"

--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     homepage = "https://phonon.kde.org/";
     description = "GStreamer backend for Phonon";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     license = licenses.lgpl21;
   };
 }

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     mainProgram = "phononsettings";
     license = lib.licenses.lgpl2;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 
   src = fetchurl {

--- a/pkgs/development/libraries/plasma-wayland-protocols/default.nix
+++ b/pkgs/development/libraries/plasma-wayland-protocols/default.nix
@@ -23,6 +23,6 @@ mkDerivation rec {
     description = "Plasma Wayland Protocols";
     license = lib.licenses.lgpl21Plus;
     platforms = qtbase.meta.platforms;
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/polkit-qt-1/default.nix
+++ b/pkgs/development/libraries/polkit-qt-1/default.nix
@@ -29,7 +29,7 @@ mkDerivation rec {
 
   meta = {
     description = "Qt wrapper around PolKit";
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/poppler/default.nix
+++ b/pkgs/development/libraries/poppler/default.nix
@@ -185,7 +185,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
     teams = [ lib.teams.freedesktop ];
   };
 })

--- a/pkgs/development/libraries/qca/default.nix
+++ b/pkgs/development/libraries/qca/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Qt Cryptographic Architecture";
     homepage = "https://invent.kde.org/libraries/qca";
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     license = licenses.lgpl21Plus;
     platforms = with platforms; unix;
   };

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -555,7 +555,6 @@ stdenv.mkDerivation (
         ];
         maintainers = with maintainers; [
           qknight
-          ttuegel
           periklis
           bkchr
         ];

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -119,7 +119,6 @@ mkDerivation (
       ];
       maintainers = with maintainers; [
         qknight
-        ttuegel
         periklis
         bkchr
       ];

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -339,6 +339,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     homepage = "https://github.com/OpenMathLib/OpenBLAS";
     platforms = attrNames configs;
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -115,7 +115,7 @@ effectiveStdenv.mkDerivation rec {
       gpl2Plus
       lgpl21Plus
     ];
-    maintainers = with maintainers; [ ttuegel ];
+    maintainers = [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -236,6 +236,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
     mainProgram = "ibus";
-    maintainers = with lib.maintainers; [ ttuegel ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
Hasn't commented since [this June](https://github.com/NixOS/nixpkgs/issues?q=commenter:ttuegel) (close, but still), hasn't opened any tickets themselves since [February 2023](https://github.com/NixOS/nixpkgs/issues?q=author:ttuegel), both of which are longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

Thomas, you have a week (until 17:00, Oct 29) to object this. Even if you don't make it, you're still welcome back.

---
@NixOS/qt-kde i'll need yall's assistance on https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/libraries/qt-5#patches, since Thomas hosts these

## Note for mergers
~~Thomas co-maintains `pkgs.iosevka` with Riley, who's getting removed in #454629, so its recipe is conflicting between these two branches.~~

Irrelevant, there's no conflict now

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
