### PR TITLE
claudia-statusline: init at 2.16.0

### DIFF
--- a/pkgs/by-name/cl/claudia-statusline/package.nix
+++ b/pkgs/by-name/cl/claudia-statusline/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "claudia-statusline";
+  version = "2.16.0";
+
+  src = fetchFromGitHub {
+    owner = "hagan";
+    repo = "claudia-statusline";
+    tag = "v${version}";
+    hash = "sha256-A6BYcHsioybpLRfcHW5KeqnpISFZpMIqVWLEk3Fy6Jc=";
+  };
+
+  cargoHash = "sha256-NAaTUfqhbXFBAh2GQHAFPXjGTC8MnNnTgN1uDA0lhJs=";
+
+  # Tests fail in sandboxed environment due to filesystem and HOME directory requirements
+  doCheck = false;
+
+  meta = {
+    description = "Enhanced statusline for Claude Code - track costs, git status, and context usage in real-time";
+    homepage = "https://github.com/hagan/claudia-statusline";
+    changelog = "https://github.com/hagan/claudia-statusline/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onsails ];
+    platforms = lib.platforms.unix;
+    mainProgram = "statusline";
+  };
+}


### PR DESCRIPTION
A high-performance statusline for Claude Code written in Rust.

Features:
- Real-time tracking of Claude API usage costs and context usage
- Git integration showing branch and file changes
- Session duration and burn rate calculations
- SQLite-based persistent stats tracking
- Dark/light theme support

https://github.com/hagan/claudia-statusline


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
