### PR TITLE
nginxModules.lua: 0.10.26 -> 0.10.28

### DIFF
--- a/pkgs/development/interpreters/luajit/openresty.nix
+++ b/pkgs/development/interpreters/luajit/openresty.nix
@@ -6,13 +6,13 @@
 }:
 
 callPackage ./default.nix rec {
-  version = "2.1-20220915";
+  version = "2.1-20250826";
 
   src = fetchFromGitHub {
     owner = "openresty";
     repo = "luajit2";
     rev = "v${version}";
-    hash = "sha256-kMHE4iQtm2CujK9TVut1jNhY2QxYP514jfBsxOCyd4s=";
+    hash = "sha256-fF3xgAy2IjFy4LdXPlk4RuX+IclOXaw3YR24wyMBNgM=";
   };
 
   inherit self passthruFun;

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -384,14 +384,14 @@ let
 
     lua = rec {
       name = "lua";
-      version = "0.10.26";
+      version = "0.10.28";
 
       src = fetchFromGitHub {
         name = "lua";
         owner = "openresty";
         repo = "lua-nginx-module";
         rev = "v${version}";
-        hash = "sha256-007up/XncaSBimBumHpbwgB1WnkXgBe8e/q/yT6vthI=";
+        hash = "sha256-GT1PpJWpEu5EciK4n9ZDz1gIU/ZdC/SAsIdu0niQy8o=";
       };
 
       inputs = [ luajit_openresty ];

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -184,13 +184,13 @@ rec {
     { fetchFromGitHub }:
     buildLuaPackage rec {
       pname = "lua-resty-lrucache";
-      version = "0.13";
+      version = "0.15";
 
       src = fetchFromGitHub {
         owner = "openresty";
         repo = "lua-resty-lrucache";
         rev = "v${version}";
-        sha256 = "sha256-J8RNAMourxqUF8wPKd8XBhNwGC/x1KKvrVnZtYDEu4Q=";
+        sha256 = "sha256-G2l4Zo9Xm/m4zRfxrgzEvRE5LMO+UuX3kd7FwlCnxDA=";
       };
 
       meta = with lib; {

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -160,13 +160,13 @@ rec {
     { fetchFromGitHub }:
     buildLuaPackage rec {
       pname = "lua-resty-core";
-      version = "0.1.28";
+      version = "0.1.31";
 
       src = fetchFromGitHub {
         owner = "openresty";
         repo = "lua-resty-core";
         rev = "v${version}";
-        sha256 = "sha256-RJ2wcHTu447wM0h1fa2qCBl4/p9XL6ZqX9pktRW64RI=";
+        sha256 = "sha256-WUiBFJ8L8NzSGoEwTAw/iHAzPqJqaOUSFyqGeEf+f94==";
       };
 
       propagatedBuildInputs = [ lua-resty-lrucache ];


### PR DESCRIPTION
Most of the changes are summarized in [this changelog](https://openresty.org/en/changelog-1027001.html).

More detailed comparisons between versions:
- https://github.com/openresty/luajit2/compare/v2.1-20220915...v2.1-20250826
- https://github.com/openresty/lua-resty-lrucache/compare/v0.13...v0.15
- https://github.com/openresty/lua-resty-core/compare/v0.1.28...v0.1.31
- https://github.com/openresty/lua-nginx-module/compare/v0.10.26...v0.10.28


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
