### PR TITLE
nebula-lighthouse-service: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3498,6 +3498,12 @@
     githubId = 37768199;
     name = "Christian Bergschneider";
   };
+  bloominstrong = {
+    email = "github@mail.bloominstrong.net";
+    github = "bloominstrong";
+    githubId = 114744388;
+    name = "bloominstrong";
+  };
   bloveless = {
     email = "brennon.loveless@gmail.com";
     github = "bloveless";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -128,7 +128,7 @@
 
 - [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).
 
-- [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service), a public nebula lighthouse service. Avaliable as [services.nebula-lighthouse-service](#opt-services.nebula-lighthouse-service.enable).
+- [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service), a public Nebula VPN lighthouse service. Available as [services.nebula-lighthouse-service](#opt-services.nebula-lighthouse-service.enable).
 
 - [angrr](https://github.com/linyinfeng/angrr), a service that automatically cleans up old auto GC roots. Available as [services.angrr](#opt-services.angrr.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -128,6 +128,8 @@
 
 - [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).
 
+- [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service), a public nebula lighthouse service. Avaliable as [services.nebula-lighthouse-service](#opt-services.nebula-lighthouse-service.enable).
+
 - [angrr](https://github.com/linyinfeng/angrr), a service that automatically cleans up old auto GC roots. Available as [services.angrr](#opt-services.angrr.enable).
 
 - [Sharkey](https://joinsharkey.org), a Sharkish microblogging platform. Available as [services.sharkey](#opt-services.sharkey.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1267,6 +1267,7 @@
   ./services/networking/ncdns.nix
   ./services/networking/ncps.nix
   ./services/networking/ndppd.nix
+  ./services/networking/nebula-lighthouse-service.nix
   ./services/networking/nebula.nix
   ./services/networking/netbird.nix
   ./services/networking/netbird/server.nix

--- a/nixos/modules/services/networking/nebula-lighthouse-service.nix
+++ b/nixos/modules/services/networking/nebula-lighthouse-service.nix
@@ -6,6 +6,8 @@
 }:
 
 let
+  inherit (lib) types;
+
   cfg = config.services.nebula-lighthouse-service;
   settingsFormat = pkgs.formats.yaml { };
 in
@@ -13,6 +15,14 @@ in
 
   options.services.nebula-lighthouse-service = {
     enable = lib.mkEnableOption "nebula-lighthouse-service";
+    user = lib.mkOption {
+      type = types.str;
+      default = "nebula-lighthouse";
+      description = ''
+        The user and group to run nebula-lighthouse-service as.
+      '';
+      example = "nebula-lighthouse";
+    };
     settings = lib.mkOption {
       type = settingsFormat.type;
       default = { };
@@ -50,8 +60,16 @@ in
         Restart = "always";
         ExecStart = "${pkgs.nebula-lighthouse-service}/bin/nebula-lighthouse-service";
         StateDirectory = "nebula-lighthouse-service";
+        User = cfg.user;
+        Group = cfg.user;
       };
     };
+    users.users.${cfg.user} = {
+      group = cfg.user;
+      description = "nebula-lighthouse-service user";
+      isSystemUser = true;
+    };
+    users.groups.${cfg.user} = { };
   };
   meta.maintainers = with lib.maintainers; [
     bloominstrong

--- a/nixos/modules/services/networking/nebula-lighthouse-service.nix
+++ b/nixos/modules/services/networking/nebula-lighthouse-service.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.nebula-lighthouse-service;
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+
+  options.services.nebula-lighthouse-service = {
+    enable = lib.mkEnableOption ''If enabled, NixOS will enable a systemd unit for nebula-lighthouse-service'';
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        Configuration for nebula-lighthouse-service.
+      '';
+      example = ''
+        max-port = 65535;
+        min-port = 49152;
+        "webserver.ip" = "127.0.0.1";
+        "webserver.port" = 8080;
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.nebula-lighthouse-service.settings = {
+      min-port = lib.mkDefault 49152;
+      max-port = lib.mkDefault 65535;
+      "webserver.port" = lib.mkDefault 8080;
+      "webserver.ip" = lib.mkDefault "127.0.0.1";
+    };
+    environment.etc."nebula-lighthouse-service/config.yaml".source =
+      settingsFormat.generate "nebula-lighthouse-service-config.yaml" cfg.settings;
+    systemd.services.nebula-lighthouse-service = {
+      description = "Run nebula-lighthouse-service";
+      wants = [ "basic.target" ];
+      after = [
+        "basic.target"
+        "network.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "exec";
+        Restart = "always";
+        ExecStart = "${pkgs.nebula-lighthouse-service}/bin/nebula-lighthouse-service";
+        StateDirectory = "nebula-lighthouse-service";
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    bloominstrong
+  ];
+}

--- a/nixos/modules/services/networking/nebula-lighthouse-service.nix
+++ b/nixos/modules/services/networking/nebula-lighthouse-service.nix
@@ -12,19 +12,19 @@ in
 {
 
   options.services.nebula-lighthouse-service = {
-    enable = lib.mkEnableOption ''If enabled, NixOS will enable a systemd unit for nebula-lighthouse-service'';
+    enable = lib.mkEnableOption "nebula-lighthouse-service";
     settings = lib.mkOption {
       type = settingsFormat.type;
       default = { };
       description = ''
         Configuration for nebula-lighthouse-service.
       '';
-      example = ''
+      example = {
         max-port = 65535;
         min-port = 49152;
         "webserver.ip" = "127.0.0.1";
         "webserver.port" = 8080;
-      '';
+      };
     };
   };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1011,9 +1011,9 @@ in
     defaults.services.ncps.cache.dataPath = "/path/to/ncps";
   };
   ndppd = runTest ./ndppd.nix;
+  nebula-lighthouse-service = runTest ./nebula-lighthouse-service.nix;
   nebula.connectivity = runTest ./nebula/connectivity.nix;
   nebula.reload = runTest ./nebula/reload.nix;
-  nebula-lighthouse-service = runTest ./nebula-lighthouse-service.nix;
   neo4j = runTest ./neo4j.nix;
   netbird = runTest ./netbird.nix;
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1013,6 +1013,7 @@ in
   ndppd = runTest ./ndppd.nix;
   nebula.connectivity = runTest ./nebula/connectivity.nix;
   nebula.reload = runTest ./nebula/reload.nix;
+  nebula-lighthouse-service = runTest ./nebula-lighthouse-service.nix;
   neo4j = runTest ./neo4j.nix;
   netbird = runTest ./netbird.nix;
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;

--- a/nixos/tests/nebula-lighthouse-service.nix
+++ b/nixos/tests/nebula-lighthouse-service.nix
@@ -1,0 +1,33 @@
+{ pkgs, lib, ... }:
+{
+  name = "nebula-lighthouse-service";
+
+  meta.maintainers = with lib.maintainers; [
+    bloominstrong
+  ];
+
+  nodes.machine =
+    { ... }:
+    {
+      environment.systemPackages = with pkgs; [
+        nebula
+      ];
+      services.nebula-lighthouse-service.enable = true;
+
+    };
+
+  testScript = ''
+    start_all()
+    machine.succeed(
+      'nebula-cert ca -duration $((10*365*24*60))m -name "NLS Test" -out-crt ca.crt -out-key ca.key',
+      'nebula-cert sign -duration $((365*24*60))m -ca-crt ca.crt -ca-key ca.key -name "lighthouse" -groups "lighthouse" -ip "10.0.100.1/24" -out-crt lighthouse.crt -out-key lighthouse.key'
+    )
+    machine.wait_for_unit("nebula-lighthouse-service.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed(
+      'curl -X POST "http://127.0.0.1:8080/lighthouse/" -F ca_crt=@./ca.crt -F host_crt=@./lighthouse.crt -F host_key=@./lighthouse.key',
+      'curl -X GET "http://127.0.0.1:8080/lighthouse/" -F ca_crt=@./ca.crt -F host_crt=@./lighthouse.crt -F host_key=@./lighthouse.key',
+      'pgrep -x nebula'
+    )
+  '';
+}

--- a/pkgs/by-name/ne/nebula-lighthouse-service/package.nix
+++ b/pkgs/by-name/ne/nebula-lighthouse-service/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nebula,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "nebula-lighthouse-service";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "manuels";
+    repo = "nebula-lighthouse-service";
+    tag = "v${version}";
+    hash = "sha256-cRwmOGuPEYlURVbaf9AwaSmhvUzzZvATv5RGPUztnbY=";
+  };
+
+  postPatch = ''
+    substituteInPlace nebula_lighthouse_service/webservice.py \
+      --replace-fail 'from pydantic' 'from pydantic.v1'
+    substituteInPlace setup.py \
+      --replace-fail 'pydantic==1.10.21' 'pydantic>=2' \
+      --replace-fail 'fastapi==0.116.1' 'fastapi' \
+      --replace-fail 'PyYAML==6.0.2' 'PyYAML' \
+      --replace-fail 'uvicorn==0.35.0' 'uvicorn' \
+      --replace-fail 'python-multipart==0.0.20' 'python-multipart'
+  '';
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    fastapi
+    pyyaml
+    uvicorn
+    pydantic
+    python-multipart
+    nebula
+  ];
+
+  pythonImportsCheck = [
+    "nebula_lighthouse_service"
+  ];
+
+  meta = {
+    description = "Public Nebula VPN Lighthouse Service, you can use it in case you don’t have a publicly accessible server to run your own Nebula Lighthouse";
+    homepage = "https://github.com/manuels/nebula-lighthouse-service";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      bloominstrong
+    ];
+    mainProgram = "nebula-lighthouse-service";
+  };
+}

--- a/pkgs/by-name/ne/nebula-lighthouse-service/package.nix
+++ b/pkgs/by-name/ne/nebula-lighthouse-service/package.nix
@@ -4,6 +4,7 @@
   python3Packages,
   nebula,
   nixosTests,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -28,6 +29,7 @@ python3Packages.buildPythonApplication rec {
       --replace-fail 'uvicorn==0.35.0' 'uvicorn' \
       --replace-fail 'python-multipart==0.0.20' 'python-multipart'
   '';
+
   build-system = with python3Packages; [
     setuptools
     wheel
@@ -50,8 +52,14 @@ python3Packages.buildPythonApplication rec {
     nebula-lighthouse-service = nixosTests.nebula-lighthouse-service;
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    description = "Public Nebula VPN Lighthouse Service, you can use it in case you don’t have a publicly accessible server to run your own Nebula Lighthouse";
+    description = "Public Nebula VPN Lighthouse Service";
+    longDescription = ''
+      In case you don't have a publicly accessible server to run your own Nebula VPN lighthouse,
+      you can use a public nebula-lighthouse-service instance without passing traffic through it.
+    '';
     homepage = "https://github.com/manuels/nebula-lighthouse-service";
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ne/nebula-lighthouse-service/package.nix
+++ b/pkgs/by-name/ne/nebula-lighthouse-service/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   python3Packages,
   nebula,
+  nixosTests,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -44,6 +45,10 @@ python3Packages.buildPythonApplication rec {
   pythonImportsCheck = [
     "nebula_lighthouse_service"
   ];
+
+  passthru.tests = {
+    nebula-lighthouse-service = nixosTests.nebula-lighthouse-service;
+  };
 
   meta = {
     description = "Public Nebula VPN Lighthouse Service, you can use it in case you don’t have a publicly accessible server to run your own Nebula Lighthouse";


### PR DESCRIPTION
init [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service) as a package and a service module with tests.

nebula-lighthouse-service is aimed to be run a a public nebula lighthouse for those who cannot host their own, or who want extra lighthouses without the burden of maintaining another lighthouse.
given that actual data does not pass through the lighthouse this can support a large number of users with minimal resources which I think is pretty cool.
Until recently it was only able to run as a snap package but with the last release the limitation was removed so I would like to maintain it as a nixpkg.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (using pkgsCross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
