### PR TITLE
nix-plugins: add missing include

### DIFF
--- a/pkgs/by-name/ni/nix-plugins/package.nix
+++ b/pkgs/by-name/ni/nix-plugins/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   nixVersions,
   nixComponents ? nixVersions.nixComponents_2_30,
   cmake,
@@ -11,7 +12,7 @@
 
 stdenv.mkDerivation rec {
   pname = "nix-plugins";
-  version = "16.0.0";
+  version = "16.0.0-patched";
 
   src = fetchFromGitHub {
     owner = "shlevy";
@@ -19,6 +20,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-yofHs1IyAkyMqrWlLkmnX+CmH+qsvlhKN1YZM4nRf1M=";
   };
+
+  patches = [
+    # https://github.com/shlevy/nix-plugins/pull/23
+    (fetchpatch2 {
+      name = "fix-build-nix-2.32.1.patch";
+      url = "https://github.com/shlevy/nix-plugins/commit/e0115e16b3835e99b7aa4ced15746159e79a1be6.patch";
+      hash = "sha256-E6QISZ8k8xKNzWqIeaOzxJN0DQvkMSQul9MJBdxwymk=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
I wasn't able to include nix-plugins due to an error:

error: could not dynamically open plugin file 
'"/nix/store/vvjwkkbs63icp70pf8nkw9rc8ra5i71q-nix-plugins-16.0.0/lib/nix/plugins/libnix-extra-builtins.so"': 
/nix/store/vvjwkkbs63icp70pf8nkw9rc8ra5i71q-nix-plugins-16.0.0/lib/nix/plugins/libnix-extra-builtins.so:
undefined symbol: _ZN3nix6Config11getSettingsERSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_14AbstractConfig11SettingInfoESt4lessIS7_ESaISt4pairIKS7_S9_EEEb

I looked into https://github.com/shlevy/nix-plugins/issues/20, precisely, https://github.com/shlevy/nix-plugins/issues/20#issuecomment-2892261782

and found that extra-builtins.cc probably misses one extra header.
This PR adds one more missing header exactly from this comment. Now it runs successfully

See https://github.com/shlevy/nix-plugins/pull/23

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
