### PR TITLE
kiwix: fix build error with latest qt

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-B3RcYr/b8pZTJV35BWuqmWbq+C2WkkcwBR0oNaUXPRw=";
   };
 
+  patches = [
+    ./remove-Werror.patch
+  ];
+
   nativeBuildInputs = [
     qmake
     pkg-config

--- a/pkgs/applications/misc/kiwix/remove-Werror.patch
+++ b/pkgs/applications/misc/kiwix/remove-Werror.patch
@@ -1,0 +1,12 @@
+diff --git a/kiwix-desktop.pro b/kiwix-desktop.pro
+index c1f4f93..bf10828 100644
+--- a/kiwix-desktop.pro
++++ b/kiwix-desktop.pro
+@@ -27,7 +27,6 @@ QMAKE_CXXFLAGS += -std=c++17
+ QMAKE_LFLAGS +=  -std=c++17
+ 
+ !win32 {
+-    QMAKE_CXXFLAGS += -Werror
+     equals(QT_MAJOR_VERSION, 6):equals(QT_MINOR_VERSION, 6) {
+         # Fail the build on errors, except for 'template-id-cdtor' due to a problem with Qt headers.
+         # This can be removed when the Ubuntu package is fixed.


### PR DESCRIPTION
As of the latest unstable build kiwix and a few other QT apps are failing. This one is easy though as it is just a warning and upstream has Werror enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
