### PR TITLE
various: fix meta.position

### DIFF
--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -144,6 +144,8 @@ let
 
       passthru = { inherit tests; };
 
+      # The recursiveUpdate below breaks default meta.position, so manually override it.
+      pos = __curPos;
       meta =
         with lib;
         recursiveUpdate {

--- a/pkgs/games/openra_2019/default.nix
+++ b/pkgs/games/openra_2019/default.nix
@@ -76,6 +76,7 @@ pkgs.recurseIntoAttrs rec {
       homepage,
       mods,
       src,
+      pos,
     }@engine:
     # Allow specifying the name at a later point if no name has been given.
     let
@@ -101,6 +102,7 @@ pkgs.recurseIntoAttrs rec {
       description,
       homepage,
       src,
+      pos,
       engine,
       assetsError ? "",
     }@mod:

--- a/pkgs/games/openra_2019/engine.nix
+++ b/pkgs/games/openra_2019/engine.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (
       )}
     '';
 
+    inherit (engine) pos;
     meta = {
       inherit (engine) description homepage;
     };

--- a/pkgs/games/openra_2019/engines.nix
+++ b/pkgs/games/openra_2019/engines.nix
@@ -27,6 +27,7 @@ let
         repo = "OpenRA";
         inherit rev sha256 postFetch;
       };
