### PR TITLE
workflows/merge-group: prevent rebuild drift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   workflow_call:
     inputs:
+      artifact-prefix:
+        required: true
+        type: string
       baseBranch:
         required: true
         type: string
@@ -100,5 +103,5 @@ jobs:
           contains(fromJSON(inputs.baseBranch).type, 'primary')
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: nixos-manual-${{ matrix.name }}
+          name: ${{ inputs.artifact-prefix }}nixos-manual-${{ matrix.name }}
           path: nixos-manual

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -122,7 +122,6 @@ jobs:
           # Note: Keep the same further down in sync!
 
       - name: Evaluate the ${{ matrix.system }} output paths at the target commit
-        if: inputs.targetSha
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
         # This is very quick, because it pulls the eval results from Cachix.
@@ -134,7 +133,6 @@ jobs:
             --out-link target
 
       - name: Compare outpaths against the target branch
-        if: inputs.targetSha
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
         run: |
@@ -145,7 +143,6 @@ jobs:
             --out-link diff
 
       - name: Upload outpaths diff and stats
-        if: inputs.targetSha
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: ${{ inputs.artifact-prefix }}${{ matrix.version && format('{0}-', matrix.version) || '' }}diff-${{ matrix.system }}
@@ -154,7 +151,7 @@ jobs:
   compare:
     runs-on: ubuntu-24.04-arm
     needs: [eval]
-    if: inputs.targetSha && !cancelled() && !failure()
+    if: "!cancelled() && !failure()"
     permissions:
       statuses: write
     timeout-minutes: 5

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -3,6 +3,9 @@ name: Eval
 on:
   workflow_call:
     inputs:
+      artifact-prefix:
+        required: true
+        type: string
       mergedSha:
         required: true
         type: string
