### PR TITLE
animdl: allow click >= 8.2.0, enable across linux and darwin

### DIFF
--- a/pkgs/by-name/an/animdl/package.nix
+++ b/pkgs/by-name/an/animdl/package.nix
@@ -21,6 +21,7 @@ python3Packages.buildPythonApplication {
   ];
 
   pythonRelaxDeps = [
+    "click"
     "cssselect"
     "httpx"
     "lxml"

--- a/pkgs/by-name/an/animdl/package.nix
+++ b/pkgs/by-name/an/animdl/package.nix
@@ -55,12 +55,12 @@ python3Packages.buildPythonApplication {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Highly efficient, powerful and fast anime scraper";
     homepage = "https://github.com/justfoolingaround/animdl";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     mainProgram = "animdl";
-    maintainers = with maintainers; [ passivelemon ];
+    maintainers = with lib.maintainers; [ passivelemon ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/an/animdl/package.nix
+++ b/pkgs/by-name/an/animdl/package.nix
@@ -62,6 +62,5 @@ python3Packages.buildPythonApplication {
     license = lib.licenses.gpl3Only;
     mainProgram = "animdl";
     maintainers = with lib.maintainers; [ passivelemon ];
-    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
