### PR TITLE
sonobus: remove webkitgtk, cleanup, add maintaner l1npengtul

### DIFF
--- a/pkgs/by-name/so/sonobus/package.nix
+++ b/pkgs/by-name/so/sonobus/package.nix
@@ -102,6 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       PowerUser64
+      l1npengtul
     ];
     platforms = lib.platforms.unix;
     mainProgram = "sonobus";

--- a/pkgs/by-name/so/sonobus/package.nix
+++ b/pkgs/by-name/so/sonobus/package.nix
@@ -17,8 +17,10 @@
   libopus,
   curl,
   gtk3,
+  nix-update-script,
+  copyDesktopItems,
+  makeDesktopItem,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "sonobus";
   version = "1.7.2";
@@ -31,10 +33,26 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "sonobus";
+      desktopName = "Sonobus";
+      comment = "High-quality network audio streaming";
+      icon = "sonobus";
+      exec = "sonobus";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
   nativeBuildInputs = [
     autoPatchelfHook
     cmake
     pkg-config
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -44,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     libopus
     curl
     gtk3
-    # webkitgtk_4_0
   ];
 
   runtimeDependencies = [
@@ -71,17 +88,22 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     cd ../linux
     ./install.sh "$out"
+
+    install -Dm444 $src/images/sonobus_logo_96.png $out/share/pixmaps/sonobus.png
+
     runHook postInstall
   '';
 
-  meta = with lib; {
-    # webkitgtk_4_0 was removed
-    broken = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     description = "High-quality network audio streaming";
     homepage = "https://sonobus.net/";
-    license = with licenses; [ gpl3Plus ];
-    maintainers = with maintainers; [ PowerUser64 ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      PowerUser64
+    ];
+    platforms = lib.platforms.unix;
     mainProgram = "sonobus";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Due to recent removal of `webkitgtk_4_0` it has been removed from this package's dependencies. I have added desktop item and nix-update-script, and have done some general cleanup.

I am also adding myself as maintainer with @PowerUser64's blessing. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
