### PR TITLE
python3.pkgs.slob: 0-unstable-20{20-06-26 -> 24-04-19}

### DIFF
--- a/pkgs/by-name/sl/slob/package.nix
+++ b/pkgs/by-name/sl/slob/package.nix
@@ -1,0 +1,5 @@
+{
+  python3Packages,
+}:
+
+python3Packages.toPythonApplication python3Packages.slob

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage {
     owner = "itkach";
     repo = "slob";
     rev = "018588b59999c5c0eb42d6517fdb84036f3880cb";
-    sha256 = "01195hphjnlcvgykw143rf06s6y955sjc1r825a58vhjx7hj54zh";
+    hash = "sha256-8JMi4ekSblRUESgHJnUpyRttgMuDBD7924xaCS8sKQQ=";
   };
 
   propagatedBuildInputs = [ pyicu ];

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage {
     description = "Reference implementation of the slob (sorted list of blobs) format";
     mainProgram = "slob";
     license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -2,16 +2,21 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  isPy3k,
+
+  # dependencies
   pyicu,
+
+  # build-system
+  setuptools,
+
+  # tests
   python,
 }:
 
 buildPythonPackage {
   pname = "slob";
   version = "unstable-2020-06-26";
-  format = "setuptools";
-  disabled = !isPy3k;
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "itkach";
@@ -20,8 +25,17 @@ buildPythonPackage {
     hash = "sha256-8JMi4ekSblRUESgHJnUpyRttgMuDBD7924xaCS8sKQQ=";
   };
 
-  propagatedBuildInputs = [ pyicu ];
+  build-system = [
+    setuptools
+  ];
 
+  dependencies = [
+    pyicu
+  ];
+
+  # The tests are part of the same slob.py file, so unittestCheckHook which
+  # runs python -m unittest with the `discover` argument which doesn't discover
+  # any tests.
   checkPhase = ''
     ${python.interpreter} -m unittest slob
   '';

--- a/pkgs/development/python-modules/slob/default.nix
+++ b/pkgs/development/python-modules/slob/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage {
   pname = "slob";
-  version = "unstable-2020-06-26";
+  version = "0-unstable-2024-04-19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "itkach";
     repo = "slob";
-    rev = "018588b59999c5c0eb42d6517fdb84036f3880cb";
-    hash = "sha256-8JMi4ekSblRUESgHJnUpyRttgMuDBD7924xaCS8sKQQ=";
+    rev = "c21d695707db7d2fe4ec7ec27a018bb7b0fcc209";
+    hash = "sha256-dy/EaRLx0LwMklk4h2eL8CsyvWN4swcJNs5cULmh46g=";
   };
 
   build-system = [


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
