### PR TITLE
splitcode: 0.31.3 -> 0.31.4

### DIFF
--- a/pkgs/by-name/sp/splitcode/package.nix
+++ b/pkgs/by-name/sp/splitcode/package.nix
@@ -7,18 +7,15 @@
   zlib,
   nix-update-script,
 }:
-let
-  version = "0.31.3";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "splitcode";
-  inherit version;
+  version = "0.31.4";
 
   src = fetchFromGitHub {
     owner = "pachterlab";
     repo = "splitcode";
-    tag = "v${version}";
-    hash = "sha256-EEYjBo52jPCSnv5WSGsXhfZEjsBCHdGerVPOZfShXBU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jaZptrF5HSQSe2KQdBNPprhsVZ2FSudZFgWPn9zQq3A=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -27,6 +24,12 @@ stdenv.mkDerivation {
     libcxx
     zlib
   ];
+
+  postPatch = ''
+    # https://github.com/pachterlab/splitcode/pull/46
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 2.8.12 3.10
+  '';
 
   doCheck = true;
   checkPhase = ''
@@ -49,4 +52,4 @@ stdenv.mkDerivation {
       "aarch64-linux"
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
