### PR TITLE
keychron-udev-rules: init at 23-10-2025

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13989,6 +13989,12 @@
     name = "Tomas Krupka";
     matrix = "@krupkat:matrix.org";
   };
+  kruziikrel13 = {
+    github = "kruziikrel13";
+    name = "Michael Petersen";
+    email = "dev@michaelpetersen.io";
+    githubId = 72793125;
+  };
   krzaczek = {
     name = "Pawel Krzaczkowski";
     email = "pawel@printu.pl";

--- a/nixos/modules/hardware/keyboard/qmk.nix
+++ b/nixos/modules/hardware/keyboard/qmk.nix
@@ -8,15 +8,18 @@
 let
   cfg = config.hardware.keyboard.qmk;
   inherit (lib) mkEnableOption mkIf;
-
 in
 {
   options.hardware.keyboard.qmk = {
     enable = mkEnableOption "non-root access to the firmware of QMK keyboards";
+    keychronSupport = mkEnableOption "udev rules for keychron QMK based keyboards";
   };
 
   config = mkIf cfg.enable {
-    services.udev.packages = [ pkgs.qmk-udev-rules ];
+    services.udev.packages = [
+      pkgs.qmk-udev-rules
+    ]
+    ++ lib.optionals cfg.keychronSupport [ pkgs.keychron-udev-rules ];
     users.groups.plugdev = { };
   };
 }

--- a/pkgs/by-name/ke/keychron-udev-rules/package.nix
+++ b/pkgs/by-name/ke/keychron-udev-rules/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenvNoCC,
+  udevCheckHook,
+  writeTextFile,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "keychron-udev-rules";
+  version = "23-10-2025";
+
+  nativeBuildInputs = [ udevCheckHook ];
+
+  src = writeTextFile {
+    name = "69-keychron.rules";
+    text = ''
+      KERNEL=="event*", SUBSYSTEM=="input", ENV{ID_VENDOR_ID}=="3434", ENV{ID_INPUT_JOYSTICK}=="*?", ENV{ID_INPUT_JOYSTICK}=""
+    '';
+  };
+
+  dontConfigure = true;
+  dontUnpack = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm644 $src $out/lib/udev/rules.d/69-keychron.rules
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Keychron Keyboard Udev Rules, fixes issues with keyboard detection on Linux";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kruziikrel13 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes an issue with keychron keyboards that causes linux to register the device as a joystick instead of a keyboard.

Haven't done a udev rule package before, and this is just a custom fix that I don't have in a repo so not sure if it needs to have a version number. Or if it's an improperly defined derivation for addition to nixpkgs.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
