### PR TITLE
libnl-tiny: 2025-03-19 -> 2025-10-20

### DIFF
--- a/pkgs/by-name/li/libnl-tiny/package.nix
+++ b/pkgs/by-name/li/libnl-tiny/package.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation {
   pname = "libnl-tiny";
-  version = "0-unstable-2025-03-19";
+  version = "0-unstable-2025-10-20";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/libnl-tiny.git";
-    rev = "c0df580adbd4d555ecc1962dbe88e91d75b67a4e";
-    hash = "sha256-j5oIEbWqVWd7rNpCMm9+WZwud43uTGeHG81lmzQOoeY=";
+    rev = "c69fb5ef80b9780fe9add345052aef9ccb5d51f4";
+    hash = "sha256-QH4w++kekejvvgTye6djs0jYzcNsxfrE3XCBed+Oizo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update `libnl-tiny` to newest unstable version
Commit [feca1d3](https://git.openwrt.org/?p=project/libnl-tiny.git;a=commit;h=feca1d341d4baa9579ec62762672aa0f20edf564) solve the issue with cmake v4 (ref: https://github.com/NixOS/nixpkgs/issues/445447)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
