### PR TITLE
Add maintainer info and descope: init at 1.7.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20295,6 +20295,11 @@
     githubId = 1219785;
     name = "Félix Baylac-Jacqué";
   };
+  pid1 = {
+    github = "pid1";
+    githubId = 4173362;
+    name = "Jonathan Roemer";
+  };
   piegames = {
     name = "piegames";
     email = "nix@piegames.de";

--- a/pkgs/development/python-modules/descope/default.nix
+++ b/pkgs/development/python-modules/descope/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   # Remove liccheck dev dependency from runtime dependencies
   pythonRemoveDeps = [ "liccheck" ];
 
-  meta = ; {
+  meta = {
     description = "Descope Python SDK";
     homepage = "https://descope.com/";
     changelog = "https://github.com/descope/python-sdk/releases/tag/${version}";

--- a/pkgs/development/python-modules/descope/default.nix
+++ b/pkgs/development/python-modules/descope/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Descope Python SDK";
     homepage = "https://descope.com/";
-    changelog = "https://github.com/descope/python-sdk/releases/tag/v${version}";
+    changelog = "https://github.com/descope/python-sdk/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ pid1 ];
   };

--- a/pkgs/development/python-modules/descope/default.nix
+++ b/pkgs/development/python-modules/descope/default.nix
@@ -16,8 +16,6 @@ buildPythonPackage rec {
   version = "1.7.11";
   pyproject = true;
 
-  disabled = pythonOlder "3.8.1";
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-x4JsBweG7d6htBqDUfAMfgatOD+a03F5Pxa9y/BEFjA=";
@@ -41,14 +39,14 @@ buildPythonPackage rec {
   # Package does not include tests in distribution
   doCheck = false;
 
-  # Skip runtime dependency check - liccheck is a dev dependency
-  dontCheckRuntimeDeps = true;
+  # Remove liccheck dev dependency from runtime dependencies
+  pythonRemoveDeps = [ "liccheck" ];
 
-  meta = with lib; {
+  meta = ; {
     description = "Descope Python SDK";
     homepage = "https://descope.com/";
     changelog = "https://github.com/descope/python-sdk/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ pid1 ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pid1 ];
   };
 }

--- a/pkgs/development/python-modules/descope/default.nix
+++ b/pkgs/development/python-modules/descope/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     homepage = "https://descope.com/";
     changelog = "https://github.com/descope/python-sdk/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ pid1 ];
   };
 }

--- a/pkgs/development/python-modules/descope/default.nix
+++ b/pkgs/development/python-modules/descope/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  cryptography,
+  email-validator,
+  fetchPypi,
+  flask,
+  poetry-core,
+  pythonOlder,
+  pyjwt,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "descope";
+  version = "1.7.11";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-x4JsBweG7d6htBqDUfAMfgatOD+a03F5Pxa9y/BEFjA=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    cryptography
+    email-validator
+    pyjwt
+    requests
+  ];
+
+  optional-dependencies = {
+    flask = [ flask ];
+  };
+
+  pythonImportsCheck = [ "descope" ];
+
+  # Package does not include tests in distribution
+  doCheck = false;
+
+  # Skip runtime dependency check - liccheck is a dev dependency
+  dontCheckRuntimeDeps = true;
+
+  meta = with lib; {
+    description = "Descope Python SDK";
+    homepage = "https://descope.com/";
+    changelog = "https://github.com/descope/python-sdk/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3630,6 +3630,8 @@ self: super: with self; {
 
   derpconf = callPackage ../development/python-modules/derpconf { };
 
+  descope = callPackage ../development/python-modules/descope { };
+
   desktop-entry-lib = callPackage ../development/python-modules/desktop-entry-lib { };
 
   desktop-notifier = callPackage ../development/python-modules/desktop-notifier { };


### PR DESCRIPTION
- Added my maintainer information
- Add the [Descope Python SDK](https://pypi.org/project/descope/) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
