### PR TITLE
top-level: simplify config module

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -26,6 +26,20 @@
 
 - The minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18.
 
+- Nixpkgs `config` can no longer be supplied as a function without `...`. \
+  If you were previously using:
+  ```nix
+  config = { pkgs }: { /* config */ };
+  ```
+  you should switch to:
+  ```nix
+  config = { pkgs, ... }: { /* config */ };
+  ```
+  Otherwise, you will see an error like:
+  ```
+  error: function 'config' called with unexpected argument 'config'
+  ```
+
 - `mono4` and `mono5` have been removed. Use `mono6` or `mono` instead.
 
 - Everything related to `bower` was removed, as it is deprecated and not used by anything in nixpkgs.

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -27,7 +27,7 @@
   # The system packages will ultimately be run on.
   crossSystem ? localSystem,
 
-  # Allow a configuration attribute set to be passed in as an argument.
+  # Allow a configuration module to be passed in as an argument.
   config ? { },
 
   # Temporary hack to let Nixpkgs forbid internal use of `lib.fileset`
@@ -111,22 +111,12 @@ let
     in
     if crossSystem0 == null || lib.systems.equals system localSystem then localSystem else system;
 
-  # Allow both:
-  # { /* the config */ } and
-  # { pkgs, ... } : { /* the config */ }
-  config1 = if lib.isFunction config0 then config0 { inherit pkgs; } else config0;
-
   configEval = lib.evalModules {
     modules = [
       ./config.nix
-      (
-        { options, ... }:
-        {
-          _file = "nixpkgs.config";
-          config = config1;
-        }
-      )
+      (lib.modules.setDefaultModuleLocation "nixpkgs.config" config0)
     ];
+    specialArgs = { inherit pkgs; };
     class = "nixpkgsConfig";
   };
 


### PR DESCRIPTION
Previously, the `config` module evaluation was restricted, and the function-module case was handled manually with a `isFunction` check, which felt odd.

This PR simplifies how Nixpkgs handles the `config` module in `pkgs/top-level/default.nix`, allowing other module forms to be passed such as paths-to-module-files, modules with `options` or `imports`, modules accepting other module args, etc.

- Remove the manual check for whether `config` is a function and the explicit application of `{ pkgs }`.
- Import the module directly and provide `pkgs` via `specialArgs`.
- Use `specialArgs.pkgs` instead of `_module.args.pkgs` to avoid potential recursion issues.
- There should be no need to define a different `pkgs` within `configEval`.

This improves clarity and reduces unnecessary special-casing of `config` functions.

## Breaking change

**`config` can no longer be a function without `...`.**

If a user was previously using:
```nix
config = { pkgs }: { /* config */ };
```
then they must switch to:
```nix
config = { pkgs, ... }: { /* config */ };
```

Users relying on the old `{ pkgs }:` form will now see a failure like:
```
error: function 'config' called with unexpected argument 'config'
```

Unfortunately, this cannot be detected automatically because:
1. `builtins.functionArgs` does not distinguish between `{ pkgs }:` and `{ pkgs, ... }:`
2. `tryEval` cannot catch the "unexpected argument" error.

Since we're now in the 25.11 release window, this PR should be merged **after 25.11 is released**. The release note should be moved to the 26.05 release notes, assuming the change will not end up in 25.11.

## Caveats

The previous manual handling may have been an intentional guardrail: restricting `config` to a simple config-only form prevented user-supplied modules from declaring new options or importing additional modules, which could later conflict with new Nixpkgs options or features. This PR removes that restriction, so users can supply richer module forms.

There’s no evidence in the comments that this restriction was intentional, so this is speculative. If the restriction _is_ still relevant, or the breaking change is unacceptable, then this PR should not be merged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
