### PR TITLE
home-assistant-custom-components.sws12500: init at 1.6.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14284,6 +14284,12 @@
     github = "langsjo";
     githubId = 104687438;
   };
+  larsianer = {
+    name = "larsianer";
+    email = "lars@feilberg.de";
+    github = "larsianer";
+    githubId = 55206664;
+  };
   larsr = {
     email = "Lars.Rasmusson@gmail.com";
     github = "larsr";

--- a/pkgs/servers/home-assistant/custom-components/sws12500/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/sws12500/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "schizza";
+  domain = "sws12500";
+  version = "1.6.6";
+
+  src = fetchFromGitHub {
+    owner = "schizza";
+    repo = "sws-12500-custom-component";
+    tag = "v${version}";
+    hash = "sha256-AH2ljZcsCXBZmmJc+97U03X2jqJlWQQTl9fmcGBtyrA=";
+  };
+
+  meta = {
+    changelog = "https://github.com/schizza/sws-12500-custom-component/releases/tag/${src.tag}";
+    description = "Integrates your Sencor SWS 12500 or 16600, GARNI, BRESSER weather stations seamlessly into Home Assistant";
+    homepage = "https://github.com/schizza/sws-12500-custom-component";
+    maintainers = with lib.maintainers; [ larsianer ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Home Assistant integration for Sencor SWS 12500 or 16600, GARNI and BRESSER weather stations.
Project URL: https://github.com/schizza/SWS-12500-custom-component

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
