### PR TITLE
appimageupdate: 2.0.0-alpha-1-20230526 -> 2.0.0-alpha-1-20251018

### DIFF
--- a/pkgs/by-name/ap/appimageupdate/package.nix
+++ b/pkgs/by-name/ap/appimageupdate/package.nix
@@ -19,26 +19,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "appimageupdate";
-  version = "2.0.0-alpha-1-20230526";
+  version = "2.0.0-alpha-1-20251018";
 
   src = fetchFromGitHub {
     owner = "AppImageCommunity";
     repo = "AppImageUpdate";
     rev = finalAttrs.version;
-    hash = "sha256-b2RqSw0Ksn9OLxQV9+3reBiqrty+Kx9OwV93jlvuPnY=";
+    hash = "sha256-S3MRBTtPc4S6lqvAZpbZFgOVgsX6GpHZ8PkwEtipT1M=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "include-algorithm-header.patch";
-      url = "https://github.com/AppImageCommunity/AppImageUpdate/commit/5e91de84aba775ba8d3a4771e4f7f06056f9b764.patch";
-      hash = "sha256-RX2HFAlGsEjXona7cL3WdwwiiA0u9CnfvHMC6S0DeLY=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail 'VERSION 1-alpha' 'VERSION ${finalAttrs.version}' \
       --replace-fail 'env LC_ALL=C date -u "+%Y-%m-%d %H:%M:%S %Z"' 'bash -c "echo 1970-01-01 00:00:01 UTC"' \
       --replace-fail 'git rev-parse --short HEAD' 'bash -c "echo unknown"' \
       --replace-fail '<local dev build>' '<nixpkgs build>'


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

Changelog: https://github.com/AppImageCommunity/AppImageUpdate/releases/tag/2.0.0-alpha-1-20251018
Diff: https://github.com/AppImageCommunity/AppImageUpdate/compare/2.0.0-alpha-1-20230526...2.0.0-alpha-1-20251018

Closes #455094

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
