### PR TITLE
ghostty: merge with `ghostty-bin`

### DIFF
--- a/pkgs/by-name/gh/ghostty/dmg.nix
+++ b/pkgs/by-name/gh/ghostty/dmg.nix
@@ -81,7 +81,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    maintainers = with lib.maintainers; [ Enzime ];
     outputsToInstall = [
       "out"
       "man"

--- a/pkgs/by-name/gh/ghostty/dmg.nix
+++ b/pkgs/by-name/gh/ghostty/dmg.nix
@@ -7,7 +7,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "ghostty-bin";
+  pname = "ghostty-dmg";
   version = "1.2.3";
 
   src = fetchurl {
@@ -80,30 +80,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -r $resourceDir/man $man/share/man
   '';
 
-  outputs = [
-    "out"
-    "man"
-    "shell_integration"
-    "terminfo"
-    "vim"
-  ];
-
   meta = {
-    description = "Fast, native, feature-rich terminal emulator pushing modern features";
-    longDescription = ''
-      Ghostty is a terminal emulator that differentiates itself by being
-      fast, feature-rich, and native. While there are many excellent terminal
-      emulators available, they all force you to choose between speed,
-      features, or native UIs. Ghostty provides all three.
-    '';
-    homepage = "https://ghostty.org/";
-    downloadPage = "https://ghostty.org/download";
-    changelog = "https://ghostty.org/docs/install/release-notes/${
-      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
-    }";
-    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Enzime ];
-    mainProgram = "ghostty";
     outputsToInstall = [
       "out"
       "man"

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -1,190 +1,48 @@
 {
   lib,
   stdenv,
-  blueprint-compiler,
-  bzip2,
   callPackage,
-  fetchFromGitHub,
-  fontconfig,
-  freetype,
-  glib,
-  glslang,
-  gtk4-layer-shell,
-  harfbuzz,
-  libGL,
-  libX11,
-  libadwaita,
-  ncurses,
-  nixosTests,
-  oniguruma,
-  pandoc,
-  pkg-config,
-  removeReferencesTo,
-  versionCheckHook,
-  wrapGAppsHook4,
-  zig_0_14,
-
-  # Usually you would override `zig.hook` with this, but we do that internally
-  # since upstream recommends a non-default level
-  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
-  optimizeLevel ? "ReleaseFast",
 }:
+
 let
-  zig = zig_0_14;
-
-  zig_hook = zig.hook.overrideAttrs {
-    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
-  };
+  expression = if stdenv.hostPlatform.isDarwin then ./dmg.nix else ./source.nix;
+  package = callPackage expression { };
 in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "ghostty";
-  version = "1.2.3";
 
-  outputs = [
-    "out"
-    "man"
-    "shell_integration"
-    "terminfo"
-    "vim"
-  ];
-
-  src = fetchFromGitHub {
-    owner = "ghostty-org";
-    repo = "ghostty";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-0tmLOJCrrEnVc/ZCp/e646DTddXjv249QcSwkaukL30=";
-  };
-
-  deps = callPackage ./deps.nix {
-    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
-  };
-
-  strictDeps = true;
-
-  nativeBuildInputs = [
-    ncurses
-    pandoc
-    pkg-config
-    removeReferencesTo
-    zig_hook
-
-    # GTK frontend
-    glib # Required for `glib-compile-schemas`
-    wrapGAppsHook4
-    blueprint-compiler
-  ];
-
-  buildInputs = [
-    oniguruma
-
-    # GTK frontend
-    libadwaita
-    libX11
-    gtk4-layer-shell
-
-    # OpenGL renderer
-    glslang
-    libGL
-
-    # Font backend
-    bzip2
-    fontconfig
-    freetype
-    harfbuzz
-  ];
-
-  zigBuildFlags = [
-    "--system"
-    "${finalAttrs.deps}"
-    "-Dversion-string=${finalAttrs.version}"
-  ]
-  ++ lib.mapAttrsToList (name: package: "-fsys=${name} --search-prefix ${lib.getLib package}") {
-    inherit glslang;
-  };
-
-  zigCheckFlags = finalAttrs.zigBuildFlags;
-
-  doCheck = true;
-
-  /**
-    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
-
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
-
-    terminfo and shell integration should also be installable on remote machines
-
-    ```nix
-    { pkgs, ... }: {
-      environment.systemPackages = [ pkgs.ghostty.terminfo ];
-
-      programs.bash = {
-        interactiveShellInit = ''
-          if [[ "$TERM" == "xterm-ghostty" ]]; then
-            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
-          fi
-        '';
-      };
-    }
-    ```
-  */
-  postFixup = ''
-    ln -s $man/share/man $out/share/man
-
-    moveToOutput share/terminfo $terminfo
-    ln -s $terminfo/share/terminfo $out/share/terminfo
-
-    mv $out/share/ghostty/shell-integration $shell_integration
-    ln -s $shell_integration $out/share/ghostty/shell-integration
-
-    mv $out/share/vim/vimfiles $vim
-    rmdir $out/share/vim
-    ln -s $vim $out/share/vim-plugins
-
-
-    remove-references-to -t ${finalAttrs.deps} $out/bin/.ghostty-wrapped
-  '';
-
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-
-  doInstallCheck = true;
-
-  versionCheckProgramArg = "--version";
-
-  passthru = {
-    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
-      inherit (nixosTests) allTerminfo;
-      nixos = nixosTests.terminal-emulators.ghostty;
-    };
-    updateScript = ./update.nu;
-  };
-
-  meta = {
-    description = "Fast, native, feature-rich terminal emulator pushing modern features";
-    longDescription = ''
-      Ghostty is a terminal emulator that differentiates itself by being
-      fast, feature-rich, and native. While there are many excellent terminal
-      emulators available, they all force you to choose between speed,
-      features, or native UIs. Ghostty provides all three.
-    '';
-    homepage = "https://ghostty.org/";
-    downloadPage = "https://ghostty.org/download";
-    changelog = "https://ghostty.org/docs/install/release-notes/${
-      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
-    }";
-    license = lib.licenses.mit;
-    mainProgram = "ghostty";
-    maintainers = with lib.maintainers; [
-      jcollie
-      pluiedev
-      getchoo
-    ];
-    outputsToInstall = [
+package.overrideAttrs (
+  finalAttrs: oldAttrs: {
+    # Enforce these for a consistent API across different expressions
+    outputs = [
       "out"
+      "man"
+      "shell_integration"
+      "terminfo"
+      "vim"
     ];
-    platforms = lib.platforms.linux;
-  };
-})
+
+    # Point `nix edit`, etc. to the file that defines the attribute, not this
+    # entry point
+    pos = oldAttrs.pos or builtins.unsafeGetAttrPos "pname" finalAttrs;
+
+    passthru = lib.recursiveUpdate {
+      updateScript = ./update.nu;
+    } oldAttrs.passthru or { };
+
+    meta = lib.recursiveUpdate {
+      description = "Fast, native, feature-rich terminal emulator pushing modern features";
+      longDescription = ''
+        Ghostty is a terminal emulator that differentiates itself by being
+        fast, feature-rich, and native. While there are many excellent terminal
+        emulators available, they all force you to choose between speed,
+        features, or native UIs. Ghostty provides all three.
+      '';
+      homepage = "https://ghostty.org/";
+      downloadPage = "https://ghostty.org/download";
+      changelog = "https://ghostty.org/docs/install/release-notes/${
+        builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+      }";
+      license = lib.licenses.mit;
+      mainProgram = "ghostty";
+    } oldAttrs.meta or { };
+  }
+)

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -42,6 +42,12 @@ package.overrideAttrs (
         builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
       }";
       license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        jcollie
