### PR TITLE
lib.makeOverridable: observe `<result>.__overriders`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -32,6 +32,8 @@ let
     extends
     toFunction
     id
+    genAttrs
+    subtractLists
     ;
   inherit (lib.strings) levenshtein levenshteinAtMost;
 
@@ -194,10 +196,19 @@ rec {
         );
         # Change the result of the function call by applying g to it
         overrideResult = g: makeOverridable (mirrorArgs (args: g (f args))) origArgs;
+        newOverriderNames =
+          filter (n: n != "override" && n != "overrideDerivation" && result ? ${n}) (
+            subtractLists (result.__overriders or [ ]) [ "overrideAttrs" ] ++ result.__overriders or [ ]
+          )
+          ++ [
+            "override"
+            "overrideDerivation"
+          ];
       in
       if isAttrs result then
         result
         // {
+          __overriders = newOverriderNames;
           override = overrideArgs;
           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
           ${if result ? overrideAttrs then "overrideAttrs" else null} =
@@ -213,10 +224,16 @@ rec {
             #       design/tech debt issue: https://github.com/NixOS/nixpkgs/issues/273815
             fdrv: overrideResult (x: x.overrideAttrs fdrv);
         }
+        // optionalAttrs (result ? __overriders) (
+          genAttrs (filter (
+            x: x != "override" && x != "overrideAttrs" && x != "overrideDerivation" && result ? ${x}
+          ) result.__overriders) (name: fdrv: overrideResult (x: x.${name} fdrv))
+        )
       else if isFunction result then
         # Transform the result into a functor while propagating its arguments
         setFunctionArgs result (functionArgs result)
         // {
+          __overriders = newOverriderNames;
           override = overrideArgs;
         }
       else

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -656,6 +656,7 @@ rec {
         newScope = scope: newScope (self // scope);
         overrideScope = g: makeScope newScope (extends g f);
         packages = f;
+        __overriders = [ "overrideScope" ];
       };
     in
     self;
@@ -774,6 +775,7 @@ rec {
             f = extends g f;
           });
         packages = f;
+        __overriders = [ "overrideScope" ];
       };
     in
     self;

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -454,6 +454,7 @@ rec {
       (rattrs self)
       // {
         ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
+        __overriders = [ extenderName ];
       }
     );
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -87,6 +87,7 @@ let
     meta
     mod
     nameValuePair
+    optionalAttrs
     optionalDrvAttr
     optionAttrSetToDocList
     overrideExisting
@@ -4810,16 +4811,19 @@ runTests {
             directory = ./packages-from-directory/scope;
           });
       expected = lib.recurseIntoAttrs {
+        __overriders = [ "overrideScope" ];
         a = "a";
         b = "b";
         # Note: Other files/directories in `./test-data/c/` are ignored and can be
         # used by `package.nix`.
         c = "c";
         my-namespace = lib.recurseIntoAttrs {
+          __overriders = [ "overrideScope" ];
           d = "d";
           e = "e";
           f = "f";
           my-sub-namespace = lib.recurseIntoAttrs {
+            __overriders = [ "overrideScope" ];
             g = "g";
             h = "h";
           };
@@ -4876,6 +4880,69 @@ runTests {
       expected = {
         foo = "foo-value-custom";
         bar = "bar-value-custom";
+
+  # Test if `makeOverridable` correctly handles `result.ovrerrideScope`,
+  # so that `makeScope`-constructed, `callPackageWith`-called scope
+  # won't lose `<scope>.override` after `<scope>.overrideScope` overriding.
+  testMakeOverridableForCallPackageAndScope =
+    let
+      scope-orig = callPackageWith (lib // { a = 3; }) (
+        {
+          callPackagesWith,
+          makeScope,
+          a,
+        }:
+        makeScope callPackagesWith (final: {
+          inherit a;
+          b = 5;
+          c = final.a * final.b;
+        })
+      ) { };
+      scope-os = scope-orig.overrideScope (
+        final: previous: {
+          b = 7;
+        }
+      );
+      scope-os-ov = scope-os.override { a = 11; };
+    in
+    {
+      expr = {
+        scope-orig-a = scope-orig.a;
+        scope-orig-b = scope-orig.b;
+        scope-orig-c = scope-orig.c;
+        scope-orig-has-override = scope-orig ? override;
+        scope-orig-has-overrideScope = scope-orig ? overrideScope;
+      }
+      // optionalAttrs (scope-orig ? overrideScope) {
+        scope-os-a = scope-os.a;
+        scope-os-b = scope-os.b;
+        scope-os-c = scope-os.c;
+        scope-os-has-override = scope-os ? override;
+        scope-os-has-overrideScope = scope-os ? overrideScope;
+      }
+      // optionalAttrs (scope-os ? override) {
+        scope-os-ov-a = scope-os-ov.a;
+        scope-os-ov-b = scope-os-ov.b;
+        scope-os-ov-c = scope-os-ov.c;
+        scope-os-ov-has-override = scope-os-ov ? override;
+        scope-os-ov-has-overrideScope = scope-os-ov ? overrideScope;
+      };
+      expected = rec {
+        scope-orig-a = 3;
+        scope-orig-b = 5;
+        scope-orig-c = scope-orig-a * scope-orig-b;
+        scope-orig-has-override = true;
+        scope-orig-has-overrideScope = true;
+        scope-os-a = scope-orig-a;
+        scope-os-b = 7;
+        scope-os-c = scope-os-a * scope-os-b;
+        scope-os-has-override = true;
+        scope-os-has-overrideScope = true;
+        scope-os-ov-a = 11;
+        scope-os-ov-b = scope-os-b;
+        scope-os-ov-c = scope-os-ov-a * scope-os-ov-b;
+        scope-os-ov-has-override = true;
+        scope-os-ov-has-overrideScope = true;
       };
     };
 


### PR DESCRIPTION
This PR solves `lib.makeOverridable`'s not handling existing overriders beside `overrideAttrs` by introducing the `__overriders` attribute.

Such attribute contains the names of existing overriders of the attribute set.
When a `lib.makeOverridable`-like function adds a new overrider, it can check `result.__overriders`, decorates existing overriders, and add the name of the overriders it provide to the `__overriders` list.

This is an extensible solution/workaround to issues like `<set>.override` lost after `<set>.overrideScope` overriding (#447012) without substantial infrastructural changes (like what #273815 proposes).

This PR helps ~unblock~ improve PR #445668. Cc: @LunNova @bb010g

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
