### PR TITLE
python3Packages.curl-cffi: 0.12.0 -> 0.14.0b2

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  addBinToPathHook,
   curl-impersonate-chrome,
   cffi,
   certifi,
@@ -24,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "curl-cffi";
-  version = "0.12.0";
+  version = "0.14.0b2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lexiforest";
     repo = "curl_cffi";
     tag = "v${version}";
-    hash = "sha256-VE/b1Cs/wpZlu7lOURT/QfP7DuNudD441zG603LT4LM=";
+    hash = "sha256-JXfqZTf26kl2P0OMAw/aTdjQaGtdyTpNnhRPlwMiZNw=";
   };
 
   patches = [ ./use-system-libs.patch ];
@@ -47,13 +48,10 @@ buildPythonPackage rec {
     certifi
   ];
 
-  env = lib.optionalAttrs stdenv.cc.isGNU {
-    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
-  };
-
   pythonImportsCheck = [ "curl_cffi" ];
 
   nativeCheckInputs = [
+    addBinToPathHook
     charset-normalizer
     cryptography
     fastapi
@@ -81,6 +79,8 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # test accesses network
     "tests/unittest/test_smoke.py::test_async"
+    # Runs out of memory while testing
+    "tests/unittest/test_websockets.py"
   ];
 
   disabledTests = [
@@ -97,11 +97,11 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/lexiforest/curl_cffi/releases/tag/${src.tag}";
     description = "Python binding for curl-impersonate via cffi";
     homepage = "https://curl-cffi.readthedocs.io";
-    license = licenses.mit;
-    maintainers = with maintainers; [ chuangzhu ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chuangzhu ];
   };
 }

--- a/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
+++ b/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
@@ -1,8 +1,6 @@
-diff --git a/scripts/build.py b/scripts/build.py
-index b705a0d..9bfcaab 100644
 --- a/scripts/build.py
 +++ b/scripts/build.py
-@@ -105,7 +105,6 @@ def get_curl_libraries():
+@@ -141,7 +141,6 @@ def get_curl_libraries():
  ffibuilder = FFI()
  system = platform.system()
  root_dir = Path(__file__).parent.parent
@@ -10,7 +8,7 @@ index b705a0d..9bfcaab 100644
  
  
  ffibuilder.set_source(
-@@ -114,9 +113,7 @@ ffibuilder.set_source(
+@@ -150,9 +149,7 @@ ffibuilder.set_source(
          #include "shim.h"
      """,
      # FIXME from `curl-impersonate`


### PR DESCRIPTION
https://github.com/lexiforest/curl_cffi/compare/v0.12.0...v0.13.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
