### PR TITLE
nix-output-monitor: allow pinning a specific Nix version

### DIFF
--- a/pkgs/by-name/ni/nix-output-monitor/package.nix
+++ b/pkgs/by-name/ni/nix-output-monitor/package.nix
@@ -3,9 +3,23 @@
   haskellPackages,
   installShellFiles,
   lib,
+  nix,
+  replaceVars,
+
+  # Allow pinning a specific Nix version.
+  withPinnedNix ? false,
 }:
 let
   inherit (haskell.lib.compose) justStaticExecutables overrideCabal;
+
+  # If we're pinning Nix, then substitute with a Nix path; otherwise, just the name of the binary.
+  ambientOrPinned = name: if withPinnedNix then lib.getExe' nix name else name;
+
+  pinnedNixPatch = replaceVars ./pin-a-specific-nix.patch {
+    nix = ambientOrPinned "nix";
+    nix-build = ambientOrPinned "nix-build";
+    nix-shell = ambientOrPinned "nix-shell";
+  };
 
   overrides = {
     passthru.updateScript = ./update.sh;
@@ -15,6 +29,9 @@ let
     testTargets = [ "unit-tests" ];
 
     buildTools = [ installShellFiles ];
+
+    patches = [ pinnedNixPatch ];
+
     postInstall = ''
       ln -s nom "$out/bin/nom-build"
       ln -s nom "$out/bin/nom-shell"
@@ -22,6 +39,7 @@ let
       installShellCompletion completions/*
     '';
   };
+
   raw-pkg = haskellPackages.callPackage ./generated-package.nix { };
 in
 lib.pipe raw-pkg [

--- a/pkgs/by-name/ni/nix-output-monitor/pin-a-specific-nix.patch
+++ b/pkgs/by-name/ni/nix-output-monitor/pin-a-specific-nix.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philip Taron <philip.taron@gmail.com>
+Date: Thu, 23 Oct 2025 10:32:59 -0700
+Subject: [PATCH] exe: allow pinning a specific Nix version
+
+---
+ exe/Main.hs | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/exe/Main.hs b/exe/Main.hs
+index 5e0f010..01b9e06 100644
+--- a/exe/Main.hs
++++ b/exe/Main.hs
+@@ -72,18 +72,18 @@ runApp :: String -> [String] -> IO Void
+ runApp = \cases
+   _ ["--version"] -> do
+     hPutStrLn stderr ("nix-output-monitor " <> fromString (showVersion version))
+-    exitWith =<< runProcess (proc "nix" ["--version"])
+-  "nom-build" args -> exitWith =<< runMonitoredCommand defaultConfig (proc "nix-build" (withJSON args))
++    exitWith =<< runProcess (proc "@nix@" ["--version"])
++  "nom-build" args -> exitWith =<< runMonitoredCommand defaultConfig (proc "@nix-build@" (withJSON args))
+   "nom-shell" args -> do
+-    exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "nix-shell" (withJSON args <> ["--run", "exit"]))
+-    exitWith =<< runProcess (proc "nix-shell" args)
+-  "nom" ("build" : args) -> exitWith =<< runMonitoredCommand defaultConfig (proc "nix" ("build" : withJSON args))
++    exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "@nix-shell@" (withJSON args <> ["--run", "exit"]))
++    exitWith =<< runProcess (proc "@nix-shell@" args)
++  "nom" ("build" : args) -> exitWith =<< runMonitoredCommand defaultConfig (proc "@nix@" ("build" : withJSON args))
+   "nom" ("shell" : args) -> do
+-    exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "nix" ("shell" : withJSON (replaceCommandWithExit args)))
+-    exitWith =<< runProcess (proc "nix" ("shell" : args))
++    exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "@nix@" ("shell" : withJSON (replaceCommandWithExit args)))
++    exitWith =<< runProcess (proc "@nix@" ("shell" : args))
+   "nom" ("develop" : args) -> do
+-    exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "nix" ("develop" : withJSON (replaceCommandWithExit args)))
+-    exitWith =<< runProcess (proc "nix" ("develop" : args))
++    exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "@nix@" ("develop" : withJSON (replaceCommandWithExit args)))
++    exitWith =<< runProcess (proc "@nix@" ("develop" : args))
+   "nom" [] -> do
+     finalState <- monitorHandle @OldStyleInput defaultConfig{piping = True} stdin
+     if CMap.size finalState.fullSummary.failedBuilds + length finalState.nixErrors == 0
+@@ -108,7 +108,7 @@ printNixCompletion = \cases
+     exitSuccess
+   "nom" args@(sub_cmd : _)
+     | sub_cmd `elem` knownSubCommands ->
+-        exitWith =<< Process.runProcess (Process.proc "nix" args)
++        exitWith =<< Process.runProcess (Process.proc "@nix@" args)
+   prog args -> do
+     putTextLn $ "No completion support for " <> unwords (toText <$> prog : args)
+     exitFailure
+@@ -170,7 +170,7 @@ monitorHandle config input_handle = withParser @a \streamParser -> do
+       Terminal.hHideCursor outputHandle
+       hSetBuffering stdout (BlockBuffering (Just 1_000_000))
+ 
+-      current_system <- Exception.handle ((Nothing <$) . printIOException) $ Just . decodeUtf8 <$> Process.readProcessStdout_ (Process.proc "nix" ["eval", "--extra-experimental-features", "nix-command", "--impure", "--raw", "--expr", "builtins.currentSystem"])
++      current_system <- Exception.handle ((Nothing <$) . printIOException) $ Just . decodeUtf8 <$> Process.readProcessStdout_ (Process.proc "@nix@" ["eval", "--extra-experimental-features", "nix-command", "--impure", "--raw", "--expr", "builtins.currentSystem"])
+       first_state <- initalStateFromBuildPlatform current_system
+       -- We enforce here, that the state type is completely strict so that we don‘t accumulate thunks while running the program.
+       let first_process_state = MkProcessState (StrictType.Strict $ firstState @a first_state) (stateToText config first_state)
+-- 
+2.51.0
+


### PR DESCRIPTION
I'm interested in using `nom` for `nixos-rebuild`, which wants to do this.

I tested with `nom --version`, which then turns around and calls `nix --version`.

- [x] `nix-build --expr 'with import ./. { }; nix-output-monitor.override { withPinnedNix = true; nix = lixPackageSets.latest.lix; }'`
- [x] `nix-build --expr 'with import ./. { }; nix-output-monitor.override { withPinnedNix = true; nix = nixVersions.nix_2_32; }'`
- [x] `nix-build --expr 'with import ./. { }; nix-output-monitor.override { withPinnedNix = true; nix = nixVersions.nix_2_28; }'`

It's moderately lame to hold a patch for this purpose in Nixpkgs, but this code appears to be quite stable over time in `nix-output-monitor`, so I don't feel too bad about it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