+      pos = __curPos;
     } name).overrideAttrs
       (origAttrs: {
         postInstall = ''

--- a/pkgs/games/openra_2019/mod.nix
+++ b/pkgs/games/openra_2019/mod.nix
@@ -110,6 +110,7 @@ stdenv.mkDerivation (
       runHook postInstall
     '';
 
+    inherit (mod) pos;
     meta = {
       inherit (mod) description homepage;
     };

--- a/pkgs/games/openra_2019/mods.nix
+++ b/pkgs/games/openra_2019/mods.nix
@@ -24,6 +24,7 @@ in
       rev = "fc3cf0baf2b827650eaae9e1d2335a3eed24bac9";
       sha256 = "15w91xs253gyrlzsgid6ixxjazx0fbzick6vlkiay0znb58n883m";
     };
+    pos = __curPos;
     engine = {
       version = "b8a7dd5";
       src = fetchFromGitHub {
@@ -48,6 +49,7 @@ in
       rev = "69a4aa708e2c26376469c0048fac13592aa452ca";
       sha256 = "1mfch4s6c05slyqvxllklbxpqq8dqcbx3515n3gyylyq43gq481r";
     };
+    pos = __curPos;
     engine = rec {
       version = "release-20181215";
       mods = [
@@ -81,6 +83,7 @@ in
       rev = "ffcd6ba72979e5f77508136ed7b0efc13e4b100e";
       sha256 = "07g4qw909649s3i1yhw75613mpwfka05jana5mpp5smhnf0pkack";
     };
+    pos = __curPos;
     engine = {
       version = "DarkReign";
       src = fetchFromGitHub {
@@ -105,6 +108,7 @@ in
       rev = "4f5e11d916e4a03d8cf1c97eef484ce2d77d7df2";
       sha256 = "1wnl4qrlhynnlahgdlxwhgsdba5wgdg9yrv9f8hkgi69j60szypd";
     };
+    pos = __curPos;
     engine = rec {
       version = "gen-20190128_3";
       src = fetchFromGitHub {
@@ -134,6 +138,7 @@ in
         rev = "5530babcb05170e0959e4cf2b079161e9fedde4f";
         sha256 = "07jczrarmgm6zdk0myzwgq200x19yvpjyxrnhdac08mjgyz75zk1";
       };
+      pos = __curPos;
       engine = {
         version = "4e8eab4ca00d1910203c8a103dfd2c002714daa8";
         src = fetchFromGitHub {
@@ -165,6 +170,7 @@ in
       rev = "c9be8f2a6f1dd710b1aedd9d5b00b4cf5020e2fe";
       sha256 = "09fp7k95jd6hjqdasbspbd43z5670wkyzbbgqkll9dfsrv0sky0v";
     };
+    pos = __curPos;
     engine = {
       version = "MedievalWarfareEngine";
       src = fetchFromGitHub {
@@ -189,6 +195,7 @@ in
       rev = "2f7c700d6d63c0625e7158ef3098221fa6741569";
       sha256 = "11vnzwczn47wjfrq6y7z9q234p27ihdrcl5p87i6h2xnrpwi8b6m";
     };
+    pos = __curPos;
     engine = rec {
       version = "release-20180923";
       src = fetchFromGitHub {
@@ -217,6 +224,7 @@ in
       rev = "c76c13e9f0912a66ddebae8d05573632b19736b2";
       sha256 = "1cnr3ccvrkjlv8kkdcglcfh133yy0fkva9agwgvc7wlj9n5ydl4g";
     };
+    pos = __curPos;
     engine = rec {
       version = "release-20190314";
       src = fetchFromGitHub {
@@ -241,6 +249,7 @@ in
       rev = "9230e6f1dd9758467832aee4eda115e18f0e635f";
       sha256 = "0bwbmmlhp1kh8rgk2nx1ca9vqssj849amndacf318d61gksc1w9n";
     };
+    pos = __curPos;
     engine = {
       version = "f3873ae";
       mods = [ "as" ];
@@ -270,6 +279,7 @@ in
       rev = "ac000cc15377cdf6d3c2b72c737d692aa0ed8bcd";
       sha256 = "16mzs5wcxj9nlpcyx2c87idsqpbm40lx0rznsccclnlb3hiwqas9";
     };
+    pos = __curPos;
     engine = {
       version = "SP-22-04-19";
       mods = [
@@ -298,6 +308,7 @@ in
       rev = "23e1f3e5d8b98c936797b6680d95d56a69a9e2ab";
       sha256 = "104clmxphchs7r8y7hpmw103bychayz80bqj98bp89i64nv9d89x";
     };
+    pos = __curPos;
     engine = {
       version = "6de92de";
       src = fetchFromGitHub {
@@ -322,6 +333,7 @@ in
       rev = "128dc53741fae923f4af556f2293ceaa0cf571f0";
       sha256 = "1mhr8kyh313z52gdrqv31d6z7jvdldiajalca5mcr8gzg6mph66p";
     };
+    pos = __curPos;
     engine = rec {
       version = "unplugged-cd82382";
       src = fetchFromGitHub {
@@ -346,6 +358,7 @@ in
       rev = "5b8b952dbe21f194a6d00485f20e215ce8362712";
       sha256 = "0hxzrqnz5d7qj1jjr20imiyih62x1cnmndf75nnil4c4sj82f9a6";
     };
+    pos = __curPos;
     engine = rec {
       version = "release-20190314";
       src = fetchFromGitHub {

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -42,8 +42,12 @@ let
     );
 in
 rec {
-  auditbeat7 = beat "auditbeat" { meta.description = "Lightweight shipper for audit data"; };
+  auditbeat7 = beat "auditbeat" {
+    pos = __curPos;
+    meta.description = "Lightweight shipper for audit data";
+  };
   filebeat7 = beat "filebeat" {
+    pos = __curPos;
     meta.description = "Lightweight shipper for logfiles";
     buildInputs = [ systemd ];
     tags = [ "withjournald" ];
@@ -51,8 +55,12 @@ rec {
       patchelf --set-rpath ${lib.makeLibraryPath [ (lib.getLib systemd) ]} "$out/bin/filebeat"
     '';
   };
-  heartbeat7 = beat "heartbeat" { meta.description = "Lightweight shipper for uptime monitoring"; };
+  heartbeat7 = beat "heartbeat" {
+    pos = __curPos;
+    meta.description = "Lightweight shipper for uptime monitoring";
+  };
   metricbeat7 = beat "metricbeat" {
+    pos = __curPos;
     meta.description = "Lightweight shipper for metrics";
     passthru.tests = lib.optionalAttrs config.allowUnfree (
       assert metricbeat7.drvPath == nixosTests.elk.unfree.ELK-7.elkPackages.metricbeat.drvPath;
@@ -63,6 +71,7 @@ rec {
   };
   packetbeat7 = beat "packetbeat" {
     buildInputs = [ libpcap ];
+    pos = __curPos;
     meta.description = "Network packet analyzer that ships data to Elasticsearch";
     meta.longDescription = ''
       Packetbeat is an open source network packet analyzer that ships the


### PR DESCRIPTION
Using `recursiveUpdate` over meta or similar, breaks `builtins.unsafeGetAttrPos` for `meta.description`. This causes `meta.position` to be unset. Fixing by passing `pos = __curPos` manually in the right spots.

This helped cause various unwanted maintainer pings in combination with #454648 recently.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
