### PR TITLE
Add intel-ipsec-mb to dpdk

### DIFF
--- a/pkgs/by-name/dp/dpdk/package.nix
+++ b/pkgs/by-name/dp/dpdk/package.nix
@@ -11,6 +11,7 @@
   libbpf,
   zlib,
   elfutils,
+  intel-ipsec-mb,
   jansson,
   openssl,
   libpcap,
@@ -54,6 +55,7 @@ stdenv.mkDerivation rec {
     jansson
     libbpf
     elfutils
+    intel-ipsec-mb
     libpcap
     numactl
     openssl.dev

--- a/pkgs/by-name/in/intel-ipsec-mb/package.nix
+++ b/pkgs/by-name/in/intel-ipsec-mb/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nasm,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "intel-ipsec-mb";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "intel-ipsec-mb";
+    rev = "v${version}";
+    hash = "sha256-k/NoPMKbiWZ25tdomsPpv2gfhQuBHxzX6KRT1UY88Ko=";
+  };
+
+  sourceRoot = "source/lib";
+
+  nativeBuildInputs = [ nasm ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NOLDCONFIG=y"
+  ];
+
+  meta = with lib; {
+    description = "Intel Multi-Buffer Crypto for IPsec Library";
+    longDescription = ''
+      Intel Multi-Buffer Crypto for IPsec Library provides software crypto
+      acceleration primarily targeting packet processing applications.
+      It supports a variety of use cases including IPsec, TLS, wireless (RAN), cable,
+      and MPEG DRM.
+    '';
+    homepage = "https://github.com/intel/intel-ipsec-mb";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a package for intel-ipsec-mb and adds it as a dependency to dpdk.  This is required to use some of the cryptodev features in dpdk: https://doc.dpdk.org/guides-25.07/cryptodevs/aesni_mb.html

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
