### PR TITLE
rabbitmq-server: 4.0.9 -> 4.1.4

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -228,6 +228,8 @@
 
 - [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
 
+- `rabbitmq-server` has been updated from 4.0.9 to 4.1.4. The 4.1.0 release includes breaking changes. For more information read the [changelog of 4.1.0](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0)
+
 - `lxde` scope has been removed, and its packages have been moved the top-level.
 
 - `pulsemeeter` has been updated to `2.0.0`. The configuration file from older versions has to be deleted. For more information and instructions see the [v2.0.0 changelog entry](https://github.com/theRealCarneiro/pulsemeeter/releases/tag/v2.0.0).

--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -6,6 +6,7 @@
   python3,
   libxml2,
   libxslt,
+  git,
   xmlto,
   docbook_xml_dtd_45,
   docbook_xsl,
@@ -21,6 +22,7 @@
   glibcLocales,
   nixosTests,
   which,
+  p7zip,
 }:
 
 let
@@ -39,14 +41,14 @@ let
   );
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rabbitmq-server";
-  version = "4.0.9";
+  version = "4.1.4";
 
   # when updating, consider bumping elixir version in all-packages.nix
   src = fetchurl {
-    url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${pname}-${version}.tar.xz";
-    hash = "sha256-imBxBn8RQS0jBGfT5KLLLt+fKvyybzLzPZu9DpFOos8=";
+    url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    hash = "sha256-dqNdrbXSysYUMN+6gMMb9GXKER/mOGXgW6j3iOLHNks=";
   };
 
   nativeBuildInputs = [
@@ -58,6 +60,7 @@ stdenv.mkDerivation rec {
     rsync
     python3
     which
+    p7zip
   ];
 
   buildInputs = [
@@ -67,6 +70,15 @@ stdenv.mkDerivation rec {
     libxslt
     glibcLocales
   ];
+
+  prePatch = ''
+    # erlang.mk assumes that the elixir lib directory is at the same level as the bin of the elixir binary,
+    # this is not for the Nixpkgs packaging, so patch this
+    substituteInPlace erlang.mk \
+      --replace-fail \
+      "ELIXIR_LIBS ?= $(abspath $(dir $(ELIXIR_BIN))/../lib)" \
+      "ELIXIR_LIBS ?= ${beamPackages.elixir}/lib/elixir/lib"
+  '';
 
   outputs = [
     "out"
@@ -129,9 +141,9 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://www.rabbitmq.com/";
     description = "Implementation of the AMQP messaging protocol";
-    changelog = "https://github.com/rabbitmq/rabbitmq-server/releases/tag/v${version}";
+    changelog = "https://github.com/rabbitmq/rabbitmq-server/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ samueltardieu ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9768,7 +9768,7 @@ with pkgs;
   qremotecontrol-server = libsForQt5.callPackage ../servers/misc/qremotecontrol-server { };
 
   rabbitmq-server = callPackage ../by-name/ra/rabbitmq-server/package.nix {
-    beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_17; });
+    beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
   };
 
   rethinkdb = callPackage ../servers/nosql/rethinkdb {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.4

4.0.x is EOL

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
