### PR TITLE
knobkraft-orm: init at 2.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2753,6 +2753,12 @@
     githubId = 333807;
     name = "Pascal Bach";
   };
+  backtail = {
+    name = "Max Genson";
+    email = "mail@maxgenson.de";
+    github = "backtail";
+    githubId = 95583524;
+  };
   backuitist = {
     email = "biethb@gmail.com";
     github = "backuitist";

--- a/pkgs/by-name/kn/knobkraft-orm/package.nix
+++ b/pkgs/by-name/kn/knobkraft-orm/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+
+  gtk3,
+  glew,
+  webkitgtk_4_1,
+  cppcheck,
+  icu,
+  python312,
+  glib,
+  curlFull,
+  boost,
+  libbtbb,
+  libsysprof-capture,
+  pcre2,
+  alsa-lib,
+  util-linux,
+  libselinux,
+  libsepol,
+  libthai,
+  libdatrie,
+  xorg,
+  lerc,
+  libxkbcommon,
+  libepoxy,
+  sqlite,
+  git,
+  libdeflate,
+  xz,
+  libwebp,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "KnobKraft-orm";
+
+  version = "2.7.1";
+
+  src = fetchFromGitHub {
+    owner = "christofmuc";
+    repo = "knobkraft-orm";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-dOgPq4r2IvKDPhhV/LWRfGeeFckN5ZUeee/T6QNfCtw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    glew
+    webkitgtk_4_1
+    cppcheck
+    icu
+    python312
+    glib
+    curlFull
+    boost
+    libbtbb
+    libsysprof-capture
+    pcre2
+    alsa-lib
+    util-linux
+    libselinux
+    libsepol
+    libthai
+    libdatrie
+    xorg.libXdmcp
+    lerc
+    libxkbcommon
+    libepoxy
+    xorg.libXtst
+    sqlite
+    git
+    libdeflate
+    xz
+    libwebp
+  ];
+
+  # Issue has been raised and should be resolved with next release.
+  # CMakeLists.txt needs three more lines to properly build.
+  patches = [ ./temporary.patch ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INTERPROCEDURAL_OP" "off")
+    (lib.cmakeFeature "PYTHON_VERSION_TO_EMBED" "${python312.pythonVersion}")
+  ];
+
+  makeFlags = [
+    "package"
+  ];
+
+  meta = {
+    homepage = "https://github.com/christofmuc/KnobKraft-orm";
+    description = "Modern FOSS MIDI Sysex Librarian";
+    mainProgram = "KnobKraftOrm";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      backtail
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/kn/knobkraft-orm/temporary.patch
+++ b/pkgs/by-name/kn/knobkraft-orm/temporary.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b98ab0e..b1fc3de 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,6 +39,9 @@ option(ASAN "Use Address Sanitization for Debug version (Windows only for now)"
+ # Gin requests C++ 20.
+ set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
++set(CMAKE_AR  "gcc-ar")
++set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
++set(CMAKE_CXX_ARCHIVE_FINISH   true)
+ add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+ 
+ # To avoid dependency on WebKit. This also came with MacOS, but as webkit is heavyweight, it is probably a good idea to turn it off for all
+diff --git a/The-Orm/CMakeLists.txt b/The-Orm/CMakeLists.txt
+index 1c7186e..39cebd0 100644
+--- a/The-Orm/CMakeLists.txt
++++ b/The-Orm/CMakeLists.txt
+@@ -5,20 +5,7 @@
+ #
+ 
+ cmake_minimum_required(VERSION 3.14)
+-
+-# Get the version from our sub cmakefile
+-execute_process(
+-    COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/gitversion.cmake"
+-    ERROR_VARIABLE PROJECT_VERSION
+-    ERROR_STRIP_TRAILING_WHITESPACE
+-)
+-# Cleanup output
+-string(REGEX REPLACE "^[[:space:]]+|[[:space:]]+$" "" PROJECT_VERSION "${PROJECT_VERSION}")
+-string(REGEX REPLACE "\n$" "" PROJECT_VERSION "${PROJECT_VERSION}")
+-message(STATUS "Project version is '${PROJECT_VERSION}'")
+-
+-# Start project
+-project(KnobKraftOrm VERSION ${PROJECT_VERSION})
++project(KnobKraftOrm VERSION 2.7.1)
+ 
+ # Now you can use PROJECT_DEV_TAG in your CMake scripts or in your code to handle the "-dev" part.
+ # For example, you could add a preprocessor definition that your code could use:


### PR DESCRIPTION
[KnobKraft-orm](https://github.com/christofmuc/KnobKraft-orm) is a FOSS MIDI Sysex Librarian application. It can talk to a broad range of vintage and modern synthesizer gear and load/store banks, effects, etc. on the fly.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
