### PR TITLE
integrity-scrub: 0.6.5 → 0.6.6; provide meta.mainProgram

### DIFF
--- a/pkgs/by-name/in/integrity-scrub/package.nix
+++ b/pkgs/by-name/in/integrity-scrub/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "integrity-scrub";
-  version = "0.6.5";
+  version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "illdefined";
     repo = "integrity-scrub";
     tag = version;
-    hash = "sha256-oWS6HxdZ8tGeIRGpfHHkNhNdepBjhhdgTjKmxElNPbk=";
+    hash = "sha256-OLO64R9AYpHSkIwk2arka5EEzCWusZPWsBhy5HEDIQI=";
   };
 
-  cargoHash = "sha256-3LC3eZNmHG6OFIvQzmvs4BCSX0CVpwaYhZM2H2YoY4M=";
+  cargoHash = "sha256-sS4z5NImUdk0EnQ+BGPofFZtXZsomfUXXbHNDmVqAos=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 

--- a/pkgs/by-name/in/integrity-scrub/package.nix
+++ b/pkgs/by-name/in/integrity-scrub/package.nix
@@ -34,5 +34,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.cc0;
     maintainers = with lib.maintainers; [ mvs ];
     platforms = lib.platforms.linux;
+    mainProgram = "integrity-scrub";
   };
 }


### PR DESCRIPTION
- Update to latest upstream release, and
- provide `meta.mainProgram`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~x86_64-darwin~
  - [ ] ~aarch64-darwin~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