@@ -145,7 +148,7 @@ jobs:
         if: inputs.targetSha
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: ${{ matrix.version && format('{0}-', matrix.version) || '' }}diff-${{ matrix.system }}
+          name: ${{ inputs.artifact-prefix }}${{ matrix.version && format('{0}-', matrix.version) || '' }}diff-${{ matrix.system }}
           path: diff/*
 
   compare:
@@ -169,7 +172,7 @@ jobs:
       - name: Download output paths and eval stats for all systems
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          pattern: diff-*
+          pattern: ${{ inputs.artifact-prefix }}diff-*
           path: diff
           merge-multiple: true
 
@@ -202,7 +205,7 @@ jobs:
       - name: Upload the comparison results
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: comparison
+          name: ${{ inputs.artifact-prefix }}comparison
           path: comparison/*
 
       - name: Add eval summary to commit statuses
@@ -250,6 +253,7 @@ jobs:
       - name: Add version comparison table to job summary
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
+          ARTIFACT_PREFIX: ${{ inputs.artifact-prefix }}
           SYSTEMS: ${{ inputs.systems }}
           VERSIONS: ${{ needs.versions.outputs.versions }}
         with:
@@ -257,6 +261,7 @@ jobs:
             const { readFileSync } = require('node:fs')
             const path = require('node:path')
 
+            const prefix = process.env.ARTIFACT_PREFIX
             const systems = JSON.parse(process.env.SYSTEMS)
             const versions = JSON.parse(process.env.VERSIONS)
 
@@ -272,7 +277,7 @@ jobs:
                   [{ data: version }].concat(
                     systems.map((system) => {
                       try {
-                        const artifact = path.join('versions', `${version}-diff-${system}`)
+                        const artifact = path.join('versions', `${prefix}${version}-diff-${system}`)
                         const time = Math.round(
                           parseFloat(
                             readFileSync(

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -23,7 +23,9 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04-arm
     outputs:
-      systems: ${{ steps.systems.outputs.systems }}
+      mergedSha: ${{ steps.prepare.outputs.mergedSha }}
+      targetSha: ${{ steps.prepare.outputs.targetSha }}
+      systems: ${{ steps.prepare.outputs.systems }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -31,19 +33,28 @@ jobs:
           sparse-checkout: |
             ci/supportedSystems.json
 
-      - name: Load supported systems
-        id: systems
-        run: |
-          echo "systems=$(jq -c <ci/supportedSystems.json)" >> "$GITHUB_OUTPUT"
+      - id: prepare
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          MERGED_SHA: ${{ inputs.mergedSha }}
+          TARGET_SHA: ${{ inputs.targetSha }}
+        with:
+          script: |
+            core.setOutput('mergedSha', context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA)
+            core.info(`mergedSha: ${context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA}`)
+            core.setOutput('targetSha', context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA)
+            core.info(`targetSha: ${context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA}`)
+            core.setOutput('systems', require('./ci/supportedSystems.json'))
 
   lint:
     name: Lint
+    needs: [prepare]
     uses: ./.github/workflows/lint.yml
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
-      mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
-      targetSha: ${{ inputs.targetSha || github.event.merge_group.base_sha }}
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
 
   eval:
     name: Eval
@@ -58,7 +69,7 @@ jobs:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
-      mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       systems: ${{ needs.prepare.outputs.systems }}
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -23,14 +23,17 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04-arm
     outputs:
+      baseBranch: ${{ steps.prepare.outputs.base }}
       mergedSha: ${{ steps.prepare.outputs.mergedSha }}
       targetSha: ${{ steps.prepare.outputs.targetSha }}
       systems: ${{ steps.prepare.outputs.systems }}
+      workflowRun: ${{ steps.prepare.outputs.workflowRun }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
           sparse-checkout: |
+            ci/supportedBranches.js
             ci/supportedSystems.json
 
       - id: prepare
@@ -40,6 +43,39 @@ jobs:
           TARGET_SHA: ${{ inputs.targetSha }}
         with:
           script: |
+            const { classify } = require('./ci/supportedBranches.js')
+            const baseBranch = (
+              context.payload.merge_group?.base_ref ??
+              context.payload.pull_request.base.ref
+            ).replace(/^refs\/heads\//, '')
+            const baseClassification = classify(baseBranch)
+            core.setOutput('base', baseClassification)
+            console.log('base classification:', baseClassification)
+
+            const merged = (
+              await github.rest.repos.getCommit({
+                ...context.repo,
+                ref:
+                  context.payload.merge_group?.head_sha ??
+                  process.env.MERGED_SHA,
+              })
+            ).data
+
+            const workflow_run = (
+              await github.rest.actions.listWorkflowRuns({
+                ...context.repo,
+                workflow_id: 'pr.yml',
+                event: 'pull_request_target',
+                exclude_pull_requests: true,
+                // Second parent is the HEAD of the PR.
+                // This works both in a pull request context and in the merge queue.
+                head_sha: merged.parents[1].sha,
+              })
+            ).data.workflow_runs[0]
+
+            core.setOutput('workflowRun', workflow_run.id)
+            core.info(`workflowRun: ${workflow_run.id}`)
+
             core.setOutput('mergedSha', context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA)
             core.info(`mergedSha: ${context.payload.merge_group?.head_sha ?? process.env.MERGED_SHA}`)
             core.setOutput('targetSha', context.payload.merge_group?.base_sha ?? process.env.TARGET_SHA)
@@ -70,7 +106,61 @@ jobs:
     with:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}
       systems: ${{ needs.prepare.outputs.systems }}
+
+  # Prevent eval drift from causing mass rebuilds on master
+  # TODO: This will only reliably prevent mass rebuilds from hitting master with the
+  # following additions:
+  # - Switch from HEADGREEN to ALLGREEN for the merge queue or implement something
+  #   similar in GHA.
+  # - Add a PR check to guard against auto-merging PRs with unknown mass rebuild
+  #   labels.
+  drift:
+    name: no drift
+    if: contains(fromJSON(needs.prepare.outputs.baseBranch).type, 'primary')
+    runs-on: ubuntu-24.04-arm
+    needs: [prepare, eval]
+    steps:
+      - name: Download comparison for PR
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          # pr-comparison for Test workflows, just comparison otherwise.
+          pattern: '{pr-,}comparison'
+          path: pr
+          run-id: ${{ needs.prepare.outputs.workflowRun }}
+
+      - name: Download comparison for queue
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: ${{ inputs.artifact-prefix }}comparison
+          path: queue
+
+      - name: Prevent accidental mass rebuilds on master
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const pr = require('./pr/changed-paths.json').rebuildCountByKernel
+            console.log('pr', pr)
+            const queue = require('./queue/changed-paths.json').rebuildCountByKernel
+            console.log('queue', queue)
+
+            const mass_rebuild = 1000
+
+            const darwin =
+              pr.darwin < mass_rebuild &&
+              queue.darwin >= mass_rebuild
+            console.log('darwin', darwin)
+
+            const linux =
+              pr.linux < mass_rebuild &&
+              queue.linux >= mass_rebuild
+            console.log('linux', linux)
+
+            if (darwin || linux)
+              core.setFailed(
+                'This PR was merged with few rebuilds, but has turned into a mass rebuild on the target branch.',
+              )
 
   # This job's only purpose is to create the target for the "Required Status Checks" branch ruleset.
   # It "needs" all the jobs that should block the Merge Queue.

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
   workflow_call:
     inputs:
+      artifact-prefix:
+        required: true
+        type: string
       mergedSha:
         required: true
         type: string
@@ -54,6 +57,7 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
+      artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ inputs.mergedSha || github.event.merge_group.head_sha }}
       systems: ${{ needs.prepare.outputs.systems }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,10 @@ name: PR
 on:
   pull_request_target:
   workflow_call:
+    inputs:
+      artifact-prefix:
+        required: true
+        type: string
     secrets:
       CACHIX_AUTH_TOKEN:
         required: true
@@ -85,6 +89,7 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
+      artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
       systems: ${{ needs.prepare.outputs.systems }}
@@ -111,6 +116,8 @@ jobs:
     uses: ./.github/workflows/reviewers.yml
     secrets:
       OWNER_APP_PRIVATE_KEY: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+    with:
+      artifact-prefix: ${{ inputs.artifact-prefix }}
 
   build:
     name: Build
@@ -119,6 +126,7 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
+      artifact-prefix: ${{ inputs.artifact-prefix }}
       baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
 

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Wait for comparison to be done
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: eval
+        env:
+          ARTIFACT: ${{ inputs.artifact-prefix }}comparison
         with:
           script: |
             const run_id = (await github.rest.actions.listWorkflowRuns({
@@ -115,7 +117,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id,
-                name: 'comparison'
+                name: process.env.ARTIFACT,
               })
               if (result.data.total_count > 0) return
               await new Promise(resolve => setTimeout(resolve, 5000))

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
     types: [ready_for_review]
   workflow_call:
+    inputs:
+      artifact-prefix:
+        required: true
+        type: string
     secrets:
       OWNER_APP_PRIVATE_KEY:
         required: true
@@ -128,7 +132,7 @@ jobs:
         with:
           run-id: ${{ steps.eval.outputs.run-id }}
           github-token: ${{ github.token }}
-          pattern: comparison
+          pattern: ${{ inputs.artifact-prefix }}comparison
           path: comparison
           merge-multiple: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     with:
+      artifact-prefix: mg-
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
 
@@ -95,3 +96,5 @@ jobs:
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+    with:
+      artifact-prefix: pr-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,21 +68,6 @@ jobs:
               '.github/workflows/test.yml',
             ].includes(file))) core.setOutput('pr', true)
 
-  merge-group:
-    if: needs.prepare.outputs.merge-group
-    name: Merge Group
-    needs: [prepare, pr]
-    uses: ./.github/workflows/merge-group.yml
-    # Those are actually only used on the merge_group event, but will throw an error if not set.
-    permissions:
-      statuses: write
-    secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-    with:
-      artifact-prefix: mg-
-      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
-      targetSha: ${{ needs.prepare.outputs.targetSha }}
-
   pr:
     if: needs.prepare.outputs.pr
     name: PR
@@ -98,3 +83,18 @@ jobs:
       NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
     with:
       artifact-prefix: pr-
+
+  merge-group:
+    if: needs.prepare.outputs.merge-group
+    name: Merge Group
+    needs: [prepare, pr]
+    uses: ./.github/workflows/merge-group.yml
+    # Those are actually only used on the merge_group event, but will throw an error if not set.
+    permissions:
+      statuses: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+    with:
+      artifact-prefix: mg-
+      mergedSha: ${{ needs.prepare.outputs.mergedSha }}
+      targetSha: ${{ needs.prepare.outputs.targetSha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
   merge-group:
     if: needs.prepare.outputs.merge-group
     name: Merge Group
-    needs: [prepare]
+    needs: [prepare, pr]
     uses: ./.github/workflows/merge-group.yml
     # Those are actually only used on the merge_group event, but will throw an error if not set.
     permissions:


### PR DESCRIPTION
If a package becomes more load-bearing between running a PR's Eval and merging it, this can cause unexpected mass rebuilds. We call this a "drift" in rebuilds and add a job to prevent this.

Small drift is OK, packages gain new dependencies all the time. For now, we implement a simple check that tests whether a package caused fewer than 1000 rebuilds when Eval last ran and then causes more than 1000 rebuilds once it hits the merge queue.

Certain improvements can and need to be made for this to work reliable in various other scenarios, but these are considered out of scope for now. Otherwise, I will never make it out of the deep rabbit hole I am currently in.

## Things done

- [ ] Test in actual merge queue in test org (last thing before merge).
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
