### PR TITLE
nixos/facter: add boot and storage detection

### DIFF
--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -5,6 +5,8 @@
 }:
 {
   imports = [
+    ./disk.nix
+    ./keyboard.nix
     ./system.nix
   ];
 

--- a/nixos/modules/hardware/facter/disk.nix
+++ b/nixos/modules/hardware/facter/disk.nix
@@ -1,0 +1,28 @@
+{ lib, config, ... }:
+let
+  facterLib = import ./lib.nix lib;
+
+  inherit (config.hardware.facter) report;
+in
+{
+  options.hardware.facter.detected.boot.disk.kernelModules = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = lib.uniqueStrings (
+      facterLib.collectDrivers (
+        # A disk might be attached.
+        (report.hardware.firewire_controller or [ ])
+        # definitely important
+        ++ (report.hardware.disk or [ ])
+        ++ (report.hardware.storage_controller or [ ])
+      )
+    );
+    defaultText = "hardware dependent";
+    description = ''
+      List of kernel modules that are needed to access the disk.
+    '';
+  };
+
+  config = {
+    boot.initrd.availableKernelModules = config.hardware.facter.detected.boot.disk.kernelModules;
+  };
+}

--- a/nixos/modules/hardware/facter/keyboard.nix
+++ b/nixos/modules/hardware/facter/keyboard.nix
@@ -1,0 +1,21 @@
+{ lib, config, ... }:
+let
+  facterLib = import ./lib.nix lib;
+
+  inherit (config.hardware.facter) report;
+in
+{
+  options.hardware.facter.detected.boot.keyboard.kernelModules = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = lib.uniqueStrings (facterLib.collectDrivers (report.hardware.usb_controller or [ ]));
+    defaultText = "hardware dependent";
+    example = [ "usbhid" ];
+    description = ''
+      List of kernel modules to include in the initrd to support the keyboard.
+    '';
+  };
+
+  config = {
+    boot.initrd.availableKernelModules = config.hardware.facter.detected.boot.keyboard.kernelModules;
+  };
+}


### PR DESCRIPTION
This adds automatic kernel module detection for boot-critical hardware:

- disk.nix: Detects and loads kernel modules for storage controllers Auto-detects modules for: disk controllers, storage controllers, and FireWire controllers (for FireWire-attached disks). Modules are automatically added to boot.initrd.availableKernelModules.

- keyboard.nix: Detects USB controller drivers for keyboard support Ensures USB HID drivers are loaded in initrd for keyboard access during boot (critical for LUKS password entry, etc.).

Follow up to #454237.
Part of incremental upstreaming from nixos-facter-modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
