### PR TITLE
nixos-rebuild-ng: make the version correlated to the release we are in

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -26,7 +26,7 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "nixos-rebuild-ng";
-  version = "0.0.0";
+  version = lib.trivial.release;
   src = ./src;
   pyproject = true;
 


### PR DESCRIPTION
This isn't 0.0.0 -- it's 25.11! 😄 

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md