### PR TITLE
nixos/systemd: CPUAccounting is deprecated

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -364,7 +364,6 @@ in
         '';
         serviceConfig = {
           Slice = "kubernetes.slice";
-          CPUAccounting = true;
           MemoryAccounting = true;
           Restart = "on-failure";
           RestartSec = "1000ms";

--- a/nixos/modules/services/scheduling/prefect.nix
+++ b/nixos/modules/services/scheduling/prefect.nix
@@ -173,7 +173,6 @@ in
           ProtectKernelLogs = true;
           ProtectControlGroups = true;
           MemoryAccounting = true;
-          CPUAccounting = true;
 
           ExecStart = "${pkgs.prefect}/bin/prefect server start --host ${cfg.host} --port ${toString cfg.port}";
           Restart = "always";
@@ -216,7 +215,6 @@ in
           ProtectKernelLogs = true;
           ProtectControlGroups = true;
           MemoryAccounting = true;
-          CPUAccounting = true;
           ExecStart = ''
             ${pkgs.prefect}/bin/prefect worker start \
               --pool ${poolName} \

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -71,7 +71,7 @@ in
     systemd.user.extraConfig = mkOption {
       default = "";
       type = types.lines;
-      example = "DefaultCPUAccounting=yes";
+      example = "DefaultTimeoutStartSec=60";
       description = ''
         Extra config options for systemd user instances. See {manpage}`systemd-user.conf(5)` for
         available options.

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -370,7 +370,6 @@ in
         Type = "simple";
         Restart = "always";
         Slice = "azure.slice";
-        CPUAccounting = true;
         MemoryAccounting = true;
       };
     };


### PR DESCRIPTION
systemd 258 has the following changes noted in systemd.resource-control(5):

> `CPUAccounting=` setting is deprecated, because it is always available on the unified cgroup hierarchy and such setting has no effect.

This commit removes it from the three services using it directly, as well as one instance of example text.

---

The above is the commit message verbatim.
It should be noted that this only covers the *nixpkgs* side, as [some upstream units ship those values too](https://github.com/Zygo/bees/issues/327).

This was found in the context of #360426 which was used to run `systemd-analyze verify` against my infrastructure, [uncovering this for the upstream *bees* unit](https://hydra.cloud.bsocat.net/build/507301/nixlog/103).
I don't use any of the services actually touched in this commit, so a thorough review would be great!

Also please don't backport this change as #427968 was not backported either.

(I'll try to get around to running the NixOS tests ASAP, for now this is entirely untested; this notice is subject to be removed)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
