### PR TITLE
tome4: fix build, modernize

### DIFF
--- a/pkgs/by-name/to/tome4/0001-web-missing-include.patch
+++ b/pkgs/by-name/to/tome4/0001-web-missing-include.patch
@@ -1,0 +1,24 @@
+From e0c17a8665250b3e3e7f4938f7b256ff50b78fc8 Mon Sep 17 00:00:00 2001
+From: Tom van Dijk <18gatenmaker6@gmail.com>
+Date: Thu, 23 Oct 2025 15:01:01 +0200
+Subject: [PATCH 1/3] web missing include
+
+---
+ src/web.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/web.c b/src/web.c
+index f12eebb..940aaf9 100644
+--- a/src/web.c
++++ b/src/web.c
+@@ -32,6 +32,7 @@
+ #include "te4web.h"
+ #include "web-external.h"
+ #include "lua_externs.h"
++#include <unistd.h>
+ 
+ /*
+  * Grab web browser methods -- availabe only here
+-- 
+2.51.0
+

--- a/pkgs/by-name/to/tome4/0002-zlib-missing-include.patch
+++ b/pkgs/by-name/to/tome4/0002-zlib-missing-include.patch
@@ -1,0 +1,24 @@
+From a14890a8a7080c73cac10ff31365833b179c0464 Mon Sep 17 00:00:00 2001
+From: Tom van Dijk <18gatenmaker6@gmail.com>
+Date: Thu, 23 Oct 2025 15:45:03 +0200
+Subject: [PATCH 2/3] zlib missing include
+
+---
+ src/zlib/gzguts.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/zlib/gzguts.h b/src/zlib/gzguts.h
+index 990a4d2..7c89751 100644
+--- a/src/zlib/gzguts.h
++++ b/src/zlib/gzguts.h
+@@ -21,6 +21,7 @@
+ #include <stdio.h>
+ #include "zlib.h"
+ #ifdef STDC
++#  include <unistd.h>
+ #  include <string.h>
+ #  include <stdlib.h>
+ #  include <limits.h>
+-- 
+2.51.0
+

--- a/pkgs/by-name/to/tome4/0003-incompatible-pointer-types.patch
+++ b/pkgs/by-name/to/tome4/0003-incompatible-pointer-types.patch
@@ -1,0 +1,71 @@
+From ed9f9819c3a0d6b8e92f66aafa6324eb4b310282 Mon Sep 17 00:00:00 2001
+From: Tom van Dijk <18gatenmaker6@gmail.com>
+Date: Thu, 23 Oct 2025 15:53:06 +0200
+Subject: [PATCH 3/3] incompatible pointer types
+
+---
+ src/display_sdl.c                  | 2 +-
+ src/physfs/archivers/bind_physfs.c | 2 +-
+ src/physfs/physfs.c                | 3 ++-
+ src/tgl.h                          | 2 +-
+ 4 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/display_sdl.c b/src/display_sdl.c
+index 61b2f0e..c533c8b 100644
+--- a/src/display_sdl.c
++++ b/src/display_sdl.c
+@@ -78,5 +78,5 @@ GLuint gl_c_shader = 0;
+ int nb_draws = 0;
+ int gl_c_vertices_nb = 0, gl_c_texcoords_nb = 0, gl_c_colors_nb = 0;
+ GLfloat *gl_c_vertices_ptr = NULL;
+-GLfloat *gl_c_texcoords_ptr = NULL;
++void *gl_c_texcoords_ptr = NULL;
+ GLfloat *gl_c_colors_ptr = NULL;
+diff --git a/src/physfs/archivers/bind_physfs.c b/src/physfs/archivers/bind_physfs.c
+index d02d323..c0d77c1 100644
+--- a/src/physfs/archivers/bind_physfs.c
++++ b/src/physfs/archivers/bind_physfs.c
+@@ -222,7 +222,7 @@ static fvoid *doOpen(dvoid *opaque, const char *name,
+ 
+ static fvoid *BIND_PHYSFS_openRead(dvoid *opaque, const char *fnm, int *exist)
+ {
+-	return(doOpen(opaque, fnm, PHYSFS_openRead, exist));
++	return(doOpen(opaque, fnm, (void * (*)(const char *)) PHYSFS_openRead, exist));
+ } /* BIND_PHYSFS_openRead */
+ 
+ 
+diff --git a/src/physfs/physfs.c b/src/physfs/physfs.c
+index 03eb86d..32e2c91 100644
+--- a/src/physfs/physfs.c
++++ b/src/physfs/physfs.c
+@@ -68,12 +68,13 @@ extern const PHYSFS_Archiver       __PHYSFS_Archiver_MVL;
+ extern const PHYSFS_ArchiveInfo    __PHYSFS_ArchiveInfo_WAD;
+ extern const PHYSFS_Archiver       __PHYSFS_Archiver_WAD;
+ extern const PHYSFS_Archiver       __PHYSFS_Archiver_DIR;
++extern const PHYSFS_ArchiveInfo    __PHYSFS_ArchiveInfo_BIND_PHYSFS;
+ extern const PHYSFS_Archiver       __PHYSFS_Archiver_BIND_PHYSFS;
+ 
+ 
+ static const PHYSFS_ArchiveInfo *supported_types[] =
+ {
+-    &__PHYSFS_Archiver_BIND_PHYSFS,
++    &__PHYSFS_ArchiveInfo_BIND_PHYSFS,
+ #if (defined PHYSFS_SUPPORTS_ZIP)
+     &__PHYSFS_ArchiveInfo_SUBZIP,
+     &__PHYSFS_ArchiveInfo_ZIP,
+diff --git a/src/tgl.h b/src/tgl.h
+index e2ec026..f905033 100644
+--- a/src/tgl.h
++++ b/src/tgl.h
+@@ -71,7 +71,7 @@ extern int nb_draws;
+ 
+ extern int gl_c_vertices_nb, gl_c_texcoords_nb, gl_c_colors_nb;
+ extern GLfloat *gl_c_vertices_ptr;
+-extern GLfloat *gl_c_texcoords_ptr;
++extern void *gl_c_texcoords_ptr;
+ extern GLfloat *gl_c_colors_ptr;
+ #define glVertexPointer(nb, t, v, p) \
+ { \
+-- 
+2.51.0
+

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   prePatch = ''
     # http://forums.te4.org/viewtopic.php?f=42&t=49478&view=next#p234354
-    sed -i 's|#include <GL/glext.h>||' src/tgl.h
+    substituteInPlace src/tgl.h \
+      --replace-fail "#include <GL/glext.h>" ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
@@ -19,9 +19,13 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "tome4";
   version = "1.7.6";
 
-  src = fetchurl {
-    url = "https://te4.org/dl/t-engine/t-engine4-src-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-mJ3qAIA/jNyt4CT0ZH1IC7GsDUN8JUKSwHVJwnKkaAw=";
+  # Official source according to https://te4.org/wiki/How_to_compile
+  src = fetchFromGitLab {
+    domain = "git.net-core.org";
+    owner = "tome";
+    repo = "t-engine4";
+    tag = "tome-${finalAttrs.version}";
+    hash = "sha256-v0YPbmaOqKYgFkOe/X0FCirucrMo2UGAyhZ7MFj+nsU=";
   };
 
   prePatch = ''

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -15,6 +15,7 @@
   SDL2_image,
   SDL2_ttf,
   xorg,
+  nix-update-script,
 }:
 
 let
@@ -124,6 +125,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "tome-(.*)"
+    ];
+  };
 
   meta = {
     description = "Tales of Maj'eyal (rogue-like game)";

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -93,12 +93,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tales of Maj'eyal (rogue-like game)";
     mainProgram = "tome4";
     homepage = "https://te4.org/";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ peterhoeg ];
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -15,12 +15,12 @@
   SDL2_ttf,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tome4";
   version = "1.7.6";
 
   src = fetchurl {
-    url = "https://te4.org/dl/t-engine/t-engine4-src-${version}.tar.bz2";
+    url = "https://te4.org/dl/t-engine/t-engine4-src-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-mJ3qAIA/jNyt4CT0ZH1IC7GsDUN8JUKSwHVJwnKkaAw=";
   };
 
