### PR TITLE
python3Packages.inline-snapshot: 0.24.0 -> 0.31.0; python312Packages.anthropic: 0.62.0 -> 0.71.0

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -11,6 +11,7 @@
   # dependencies
   anyio,
   distro,
+  docstring-parser,
   httpx,
   jiter,
   pydantic,
@@ -23,6 +24,7 @@
 
   # test
   dirty-equals,
+  inline-snapshot,
   nest-asyncio,
   pytest-asyncio,
   pytest-xdist,
@@ -32,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "anthropic";
-  version = "0.62.0";
+  version = "0.71.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${version}";
-    hash = "sha256-EVLSC6ClHnmGqMoefMXj3M4dh812ZN5t9nF3gfCLyCo=";
+    hash = "sha256-n8hu2RFuZN0ojHhhU4qPQaT2DUvqSglFhBo2ORln/mc=";
   };
 
   postPatch = ''
@@ -55,6 +57,7 @@ buildPythonPackage rec {
   dependencies = [
     anyio
     distro
+    docstring-parser
     httpx
     jiter
     pydantic
@@ -68,6 +71,7 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
+    inline-snapshot
     dirty-equals
     nest-asyncio
     pytest-asyncio

--- a/pkgs/development/python-modules/inline-snapshot/default.nix
+++ b/pkgs/development/python-modules/inline-snapshot/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "inline-snapshot";
-  version = "0.24.0";
+  version = "0.30.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "15r10nk";
     repo = "inline-snapshot";
     tag = version;
-    hash = "sha256-UiVxG9W1lwvvoflVey4250iL8gL8Tm41LBo0ab0tTqk=";
+    hash = "sha256-i/ocUiNHvtAYzBFEM0RSYzRLhfRZMWKL8rUB0BHaSVE=";
   };
 
   build-system = [ hatchling ];


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
