### PR TITLE
maintainers: drop rileyinman

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22013,12 +22013,6 @@
     githubId = 1810487;
     name = "Rika";
   };
-  rileyinman = {
-    email = "rileyminman@gmail.com";
-    github = "rileyinman";
-    githubId = 37246692;
-    name = "Riley Inman";
-  };
   rinx = {
     email = "rintaro.okamura@gmail.com";
     github = "rinx";

--- a/pkgs/applications/video/streamlink-twitch-gui/bin.nix
+++ b/pkgs/applications/video/streamlink-twitch-gui/bin.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.mit;
     mainProgram = "streamlink-twitch-gui";
-    maintainers = with maintainers; [ rileyinman ];
+    maintainers = [ ];
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/by-name/io/iosevka/package.nix
+++ b/pkgs/by-name/io/iosevka/package.nix
@@ -148,7 +148,6 @@ buildNpmPackage rec {
     platforms = platforms.all;
     maintainers = with maintainers; [
       ttuegel
-      rileyinman
       lunik1
     ];
   };

--- a/pkgs/by-name/no/noto-fonts-emoji-blob-bin/package.nix
+++ b/pkgs/by-name/no/noto-fonts-emoji-blob-bin/package.nix
@@ -30,7 +30,6 @@ stdenvNoCC.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
-      rileyinman
       jk
     ];
   };

--- a/pkgs/development/python-modules/pyctr/default.nix
+++ b/pkgs/development/python-modules/pyctr/default.nix
@@ -27,6 +27,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ihaveamac/pyctr";
     changelog = "https://github.com/ihaveamac/pyctr/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ rileyinman ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Hasn't commented since [March 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter:rileyinman), hasn't opened any tickets themselves since [March 2022 as well](https://github.com/NixOS/nixpkgs/issues?q=author:rileyinman), both of which are _muuuuuch_ longer than the 3 months, specified in the [maintainer README](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status), which makes them eligible for removal from Nixpkgs.

Riley, you have a week (until 18:00, Oct 29) to object this. Even if you don't make it, you're still welcome back.

## Note for mergers
Riley and Thomas (who's getting removed in #454605) co-maintain `pkgs.iosevka`, so its recipe is conflicting between these two branches.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