@@ -81,11 +81,11 @@ stdenv.mkDerivation rec {
     makeWrapper $dir/t-engine $out/bin/tome4 \
       --chdir "$dir"
 
-    install -Dm755 ${desktop}/share/applications/tome4.desktop $out/share/applications/tome4.desktop
+    install -Dm755 ${finalAttrs.desktop}/share/applications/tome4.desktop $out/share/applications/tome4.desktop
     substituteInPlace $out/share/applications/tome4.desktop \
       --subst-var out
 
-    unzip -oj -qq game/engines/te4-${version}.teae data/gfx/te4-icon.png
+    unzip -oj -qq game/engines/te4-${finalAttrs.version}.teae data/gfx/te4-icon.png
     install -Dm644 te4-icon.png $out/share/icons/hicolor/64x64/tome4.png
 
     install -Dm644 -t $out/share/doc/tome4 CONTRIBUTING COPYING COPYING-MEDIA CREDITS
@@ -104,4 +104,4 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
     ];
   };
-}
+})

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -2,10 +2,10 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   premake4,
-  unzip,
   openal,
   libpng,
   libvorbis,
@@ -24,28 +24,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-mJ3qAIA/jNyt4CT0ZH1IC7GsDUN8JUKSwHVJwnKkaAw=";
   };
 
