### PR TITLE
glm: Add patch to fix on big-endian, mark broken on non-Linux big-endian

### DIFF
--- a/pkgs/by-name/gl/glm/1001-glm-Fix-packing-on-BE.patch
+++ b/pkgs/by-name/gl/glm/1001-glm-Fix-packing-on-BE.patch
@@ -1,0 +1,181 @@
+From 06ce42e72324b32b1f4c37c646e99950c2bd5f6b Mon Sep 17 00:00:00 2001
+From: Max Rees <maxcrees@me.com>
+Date: Sun, 15 Mar 2020 15:13:27 -0400
+Subject: [PATCH] Fix test suite on big endian platforms
+
+---
+ glm/gtc/packing.inl      | 55 ++++++++++++++++++++++++++++++++++++++++
+ test/gtc/gtc_packing.cpp |  3 ++-
+ 2 files changed, 57 insertions(+), 1 deletion(-)
+
+diff --git a/glm/gtc/packing.inl b/glm/gtc/packing.inl
+index 8c906e16c1..b1c99a5076 100644
+--- a/glm/gtc/packing.inl
++++ b/glm/gtc/packing.inl
+@@ -9,6 +9,9 @@
+ #include "../detail/type_half.hpp"
+ #include <cstring>
+ #include <limits>
++extern "C" {
++#include <endian.h>
++}
+ 
+ namespace glm{
+ namespace detail
+@@ -183,9 +186,15 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 3;
+ 			uint y : 3;
+ 			uint z : 2;
++#else
++			uint z : 2;
++			uint y : 3;
++			uint x : 3;
++#endif
+ 		} data;
+ 		uint8 pack;
+ 	};
+@@ -194,8 +203,13 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 4;
+ 			uint y : 4;
++#else
++			uint y : 4;
++			uint x : 4;
++#endif
+ 		} data;
+ 		uint8 pack;
+ 	};
+@@ -204,10 +218,17 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 4;
+ 			uint y : 4;
+ 			uint z : 4;
+ 			uint w : 4;
++#else
++			uint w : 4;
++			uint z : 4;
++			uint y : 4;
++			uint x : 4;
++#endif
+ 		} data;
+ 		uint16 pack;
+ 	};
+@@ -216,9 +237,15 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 5;
+ 			uint y : 6;
+ 			uint z : 5;
++#else
++			uint z : 5;
++			uint y : 6;
++			uint x : 5;
++#endif
+ 		} data;
+ 		uint16 pack;
+ 	};
+@@ -227,10 +254,17 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 5;
+ 			uint y : 5;
+ 			uint z : 5;
+ 			uint w : 1;
++#else
++			uint w : 1;
++			uint z : 5;
++			uint y : 5;
++			uint x : 5;
++#endif
+ 		} data;
+ 		uint16 pack;
+ 	};
+@@ -239,10 +273,17 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 10;
+ 			uint y : 10;
+ 			uint z : 10;
+ 			uint w : 2;
++#else
++			uint w : 2;
++			uint z : 10;
++			uint y : 10;
++			uint x : 10;
++#endif
+ 		} data;
+ 		uint32 pack;
+ 	};
+@@ -251,10 +292,17 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			int x : 10;
+ 			int y : 10;
+ 			int z : 10;
+ 			int w : 2;
++#else
++			int w : 2;
++			int z : 10;
++			int y : 10;
++			int x : 10;
++#endif
+ 		} data;
+ 		uint32 pack;
+ 	};
+@@ -263,10 +311,17 @@ namespace detail
+ 	{
+ 		struct
+ 		{
++#if BYTE_ORDER == LITTLE_ENDIAN
+ 			uint x : 9;
+ 			uint y : 9;
+ 			uint z : 9;
+ 			uint w : 5;
++#else
++			uint w : 5;
++			uint z : 9;
++			uint y : 9;
++			uint x : 9;
++#endif
+ 		} data;
+ 		uint32 pack;
+ 	};
+diff --git a/test/gtc/gtc_packing.cpp b/test/gtc/gtc_packing.cpp
+index df5b3bb1a9..fbaaa5bccd 100644
+--- a/test/gtc/gtc_packing.cpp
++++ b/test/gtc/gtc_packing.cpp
+@@ -4,6 +4,7 @@
+ #include <glm/ext/vector_relational.hpp>
+ #include <cstdio>
+ #include <vector>
++#include <arpa/inet.h>
+ 
+ void print_bits(float const& s)
+ {
+@@ -156,7 +157,7 @@ int test_U3x10_1x2()
+ 
+ 	glm::u8vec4 const v0(0xff, 0x77, 0x0, 0x33);
+ 	glm::uint32 const p0 = *reinterpret_cast<glm::uint32 const*>(&v0[0]);
+-	glm::uint32 const r0 = 0x330077ff;
++	glm::uint32 const r0 = htonl(0xff770033);
+ 
+ 	Error += p0 == r0 ? 0 : 1;
+ 

--- a/pkgs/by-name/gl/glm/package.nix
+++ b/pkgs/by-name/gl/glm/package.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
     "doc"
   ];
 
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
+    # Remove when https://github.com/g-truc/glm/pull/1001 merged & in release.
+    # Relies on <endian.h>, Linux-specific
+    ./1001-glm-Fix-packing-on-BE.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   env.NIX_CFLAGS_COMPILE =
@@ -62,6 +68,9 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/g-truc/glm";
     license = licenses.mit;
     platforms = platforms.unix;
+    # https://github.com/g-truc/glm/issues/897 indicates that packing isn't implemented properly on non-LE.
+    # Patch from https://github.com/g-truc/glm/pull/1001 currently relies on Linux-only header.
+    broken = !stdenv.hostPlatform.isLittleEndian && !stdenv.hostPlatform.isLinux;
     maintainers = with maintainers; [ smancill ];
   };
 }


### PR DESCRIPTION
See:

- https://github.com/g-truc/glm/issues/897
  Report from the Gentoo people about a test failure on ppc64, due to an endianness issue in the code.
- https://github.com/g-truc/glm/pull/1001
  Fixes packing code and the test, but currently relies on Linux-only `<endian.h>` header (because also from the Gentoo people).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] powerpc64-linux (native, ELFv1)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
