### PR TITLE
openssl: fix mingwW64 build

### DIFF
--- a/pkgs/development/libraries/openssl/3.5/fix-mingw-linking.patch
+++ b/pkgs/development/libraries/openssl/3.5/fix-mingw-linking.patch
@@ -1,0 +1,33 @@
+From af3a3f8205968f9e652efa7adf2a359f4eb9d9cc Mon Sep 17 00:00:00 2001
+From: Alexandr Nedvedicky <sashan@openssl.org>
+Date: Mon, 6 Oct 2025 09:33:09 +0200
+Subject: [PATCH] OPENSSL_SYS_WINDOWS is also enabled for mingw build
+
+the test_n() in bioprinttest.c must differentiate between
+MSVC runtime libc and ming runtime libc. The function
+_set_printf_count_output() must be called when openssl
+is linked with MSVC libc only.
+
+Fixes #28679
+
+Reviewed-by: Bernd Edlinger <bernd.edlinger@hotmail.de>
+Reviewed-by: Tom Cosgrove <tom.cosgrove@arm.com>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/28759)
+---
+ test/bioprinttest.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/bioprinttest.c b/test/bioprinttest.c
+index bd99b9820ecc0..28730631bc201 100644
+--- a/test/bioprinttest.c
++++ b/test/bioprinttest.c
+@@ -541,7 +541,7 @@ static int test_n(int i)
+         ptrdiff_t t;
+     } n = { 0 };
+ 
+-#if defined(OPENSSL_SYS_WINDOWS)
++#if defined(_set_printf_count_output)
+     /*
+      * MS CRT is special and throws an exception when %n is used even
+      * in non-*_s versions of printf routines, and there is a special function

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -422,6 +422,9 @@ in
         else
           ./3.5/use-etc-ssl-certs.patch
       )
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isMinGW [
+      ./3.5/fix-mingw-linking.patch
     ];
 
     withDocs = true;


### PR DESCRIPTION
Closed #454902

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
