### PR TITLE
netcdf-mpi: enable pnetcdf

### DIFF
--- a/pkgs/by-name/ne/netcdf/package.nix
+++ b/pkgs/by-name/ne/netcdf/package.nix
@@ -45,7 +45,8 @@ stdenv.mkDerivation rec {
     m4
     removeReferencesTo
     libxml2 # xml2-config
-  ];
+  ]
+  ++ lib.optional mpiSupport mpi;
 
   buildInputs = [
     curl
@@ -82,7 +83,7 @@ stdenv.mkDerivation rec {
   ++ (lib.optionals mpiSupport [
     "--enable-pnetcdf"
     "--enable-parallel-tests"
-    "CC=${lib.getDev mpi}/bin/mpicc"
+    "CC=mpicc"
   ]);
 
   enableParallelBuilding = true;
@@ -90,7 +91,9 @@ stdenv.mkDerivation rec {
   disallowedReferences = [ stdenv.cc ];
 
   postFixup = ''
-    remove-references-to -t ${stdenv.cc} "$(readlink -f $out/lib/libnetcdf.settings)"
+    remove-references-to -t ${
+      if mpiSupport then lib.getDev mpi else stdenv.cc
+    } "$(readlink -f $out/lib/libnetcdf.settings)"
   '';
 
   doCheck = !mpiSupport;

--- a/pkgs/by-name/ne/netcdf/package.nix
+++ b/pkgs/by-name/ne/netcdf/package.nix
@@ -9,6 +9,7 @@
   zstd,
   szipSupport ? false,
   szip,
+  pnetcdf,
   libxml2,
   m4,
   curl, # for DAP
@@ -55,7 +56,10 @@ stdenv.mkDerivation rec {
     zstd
   ]
   ++ lib.optional szipSupport szip
-  ++ lib.optional mpiSupport mpi;
+  ++ lib.optionals mpiSupport [
+    mpi
+    pnetcdf
+  ];
 
   strictDeps = true;
 
@@ -76,6 +80,7 @@ stdenv.mkDerivation rec {
     "--with-plugin-dir=${placeholder "out"}/lib/hdf5-plugins"
   ]
   ++ (lib.optionals mpiSupport [
+    "--enable-pnetcdf"
     "--enable-parallel-tests"
     "CC=${lib.getDev mpi}/bin/mpicc"
   ]);

--- a/pkgs/by-name/pn/pnetcdf/package.nix
+++ b/pkgs/by-name/pn/pnetcdf/package.nix
@@ -21,17 +21,24 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-nz40Ji9qh6UatlLOuChsWYvHwfVNacJI87usGBcYyFk=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     perl
     autoreconfHook
     gfortran
+    mpi
   ];
-
-  buildInputs = [ mpi ];
 
   postPatch = ''
     patchShebangs src/binding/f77/buildiface test examples benchmarks
+
+    # do not use fullpath of mpi, remove reference to mpi^dev
+    substituteInPlace  m4/check_mpi.m4 \
+      --replace-fail ''\'''$1=''${ac_mpi_prog_''$1}' ''\'''$1=`basename ''${ac_mpi_prog_''$1}`'
   '';
+
+  enableParallelBuilding = true;
 
   __darwinAllowLocalNetworking = true;
 
@@ -50,8 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   # cannot do parallel check otherwise failed
   enableParallelChecking = false;
-
-  enableParallelBuilding = true;
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "checkpoint.";


### PR DESCRIPTION
enabled pnetcdf for netcdf-mpi variant.

To avoid rebuild of netcdf, the diff looks ugly. I will rewrite netcdf with cmake build system in next release.

I tried to remove refference to mpi^dev, this work for openmpi but not work for mpich (mpich does not split dev output).

what will happen if we dont hardcoding CC/CXX in mpicc/mpicxx wrapper ?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
