### PR TITLE
netlify-cli: 19.0.2 -> 23.9.2

### DIFF
--- a/pkgs/by-name/ne/netlify-cli/package.nix
+++ b/pkgs/by-name/ne/netlify-cli/package.nix
@@ -11,16 +11,22 @@
 
 buildNpmPackage rec {
   pname = "netlify-cli";
-  version = "19.0.2";
+  version = "23.9.2";
 
   src = fetchFromGitHub {
     owner = "netlify";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-+P+hS/g/xRFNvzESZ5LyxyQSSRZ7BzCg9ZX/ndNLeDg=";
+    hash = "sha256-rjxm/TrKsvYCKwoHkZRZXFpFTfLd0s0D/H6p5Bull0E=";
   };
 
-  npmDepsHash = "sha256-3C+tTqLJCm48pAbQMiIq2SsHmb4bcCaf3IU/cTeR5BA=";
+  # Prevent postinstall script from running before package is built
+  # See https://github.com/netlify/cli/blob/v23.9.2/scripts/postinstall.js#L70
+  postPatch = ''
+    touch .git
+  '';
+
+  npmDepsHash = "sha256-itzEmCOBXxspGiwxt8t6di7/EuCo2Qkl5JVSkMfUemI=";
 
   inherit nodejs;
 

--- a/pkgs/by-name/ne/netlify-cli/package.nix
+++ b/pkgs/by-name/ne/netlify-cli/package.nix
@@ -22,6 +22,7 @@ buildNpmPackage rec {
 
   # Prevent postinstall script from running before package is built
   # See https://github.com/netlify/cli/blob/v23.9.2/scripts/postinstall.js#L70
+  # This currently breaks completions: https://github.com/NixOS/nixpkgs/issues/455005
   postPatch = ''
     touch .git
   '';

--- a/pkgs/by-name/ne/netlify-cli/test.nix
+++ b/pkgs/by-name/ne/netlify-cli/test.nix
@@ -27,10 +27,15 @@ runCommand "netlify-cli-test"
     echo '/with-redirect /' >_redirects
 
     # Start a local server and wait for it to respond
-    netlify dev --offline --port 8888 2>&1 | tee log &
+    # Edge functions require specific version of Deno and internet access for other Netlify stuff
+    netlify dev --offline --internal-disable-edge-functions --port 8888 --debug 2>&1 | tee log &
     sleep 0.1 || true
     for (( i=0; i<300; i++ )); do
-      if grep --ignore-case 'Server now ready' <log; then
+      if ! jobs %% > /dev/null; then
+        echo "Server died before starting" >&2
+        exit 1
+      fi
+      if grep --ignore-case 'Local dev server ready' <log; then
         break
       else
         sleep 1


### PR DESCRIPTION
## Things done

Upgrades for netlify-cli were broken for a while because postinstall
script was changed to not build the packages into dist directory ahead
of time, but rather expect the user to do this. Add an workaround to not
run postinstall logic entirely.
Also disable edge functions in tests using an internal flag, because
they try to download Deno, some types definitions, and maybe other stuff
at runtime.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
