### PR TITLE
jack-passthrough: cleanup, change version to be 0-unstable format, add nix-update-script, add maintainer l1npengtul

### DIFF
--- a/pkgs/by-name/ja/jack-passthrough/package.nix
+++ b/pkgs/by-name/ja/jack-passthrough/package.nix
@@ -7,11 +7,12 @@
   meson,
   ninja,
   fmt_9,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
   pname = "jack-passthrough";
-  version = "2021-9-25";
+  version = "0-unstable-2021-9-25";
 
   # https://github.com/guysherman/jack-passthrough
   src = fetchFromGitHub {
@@ -26,10 +27,13 @@ stdenv.mkDerivation {
     meson
     ninja
   ];
+
   buildInputs = [
     fmt_9
     libjack2
   ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Simple app to help with JACK apps that behave strangely";
@@ -41,7 +45,7 @@ stdenv.mkDerivation {
     '';
     # license unknown: https://github.com/guysherman/jack-passthrough/issues/2
     license = lib.licenses.unfree;
-    maintainers = [ lib.maintainers.PowerUser64 ];
+    maintainers = with lib.maintainers; [ PowerUser64 l1npengtul ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "jack-passthru";
   };

--- a/pkgs/by-name/ja/jack-passthrough/package.nix
+++ b/pkgs/by-name/ja/jack-passthrough/package.nix
@@ -45,7 +45,10 @@ stdenv.mkDerivation {
     '';
     # license unknown: https://github.com/guysherman/jack-passthrough/issues/2
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ PowerUser64 l1npengtul ];
+    maintainers = with lib.maintainers; [
+      PowerUser64
+      l1npengtul
+    ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "jack-passthru";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Cleaned up the file, made the version to the `0-unstable` format since upstream does not have a formal versioning scheme. Added a nix-update-script, and added myself as maintainer on @PowerUser64's request. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
