### PR TITLE
isponsorblocktv: 2.5.3 -> 2.6.1

### DIFF
--- a/pkgs/by-name/is/isponsorblocktv/package.nix
+++ b/pkgs/by-name/is/isponsorblocktv/package.nix
@@ -7,27 +7,21 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "isponsorblocktv";
-  version = "2.5.3";
+  version = "2.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dmunozv04";
     repo = "iSponsorBlockTV";
     tag = "v${version}";
-    hash = "sha256-vxTEec5SMq5zcX70PiRD61aDPJUySuBG0TBQH5Qw8ow=";
+    hash = "sha256-AGjLehhGYz8FyojSFmSYKLCkHAExtpQiukQnTNt1YoY=";
   };
 
   patches = [
     # Port iSponsorBlockTV to pyytlounge v3
     (fetchpatch {
-      url = "https://github.com/lukegb/iSponsorBlockTV/commit/3b50819fffbea23ef02f24726982a1b3313fa952.patch";
-      hash = "sha256-2adgGE3rBnp+/z+2iblWCxO+6qV9RHx0dqTxv/kjDJU=";
-    })
-
-    # Update setup_wizard for Textual v3
-    (fetchpatch {
-      url = "https://github.com/lukegb/iSponsorBlockTV/commit/4a3874b781f796ad32e40fc871fee7c080716171.patch";
-      hash = "sha256-kdfAaIuvQovst55sOmKv+zH/7JxN1JHI9aTF0c9fYAY=";
+      url = "https://github.com/ameertaweel/iSponsorBlockTV/commit/1809ca5a0d561bc9326a51e82118f290423ed3e6.patch";
+      hash = "sha256-v5YXfKUPTzpZPIkVSQF2VUe9EvclAH+kJyiiyUEe/HM=";
     })
   ];
 


### PR DESCRIPTION
## Release Info

- `2.6.0`: https://github.com/dmunozv04/iSponsorBlockTV/releases/tag/v2.6.0
- `2.6.1`: https://github.com/dmunozv04/iSponsorBlockTV/releases/tag/v2.6.1
- Diff: https://github.com/dmunozv04/iSponsorBlockTV/compare/v2.5.3...v2.6.1

## @lukegb's Patches

This still carries @lukegb patche for the new `pyytlounge` API. However, @lukegb's patch doesn't apply cleanly so I made my own version of it that applies cleanly.

Also, I removed @lukegb's patch for `textual`, as upstream has moved to newer version.

## Testing

I didn't just run the binary. I made sure it actually mutes and skips ads on my TV.
I did this on `x86_64-linux` and on `aarch64-linux`.

## Things Done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
