### PR TITLE
nixbit: init at 0.1.5, nixos/nixbit: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -168,6 +168,8 @@
 
 - [Tenstorrent](https://tenstorrent.com) hardware module has been added.
 
+- [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -277,6 +277,7 @@
   ./programs/nix-index.nix
   ./programs/nix-ld.nix
   ./programs/nix-required-mounts.nix
+  ./programs/nixbit.nix
   ./programs/nm-applet.nix
   ./programs/nncp.nix
   ./programs/noisetorch.nix

--- a/nixos/modules/programs/nixbit.nix
+++ b/nixos/modules/programs/nixbit.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.programs.nixbit;
+in
+{
+  options.programs.nixbit = {
+    enable = mkEnableOption "Nixbit configuration";
+
+    package = mkPackageOption pkgs "nixbit" { };
+
+    repository = mkOption {
+      type = types.str;
+      description = "Git repository URL for Nixbit";
+    };
+
+    forceAutostart = mkEnableOption "" // {
+      description = "Force creation of autostart desktop entry when application starts";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ cfg.package ];
+
+      etc."nixbit.conf".text =
+        lib.optionalString (cfg.repository != "") ''
+          [Repository]
+          Url = ${cfg.repository}
+        ''
+        + ''
+          [Autostart]
+          Force = ${if cfg.forceAutostart then "true" else "false"}
+        '';
+    };
+  };
+}

--- a/pkgs/by-name/ni/nixbit/package.nix
+++ b/pkgs/by-name/ni/nixbit/package.nix
@@ -1,0 +1,63 @@
+{
+  cmake,
+  fetchFromGitHub,
+  installShellFiles,
+  kdePackages,
+  lib,
+  libgit2,
+  ninja,
+  pkg-config,
+  qt6,
+  stdenv,
+  xvfb-run,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nixbit";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "pbek";
+    repo = "nixbit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DpjLPvmn61rEn6ui8cFfqeZEPYGyCUVVP/V7mQw1l5Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    installShellFiles
+    kdePackages.extra-cmake-modules
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ xvfb-run ];
+
+  buildInputs = [
+    kdePackages.kconfig
+    kdePackages.kcoreaddons
+    kdePackages.ki18n
+    kdePackages.kirigami
+    libgit2
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtwayland
+  ];
+
+  # Install shell completion on Linux (with xvfb-run)
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd nixbit \
+      --bash <(xvfb-run $out/bin/nixbit --completion-bash) \
+      --fish <(xvfb-run $out/bin/nixbit --completion-fish)
+  '';
+
+  meta = with lib; {
+    description = "KDE Plasma application to update your NixOS system from a git repository";
+    homepage = "https://github.com/pbek/nixbit";
+    changelog = "https://github.com/pbek/nixbit/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pbek ];
+    platforms = platforms.linux;
+    mainProgram = "nixbit";
+  };
+})


### PR DESCRIPTION
Adds package and module for https://github.com/pbek/nixbit.
A GUI application for updating your NixOS system from a Nix Flakes Git repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
