### PR TITLE
twemoji-color-font: refresh the recipe

### DIFF
--- a/pkgs/by-name/tw/twemoji-color-font/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchzip,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 fontconfig/46-twemoji-color.conf $out/etc/fonts/conf.d/46-twemoji-color.conf
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Color emoji SVGinOT font using Twitter Unicode 10 emoji with diversity and country flags";

--- a/pkgs/by-name/tw/twemoji-color-font/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font/package.nix
@@ -15,11 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Xy6Lkm340ldm9ssQWn/eRFIJ5kyhYaXPNy/Y/9vUt40=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
+    runHook preInstall
     install -Dm755 TwitterColorEmoji-SVGinOT.ttf $out/share/fonts/truetype/TwitterColorEmoji-SVGinOT.ttf
     install -Dm644 fontconfig/46-twemoji-color.conf $out/etc/fonts/conf.d/46-twemoji-color.conf
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/tw/twemoji-color-font/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Color emoji SVGinOT font using Twitter Unicode 10 emoji with diversity and country flags";
     longDescription = ''
       A color and B&W emoji SVGinOT font built from the Twitter Emoji for
@@ -37,10 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/eosrei/twemoji-color-font";
     downloadPage = "https://github.com/eosrei/twemoji-color-font/releases";
-    license = with licenses; [
+    license = with lib.licenses; [
       cc-by-40
       mit
     ];
-    maintainers = [ maintainers.fgaz ];
+    maintainers = [ lib.maintainers.fgaz ];
   };
 })

--- a/pkgs/by-name/tw/twemoji-color-font/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   # We fetch the prebuilt font because building it takes 1.5 hours on hydra.
   # Relevant issue: https://github.com/NixOS/nixpkgs/issues/97871
   src = fetchzip {
-    url = "https://github.com/eosrei/twemoji-color-font/releases/download/v${finalAttrs.version}/TwitterColorEmoji-SVGinOT-Linux-${finalAttrs.version}.tar.gz";
+    url = "https://github.com/13rac1/twemoji-color-font/releases/download/v${finalAttrs.version}/TwitterColorEmoji-SVGinOT-Linux-${finalAttrs.version}.tar.gz";
     hash = "sha256-Xy6Lkm340ldm9ssQWn/eRFIJ5kyhYaXPNy/Y/9vUt40=";
   };
 
@@ -35,8 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
       systems and applications. Regular B&W outline emoji are included for
       backwards/fallback compatibility.
     '';
-    homepage = "https://github.com/eosrei/twemoji-color-font";
-    downloadPage = "https://github.com/eosrei/twemoji-color-font/releases";
+    homepage = "https://github.com/13rac1/twemoji-color-font";
+    downloadPage = "https://github.com/13rac1/twemoji-color-font/releases";
     license = with lib.licenses; [
       cc-by-40
       mit

--- a/pkgs/by-name/tw/twemoji-color-font/package.nix
+++ b/pkgs/by-name/tw/twemoji-color-font/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchzip,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -10,9 +10,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # We fetch the prebuilt font because building it takes 1.5 hours on hydra.
   # Relevant issue: https://github.com/NixOS/nixpkgs/issues/97871
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/eosrei/twemoji-color-font/releases/download/v${finalAttrs.version}/TwitterColorEmoji-SVGinOT-Linux-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-yKUwLuTkwhiM54Xt2ExQxhagf26Z/huRrsuk4ds0EpU=";
+    hash = "sha256-Xy6Lkm340ldm9ssQWn/eRFIJ5kyhYaXPNy/Y/9vUt40=";
   };
 
   dontBuild = true;


### PR DESCRIPTION
Note: `fetchurl` -> `fetchzip` here is my personal preference, I like introspectable sources more
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