-  desktop = makeDesktopItem {
-    desktopName = "tome4";
-    name = "Tales of Maj'Eyal";
-    exec = "@out@/bin/tome4";
-    icon = "tome4";
-    comment = "An open-source, single-player, role-playing roguelike game set in the world of Eyal.";
-    type = "Application";
-    categories = [
-      "Game"
-      "RolePlaying"
-    ];
-    genericName = "2D roguelike RPG";
-  };
-
   prePatch = ''
     # http://forums.te4.org/viewtopic.php?f=42&t=49478&view=next#p234354
     sed -i 's|#include <GL/glext.h>||' src/tgl.h
   '';
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
-    unzip
     premake4
   ];
 
@@ -68,6 +54,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [ "config=release" ];
 
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Tales of Maj'Eyal";
+      name = "tome4";
+      exec = "tome4";
+      icon = "te4-icon";
+      comment = "An open-source, single-player, role-playing roguelike game set in the world of Eyal.";
+      type = "Application";
+      categories = [
+        "Game"
+        "RolePlaying"
+      ];
+      genericName = "2D roguelike RPG";
+    })
+  ];
+
   # The wrapper needs to cd into the correct directory as tome4's detection of
   # the game asset root directory is faulty.
 
@@ -81,12 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper $dir/t-engine $out/bin/tome4 \
       --chdir "$dir"
 
-    install -Dm755 ${finalAttrs.desktop}/share/applications/tome4.desktop $out/share/applications/tome4.desktop
-    substituteInPlace $out/share/applications/tome4.desktop \
-      --subst-var out
-
-    unzip -oj -qq game/engines/te4-${finalAttrs.version}.teae data/gfx/te4-icon.png
-    install -Dm644 te4-icon.png $out/share/icons/hicolor/64x64/tome4.png
+    install -Dm644 game/engines/default/data/gfx/te4-icon.png -t $out/share/icons/hicolor/64x64
 
     install -Dm644 -t $out/share/doc/tome4 CONTRIBUTING COPYING COPYING-MEDIA CREDITS
 

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -25,17 +25,17 @@ stdenv.mkDerivation rec {
   };
 
   desktop = makeDesktopItem {
-    desktopName = pname;
-    name = pname;
-    exec = "@out@/bin/${pname}";
-    icon = pname;
+    desktopName = "tome4";
+    name = "Tales of Maj'Eyal";
+    exec = "@out@/bin/tome4";
+    icon = "tome4";
     comment = "An open-source, single-player, role-playing roguelike game set in the world of Eyal.";
     type = "Application";
     categories = [
       "Game"
       "RolePlaying"
     ];
-    genericName = pname;
+    genericName = "2D roguelike RPG";
   };
 
   prePatch = ''
@@ -74,21 +74,21 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    dir=$out/share/${pname}
+    dir=$out/share/tome4
 
     install -Dm755 t-engine $dir/t-engine
     cp -r bootstrap game $dir
-    makeWrapper $dir/t-engine $out/bin/${pname} \
+    makeWrapper $dir/t-engine $out/bin/tome4 \
       --chdir "$dir"
 
-    install -Dm755 ${desktop}/share/applications/${pname}.desktop $out/share/applications/${pname}.desktop
-    substituteInPlace $out/share/applications/${pname}.desktop \
+    install -Dm755 ${desktop}/share/applications/tome4.desktop $out/share/applications/tome4.desktop
+    substituteInPlace $out/share/applications/tome4.desktop \
       --subst-var out
 
     unzip -oj -qq game/engines/te4-${version}.teae data/gfx/te4-icon.png
-    install -Dm644 te4-icon.png $out/share/icons/hicolor/64x64/${pname}.png
+    install -Dm644 te4-icon.png $out/share/icons/hicolor/64x64/tome4.png
 
-    install -Dm644 -t $out/share/doc/${pname} CONTRIBUTING COPYING COPYING-MEDIA CREDITS
+    install -Dm644 -t $out/share/doc/tome4 CONTRIBUTING COPYING COPYING-MEDIA CREDITS
 
     runHook postInstall
   '';

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://te4.org/dl/t-engine/t-engine4-src-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-mJ3qAIA/jNyt4CT0ZH1IC7GsDUN8JUKSwHVJwnKkaAw=";
+    hash = "sha256-mJ3qAIA/jNyt4CT0ZH1IC7GsDUN8JUKSwHVJwnKkaAw=";
   };
 
   prePatch = ''


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/368887

Hydra: https://hydra.nixos.org/build/309188854

Early ZHF if you will...

Further steps: look into unvendoring. The vendored dependencies seem to be incompatible with nixpkgs ones though, possibly because they have been modified to be custom to t-engine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
