### PR TITLE
google-cloud-sdk: fix build determinism

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -87,6 +87,9 @@ stdenv.mkDerivation rec {
     ./gsutil-disable-updates.patch
   ];
 
+  # Prevent Python from writing bytecode to ensure build determinism
+  PYTHONDONTWRITEBYTECODE = "1";
+
   installPhase = ''
     runHook preInstall
 
@@ -161,8 +164,6 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     # Avoid trying to write logs to homeless-shelter
     export HOME=$(mktemp -d)
-    # Prevent Python from writing bytecode to ensure build determinism
-    export PYTHONDONTWRITEBYTECODE=1
     $out/bin/gcloud version --format json | jq '."Google Cloud SDK"' | grep "${version}"
     $out/bin/gsutil version | grep -w "$(cat platform/gsutil/VERSION)"
   '';

--- a/pkgs/by-name/go/google-cloud-sdk/withExtraComponents.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/withExtraComponents.nix
@@ -78,11 +78,12 @@ symlinkJoin {
   ]
   ++ comps;
 
+  # Prevent Python from writing bytecode to ensure build determinism
+  PYTHONDONTWRITEBYTECODE = "1";
+
   postBuild = ''
     sed -i ';' $out/google-cloud-sdk/bin/.gcloud-wrapped
     sed -i -e "s#${google-cloud-sdk}#$out#" "$out/google-cloud-sdk/bin/gcloud"
-    # Prevent Python from writing bytecode to ensure build determinism
-    export PYTHONDONTWRITEBYTECODE=1
     ${installCheck}
   '';
 }


### PR DESCRIPTION
The `google-cloud-sdk` package produces non-deterministic builds. On some machines, the build output contains `__pycache__` directories with Python bytecode (`.pyc` files), while on others it doesn't.

This was attempted to be fixed in https://github.com/NixOS/nixpkgs/pull/452502, however `PYTHONDONTWRITEBYTECODE=1` was only set in the `installCheckPhase`, but not in the `installPhase` where the installation happens. When Python code executes during installation, it creates bytecode files.

This issue can be reproduced synthetically (see [070f7782556566393bc344d693c136ee2f1021e6](https://github.com/NixOS/nixpkgs/commit/070f7782556566393bc344d693c136ee2f1021e6)). It's difficult to get the actual derivation to reproduce, but it does happen on my CI machines regularly, which I have verified with 

```
$ nix-store --verify-path /nix/store/4q5pwaa5afm1rxq3cn8p9z0qglsqpzvv-google-cloud-sdk-519.0.0
path '/nix/store/4q5pwaa5afm1rxq3cn8p9z0qglsqpzvv-google-cloud-sdk-519.0.0' was modified! expected hash 'sha256:0whw5faqwxi29q2bzg1qj9b6bhjij2vfklwcwshmrh1z47liz4mq', got 'sha256:1sg6vkjx9fxjqa52blqlnbm5ijmcha599jvy6fkqs11l93v0ijx0'
```

These nix store paths continue to have extra  `__pycache__` directories when compared to the nixpkgs binary cache version.

The fix is to add `PYTHONDONTWRITEBYTECODE` as a derivation attribute to ensure that this env var is used by all phases.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
