### PR TITLE
prometheus: Move assets to npmBuildPackage; 3.8.0 → 3.8.1

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -1980,6 +1980,7 @@ in
         StateDirectory = cfg.stateDir;
         StateDirectoryMode = "0700";
         # Hardening
+        CapabilityBoundingSet = [ "" ];
         DeviceAllow = [ "/dev/null rw" ];
         DevicePolicy = "strict";
         LockPersonality = true;

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -1969,7 +1969,7 @@ in
       after = [ "network.target" ];
       serviceConfig = {
         ExecStart =
-          "${cfg.package}/bin/prometheus"
+          "${lib.getExe cfg.package}"
           + optionalString (length cmdlineArgs != 0) (" \\\n  " + concatStringsSep " \\\n  " cmdlineArgs);
         ExecReload = mkIf cfg.enableReload "+${reload}/bin/reload-prometheus";
         User = "prometheus";

--- a/pkgs/by-name/pr/prometheus/disable-react-app.diff
+++ b/pkgs/by-name/pr/prometheus/disable-react-app.diff
@@ -1,0 +1,10 @@
+--- ./build_ui.sh	2025-10-22 23:32:08.739188520 +0100
++++ ./build_ui.sh	2025-10-22 23:32:23.753242986 +0100
+@@ -50,7 +50,6 @@ for i in "$@"; do
+   case ${i} in
+   --all)
+     buildModule
+-    buildReactApp
+     buildMantineUI
+     shift
+     ;;

--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -1,6 +1,5 @@
 {
   stdenv,
-  buildPackages,
   lib,
   go,
   buildGoModule,
@@ -33,14 +32,17 @@
 }:
 
 let
+  source = import ./source.nix;
+
+  inherit (source) version vendorHash;
+
   pname = "prometheus";
