### PR TITLE
unicode-paracode: Fix crash on Python ≥ 3.13

### DIFF
--- a/pkgs/by-name/un/unicode-paracode/package.nix
+++ b/pkgs/by-name/un/unicode-paracode/package.nix
@@ -19,6 +19,14 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-FHAlZ5HID/FE9+YR7Dmc3Uh7E16QKORoD8g9jgTeQdY=";
   };
 
+  patches = [
+    # Fix 3.13+ mutable locals()
+    (fetchurl {
+      url = "https://github.com/garabik/unicode/commit/412952b9b4730263f5b560924b84f8934ea4ba21.patch";
+      hash = "sha256-Rfm6Jc7V5n7ggQzA/yeDrYedGMWqRkeUX6FRCUkBWcI=";
+    })
+  ];
+
   ucdtxt = fetchurl {
     url = "https://www.unicode.org/Public/16.0.0/ucd/UnicodeData.txt";
     sha256 = "sha256-/1jlgjvQlRZlZKAG5H0RETCBPc+L8jTvefpRqHDttI8=";


### PR DESCRIPTION
Now that Python 3.13 is our default, this upstream patch is required to avoid a `KeyError` when formatting output.

- garabik/unicode#25

```pytb
$ unicode a
Traceback (most recent call last):
  File "/nix/store/3cafbdia5bfwywvs9nkd2kn2449d323w-unicode-2.9/bin/.unicode-wrapped", line 1067, in <module>
    main()
    ~~~~^^
  File "/nix/store/3cafbdia5bfwywvs9nkd2kn2449d323w-unicode-2.9/bin/.unicode-wrapped", line 1064, in main
    print_characters(processed_args, options.maxcount, format_string, options.query_wikipedia, options.query_wiktionary)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/3cafbdia5bfwywvs9nkd2kn2449d323w-unicode-2.9/bin/.unicode-wrapped", line 724, in print_characters
    opt_uppercase = '\n{green}Uppercase:{default} {ord_uppercase:04X}'.format(**locals())
KeyError: 'green'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