+        pluiedev
+        getchoo
+        Enzime
+      ];
       mainProgram = "ghostty";
     } oldAttrs.meta or { };
   }

--- a/pkgs/by-name/gh/ghostty/source.nix
+++ b/pkgs/by-name/gh/ghostty/source.nix
@@ -1,0 +1,168 @@
+{
+  lib,
+  stdenv,
+  blueprint-compiler,
+  bzip2,
+  callPackage,
+  fetchFromGitHub,
+  fontconfig,
+  freetype,
+  glib,
+  glslang,
+  gtk4-layer-shell,
+  harfbuzz,
+  libGL,
+  libX11,
+  libadwaita,
+  ncurses,
+  nixosTests,
+  oniguruma,
+  pandoc,
+  pkg-config,
+  removeReferencesTo,
+  versionCheckHook,
+  wrapGAppsHook4,
+  zig_0_14,
+
+  # Usually you would override `zig.hook` with this, but we do that internally
+  # since upstream recommends a non-default level
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
+  optimizeLevel ? "ReleaseFast",
+}:
+let
+  zig = zig_0_14;
+
+  zig_hook = zig.hook.overrideAttrs {
+    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ghostty";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "ghostty-org";
+    repo = "ghostty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0tmLOJCrrEnVc/ZCp/e646DTddXjv249QcSwkaukL30=";
+  };
+
+  deps = callPackage ./deps.nix {
+    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    ncurses
+    pandoc
+    pkg-config
+    removeReferencesTo
+    zig_hook
+
+    # GTK frontend
+    glib # Required for `glib-compile-schemas`
+    wrapGAppsHook4
+    blueprint-compiler
+  ];
+
+  buildInputs = [
+    oniguruma
+
+    # GTK frontend
+    libadwaita
+    libX11
+    gtk4-layer-shell
+
+    # OpenGL renderer
+    glslang
+    libGL
+
+    # Font backend
+    bzip2
+    fontconfig
+    freetype
+    harfbuzz
+  ];
+
+  zigBuildFlags = [
+    "--system"
+    "${finalAttrs.deps}"
+    "-Dversion-string=${finalAttrs.version}"
+  ]
+  ++ lib.mapAttrsToList (name: package: "-fsys=${name} --search-prefix ${lib.getLib package}") {
+    inherit glslang;
+  };
+
+  zigCheckFlags = finalAttrs.zigBuildFlags;
+
+  doCheck = true;
+
+  /**
+    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
+
+    terminfo and shell integration should also be installable on remote machines
+
+    ```nix
+    { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.ghostty.terminfo ];
+
+      programs.bash = {
+        interactiveShellInit = ''
+          if [[ "$TERM" == "xterm-ghostty" ]]; then
+            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
+          fi
+        '';
+      };
+    }
+    ```
+  */
+  postFixup = ''
+    ln -s $man/share/man $out/share/man
+
+    moveToOutput share/terminfo $terminfo
+    ln -s $terminfo/share/terminfo $out/share/terminfo
+
+    mv $out/share/ghostty/shell-integration $shell_integration
+    ln -s $shell_integration $out/share/ghostty/shell-integration
+
+    mv $out/share/vim/vimfiles $vim
+    rmdir $out/share/vim
+    ln -s $vim $out/share/vim-plugins
+
+
+    remove-references-to -t ${finalAttrs.deps} $out/bin/.ghostty-wrapped
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      inherit (nixosTests) allTerminfo;
+      nixos = nixosTests.terminal-emulators.ghostty;
+    };
+    updateScript = ./update.nu;
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      jcollie
+      pluiedev
+      getchoo
+    ];
+    outputsToInstall = [
+      "out"
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gh/ghostty/source.nix
+++ b/pkgs/by-name/gh/ghostty/source.nix
@@ -155,11 +155,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    maintainers = with lib.maintainers; [
-      jcollie
-      pluiedev
-      getchoo
-    ];
     outputsToInstall = [
       "out"
     ];

--- a/pkgs/by-name/gh/ghostty/update.nu
+++ b/pkgs/by-name/gh/ghostty/update.nu
@@ -16,7 +16,7 @@ if $latest == $current {
 
 print $"Updating Ghostty: ($current) -> ($latest)"
 
-^update-source-version ghostty $latest --file=./pkgs/by-name/gh/ghostty/package.nix
+^update-source-version ghostty $latest --file=./pkgs/by-name/gh/ghostty/source.nix
 
 # Update deps.nix
 http get $"https://raw.githubusercontent.com/ghostty-org/ghostty/refs/tags/v($latest)/build.zig.zon.nix"
@@ -27,8 +27,8 @@ http get $"https://raw.githubusercontent.com/ghostty-org/ghostty/refs/tags/v($la
 # and so it's possible for a Git tag to have no corresponding notarized DMG download.
 # Don't fail here if that happens.
 try {
-  ^update-source-version ghostty-bin $latest --file=./pkgs/by-name/gh/ghostty-bin/package.nix
+  ^update-source-version ghostty $latest --file=./pkgs/by-name/gh/ghostty/dmg.nix
 } catch {
-  print "Failed to update bin package (is the DMG file uploaded yet?)"
+  print "Failed to update DMG package (is the DMG file uploaded yet?)"
 }
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1048,6 +1048,7 @@ mapAliases {
   gfortran12 = throw "gfortran12 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2025-08-08
   gg = go-graft; # Added 2025-03-07
   ggobi = throw "'ggobi' has been removed from Nixpkgs, as it is unmaintained and broken"; # Added 2025-05-18
+  ghostty-bin = lib.warnOnInstantiate "'ghostty-bin' has been merged with and renamed to 'ghostty'" ghostty; # Added 2025-10-24
   ghostwriter = makePlasma5Throw "ghostwriter"; # Added 2023-03-18
   gimp3 = gimp; # added 2025-10-03
   gimp3-with-plugins = gimp-with-plugins; # added 2025-10-03


### PR DESCRIPTION
This is meant to make the end-user experience of Ghostty across platforms consistent and more understandable, as well as allow us maintainers to easily share some things between them - like what outputs we create!

Should be a no-op for Linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
