### PR TITLE
Add more Limine Nix options

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -26,6 +26,9 @@ let
       enrollConfig = cfg.enrollConfig;
       style = cfg.style;
       maxGenerations = if cfg.maxGenerations == null then 0 else cfg.maxGenerations;
+      enableDefaultSpecialisation = cfg.enableDefaultSpecialisation;
+      groupSpecialisations = cfg.groupSpecialisations;
+      createUnnecessarySubmenus = cfg.createUnnecessarySubmenus;
       hostArchitecture = pkgs.stdenv.hostPlatform.parsed.cpu;
       timeout = if config.boot.loader.timeout != null then config.boot.loader.timeout else 10;
       enableEditor = cfg.enableEditor;
@@ -71,6 +74,40 @@ in
         Useful to prevent boot partition of running out of disk space.
         `null` means no limit i.e. all generations that were not
         garbage collected yet.
+      '';
+    };
+
+    enableDefaultSpecialisation = lib.mkOption {
+      default = true;
+      example = false;
+      type = lib.types.bool;
+      description = ''
+        Whether to list the default specialisation in the boot
+        menu. Nice if you want all listed specialisations to be named.
+        If there are no non-default specialisations, the default will
+        show regardless of this setting.
+      '';
+    };
+
+    groupSpecialisations = lib.mkOption {
+      default = false;
+      example = true;
+      type = lib.types.bool;
+      description = ''
+        If enabled, groups all specialisations under a submenu in the
+        boot menu, separate from the default specialisation.
+        Doesn't change anything if `boot.loader.limine.enableDefaultSpecialisation = false`.
+        Good to keep menus compact with many specialisations.
+      '';
+    };
+
+    createUnnecessarySubmenus = lib.mkOption {
+      default = true;
+      example = false;
+      type = lib.types.bool;
+      description = ''
+        When enabled, submenus are created for profiles and generations even if there is only one profile/generation.
+        If there are multiples profiles, and multiple generations, there will be no difference to the boot menu with this enabled.
       '';
     };
 


### PR DESCRIPTION
Options:

- `boot.loader.limine.enableDefaultSpecialisation` defaults to `true`
  When disabled, and specialisations are present (per-generation), only those specialisations are listed. 
- `boot.loader.limine.groupSpecialisations` defaults to `false`
  Groups any specialisations under a submenu, as long as the above option is enabled.
- `boot.loader.limine.createUnnecessarySubmenus` defaults to `true`
  When disabled, and on a single-profile system, the profile submenu is excluded. Also, if there is only one generation built, the generation submenu is excluded. \

<details><summary>Visual examples</summary>
## `boot.loader.limine.groupSpecialisations`:

The old behavior is replicated with `false`.

#### without:

Specialisations are listed alongside the default one. This may be troublesome with large numbers of specialisations.

```
⏷ Generation 100
├ Default
├ Specialisation 1
└ Specialisation 2
⏵ Generation 99
```

#### with:

All specialisations are grouped under a special submenu.

```
⏷ Generation 100
├ Default
└ ⏷ Specialisations
  ├ Specialisation 1
  └ Specialisation 2
⏵ Generation 99
```

## `boot.loader.limine.createUnnecessarySubmenus`:

The old behavior is replicated with `true`.

### Example 1

Since there is only one profile, it doesn't really need to be shown.

#### with:

'`NixOS Default Profile`' is present, a submenu wrapping everything else. Seems a little unnecessary.

```
⏷ NixOS Default Profile
├ ⏷ Generation 100
│ ├ Default
│ ├ Specialisation 1
│ └ Specialisation 2
└ ⏵ Generation 99
```

#### without:

'`NixOS Default Profile`' submenu is stripped away, as there's only one profile anyway.

```
⏷ Generation 100
├ Default
├ Specialisation 1
└ Specialisation 2
⏵ Generation 99
```

### Example 2

Since there is only one generation, it doesn't really need to be shown.

#### with:

```
⏷ NixOS Default Profile
└ ⏷ Generation 100
  ├ Default
  ├ Specialisation 1
  └ Specialisation 2
```

#### without:

```
Default
Specialisation 1
Specialisation 2
```

</details>

Those default values ensure backward-compatibility.

Python variable name change:

- '`special`' -> '`expanded`': Changed for clarity, matching the terminology used by [Limine documentation.](https://github.com/limine-bootloader/limine/blob/v10.x/CONFIG.md#menu-entries-and-sub-entries)

_I'm still new to this process, so assistance is appreciated._

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
