### PR TITLE
kde-rounded-corners: add upstream patch for Qt >=6.10

### DIFF
--- a/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
+++ b/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   extra-cmake-modules,
   wrapQtAppsHook,
@@ -22,6 +23,13 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-ef63PVG0JOHY4zyq5M5oAAcxtfhm1XOvpsxgSeXvgDo=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/matinlotfali/KDE-Rounded-Corners/commit/5d63212e65ed06ca65a2a7f0ad2436045b839ddd.patch";
+      hash = "sha256-wfjxMKRmJu3gflldNvWLghw5oFyyxY2ml1lsl/TVzxI=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Without this, it fails to build:

```text
> -- Configuring done (11.6s)
> CMake Error at src/CMakeLists.txt:28 (target_link_libraries):
>   Target "kwin4_effect_shapecorners" links to:
>
>     Qt6::CorePrivate
>
>   but the target was not found.  Possible reasons include:
>
>     * There is a typo in the target name.
>     * A find_package call is missing for an IMPORTED target.
>     * An ALIAS target is missing.
>
>
> 
> CMake Error at src/kcm/CMakeLists.txt:17 (target_link_libraries):
>   Target "kwin_shapecorners_config" links to:
>
>     Qt6::CorePrivate
>
>   but the target was not found.  Possible reasons include:
>
>     * There is a typo in the target name.
>     * A find_package call is missing for an IMPORTED target.
>     * An ALIAS target is missing.
>
>
> 
> -- Generating done (0.1s)
> CMake Warning:
>   Manually-specified variables were not used by the project:
>
>     CMAKE_C_COMPILER
>     CMAKE_EXPORT_NO_PACKAGE_REGISTRY
>     CMAKE_POLICY_DEFAULT_CMP0025
>
> 
> CMake Generate step failed.  Build files cannot be regenerated correctly.
For full logs, run 'nix log /nix/store/w1pcp9c9ji1yrfmm5cb30dkalkkwskhj-kde-rounded-corners-0.8.5.drv'.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
