### PR TITLE
python3Packages.google-cloud-*: bump to current

### DIFF
--- a/pkgs/development/python-modules/google-api-core/default.nix
+++ b/pkgs/development/python-modules/google-api-core/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "google-api-core";
-  version = "2.25.1";
+  version = "2.26.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "python-api-core";
     tag = "v${version}";
-    hash = "sha256-lh4t03upQQxY2KGwucXfEeNvqVVXlZ6hjR/e47imetk=";
+    hash = "sha256-BA2OWzr0sH77YUkFqMsGJQppqbG3R4sQ2kepicdzejE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/google-api-python-client/default.nix
+++ b/pkgs/development/python-modules/google-api-python-client/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "google-api-python-client";
-  version = "2.177.0";
+  version = "2.185.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-api-python-client";
     tag = "v${version}";
-    hash = "sha256-CEjbUIXtG5z1/28DsNCm/npMSd/+DyY5PMJHm9XDe2M=";
+    hash = "sha256-y6MfDwA1CKsKmXH9NIqFtKIz8vk5XC6d91scrTI4xdY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/google-auth/default.nix
+++ b/pkgs/development/python-modules/google-auth/default.nix
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "google-auth";
-  version = "2.40.3";
+  version = "2.41.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-auth-library-python";
     tag = "v${version}";
-    hash = "sha256-X1HTh24oos2GUxB9DDLtNH7BsBRLD0S/ngjsDAQYvhI=";
+    hash = "sha256-EPiI3cJy+NkT1oyKZJKcvQwAb64UQZDSNfWorZjIew8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/google-cloud-iam/default.nix
+++ b/pkgs/development/python-modules/google-cloud-iam/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-iam";
-  version = "2.19.0";
+  version = "2.20.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-python";
     tag = "google-cloud-iam-v${version}";
-    hash = "sha256-E1LISOLQcXqUMTTPLR+lwkR6gF1fuGGB44j38cIK/Z4=";
+    hash = "sha256-ICSBKEqNaXZZopGDwB0pkt06xN0gnsTBUA/HCQVxQTU=";
   };
 
   sourceRoot = "${src.name}/packages/google-cloud-iam";

--- a/pkgs/development/python-modules/google-cloud-kms/default.nix
+++ b/pkgs/development/python-modules/google-cloud-kms/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-kms";
-  version = "3.4.1";
+  version = "3.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-python";
     tag = "google-cloud-kms-v${version}";
-    hash = "sha256-5PzidE1CWN+pt7+gcAtbuXyL/pq6cnn0MCRkBfmeUSw=";
+    hash = "sha256-/ZBpSn6bZpzFgIg3LmfV7xMowh9Gpslw0fcN021jAow=";
   };
 
   sourceRoot = "${src.name}/packages/google-cloud-kms";

--- a/pkgs/development/python-modules/google-cloud-storage/default.nix
+++ b/pkgs/development/python-modules/google-cloud-storage/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-storage";
-  version = "3.3.0";
+  version = "3.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "python-storage";
     tag = "v${version}";
-    hash = "sha256-I0wC/BV8fJr3JW1nyq2TPJZlZaT4+h2lJBdGTttSzRo=";
+    hash = "sha256-fLS1rrblNKm8dTG/Srg6IfcEjeZCS2QGNwW6ZXIo7UQ=";
   };
 
   pythonRelaxDeps = [ "google-auth" ];


### PR DESCRIPTION
python3Packages.google-cloud-kms: 3.4.1 -> 3.7.0
python3Packages.google-cloud-iam: 2.19.0 -> 2.20.0
python3Packages.google-cloud-storage: 3.3.0 -> 3.4.1
python3Packages.google-auth: 2.40.3 -> 2.41.1
python3Packages.google-api-python-client: 2.177.0 -> 2.185.0
python3Packages.google-api-core: 2.25.1 -> 2.26.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
