### PR TITLE
everest{,-bin}: 5806 -> 5935

### DIFF
--- a/pkgs/by-name/ev/everest-bin/package.nix
+++ b/pkgs/by-name/ev/everest-bin/package.nix
@@ -8,15 +8,15 @@
 
 let
   pname = "everest";
-  version = "5806";
+  version = "5935";
   phome = "$out/lib/Celeste";
 in
 stdenvNoCC.mkDerivation {
   inherit pname version;
   src = fetchzip {
-    url = "https://github.com/EverestAPI/Everest/releases/download/stable-1.5806.0/main.zip";
+    url = "https://github.com/EverestAPI/Everest/releases/download/stable-1.5935.0/main.zip";
     extension = "zip";
-    hash = "sha256-Hw/BNvWfhdO7bvYrY/Px12BRG1SYcCBeAXBH4QnKyeY=";
+    hash = "sha256-XYvXrfHSjSShAg3r2qikt1CPXldYvsU1EvRJNzJoGTU=";
   };
   buildInputs = [
     icu

--- a/pkgs/by-name/ev/everest/deps.json
+++ b/pkgs/by-name/ev/everest/deps.json
@@ -1,5 +1,15 @@
 [
   {
+    "pname": "DotNet.ReproducibleBuilds",
+    "version": "1.2.25",
+    "hash": "sha256-Vl9RPq9vCO4bjulPZiOr3gDVKlr9vnuKIIX3KWlRxvw="
+  },
+  {
+    "pname": "DotNet.ReproducibleBuilds.Isolated",
+    "version": "1.2.25",
+    "hash": "sha256-NpGbG9rnKKN6ejz1xqUa2AYx8mGSv+ZHbducFGhhrwA="
+  },
+  {
     "pname": "DotNetZip",
     "version": "1.16.0",
     "hash": "sha256-RlzHkO7DxCvRkr+gpM8Abs34XbovmBTmXfO7LtnE75E="
@@ -26,16 +36,6 @@
   },
   {
     "pname": "Microsoft.AspNetCore.App.Ref",
-    "version": "3.0.1",
-    "hash": "sha256-y4VQ8teCZOnCJyg0rh3s1SbbqfoEclB5T6lCfMrxWUw="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.App.Ref",
-    "version": "3.1.10",
-    "hash": "sha256-51D1XkqFMPHJzOmt1HQ0Bf1n9K0auwEyxTJuqA/8xHY="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.App.Ref",
     "version": "5.0.0",
     "hash": "sha256-z22ZDldoIlDUYeF9Rje0aVPlYAGKIpdj5wDzn1CW+jQ="
   },
@@ -48,21 +48,6 @@
     "pname": "Microsoft.AspNetCore.App.Ref",
     "version": "7.0.20",
     "hash": "sha256-OEDXXjQ1HDRPiA4Y1zPr1xUeH6wlzTCJpts+DZL61wI="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.App.Ref",
-    "version": "8.0.20",
-    "hash": "sha256-A6300qL9iP7iuY4wF9QkmOcuvoJFB0H64BAM5oGZF/4="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
-    "version": "3.0.3",
-    "hash": "sha256-CbtnZSF+lvyeIfEUC8a0Jf4EMvYAxa9mvWF9lyLymMk="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
-    "version": "3.1.32",
-    "hash": "sha256-OV3Ie8JGTEwNI4Y6DJFh+ZUrBTwrSdFjEbfljfAwn3s="
   },
   {
     "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
@@ -78,11 +63,6 @@
     "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
     "version": "7.0.20",
     "hash": "sha256-vq59xMfrET8InzUhkAsbs2xp3ML+SO9POsbwAiYKzkA="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
-    "version": "8.0.20",
-    "hash": "sha256-rToqTSs66gvIi2I69+0/qjhKAXk5/rRQUh0KetP3ZxE="
   },
   {
     "pname": "Microsoft.Build.Tasks.Git",
@@ -130,26 +110,6 @@
     "hash": "sha256-42cFtaZFzM93I0gZjuDbcEYWM5Pld+kx2MkWu0J66ww="
   },
   {
-    "pname": "Microsoft.NET.Sdk.IL",
-    "version": "8.0.0",
-    "hash": "sha256-guQcVwSaVwJ0uJvUYZqk1bZ9ATLBk3zWHZmTW7EV1KM="
-  },
-  {
-    "pname": "Microsoft.NETCore.App",
-    "version": "2.1.0",
-    "hash": "sha256-RJksv5W7LhWJYGmkwYHfiU0s9XLCvT05KxSMz6U1/OE="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Host.linux-x64",
-    "version": "3.0.3",
-    "hash": "sha256-hIdA8ncOXoDM6/ryKCTVz/vZrqFLffxAgpN/qfl2L6Y="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Host.linux-x64",
-    "version": "3.1.32",
-    "hash": "sha256-ajR6pZv0zuzWDyxEnWtAuhasV5biV5lvweEbefTISiM="
-  },
-  {
     "pname": "Microsoft.NETCore.App.Host.linux-x64",
     "version": "5.0.17",
     "hash": "sha256-exMpVamk8ZzfCQDQcDmQDYJplDcOOU99ic7NSDKUgtE="
@@ -163,21 +123,6 @@
     "pname": "Microsoft.NETCore.App.Host.linux-x64",
     "version": "7.0.20",
     "hash": "sha256-Y1Dg8Sqhya86xD+9aJOuznT4mJUyFmoF/YZc0+5LBdc="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Host.linux-x64",
-    "version": "8.0.20",
-    "hash": "sha256-NlwDtSJmxP+9oIqWEMKU12o96g9TzQAEt//votxI2PU="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Ref",
-    "version": "3.0.0",
-    "hash": "sha256-PHovvd+mPN9HoCF0rFEnS015p7Yj76+e9cfSU4JAI+I="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Ref",
-    "version": "3.1.0",
-    "hash": "sha256-nuAvHwmJ2s3Ob1qNDH1+uV3awOZaWlaV3FenTmPUWyM="
   },
   {
     "pname": "Microsoft.NETCore.App.Ref",
@@ -195,21 +140,6 @@
     "hash": "sha256-W9RU3bja4BQLAbsaIhANQPJJh6DycDiBR+WZ3mK6Zrs="
   },
   {
-    "pname": "Microsoft.NETCore.App.Ref",
-    "version": "8.0.20",
-    "hash": "sha256-1YXXJaiMZOIbLduuWyFGSWt6hOxKa3URNsPDfiMrnDM="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
-    "version": "3.0.3",
-    "hash": "sha256-mxA9JF2WyEDV8yahdwhe4qfCTbIFroUfmMzPBa91b/o="
-  },
-  {
-    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
-    "version": "3.1.32",
-    "hash": "sha256-h4HjfRnvH81dW84S3TCPcCfxeQLiLN7b1ZleRNsprFY="
-  },
-  {
     "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
     "version": "5.0.17",
     "hash": "sha256-2NpVvrbqct3M1fKiSe/zyt41mf1aV6WUdxIlJod27Ek="
@@ -225,34 +155,9 @@
     "hash": "sha256-L+WaGvoXVMT3tZ7R5xFE06zaLcC3SI7LEf4ATBkUAGQ="
   },
   {
-    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
-    "version": "8.0.20",
-    "hash": "sha256-BkV2ZjBpQvLhijWFSwWDpr5m2ffNlCtYJA5TUTro6no="
-  },
-  {
-    "pname": "Microsoft.NETCore.DotNetAppHost",
-    "version": "2.1.0",
-    "hash": "sha256-LV8pnNFsKGFONyCTGsd8qB5A+EUIiyvbYWAr0eOEFoI="
-  },
-  {
-    "pname": "Microsoft.NETCore.DotNetHostPolicy",
-    "version": "2.1.0",
-    "hash": "sha256-FqQm4BLznzRmF1nhk3nEwrdeAdCY35eBmHk6/4+MCPY="
-  },
-  {
-    "pname": "Microsoft.NETCore.DotNetHostResolver",
-    "version": "2.1.0",
-    "hash": "sha256-5nQTmMhaEvbuT+1f7u0t0tEK3SCVUeXhsExq8tiYBI0="
-  },
-  {
     "pname": "Microsoft.NETCore.Platforms",
     "version": "1.1.0",
     "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
-  },
-  {
-    "pname": "Microsoft.NETCore.Platforms",
-    "version": "2.1.0",
-    "hash": "sha256-v09ltBAKTX8iAKuU2nCl+Op/ilVJQ0POZUh2z+u0rVo="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -268,11 +173,6 @@
     "pname": "Microsoft.NETCore.Targets",
     "version": "1.1.0",
     "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
-  },
-  {
-    "pname": "Microsoft.NETCore.Targets",
-    "version": "2.1.0",
-    "hash": "sha256-+KdWdA9I392SRqMb9KaiiRZatfvJ9RcdbtyGUkpHW7U="
   },
   {
     "pname": "Microsoft.NETFramework.ReferenceAssemblies",
@@ -331,33 +231,28 @@
   },
   {
     "pname": "Mono.Cecil",
-    "version": "0.11.5",
-    "hash": "sha256-nPFwbzW08gnCjadBdgi+16MHYhsPAXnFIliveLxGaNA="
+    "version": "0.11.6",
+    "hash": "sha256-0qI4MqqpSLqaAazEK1cm40xfmVlY8bMNRcDnxws6ctU="
   },
   {
     "pname": "MonoMod.Backports",
-    "version": "1.1.0",
-    "hash": "sha256-ruRX10/u+lRfMKr0UMbCVYS/nUK5fzV4+8ujJXBnles="
+    "version": "1.1.2",
+    "hash": "sha256-oXhcnMo0rDZDcpmhGVhQhax0lFeb9DT3GfSooesOo38="
   },
   {
     "pname": "MonoMod.Core",
-    "version": "1.0.0",
-    "hash": "sha256-Y55fgMd0d35qztqqC0drzn3NdSMYLiWie8IL9LbmFnc="
+    "version": "1.3.0",
+    "hash": "sha256-B/pb8hor4npd3YSkvEF8FEO7xbbcHIfLapTUcrd5qRY="
   },
   {
     "pname": "MonoMod.ILHelpers",
-    "version": "1.0.0",
-    "hash": "sha256-N6ybnOMkEtxXy/PdJAEkqHggHYSLETbCMF+mgNGXAvo="
-  },
-  {
-    "pname": "MonoMod.Patcher",
-    "version": "25.0.0-prerelease.1",
-    "hash": "sha256-+5kddzc3FheDIRNoTPWQREc1ufVFjfPFiiKrXTPCTWQ="
+    "version": "1.1.0",
+    "hash": "sha256-seoET5fqsyOY8g7DfNpLQHNTdUVY3U/xCoYFC4UrOKw="
   },
   {
     "pname": "MonoMod.RuntimeDetour",
-    "version": "25.0.0",
-    "hash": "sha256-yyP3kTN+OcOoO8xmHZfebKB/EtWNi7V6aJnXUTjVU/8="
+    "version": "25.3.0",
+    "hash": "sha256-ZDS2MYHwL+cGuGycqivqfS/i+Uglx203SGtFx3vCSOA="
   },
   {
     "pname": "MonoMod.RuntimeDetour.HookGen",
@@ -366,8 +261,8 @@
   },
   {
     "pname": "MonoMod.Utils",
-    "version": "25.0.0",
-    "hash": "sha256-PL7/F0zXnLRb5icD5zl/QCeMyTEsJZKOvSBvM1t8BEY="
+    "version": "25.0.8",
+    "hash": "sha256-k2Nh8btGmOhKCEmCnO7t5pQszrzH0Lok5mgwWBRXviE="
   },
   {
     "pname": "NETStandard.Library",
@@ -498,36 +393,6 @@
     "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
-  },
-  {
-    "pname": "runtime.linux-x64.Microsoft.NETCore.App",
-    "version": "2.1.0",
-    "hash": "sha256-qFtPLe3t/V9DZTaYhAO6MbVsyzH4hcQQUvyIJ6ywbEw="
-  },
-  {
-    "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost",
-    "version": "2.1.0",
-    "hash": "sha256-NMuEFKc68Vn4bVoX6kdGSQeyDpktUYliUg6Lbj4E8FU="
-  },
-  {
-    "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy",
-    "version": "2.1.0",
-    "hash": "sha256-U/WlbUpImqPjZf075WgBOb1o1i1H3VOL4QbzHfQ9Itk="
-  },
-  {
-    "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver",
-    "version": "2.1.0",
-    "hash": "sha256-vcB6FY1GDP+kTsmp9OXpPg50sXKqOSJzWUSuNlN1+rs="
-  },
-  {
-    "pname": "runtime.linux-x64.Microsoft.NETCore.ILAsm",
-    "version": "6.0.0",
-    "hash": "sha256-i/UcSf9HhYBtscSZKsaPReL/ntN8EQhmEpFIkEfoGhQ="
-  },
-  {
-    "pname": "runtime.linux-x64.Microsoft.NETCore.ILDAsm",
-    "version": "6.0.0",
-    "hash": "sha256-flN7eEFoqIUmbuGHgVu/R1F7trwjOXwxmBVw/+Jv2Hg="
   },
   {
     "pname": "runtime.native.System",
@@ -661,11 +526,6 @@
   },
   {
     "pname": "System.Collections.Immutable",
-    "version": "6.0.0",
-    "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
-  },
-  {
-    "pname": "System.Collections.Immutable",
     "version": "8.0.0",
     "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
   },
@@ -776,11 +636,6 @@
   },
   {
     "pname": "System.Numerics.Vectors",
-    "version": "4.4.0",
-    "hash": "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U="
-  },
-  {
-    "pname": "System.Numerics.Vectors",
     "version": "4.5.0",
     "hash": "sha256-qdSTIFgf2htPS+YhLGjAGiLN8igCYJnCCo6r78+Q+c8="
   },
@@ -863,11 +718,6 @@
     "pname": "System.Runtime",
     "version": "4.3.0",
     "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.3",
-    "hash": "sha256-lnZMUqRO4RYRUeSO8HSJ9yBHqFHLVbmenwHWkIU20ak="
   },
   {
     "pname": "System.Runtime.CompilerServices.Unsafe",
@@ -1028,6 +878,11 @@
     "pname": "System.Xml.XDocument",
     "version": "4.3.0",
     "hash": "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI="
+  },
+  {
+    "pname": "Vezel.Zig.Toolsets.linux-x64",
+    "version": "0.14.1.1",
+    "hash": "sha256-H32XG4157eWqa6qcVtd4t6Ef35MzYnXqr62FcwMAxSo="
   },
   {
     "pname": "YamlDotNet",

--- a/pkgs/by-name/ev/everest/package.nix
+++ b/pkgs/by-name/ev/everest/package.nix
@@ -11,7 +11,7 @@
 
 let
   pname = "everest";
-  version = "5806";
+  version = "5935";
   phome = "$out/lib/Celeste";
 in
 buildDotnetModule {
@@ -20,11 +20,11 @@ buildDotnetModule {
   src = fetchFromGitHub {
     owner = "EverestAPI";
     repo = "Everest";
-    rev = "e47f67fc8c4b0b60b0a75112c5c90704ed371040";
+    rev = "6a6da718227b357f5b997499e454d5dc5c3e2788";
     fetchSubmodules = true;
     # TODO: use leaveDotGit = true and modify external/MonoMod in postFetch to please SourceLink
     # Microsoft.SourceLink.Common.targets(53,5): warning : Source control information is not available - the generated source link is empty.
-    hash = "sha256-scizz5U9DQaeJsh0dg7Lllycd/D3Ezu8QNYPPZFGJhY=";
+    hash = "sha256-qSDcwqjJeb2pNbyriZ/9Gk72DyR5KdIoncXol7JZvFg=";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];
@@ -44,8 +44,24 @@ buildDotnetModule {
     autoPatchelf lib-ext/piton/piton-linux_x64
   '';
 
-  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-sdk =
+    with dotnetCorePackages;
+    sdk_9_0
+    // {
+      inherit
+        (combinePackages [
+          sdk_9_0
+          sdk_8_0
+        ])
+        packages
+        targetPackages
+        ;
+    };
   nugetDeps = ./deps.json;
+
+  # Workaround from https://github.com/NixOS/nixpkgs/issues/454432
+  # Necessitated by https://github.com/MonoMod/MonoMod/pull/246
+  dotnetRestoreFlags = [ "--force-evaluate" ];
 
   # Needed for ILAsm projects: https://github.com/NixOS/nixpkgs/issues/370754#issuecomment-2571475814
   linkNugetPackages = true;

--- a/pkgs/by-name/ev/everest/update.sh
+++ b/pkgs/by-name/ev/everest/update.sh
@@ -19,6 +19,5 @@ version=$(echo "$latest" | jq -r .version)
 url=$(echo "$latest" | jq -r .mainDownload)
 
 update-source-version everest $version --rev=$commit
-echo > "$(dirname "$(nix-instantiate --eval --strict -A everest.meta.position | sed -re 's/^"(.*):[0-9]+"$/\1/')")/deps.json"
 "$(nix-build --attr everest.fetch-deps --no-out-link)"
 update-source-version everest-bin $version "" $url


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Just after #452674 was opened, an update landed in the stable release channel of Everest that broke the package due to MonoMod/MonoMod#246 and #454432, which I was not aware of before it was merged, so I am opening a new PR to fix this.

Also applied the fix in https://github.com/NixOS/nixpkgs/pull/452674#issuecomment-3420011598.

CC @rhelmot.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
