### PR TITLE
top-level: group throwIfNot checks and simplify

### DIFF
--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -80,14 +80,10 @@ let
 
   checked =
     (throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list.")
-      (lib.foldr (
-        x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions."
-      ) lib.id overlays)
+      (throwIfNot (lib.all lib.isFunction overlays) "All overlays passed to nixpkgs must be functions.")
       (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
       (
-        lib.foldr (
-          x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions."
-        ) lib.id crossOverlays
+        throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions."
       );
 
   localSystem = lib.systems.elaborate args.localSystem;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -79,17 +79,16 @@ let
   inherit (lib) throwIfNot;
 
   checked =
-    throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list." lib.foldr
-      (x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions.")
-      (r: r)
-      overlays
-      throwIfNot
-      (lib.isList crossOverlays)
-      "The crossOverlays argument to nixpkgs must be a list."
-      lib.foldr
-      (x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions.")
-      (r: r)
-      crossOverlays;
+    (throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list.")
+      (lib.foldr (
+        x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions."
+      ) lib.id overlays)
+      (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
+      (
+        lib.foldr (
+          x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions."
+        ) lib.id crossOverlays
+      );
 
   localSystem = lib.systems.elaborate args.localSystem;
 


### PR DESCRIPTION
This PR cleans up the `checked` implementation in `pkgs/top-level/default.nix` for clarity and to better preserve its intent.

[Before the treewide nixfmt reformatting](https://github.com/NixOS/nixpkgs/blob/cf73196411928e1dfc6784a8a1c67a467533af4c/pkgs/top-level/default.nix#L54-L59), the implementation looked like this:
```nix
checked =
  throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list."
  lib.foldr (x: throwIfNot (lib.isFunction x) "All overlays passed to nixpkgs must be functions.") (r: r) overlays
  throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list."
  lib.foldr (x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions.") (r: r) crossOverlays
  ;
```

The first commit restores a layout closer to the original, by grouping each `throwIfNot` application in parentheses. This helps nixfmt preserve the intended structure, instead of flattening it.

The second commit simplifies the logic by replacing the `lib.foldr` usage with a more direct and readable `lib.all`.

These changes are purely cosmetic to improve readability and better communicate intent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

