### PR TITLE
kdePackages.libquotient: 0.9.1 -> 0.9.5; fix use by library consumers

### DIFF
--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libquotient";
-  version = "0.9.1";
+  version = "0.9.5";
 
   outputs = [
     "out"
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "quotient-im";
     repo = "libQuotient";
-    rev = version;
-    hash = "sha256-R9ms3sYGdHaYKUMnZyBjw5KCik05k93vlvXMRtAXh5Y=";
+    tag = version;
+    hash = "sha256-wdIE5LI4l3WUvpGfoJBL8sjBl2k8NfZTh9CjfJc9FIA=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -34,10 +34,6 @@ stdenv.mkDerivation rec {
     olm
     openssl
     qtmultimedia
-  ];
-
-  cmakeFlags = [
-    "-DQuotient_ENABLE_E2EE=ON"
   ];
 
   # https://github.com/quotient-im/libQuotient/issues/551

--- a/pkgs/development/libraries/libquotient/default.nix
+++ b/pkgs/development/libraries/libquotient/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   olm,
   openssl,
@@ -25,6 +26,17 @@ stdenv.mkDerivation rec {
     tag = version;
     hash = "sha256-wdIE5LI4l3WUvpGfoJBL8sjBl2k8NfZTh9CjfJc9FIA=";
   };
+
+  patches = [
+    # Fix use of libquotient by library consumers like NeoChat;
+    # without this (upstreamed) patch, consumers will fail to
+    # build when trying to link to Qt6::CorePrivate.
+    # Remove when bumping package version.
+    (fetchpatch {
+      url = "https://github.com/quotient-im/libQuotient/commit/6d5a80ddaab5803c318240c7978a16fbdc36bb34.patch";
+      hash = "sha256-JMdcywGgZ0Gev/Nce4oPiMJQxTBJYPoq+WoT3WLWWNQ=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
- **kdePackages.libquotient: 0.9.1 -> 0.9.5**
- **kdePackages.libquotient: add patch to fix library consumers**

Without the patch from <https://github.com/quotient-im/libQuotient/pull/932>, library consumers like NeoChat fail to build with the error mentioned in the patch's pull request.

Closes: #455152

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
