### PR TITLE
nixosTests.ly: adapt test to new user selection login

### DIFF
--- a/nixos/tests/ly.nix
+++ b/nixos/tests/ly.nix
@@ -36,27 +36,56 @@ in
     let
       user = nodes.machine.users.users.alice;
     in
+    # python
     ''
+      from test_driver.errors import RequestedAssertionFailed
       start_all()
 
-      machine.wait_until_tty_matches("1", "password:")
+      # old ly versions before 1.1.2 used to allow typing the username
+      # but now a user can only be selected from a set of users
+      def navigate_user(machine, username, wm, tty="1"):
+          wm = wm.lower()
+          tries = 0
+          while username not in machine.get_tty_text(tty):
+              machine.send_key("left")
+              machine.sleep(0.3)
+              if tries > 3:
+                  RequestedAssertionFailed(f"Failed to find user:{username} in ly")
+              tries += 1
+
+          # move cursor to wm selection
+          machine.send_key("up")
+
+          tries = 0
+          while wm not in machine.get_tty_text(tty).lower():
+              machine.send_key("left")
+              machine.sleep(0.3)
+              if tries > 3:
+                  RequestedAssertionFailed(f"Failed to find wm:{wm} in ly")
+              tries += 1
+
+          # reset cursor to user selection
+          machine.send_key("tab")
+
+      machine.wait_until_tty_matches("1", "password")
       machine.send_key("ctrl-alt-f1")
       machine.sleep(1)
       machine.screenshot("ly")
-      machine.send_chars("alice")
+      navigate_user(machine, "${user.name}", "icewm")
       machine.send_key("tab")
       machine.send_chars("${user.password}")
       machine.send_key("ret")
       machine.wait_for_file("/run/user/${toString user.uid}/lyxauth")
       machine.succeed("xauth merge /run/user/${toString user.uid}/lyxauth")
       machine.wait_for_window("^IceWM ")
+      machine.sleep(2)
       machine.screenshot("icewm")
 
-      machineNoX11.wait_until_tty_matches("1", "password:")
+      machineNoX11.wait_until_tty_matches("1", "password")
       machineNoX11.send_key("ctrl-alt-f1")
       machineNoX11.sleep(1)
       machineNoX11.screenshot("ly-no-x11")
-      machineNoX11.send_chars("alice")
+      navigate_user(machineNoX11, "${user.name}", "Sway")
       machineNoX11.send_key("tab")
       machineNoX11.send_chars("${user.password}")
       machineNoX11.send_key("ret")

--- a/nixos/tests/ly.nix
+++ b/nixos/tests/ly.nix
@@ -67,6 +67,8 @@ in
           # reset cursor to user selection
           machine.send_key("tab")
 
+      # https://github.com/NixOS/nixpkgs/pull/455191#discussion_r2507716719
+      machine.wait_until_succeeds("getfacl /dev/dri/card0 | grep video")
       machine.wait_until_tty_matches("1", "password")
       machine.send_key("ctrl-alt-f1")
       machine.sleep(1)


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/457852

Hydra: https://hydra.nixos.org/build/311255910

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
