### PR TITLE
macvim: 179 -> 181

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14728,6 +14728,13 @@
     githubId = 54189319;
     name = "Lilly Cham";
   };
+  lilyball = {
+    email = "lily@ballards.net";
+    github = "lilyball";
+    githubId = 714;
+    matrix = "@esperlily:matrix.org";
+    name = "Lily Ballard";
+  };
   limeytexan = {
     email = "limeytexan@gmail.com";
     github = "limeytexan";

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -242,7 +242,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Vim - the text editor - for macOS";
     homepage = "https://macvim.org/";
     license = licenses.vim;
-    maintainers = [ ];
+    maintainers = with maintainers; [ lilyball ];
     platforms = platforms.darwin;
     hydraPlatforms = [ ]; # hydra can't build this as long as we rely on Xcode and sandboxProfile
     knownVulnerabilities = [

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       # ideally we'd recurse, but we don't need that right now
       inputs = [ ncurses ] ++ perl.propagatedBuildInputs;
-      ldflags = map (drv: "-L${lib.getLib drv}/lib") inputs;
+      ldflags = map (drv: "-L${lib.getLib drv}/lib") inputs ++ [ "-headerpad_max_install_names" ];
       cppflags = map (drv: "-isystem ${lib.getDev drv}/include") inputs;
     in
     ''
@@ -138,7 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     # as the scheme seems to have the wrong default.
     + ''
       configureFlagsArray+=(
-        XCODEFLAGS="-scheme MacVim -derivedDataPath $NIX_BUILD_TOP/derivedData"
+        XCODEFLAGS="-scheme MacVim -derivedDataPath $NIX_BUILD_TOP/derivedData LDFLAGS='\$(inherited) -headerpad_max_install_names' ENABLE_CODE_COVERAGE=NO"
         --with-xcodecfg="Release"
       )
     '';

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -14,11 +14,12 @@
   darwin,
   libiconv,
   python3,
+  enablePython ? false,
   rcodesign,
 }:
 
 let
-  inherit (lib) optional optionalString;
+  inherit (lib) optional optionals optionalString;
 in
 
 # Try to match MacVim's documented script interface compatibility
@@ -64,8 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     ruby
     tcl
     perl
-    python3
-  ];
+  ]
+  ++ optional enablePython python3;
 
   patches = [ ./macvim.patch ];
 
@@ -77,14 +78,22 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-multibyte"
     "--enable-nls"
     "--enable-luainterp=dynamic"
