### PR TITLE
[Backport release-25.05] dprint-plugins.dprint-plugin-biome: 0.10.4 -> 0.10.6

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "Biome (JS/TS) wrapper plugin";
-  hash = "sha256-czgTZXlW+LdTKGtX7JJtG7qAbnWlQpunMY92WiC+X8A=";
+  hash = "sha256-GHl8Uo2U6K1yirfjwuD43ixkVtGdbZ2qxk0cySRLXys=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "biome";
@@ -16,6 +16,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-biome";
   updateUrl = "https://plugins.dprint.dev/dprint/biome/latest.json";
-  url = "https://plugins.dprint.dev/biome-0.10.4.wasm";
-  version = "0.10.4";
+  url = "https://plugins.dprint.dev/biome-0.10.5.wasm";
+  version = "0.10.5";
 }

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "Biome (JS/TS) wrapper plugin";
-  hash = "sha256-GHl8Uo2U6K1yirfjwuD43ixkVtGdbZ2qxk0cySRLXys=";
+  hash = "sha256-Ht63tW4FqykpuNlWtyw3cHD2HXs0b6U6Zo9Rd9AXqD8=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "biome";
@@ -16,6 +16,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-biome";
   updateUrl = "https://plugins.dprint.dev/dprint/biome/latest.json";
-  url = "https://plugins.dprint.dev/biome-0.10.5.wasm";
-  version = "0.10.5";
+  url = "https://plugins.dprint.dev/biome-0.10.6.wasm";
+  version = "0.10.6";
 }


### PR DESCRIPTION
Manual backport to release-25.05, for #453041 and  #455028.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-10-18T03%3A35%3A26Z#changes-acceptable-for-releases).
  - Even as a non-committer, if you find that it is not acceptable, leave a comment.

