### PR TITLE
ocamlPackages.camlp5: 8.03.2 → 8.04.00

### DIFF
--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -14,92 +14,83 @@
   legacy ? false,
 }:
 
-if lib.versionOlder ocaml.version "4.02" then
-  throw "camlp5 is not available for OCaml ${ocaml.version}"
-else
-
+stdenv.mkDerivation (
+  finalAttrs:
   let
-    params =
-      if lib.versionAtLeast ocaml.version "4.12" && !legacy then
-        rec {
-          version = "8.03.02";
-
-          src = fetchFromGitHub {
-            owner = "camlp5";
-            repo = "camlp5";
-            rev = version;
-            hash = "sha256-nz+VfGR/6FdBvMzPPpVpviAXXBWNqM3Ora96Yzx964o=";
-          };
-
-          nativeBuildInputs = [
-            makeWrapper
-            ocaml
-            findlib
-            perl
-          ];
-          buildInputs = [
-            bos
-            pcre2
-            re
-            rresult
-          ];
-          propagatedBuildInputs = [ camlp-streams ];
-          postInstall = ''
-            for prog in camlp5 camlp5o camlp5r camlp5sch mkcamlp5 ocpp5
-            do
-              wrapProgram $out/bin/$prog \
-                --prefix CAML_LD_LIBRARY_PATH : "$CAML_LD_LIBRARY_PATH"
-            done
-          '';
-
-        }
-      else
-        rec {
-          version = "7.14";
-          src = fetchFromGitHub {
-            owner = "camlp5";
-            repo = "camlp5";
-            rev = "rel${builtins.replaceStrings [ "." ] [ "" ] version}";
-            sha256 = "1dd68bisbpqn5lq2pslm582hxglcxnbkgfkwhdz67z4w9d5nvr7w";
-          };
-          nativeBuildInputs = [
-            ocaml
-            perl
-          ];
-        };
+    recent = lib.versionAtLeast (lib.versions.major finalAttrs.version) "8";
   in
+  {
 
-  stdenv.mkDerivation (
-    params
-    // {
+    version = if lib.versionAtLeast ocaml.version "4.12" && !legacy then "8.04.00" else "7.14";
 
-      pname = "ocaml${ocaml.version}-camlp5";
+    pname = "ocaml${ocaml.version}-camlp5";
 
-      strictDeps = true;
+    src = fetchFromGitHub {
+      owner = "camlp5";
+      repo = "camlp5";
+      tag =
+        if recent then
+          finalAttrs.version
+        else
+          "rel${builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version}";
+      hash =
+        {
+          "8.04.00" = "sha256-5IQVGm/tqEzXmZmSYGbGqX+KN9nQLQgw+sBP+F2keXo=";
+          "8.03.2" = "sha256-nz+VfGR/6FdBvMzPPpVpviAXXBWNqM3Ora96Yzx964o=";
+          "7.14" = "sha256-/ORtS0uc/GN+g3y6N5ftjL4OBSqV6iswLRbfpeNCprU=";
+        }
+        ."${finalAttrs.version}";
+    };
+    nativeBuildInputs = [
+      ocaml
+      perl
+    ]
+    ++ lib.optionals recent [
+      makeWrapper
+      findlib
+    ];
 
-      prefixKey = "-prefix ";
+    buildInputs = lib.optionals recent [
+      bos
+      pcre2
+      re
+      rresult
+    ];
 
-      preConfigure = ''
-        configureFlagsArray=(--strict --libdir $out/lib/ocaml/${ocaml.version}/site-lib)
-        patchShebangs ./config/find_stuffversion.pl etc/META.pl
+    propagatedBuildInputs = lib.optional recent camlp-streams;
+
+    strictDeps = true;
+
+    prefixKey = "-prefix ";
+
+    preConfigure = ''
+      configureFlagsArray=(--strict --libdir $out/lib/ocaml/${ocaml.version}/site-lib)
+      patchShebangs ./config/find_stuffversion.pl etc/META.pl tools/ ocaml_src/tools/
+    '';
+
+    buildFlags = [ "world.opt" ];
+
+    postInstall = lib.optionalString recent ''
+      for prog in camlp5 camlp5o camlp5r camlp5sch mkcamlp5 ocpp5
+      do
+        wrapProgram $out/bin/$prog \
+          --prefix CAML_LD_LIBRARY_PATH : "$CAML_LD_LIBRARY_PATH"
+      done
+    '';
+    dontStrip = true;
+
+    meta = {
+      broken =
+        lib.versionAtLeast ocaml.version "5.04" && !lib.versionAtLeast finalAttrs.version "8.04.00";
+      description = "Preprocessor-pretty-printer for OCaml";
+      longDescription = ''
+        Camlp5 is a preprocessor and pretty-printer for OCaml programs.
+        It also provides parsing and printing tools.
       '';
-
-      buildFlags = [ "world.opt" ];
-
-      dontStrip = true;
-
-      meta = with lib; {
-        description = "Preprocessor-pretty-printer for OCaml";
-        longDescription = ''
-          Camlp5 is a preprocessor and pretty-printer for OCaml programs.
-          It also provides parsing and printing tools.
-        '';
-        homepage = "https://camlp5.github.io/";
-        license = licenses.bsd3;
-        platforms = ocaml.meta.platforms or [ ];
-        maintainers = with maintainers; [
-          vbgl
-        ];
-      };
-    }
-  )
+      homepage = "https://camlp5.github.io/";
+      license = lib.licenses.bsd3;
+      platforms = ocaml.meta.platforms or [ ];
+      maintainers = [ lib.maintainers.vbgl ];
+    };
+  }
+)

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2245,7 +2245,16 @@ let
 
         google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };
 
-        hol_light = callPackage ../applications/science/logic/hol_light { };
+        hol_light = callPackage ../applications/science/logic/hol_light {
+          camlp5 =
+            if lib.versionAtLeast camlp5.version "8.04.00" then
+              camlp5.overrideAttrs {
+                version = "8.03.2";
+                __intentionallyOverridingVersion = true;
+              }
+            else
+              camlp5;
+        };
 
         ### End ###
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
