### PR TITLE
jart-jsoncpp: init at 0-unstable-2025-10-25

### DIFF
--- a/pkgs/by-name/ja/jart-jsoncpp/package.nix
+++ b/pkgs/by-name/ja/jart-jsoncpp/package.nix
@@ -1,0 +1,82 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  copyPkgconfigItems,
+  makePkgconfigItem,
+  lib,
+  testers,
+  ctestCheckHook,
+  ninja,
+  double-conversion,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "json.cpp";
+  version = "0-unstable-2025-10-25";
+
+  src = fetchFromGitHub {
+    owner = "jart";
+    repo = "json.cpp";
+    rev = "6ec4e44a5bbaadbe677473378c3d2133644c58a1";
+    hash = "sha256-kUFtyFPoHGCFWTGRD8SoBsqHYCplGPw/AcpMR9T0Ffk=";
+  };
+
+  doCheck = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "JSON_CPP_BUILD_TESTS" true)
+    (lib.cmakeBool "DOUBLE_CONVERSION_VENDORED" false)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" stdenv.hostPlatform.hasSharedLibraries)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    copyPkgconfigItems
+    ctestCheckHook
+    ninja
+  ];
+
+  buildInputs = [
+    double-conversion
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  # https://github.com/jart/json.cpp/issues/17
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "json.cpp";
+      inherit (finalAttrs) version;
+      cflags = [ "-I${variables.includedir}" ];
+      libs = [
+        "-L${variables.libdir}"
+        "-ljson"
+      ];
+      libsPrivate = [
+        # nixpkgs double-conversion does not support pkg-config
+        # as of yet.
+        "-ldouble-conversion"
+      ];
+      variables = {
+        includedir = "${placeholder "dev"}/include";
+        libdir = "${placeholder "out"}/lib";
+      };
+      inherit (finalAttrs.meta) description;
+    })
+  ];
+
+  meta = {
+    pkgConfigModules = [ "json.cpp" ];
+    description = "JSON for Classic C++";
+    homepage = "https://github.com/jart/json.cpp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fzakaria ];
+  };
+})


### PR DESCRIPTION
_There is already a jsoncpp so I prefixed this package with the author @jart handle to distinguish it_

```bash
> nix build .#jart-jsoncpp

> tree result
result
├── include
│   └── json.h
└── lib
    ├── libdouble-conversion.a
    ├── libjson.a
    └── pkgconfig
        └── json.cpp.pc

> cat result/lib/pkgconfig/json.cpp.pc 
includedir=/nix/store/86bg8cs6h4sr9pg2gs4ykfih84yd1y2v-json.cpp-0-unstable-2025-10-22/include
libdir=/nix/store/86bg8cs6h4sr9pg2gs4ykfih84yd1y2v-json.cpp-0-unstable-2025-10-22/lib
prefix=/nix/store/86bg8cs6h4sr9pg2gs4ykfih84yd1y2v-json.cpp-0-unstable-2025-10-22

Cflags: -I/nix/store/86bg8cs6h4sr9pg2gs4ykfih84yd1y2v-json.cpp-0-unstable-2025-10-22/include
Description: JSON for Classic C++
Libs: -L/nix/store/86bg8cs6h4sr9pg2gs4ykfih84yd1y2v-json.cpp-0-unstable-2025-10-22/lib -ljson -ldouble-conversion
Name: json.cpp
Version: 0-unstable-2025-10-22
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