-  version = "3.8.0";
 
   src = fetchFromGitHub {
     owner = "prometheus";
     repo = "prometheus";
     tag = "v${version}";
-    hash = "sha256-bitRDX1oymFfzvQVYL31BON6UBfQYnqjZefQKc+yXx0=";
+    hash = source.hash;
   };
 
   assets = buildNpmPackage {
@@ -49,7 +51,7 @@ let
 
     src = "${src}/web/ui";
 
-    npmDepsHash = "sha256-Uq7vikiYLqhRQNCpB49aMJgAE/uK4Mst/Iz6W+hdxBw=";
+    npmDepsHash = source.npmDepsHash;
 
     patches = [
       # Disable old React app as it depends on deprecated create-react-apps
@@ -79,15 +81,18 @@ let
   };
 in
 buildGoModule (finalAttrs: {
-  inherit pname version src;
+  inherit
+    pname
+    version
+    vendorHash
+    src
+    ;
 
   outputs = [
     "out"
     "doc"
     "cli"
   ];
-
-  vendorHash = "sha256-V+qLxjqGOaT1veEwtklqcS7iO31ufvDHBA9DbZLzDiE=";
 
   excludedPackages = [
     "documentation/prometheus-mixin"

--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -29,6 +29,7 @@
   enableVultr ? true,
   enableXDS ? true,
   enableZookeeper ? true,
+  versionCheckHook,
 }:
 
 let
@@ -185,6 +186,12 @@ buildGoModule (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [
     "-skip=TestEvaluations/testdata/aggregators.test"
   ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru = {
     tests = { inherit (nixosTests) prometheus; };

--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -199,6 +199,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       fpletz
       Frostman
+      jpds
     ];
     mainProgram = "prometheus";
   };

--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -186,12 +186,16 @@ buildGoModule (finalAttrs: {
     "-skip=TestEvaluations/testdata/aggregators.test"
   ];
 
-  passthru.tests = { inherit (nixosTests) prometheus; };
+  passthru = {
+    tests = { inherit (nixosTests) prometheus; };
+    updateScript = ./update.sh;
+  };
 
   meta = {
     description = "Service monitoring system and time series database";
     homepage = "https://prometheus.io";
     license = lib.licenses.asl20;
+    changelog = "https://github.com/prometheus/prometheus/blob/v${version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       fpletz
       Frostman

--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,0 +1,6 @@
+{
+  version = "3.8.0";
+  hash = "sha256-hRuZxwPPDLxQvy5MPKEyfmanNabcSjLRO+XbNKugPtk=";
+  npmDepsHash = "sha256-pOHEchYVDv7A/3v37hpN60kK620SgQduhVIn6GMyOLM=";
+  vendorHash = "sha256-5wDaG01vcTtGzrS/S33U5XWXoSWM+N9z3dzXZlILxD8=";
+}

--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,6 +1,6 @@
 {
-  version = "3.8.0";
-  hash = "sha256-hRuZxwPPDLxQvy5MPKEyfmanNabcSjLRO+XbNKugPtk=";
-  npmDepsHash = "sha256-pOHEchYVDv7A/3v37hpN60kK620SgQduhVIn6GMyOLM=";
-  vendorHash = "sha256-5wDaG01vcTtGzrS/S33U5XWXoSWM+N9z3dzXZlILxD8=";
+  version = "3.8.1";
+  hash = "sha256-mb1aMWpIELyZaqjYX1teYdtAK/+W9jzdPwzgbT7AVj4=";
+  npmDepsHash = "sha256-wmxvlQWQO2gP2apupMJssqAPr1ntWWIazduQU3AuodU=";
+  vendorHash = "sha256-35pVMl1Hu970BQE6jMzT1xaz/3FaIFWUtel0cl/uBdw=";
 }

--- a/pkgs/by-name/pr/prometheus/update.sh
+++ b/pkgs/by-name/pr/prometheus/update.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix coreutils curl jq nix-prefetch-git prefetch-npm-deps
+
+set -euo pipefail
+
+OWNER=prometheus
+REPO=prometheus
+
+# Current version.
+LATEST_NIXPKGS_VERSION=$(nix eval --raw .#prometheus.version 2>/dev/null)
+UPDATE_NIX_OLD_VERSION=${UPDATE_NIX_OLD_VERSION:-$LATEST_NIXPKGS_VERSION}
+
+TARGET_TAG="$(curl -L -s ${GITHUB_TOKEN:+-u ":${GITHUB_TOKEN}"} "https://api.github.com/repos/$OWNER/$REPO/releases/latest" | jq -r '.tag_name')"
+TARGET_VERSION="$(echo "$TARGET_TAG" | sed -e 's/^v//')"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$TARGET_VERSION" ]]; then
+    # prometheus is up-to-date
+    if [[ -n "$UPDATE_NIX_ATTR_PATH" ]]; then
+        echo "[{}]";
+    fi
+
+    exit 0
+fi
+
+extractVendorHash() {
+    original="${1?original hash missing}"
+    result="$(nix-build -A prometheus.goModules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+    [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+NIXPKGS_PROMETHEUS_PATH=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)/
+SOURCE_NIX="$NIXPKGS_PROMETHEUS_PATH/source.nix"
+
+PREFETCH_JSON=$TMP/prefetch.json
+nix-prefetch-git --rev "$TARGET_TAG" --url "https://github.com/$OWNER/$REPO" > "$PREFETCH_JSON"
+PREFETCH_HASH="$(jq '.hash' -r < "$PREFETCH_JSON")"
+PREFETCH_PATH="$(jq '.path' -r < "$PREFETCH_JSON")"
+NPM_DEPS_HASH="$(prefetch-npm-deps "$PREFETCH_PATH/web/ui/package-lock.json")"
+
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+cat > "$SOURCE_NIX" <<-EOF
+{
+  version = "$TARGET_VERSION";
+  hash = "$PREFETCH_HASH";
+  npmDepsHash = "$NPM_DEPS_HASH";
+  vendorHash = "$FAKE_HASH";
+}
+EOF
+
+GO_HASH="$(nix-instantiate --eval -A prometheus.vendorHash | tr -d '"')"
+VENDOR_HASH=$(extractVendorHash "$GO_HASH")
+
+cat > "$SOURCE_NIX" <<-EOF
+{
+  version = "$TARGET_VERSION";
+  hash = "$PREFETCH_HASH";
+  npmDepsHash = "$NPM_DEPS_HASH";
+  vendorHash = "$VENDOR_HASH";
+}
+EOF
+
+if [[ -z "$UPDATE_NIX_ATTR_PATH" ]]; then
+    exit 0
+fi
+
+cat <<-EOF
+[{
+  "attrPath": "$UPDATE_NIX_ATTR_PATH",
+  "oldVersion": "$UPDATE_NIX_OLD_VERSION",
+  "newVersion": "$TARGET_VERSION",
+  "files": ["$SOURCE_NIX"]
+}]
+EOF


### PR DESCRIPTION
Moves the web UI assets to a `npmBuildPackage` derivation. Trying to enable `nix-update-script` so the bot can handle upgrades.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
