### PR TITLE
python312.pkgs.pyqtgraph: fix build with Qt 6.10

### DIFF
--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -36,6 +37,17 @@ buildPythonPackage rec {
     tag = "pyqtgraph-${version}";
     hash = "sha256-MUwg1v6oH2TGmJ14Hp9i6KYierJbzPggK59QaHSXHVA=";
   };
+
+  patches = [
+    # Fixes a segmentation fault in tests with Qt 6.10. See:
+    # https://github.com/pyqtgraph/pyqtgraph/issues/3390
+    # The patch is the merge commit of:
+    # https://github.com/pyqtgraph/pyqtgraph/pull/3370
+    (fetchpatch {
+      url = "https://github.com/pyqtgraph/pyqtgraph/commit/bf38b8527e778c9c0bb653bc0df7bb36018dcbae.patch";
+      hash = "sha256-Tv4QK/OZvmDO3MOjswjch7DpF96U1uRN0dr8NIQ7+LY=";
+    })
+  ];
 
   build-system = [
     setuptools
@@ -78,11 +90,6 @@ buildPythonPackage rec {
       # https://github.com/pyqtgraph/pyqtgraph/issues/2645
       "test_rescaleData"
     ];
-
-  disabledTestPaths = [
-    # Segmentation fault
-    "tests/test_qpainterpathprivate.py"
-  ];
 
   meta = {
     description = "Scientific Graphics and GUI Library for Python";

--- a/pkgs/development/python-modules/pyqtgraph/default.nix
+++ b/pkgs/development/python-modules/pyqtgraph/default.nix
@@ -3,15 +3,23 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   scipy,
   numpy,
-  pyqt6,
   pyopengl,
+
+  # buildInputs
+  pyqt6,
+
+  # tests
   qt6,
   pytestCheckHook,
   freefont_ttf,
   makeFontsConf,
-  setuptools,
 }:
 
 let
@@ -29,7 +37,9 @@ buildPythonPackage rec {
     hash = "sha256-MUwg1v6oH2TGmJ14Hp9i6KYierJbzPggK59QaHSXHVA=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+  ];
 
   dependencies = [
     numpy


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
