### PR TITLE
libtheora: apply ARMv7 conditionals to all 32-bit ARM

### DIFF
--- a/pkgs/by-name/li/libtheora/package.nix
+++ b/pkgs/by-name/li/libtheora/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = lib.optionals stdenv.hostPlatform.isMinGW [ ./mingw-remove-export.patch ];
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isArmv7 ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isAarch32 ''
     patchShebangs lib/arm/arm2gnu.pl
   '';
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     validatePkgConfig
   ]
-  ++ lib.optionals stdenv.hostPlatform.isArmv7 [
+  ++ lib.optionals stdenv.hostPlatform.isAarch32 [
     # Needed to run lib/arm/arm2gnu.pl for ARM assembly optimizations
     perl
   ];


### PR DESCRIPTION
armv6l (and presumably armv5tel) have the same problems as armv7l, so change the conditional from `isArmv7` to `isAarch32`.

Fixes building ffmpeg on armv6l. No rebuilds on other platforms.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] armv6l-linux (cross)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc @SFrijters