### PR TITLE
ubertooth: fix build with cmake4

### DIFF
--- a/pkgs/by-name/ub/ubertooth/fix-cmake4-build.patch
+++ b/pkgs/by-name/ub/ubertooth/fix-cmake4-build.patch
@@ -1,0 +1,37 @@
+commit 111bb8d98b4ff1897c36ff23806c492e9a313457
+Author: Will Dillon <william@housedillon.com>
+Date:   Mon Aug 11 13:58:40 2025 -0700
+
+    Update CMAKE version
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea0dfa6..9f1bcb3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,7 @@
+ #
+ #top level cmake project for ubertooth lib + tools
+ 
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10)
+ project(ubertooth_all)
+ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules
+ 	CACHE STRING "CMake module path")
+diff --git a/misc/CMakeLists.txt b/misc/CMakeLists.txt
+index f728056..4336fb0 100644
+--- a/misc/CMakeLists.txt
++++ b/misc/CMakeLists.txt
+@@ -1,2 +1,2 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10)
+ add_subdirectory(udev)
+diff --git a/misc/udev/CMakeLists.txt b/misc/udev/CMakeLists.txt
+index a7d4ed0..f7dcaf8 100644
+--- a/misc/udev/CMakeLists.txt
++++ b/misc/udev/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.10)
+ 
+ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+     SET(SYSTEM_IS_LINUX TRUE)

--- a/pkgs/by-name/ub/ubertooth/package.nix
+++ b/pkgs/by-name/ub/ubertooth/package.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/host";
 
+  patches = [
+    # https://github.com/greatscottgadgets/ubertooth/pull/546
+    ./fix-cmake4-build.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes cmake
#445447

PR to update cmake minimum version is already in source repository:
https://github.com/greatscottgadgets/ubertooth/pull/546

But not sure if it will be merged, since last commit in this repository was 2 years ago, and last release was 5 years ago.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
