### PR TITLE
ly: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/by-name/ly/ly/deps.nix
+++ b/pkgs/by-name/ly/ly/deps.nix
@@ -89,27 +89,36 @@ let
 in
 linkFarm name [
   {
-    name = "clap-0.10.0-oBajB434AQBDh-Ei3YtoKIRxZacVPF1iSwp3IX_ZB8f0";
+    name = "clap-0.11.0-oBajB-HnAQDPCKYzwF7rO3qDFwRcD39Q0DALlTSz5H7e";
     path = fetchZigArtifact {
       name = "clap";
-      url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.10.0.tar.gz";
-      hash = "sha256-cbPGmVlIXwIuRPIfQoFXzwLulT4XEv8rQWcJUl1ueyo=";
+      url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.11.0.tar.gz";
+      hash = "sha256-fDWd7EQYZuAlBlrpynBuznK89OiiX74xcZsekv84lkg=";
     };
   }
   {
-    name = "zigini-0.3.1-BSkB7XJGAAB2E-sKyzhTaQCBlYBL8yqzE4E_jmSY99sC";
+    name = "zigini-0.3.2-BSkB7WJJAADybd5DGd9MLCp6ikGGUq9wicxsjv0HF1Qc";
     path = fetchZigArtifact {
       name = "zigini";
-      url = "https://github.com/Kawaii-Ash/zigini/archive/2ed3d417f17fab5b0ee8cad8a63c6d62d7ac1042.tar.gz";
-      hash = "sha256-Zj9uU6EEHkNZ1cPIDgDj1E2CEpbmPmpJYjSSFnxxdf0=";
+      url = "https://github.com/AnErrupTion/zigini/archive/96ca1d9f1a7ec741f07ceb104dae2b3a7bdfd48a.tar.gz";
+      hash = "sha256-Hhc/+a8ToHI9RAJTIQ6Z3KZKQFvoPvd5ODz7HRbytdw=";
     };
   }
   {
-    name = "N-V-__8AAB9qAACwl56piR-krrhXSPxCvEskA52cmaTWXYk_";
+    name = "ini-0.1.0-YCQ9YkUnAAA7SjpLwvomwrngMn3TConSAlNgo7Q8ibMZ";
     path = fetchZigArtifact {
       name = "ini";
-      url = "https://github.com/ziglibs/ini/archive/e18d36665905c1e7ba0c1ce3e8780076b33e3002.tar.gz";
-      hash = "sha256-RQ6OPJBqqH7PCL+xiI58JT7vnIo6zbwpLWn+byZO5iM=";
+      url = "https://github.com/AnErrupTion/ini/archive/ac6e656157b2ac6c98392283a139b47c44a85d54.tar.gz";
+      hash = "sha256-rOXuHsd4WiLDODruQioADMWQ7UkNtx5LUdTcK2dve40=";
+    };
+  }
+  {
+    name = "N-V-__8AAGcUBQAa5vov1Yi_9AXEffFQ1e2KsXaK4dgygRKq";
+    path = fetchZigArtifact {
+      name = "termbox2";
+      url = "git+https://github.com/AnErrupTion/termbox2?ref=master#290ac6b8225aacfd16851224682b851b65fcb918";
+      hash = "sha256-of95/wJeCTWI3p7NxvnUlb618qffUZv2YxgBgzp+crs=";
+      rev = "290ac6b8225aacfd16851224682b851b65fcb918";
     };
   }
 ]

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -5,7 +5,7 @@
   linux-pam,
   libxcb,
   makeBinaryWrapper,
-  zig_0_14,
+  zig_0_15,
   callPackage,
   nixosTests,
   x11Support ? true,
@@ -13,19 +13,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ly";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
-    owner = "AnErrupTion";
+    owner = "fairyglade";
     repo = "ly";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xD1FLW8LT+6szfjZbP++qJThf4xxbmw4jRHB8TdrG70=";
+    hash = "sha256-2JOpC70uBvGk17edXDNeNhNqn2hHZBpOoQaUxN0IlLk=";
   };
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    zig_0_14.hook
+    zig_0_15.hook
   ];
   buildInputs = [
     linux-pam
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     ln -s ${
       callPackage ./deps.nix {
-        zig = zig_0_14;
+        zig = zig_0_15;
       }
     } $ZIG_GLOBAL_CACHE_DIR/p
   '';
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "TUI display manager";
     license = lib.licenses.wtfpl;
-    homepage = "https://codeberg.org/AnErrupTion/ly";
+    homepage = "https://codeberg.org/fairyglade/ly";
     maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "ly";


### PR DESCRIPTION
update to newest release
changelog: https://codeberg.org/fairyglade/ly/releases/tag/v1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
