### PR TITLE
antec-flux-pro-display: init at 1.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -71,6 +71,8 @@
 
 - [knot-resolver](https://www.knot-resolver.cz/), in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
 
+- [antec-flux-pro-display](https://github.com/Reikooters/antec-flux-pro-display) a service to enable support for the Antec Flux Pro Case temperature display. Available as [hardware.antec.enable](#opt-hardware.antec.enable)
+
 - [ImmichFrame](https://immichframe.dev/), display your photos from Immich as a digital photo frame. Available as `services.immichframe`.
 
 - [PdfDing](https://www.pdfding.com/), manage, view and edit your PDFs seamlessly on all your devices wherever you are. Available as [services.pdfding](#opt-services.pdfding.enable).

--- a/nixos/modules/hardware/antec.nix
+++ b/nixos/modules/hardware/antec.nix
@@ -1,0 +1,76 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.modules) mkIf;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) str;
+  inherit (lib.options) mkEnableOption mkOption;
+
+  cfg = config.hardware.antec;
+in
+{
+  meta.maintainers = [ lib.maintainers.kruziikrel13 ];
+
+  options = {
+    hardware.antec = {
+      enable = mkEnableOption "support for Antec Flux Pro GPU and CPU Temperature Sensor.";
+      cpu-device = mkOption {
+        type = str;
+        default = "k10temp";
+        description = "CPU temperature device name";
+      };
+      cpu-temp-type = mkOption {
+        type = str;
+        default = "tctl";
+        description = "CPU temperature sensor label";
+      };
+      gpu-device = mkOption {
+        type = str;
+        default = "amdgpu";
+        description = "GPU temperature device name";
+      };
+      gpu-temp-type = mkOption {
+        type = str;
+        default = "edge";
+        description = "GPU temperature sensor label";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.antec-flux-pro ];
+    services.udev.packages = [ pkgs.antec-flux-pro.udev ];
+    environment.etc."antec-flux-pro-display/config.conf".text = ''
+      cpu_device=${cfg.cpu-device}
+      cpu_temp_type=${cfg.cpu-temp-type}
+      gpu_device=${cfg.gpu-device}
+      gpu_temp_type=${cfg.gpu-temp-type}
+      update_interval=1000
+    '';
+
+    systemd.services.antec-flux-pro-display = {
+      unitConfig = {
+        Description = "Service for monitoring and displaying Antec Flux Pro case temperature sensors.";
+        StartLimitIntervalSec = "0";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = getExe pkgs.antec-flux-pro;
+        Restart = "always";
+        RestartSec = "5";
+        ProtectSystem = "strict";
+        ProtectHome = "true";
+        PrivateTmp = "true";
+        NoNewPrivileges = "true";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -49,6 +49,7 @@
   ./config/xdg/terminal-exec.nix
   ./config/zram.nix
   ./hardware/acpilight.nix
+  ./hardware/antec.nix
   ./hardware/all-firmware.nix
   ./hardware/all-hardware.nix
   ./hardware/apple-touchbar.nix

--- a/pkgs/by-name/an/antec-flux-pro/package.nix
+++ b/pkgs/by-name/an/antec-flux-pro/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  lm_sensors,
+  usbutils,
+  udevCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "antec-flux-pro";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "Reikooters";
+    repo = "antec-flux-pro-display";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1omQVWSIrwQIsB+pfhDz0N8A3T/qMRBlLseBxANMS9c=";
+  };
+  cargoHash = "sha256-GR/ZcT1v1Tv4KAfD+IldhkYwz0kaT/lhN6wXtMbmO9o=";
+
+  buildInputs = [
+    lm_sensors
+    usbutils
+  ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  outputs = [
+    "out"
+    "udev"
+  ];
+
+  udevRules = ''
+    SUBSYSTEM=="usb", ATTR{idVendor}=="2022", ATTR{idProduct}=="0522", GROUP="plugdev", TAG+="uaccess"
+  '';
+
+  passAsFile = [ "udevRules" ];
+
+  postInstall = ''
+    install -Dm644 "$udevRulesPath" $udev/lib/udev/rules.d/70-antec-flux-pro.rules
+  '';
+
+  meta = {
+    homepage = "https://github.com/Reikooters/antec-flux-pro-display";
+    description = "Antec Flux Pro Hardware Display Service";
+    mainProgram = "antec-flux-pro-display";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.kruziikrel13 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This supplies a program / service for the antec flux pro display case that allows for GPU / CPU Temperature to be displayed on the case.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
