### PR TITLE
wireshark: 4.4.9 -> 4.6.0

### DIFF
--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   asciidoctor,
   autoreconfHook,
   pkg-config,
@@ -42,6 +43,12 @@ stdenv.mkDerivation rec {
 
     # https://github.com/dns-stats/compactor/pull/91
     ./patches/update-golden-cbor2diag-output.patch
+
+    # https://github.com/dns-stats/compactor/commit/f7deaf89f55a12c586b6662a3a7d04b10a4c7bcb
+    (fetchpatch {
+      url = "https://github.com/dns-stats/compactor/commit/f7deaf89f55a12c586b6662a3a7d04b10a4c7bcb.patch";
+      hash = "sha256-eEaVS5rfrLkRGc668PwVfb/xw3n1SoCm30xEf1NjbeY=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -25,6 +25,7 @@
   libpcap,
   libsmi,
   libssh,
+  libxml2,
   lua5_4,
   lz4,
   makeWrapper,
@@ -56,7 +57,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.4.9";
+  version = "4.6.0";
 
   outputs = [
     "out"
@@ -67,7 +68,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-0+uPXSNabsYNGn+4753WNoUBe9lJ2EH3i3J36lqI4Ak=";
+    hash = "sha256-XkHcVN3xCYwnS69nJ4/AT76Iaggt1GXA6JWi+IG15IM=";
   };
 
   patches = [
@@ -111,6 +112,7 @@ stdenv.mkDerivation rec {
     libpcap
     libsmi
     libssh
+    libxml2
     lua5_4
     lz4
     minizip

--- a/pkgs/development/python-modules/pyshark/default.nix
+++ b/pkgs/development/python-modules/pyshark/default.nix
@@ -35,6 +35,12 @@ buildPythonPackage rec {
       url = "https://github.com/KimiNewt/pyshark/commit/7142c5bf88abcd4c65c81052a00226d6155dda42.patch";
       hash = "sha256-Ti7cwRyYSbF4a4pEEV9FntNevkV/JVXNqACQWzoma7g=";
     })
+    # fixes tests that failed related to elastic-mapping
+    # remove fix if this is ever merged upstream
+    (fetchpatch {
+      url = "https://github.com/KimiNewt/pyshark/commit/0e1d8d0e06108f2887c3147c93049de63b475f8a.patch";
+      hash = "sha256-fpgiBHcfS/TGYIB65ioZJrWUuDIrLxxXqGVJ9y18b2w=";
+    })
     (replaceVars ./hardcode-tshark-path.patch {
       tshark = lib.getExe' wireshark-cli "tshark";
     })


### PR DESCRIPTION
Replaces https://github.com/NixOS/nixpkgs/pull/450163 , as the hash was incorrect?

I've tested this on my own system, and it works just fine.

EDIT: It seems like according to nixpkgs-review, that wireshark-cli does not want to work. 
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
