### PR TITLE
emacsPackages.typst-preview: init at 0-unstable-2025-10-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24924,6 +24924,12 @@
     githubId = 73298492;
     name = "Mikhail Kiselev";
   };
+  sunworms = {
+    email = "sunnybhowmick0310@gmail.com";
+    github = "sunworms";
+    githubId = 89862130;
+    name = "Sunny Bhowmick";
+  };
   suominen = {
     email = "kimmo@suominen.com";
     github = "suominen";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/typst-preview/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/typst-preview/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  melpaBuild,
+  websocket,
+  f,
+  fetchFromGitHub,
+}:
+melpaBuild {
+  pname = "typst-preview";
+  version = "0-unstable-2025-10-13";
+  src = fetchFromGitHub {
+    owner = "havarddj";
+    repo = "typst-preview.el";
+    rev = "74244aef2545d7bb79b5396dc6503e23e6d239a7";
+    hash = "sha256-Bt2YvUpHx5vR+NwUVfk21h0BrLbuW182E0qqx1DNIOo=";
+  };
+
+  packageRequires = [
+    websocket
+    f
+  ];
+
+  meta = {
+    description = "Typst live preview minor mode for Emacs";
+    homepage = "https://github.com/havarddj/typst-preview.el";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ sunworms ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
