### PR TITLE
miniflux: 2.2.13 -> 2.2.14

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -317,6 +317,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - The systemd target `kbrequest.target` is now unset by default, instead of being forcibly symlinked to `rescue.target`. In case you were relying on this behavior (Alt + ArrowUp on the tty causing the current target to be changed to `rescue.target`), you can restore it by setting `systemd.targets.rescue.aliases = [ "kbrequest.target" ];` in your configuration.
 
+- `miniflux` no longer uses the hstore PostgreSQL extension. Having the extension would prevent Miniflux from starting. In case you are managing your `miniflux` PostgreSQL database externally, disable the extension with `DROP EXTENSION IF EXISTS hstore;`.
+
 ## Other Notable Changes {#sec-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -20,9 +20,11 @@ let
   boolToInt = b: if b then 1 else 0;
 
   pgbin = "${config.services.postgresql.package}/bin";
+  # The hstore extension is no longer needed as of v2.2.14
+  # and would prevent Miniflux from starting.
   preStart = pkgs.writeScript "miniflux-pre-start" ''
     #!${pkgs.runtimeShell}
-    ${pgbin}/psql "miniflux" -c "CREATE EXTENSION IF NOT EXISTS hstore"
+    ${pgbin}/psql "miniflux" -c "DROP EXTENSION IF EXISTS hstore"
   '';
 in
 
@@ -39,7 +41,7 @@ in
         description = ''
           Whether a PostgreSQL database should be automatically created and
           configured on the local host. If set to `false`, you need provision a
-          database yourself and make sure to create the hstore extension in it.
+          database yourself.
         '';
       };
 

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -80,9 +80,6 @@ in
             host sameuser miniflux samenet scram-sha-256
           '';
         };
-        systemd.services.postgresql-setup.postStart = lib.mkAfter ''
-          psql -tAd miniflux -c 'CREATE EXTENSION hstore;'
-        '';
         networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
       };
     externalDb =

--- a/pkgs/by-name/mi/miniflux/package.nix
+++ b/pkgs/by-name/mi/miniflux/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "miniflux";
-  version = "2.2.13";
+  version = "2.2.14";
 
   src = fetchFromGitHub {
     owner = "miniflux";
     repo = "v2";
     tag = finalAttrs.version;
-    hash = "sha256-u3YnABf+ik7q29JtOSlK+UlInLRq5mMlH7vIDpxOOvk=";
+    hash = "sha256-x6I5PMlQtsjvFtEyoaKKE6if3I0IBIyps4kPQL4c8aw=";
   };
 
-  vendorHash = "sha256-JBT3BUFbPrSpkeZUoGiJJaeiSyXu8y+xcHWPNpxo3cU=";
+  vendorHash = "sha256-X/6YvAhIHSOS3qaoR6/pa2b7EziZzx8B+CbYrJ9/mcM=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
https://miniflux.app/releases/2.2.14.html
https://github.com/miniflux/v2/releases/tag/2.2.14
diff: https://github.com/miniflux/v2/compare/v2.2.13...2.2.14

## Tests Failing Due to AppArmor

`nixosTests.miniflux` is currently failing because AppArmor on master.
The failure itself is unrelated to this `miniflux` bump.
See https://github.com/NixOS/nixpkgs/pull/443744#issuecomment-3303395290.

With the following line commented out of the VM test, things pass as intended:
`machine.fail('journalctl -b --no-pager --grep "^audit: .*apparmor=\\"DENIED\\""')`

## Things Done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] **(Failing only due to AppArmor)**.
  - [x] [Package tests] at `passthru.tests` **(Failing only due to AppArmor)**.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
