### PR TITLE
armagetronad: add curl dependency (fixing NixOS tests)

### DIFF
--- a/pkgs/by-name/ar/armagetronad/package.nix
+++ b/pkgs/by-name/ar/armagetronad/package.nix
@@ -10,6 +10,7 @@
   python3,
   which,
   boost,
+  curl,
   ftgl,
   freetype,
   glew,
@@ -70,11 +71,11 @@ let
       # https://gitlab.com/armagetronad/armagetronad/-/commits/trunk/?ref_type=heads
       ${unstableVersionMajor} =
         let
-          rev = "813b684ab0de8ee9737c9fc1f9b90ba0543dd418";
-          hash = "sha256-01jWE9rSBJn+JS8p8LTFqIGquOY1avXsAZnfYfo5pPk=";
+          rev = "3675f21cd5be4932a7a168b321576e0b09e64aaf";
+          hash = "sha256-d2vPFAyx6LhEIxtEUdhrlqqYeCY0NnETlq7TVvX5vVo=";
         in
         dedicatedServer: {
-          version = "${unstableVersionMajor}-${builtins.substring 0 8 rev}";
+          version = "${unstableVersionMajor}-${lib.substring 0 8 rev}";
           src = fetchArmagetron rev hash;
           extraBuildInputs = [
             protobuf
@@ -97,11 +98,11 @@ let
       # https://gitlab.com/armagetronad/armagetronad/-/commits/hack-0.2.8-sty+ct+ap/?ref_type=heads
       "${latestVersionMajor}-sty+ct+ap" =
         let
-          rev = "5a17cc9fb6e1e27a358711afbd745ae54d4a8c60";
-          hash = "sha256-111C1j/hSaASGcvYy3//TyHs4Z+3fuiOvCmtcWLdFd4=";
+          rev = "c907ee3efd76f3b1e6eb41257cf7127f3eab280c";
+          hash = "sha256-d5uWBSz07OinbGHoxUQ64go3eOugLu/tWNjeihobQdo=";
         in
         dedicatedServer: {
-          version = "${latestVersionMajor}-sty+ct+ap-${builtins.substring 0 8 rev}";
+          version = "${latestVersionMajor}-sty+ct+ap-${lib.substring 0 8 rev}";
           src = fetchArmagetron rev hash;
           extraBuildInputs = lib.optionals (!dedicatedServer) [
             libGL
@@ -127,13 +128,13 @@ let
 
       # Split the version into the major and minor parts
       versionParts = lib.splitString "-" resolvedParams.version;
-      splitVersion = lib.splitVersion (builtins.elemAt versionParts 0);
-      majorVersion = builtins.concatStringsSep "." (lib.lists.take 2 splitVersion);
+      splitVersion = lib.splitVersion (lib.elemAt versionParts 0);
+      majorVersion = lib.concatStringsSep "." (lib.lists.take 2 splitVersion);
 
       minorVersionPart =
         parts: sep: expectedSize:
-        if builtins.length parts > expectedSize then
-          sep + (builtins.concatStringsSep sep (lib.lists.drop expectedSize parts))
+        if lib.length parts > expectedSize then
+          sep + (lib.concatStringsSep sep (lib.lists.drop expectedSize parts))
         else
           "";
 
@@ -172,8 +173,11 @@ let
       ++ lib.optional dedicatedServer "--enable-dedicated"
       ++ lib.optional (!dedicatedServer) "--enable-music";
 
-      buildInputs =
-        lib.singleton (libxml2.override { enableHttp = true; }) ++ (resolvedParams.extraBuildInputs or [ ]);
+      buildInputs = [
+        (libxml2.override { enableHttp = true; })
+        curl
+      ]
+      ++ (resolvedParams.extraBuildInputs or [ ]);
 
       nativeBuildInputs = [
         autoconf


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

We now need to explicitly depend on curl, since the 0.4 compile was broken without it.

Can be checked using nixosTests.armagetronad.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
