### PR TITLE
ci/eval/compare/maintainers: fix maintainer pings without meta.position

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -72,7 +72,8 @@ let
           (lib.unsafeGetAttrPos "src" drv)
           (lib.unsafeGetAttrPos "pname" drv)
           (lib.unsafeGetAttrPos "version" drv)
-
+        ]
+        ++ lib.optionals (drv.meta.position or null != null) [
           # Use ".meta.position" for cases when most of the package is
           # defined in a "common" section and the only place where
           # reference to the file with a derivation the "pos"
@@ -82,7 +83,7 @@ let
           #   "pkgs/tools/package-management/nix/default.nix:155"
           # We transform it to the following:
           #   { file = "pkgs/tools/package-management/nix/default.nix"; }
-          { file = lib.head (lib.splitString ":" (drv.meta.position or "")); }
+          { file = lib.head (lib.splitString ":" drv.meta.position); }
         ]
       )
     ));


### PR DESCRIPTION
In a [recent change](https://github.com/NixOS/nixpkgs/pull/452566), the path matching was simplified in maintainers.nix. This revealed a pre-existing logic bug: Packages without `meta.position` would get an empty string as their file name. The change would then cause this empty string to always be matched, which lead to maintainer pings for these packages in seemingly random PRs, when some of their dependencies were changed.

Random pings observed in: #454434, #454320

cc @dotlambda 

## Things done

- [x] Tested pieces of maintainer.nix in `nix repl`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
