### PR TITLE
tgv: init at 0.1.0

### DIFF
--- a/pkgs/by-name/tg/tgv/package.nix
+++ b/pkgs/by-name/tg/tgv/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  perl,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tgv";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "zeqianli";
+    repo = "tgv";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-i+ODCIpR7RpcC4y7c9hbH/mBilvZZRhu9/hJwUcdoNI=";
+  };
+
+  cargoHash = "sha256-+VggRnjIq+nB91pB5LEbPAsSigXJEV3IcBEQQnWjKRI=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    pkg-config
+    perl
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  checkFlags = [
+    # requires network access
+    "--skip=tests::download_integration_test"
+    "--skip=tests::integration_test::case_1"
+    "--skip=tests::integration_test::case_2"
+    "--skip=tests::integration_test::case_3"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal genome explorer";
+    homepage = "https://github.com/zeqianli/tgv";
+    changelog = "https://github.com/zeqianli/tgv/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      idlip
+      mvs
+    ];
+
+    mainProgram = "tgv";
+  };
+})


### PR DESCRIPTION
[`tgv`](https://github.com/zeqianli/tgv) is a terminal‐based genome explorer.

This PR is based on and supersedes #396728. I took the liberty of keeping @idlip as co‐maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