+  ]
+  ++ optionals enablePython [
     "--enable-python3interp=dynamic"
+  ]
+  ++ [
     "--enable-perlinterp=dynamic"
     "--enable-rubyinterp=dynamic"
     "--enable-tclinterp=yes"
     "--without-local-dir"
     "--with-luajit"
     "--with-lua-prefix=${luajit}"
+  ]
+  ++ optionals enablePython [
     "--with-python3-command=${python3}/bin/python3"
+  ]
+  ++ [
     "--with-ruby-command=${ruby}/bin/ruby"
     "--with-tclsh=${tcl}/bin/tclsh"
     "--with-tlib=ncurses"
@@ -204,7 +213,11 @@ stdenv.mkDerivation (finalAttrs: {
     libperl=$(dirname $(find ${perl} -name "libperl.dylib"))
     install_name_tool -add_rpath ${luajit}/lib $exe
     install_name_tool -add_rpath ${tcl}/lib $exe
+  ''
+  + optionalString enablePython ''
     install_name_tool -add_rpath ${python3}/lib $exe
+  ''
+  + ''
     install_name_tool -add_rpath $libperl $exe
     install_name_tool -add_rpath ${ruby}/lib $exe
 
@@ -233,8 +246,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = platforms.darwin;
     hydraPlatforms = [ ]; # hydra can't build this as long as we rely on Xcode and sandboxProfile
-    # Needs updating to a newer MacVim for Python and Ruby version support
-    broken = true;
     knownVulnerabilities = [
       "CVE-2023-46246"
       "CVE-2023-48231"

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -7,7 +7,7 @@
   gettext,
   pkg-config,
   cscope,
-  ruby,
+  ruby_3_4,
   tcl,
   perl,
   luajit,
@@ -24,9 +24,8 @@ in
 
 # Try to match MacVim's documented script interface compatibility
 let
-  #perl = perl540;
-  # Ruby 3.3
-  #ruby = ruby_3_3;
+  # Ruby 3.4
+  ruby = ruby_3_4;
 
   # Building requires a few system tools to be in PATH.
   # Some of these we could patch into the relevant source files (such as xcodebuild and
@@ -41,13 +40,13 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "macvim";
 
-  version = "179";
+  version = "181";
 
   src = fetchFromGitHub {
     owner = "macvim-dev";
     repo = "macvim";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-L9LVXyeA09aMtNf+b/Oo+eLpeVEKTD1/oNWCiFn5FbU=";
+    hash = "sha256-Wdq+eXSaGs+y+75ZbxoNAcyopRkWRHHRm05T0SHBrow=";
   };
 
   enableParallelBuilding = true;
@@ -247,27 +246,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.darwin;
     hydraPlatforms = [ ]; # hydra can't build this as long as we rely on Xcode and sandboxProfile
     knownVulnerabilities = [
-      "CVE-2023-46246"
-      "CVE-2023-48231"
-      "CVE-2023-48232"
-      "CVE-2023-48233"
-      "CVE-2023-48234"
-      "CVE-2023-48235"
-      "CVE-2023-48236"
-      "CVE-2023-48237"
-      "CVE-2023-48706"
-      "CVE-2023-5344"
-      "CVE-2023-5441"
-      "CVE-2023-5535"
-      "CVE-2024-22667"
-      "CVE-2024-41957"
-      "CVE-2024-41965"
-      "CVE-2024-43374"
-      "CVE-2024-47814"
-      "CVE-2025-1215"
-      "CVE-2025-22134"
-      "CVE-2025-24014"
-      "CVE-2025-26603"
       "CVE-2025-29768"
       "CVE-2025-53905"
       "CVE-2025-53906"

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -203,7 +203,8 @@ stdenv.mkDerivation (finalAttrs: {
     install_name_tool -add_rpath ${ruby}/lib $exe
 
     # Remove manpages from tools we aren't providing
-    find $out/Applications/MacVim.app/Contents/man -name evim.1 -delete
+    find $out/Applications/MacVim.app/Contents/man \( -name evim.1 -or -name eview.1 \) -delete
+    rm $out/Applications/MacVim.app/Contents/man/man1/mvim.1
   '';
 
   # We rely on the user's Xcode install to build. It may be located in an arbitrary place, and

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -14,7 +14,12 @@
   darwin,
   libiconv,
   python3,
+  rcodesign,
 }:
+
+let
+  inherit (lib) optional optionalString;
+in
 
 # Try to match MacVim's documented script interface compatibility
 let
@@ -49,7 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     buildSymlinks
-  ];
+  ]
+  ++ optional stdenv.isAarch64 rcodesign;
   buildInputs = [
     gettext
     ncurses
@@ -205,6 +211,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Remove manpages from tools we aren't providing
     find $out/Applications/MacVim.app/Contents/man \( -name evim.1 -or -name eview.1 \) -delete
     rm $out/Applications/MacVim.app/Contents/man/man1/mvim.1
+  ''
+  + optionalString stdenv.isAarch64 ''
+    # Resign the binary and set the linker-signed flag.
+    rcodesign sign --code-signature-flags linker-signed $exe
   '';
 
   # We rely on the user's Xcode install to build. It may be located in an arbitrary place, and

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -199,16 +199,3 @@ index 6e33142..6185f45 100644
  #ifdef AMIGA
  # include "os_amiga.h"
  #endif
-diff --git a/src/vimtutor b/src/vimtutor
-index 3b154f2..e89f260 100755
---- a/src/vimtutor
-+++ b/src/vimtutor
-@@ -16,7 +16,7 @@ seq="vim vim81 vim80 vim8 vim74 vim73 vim72 vim71 vim70 vim7 vim6 vi"
- if test "$1" = "-g"; then
-     # Try to use the GUI version of Vim if possible, it will fall back
-     # on Vim if Gvim is not installed.
--    seq="gvim gvim81 gvim80 gvim8 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
-+    seq="mvim gvim gvim81 gvim80 gvim8 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
-     shift
- fi
- 


### PR DESCRIPTION
This fixes the various ways in which the MacVim package was broken, and then updates it to r181.

One of the changes here is Python support has been disabled by default, with an `enablePython` configuration option added to reenable it. Enabling Python also requires overriding the `python3` input to fix the breakage (e.g. by disabling static libpython and symlinking in `libpython${pythonVersion}.dylib` into the correct location).

This also adds me back to the maintainer list and marks myself as maintainer of this package.

Changelogs:
- [MacVim r180](https://github.com/macvim-dev/macvim/releases/tag/release-180)
- [MacVim r181](https://github.com/macvim-dev/macvim/releases/tag/release-181)

Fixes #399964.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
