### PR TITLE
weblate: 5.13.3 -> 5.14

### DIFF
--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -16,18 +16,13 @@
 let
   python = python3.override {
     packageOverrides = final: prev: {
-      # https://github.com/django-crispy-forms/crispy-bootstrap3/issues/12
-      django = prev.django_5_1;
-      djangorestframework = prev.djangorestframework.overridePythonAttrs (old: {
-        # https://github.com/encode/django-rest-framework/discussions/9342
-        disabledTests = (old.disabledTests or [ ]) ++ [ "test_invalid_inputs" ];
-      });
+      django = prev.django_5_2;
     };
   };
 in
 python.pkgs.buildPythonApplication rec {
   pname = "weblate";
-  version = "5.13.3";
+  version = "5.14";
 
   pyproject = true;
 
@@ -40,7 +35,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "WeblateOrg";
     repo = "weblate";
     tag = "weblate-${version}";
-    hash = "sha256-PM5h9RqCMdt0FODE7MoCWv9I+RMFTgjDmSrid59cHOA=";
+    hash = "sha256-XIaVM9bsgv6qJ1Q/6wzfO7D04WsUEkxNnJlyLd5+bY4=";
   };
 
   build-system = with python.pkgs; [ setuptools ];
@@ -68,7 +63,7 @@ python.pkgs.buildPythonApplication rec {
     '';
 
   pythonRelaxDeps = [
-    "rapidfuzz"
+    "certifi"
   ];
 
   dependencies =

--- a/pkgs/development/python-modules/ahocorasick-rs/default.nix
+++ b/pkgs/development/python-modules/ahocorasick-rs/default.nix
@@ -13,19 +13,19 @@
 
 buildPythonPackage rec {
   pname = "ahocorasick-rs";
-  version = "0.22.2";
+  version = "1.0.3";
 
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ahocorasick_rs";
-    hash = "sha256-h/J6ZCLb+U7A+f6ErAGI1KZrXHsvX23rFl8MXj25dpw=";
+    hash = "sha256-V503Bwp8Idqc2ZiLn7RxKXJztgy0EmWG1tzZn6r8XKU=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-uB3r6+Ewpi4dVke/TsCZltfc+ZABYLOLKuNxw+Jfu/M=";
+    hash = "sha256-RfgjO0qffiAZynQ/xChd81L8S0sqTGdWvpHPrz3bKlQ=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/crispy-bootstrap3/default.nix
+++ b/pkgs/development/python-modules/crispy-bootstrap3/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "crispy_bootstrap3" ];
 
+  # Tests are broken on Django >= 5.1
+  # https://github.com/django-crispy-forms/crispy-bootstrap3/issues/12
+  doCheck = lib.versionOlder django.version "5.1";
+
   meta = with lib; {
     description = "Bootstrap 3 template pack for django-crispy-forms";
     homepage = "https://github.com/django-crispy-forms/crispy-bootstrap3";

--- a/pkgs/development/python-modules/weblate-schemas/default.nix
+++ b/pkgs/development/python-modules/weblate-schemas/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "weblate-schemas";
-  version = "2025.5";
+  version = "2025.6";
 
   pyproject = true;
 
   src = fetchPypi {
     pname = "weblate_schemas";
     inherit version;
-    hash = "sha256-ZhFF3UD7lX/KXVDZFOn+Gc1w/cpzzVYVrbpVeJ9/wiE=";
+    hash = "sha256-Kxu+8CiJ343PmCdY5rSbTqsWmVMLnz9inAH726g5TQQ=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Changelog: https://github.com/WeblateOrg/weblate/releases/tag/weblate-5.14

Upstream requires Django 5.2 now, so I decided to just disable [the failing tests for `crispy-bootstrap3`](https://github.com/django-crispy-forms/crispy-bootstrap3/issues/12) now.

Closes https://github.com/NixOS/nixpkgs/pull/450368 
Closes https://github.com/NixOS/nixpkgs/pull/442504

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
