### PR TITLE
[staging-next-25.05 backport] nodejs: disable failing test on darwin

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -73,7 +73,7 @@ let
           (lib.unsafeGetAttrPos "pname" drv)
           (lib.unsafeGetAttrPos "version" drv)
         ]
-        ++ lib.optionals (drv.meta.position or null != null) [
+        ++ lib.optionals (drv ? meta.position) [
           # Use ".meta.position" for cases when most of the package is
           # defined in a "common" section and the only place where
           # reference to the file with a derivation the "pos"

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -668,6 +668,9 @@ in
           ${artisanWrapper}/bin/librenms-artisan optimize
           echo "${package}" > ${cfg.dataDir}/package
         fi
+
+        # to make sure to not read an outdated .env file
+        ${artisanWrapper}/bin/librenms-artisan config:cache
       '';
     };
 

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -36,20 +36,20 @@ let
 
   hash =
     {
-      x86_64-linux = "sha256-0zgsR0nk9zsOeEcKhrmAFbAhvKKFNsC8fXjCnxFcndE=";
-      x86_64-darwin = "sha256-4+3T3axXNfePEkevhLwRPeqoxKs2OTL7B7TiV2BxZWc=";
-      aarch64-linux = "sha256-iGLtuVFA5NphiF1PU9Pus/nZ8PyCNNzDOpcQ+utYE2I=";
-      aarch64-darwin = "sha256-E4BopxbqH1lg1Q2NlyWjH8jytabiv5y4hG5ZJW4nqzs=";
-      armv7l-linux = "sha256-YIidKSsqK3DSAfPd7O1pbft1C/ny/iB+CFbR/T9u7L8=";
+      x86_64-linux = "sha256-S9H1IZGV3BZe2kjSdkt8S+ShE1EQA0yiKEl65tNNtJw=";
+      x86_64-darwin = "sha256-Wi21LByNSjaTKdpJJM9d/5yspaoplJ1pDxGBMxAxLT0=";
+      aarch64-linux = "sha256-m1AkCRiVJbUPArvK/QyG+Y/7qCLHY20vv40suFXK1fk=";
+      aarch64-darwin = "sha256-iwUegTexE0Iroh+VN9/cQ/s1f2SjLSePjIJanjMDzHU=";
+      armv7l-linux = "sha256-06LY6PrWg1VBjUjoLNIrbuKu9YzJS4MM38wlx8JQdvw=";
     }
     .${system} or throwSystem;
 
   # Please backport all compatible updates to the stable release.
   # This is important for the extension ecosystem.
-  version = "1.104.2";
+  version = "1.104.3";
 
   # This is used for VS Code - Remote SSH test
-  rev = "e3a5acfb517a443235981655413d566533107e92";
+  rev = "385651c938df8a906869babee516bffd0ddb9829";
 in
 callPackage ./generic.nix {
   pname = "vscode" + lib.optionalString isInsiders "-insiders";
@@ -82,7 +82,7 @@ callPackage ./generic.nix {
     src = fetchurl {
       name = "vscode-server-${rev}.tar.gz";
       url = "https://update.code.visualstudio.com/commit:${rev}/server-linux-x64/stable";
-      hash = "sha256-Tz1P8eGokG+8thao9dRllAdTxvllhfOEDKH9lC2QwB0=";
+      hash = "sha256-0tGqGDMmLURqdQwqFWCO10d/RkVha8iC0Uv/JFp9nNQ=";
     };
     stdenv = stdenvNoCC;
   };

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -36,20 +36,20 @@ let
 
   hash =
     {
-      x86_64-linux = "sha256-S9H1IZGV3BZe2kjSdkt8S+ShE1EQA0yiKEl65tNNtJw=";
-      x86_64-darwin = "sha256-Wi21LByNSjaTKdpJJM9d/5yspaoplJ1pDxGBMxAxLT0=";
-      aarch64-linux = "sha256-m1AkCRiVJbUPArvK/QyG+Y/7qCLHY20vv40suFXK1fk=";
-      aarch64-darwin = "sha256-iwUegTexE0Iroh+VN9/cQ/s1f2SjLSePjIJanjMDzHU=";
-      armv7l-linux = "sha256-06LY6PrWg1VBjUjoLNIrbuKu9YzJS4MM38wlx8JQdvw=";
+      x86_64-linux = "sha256-i1MFtqfWiAsvxgyc/MZlOdo/Py6PQlJmjHGeYnhygso=";
+      x86_64-darwin = "sha256-HElY2mOgYxfE5LULFMpipmd/igDAapd6G2VlZeCGWTI=";
+      aarch64-linux = "sha256-NiVXjiii9Df3mRkDVULsiLgRhfJKX+H2/VYuxUImFzI=";
+      aarch64-darwin = "sha256-IDqupYgoslZb7Po8nimOTwojTJ0TO5efgfTqtTQ+dUI=";
+      armv7l-linux = "sha256-cN4EXCM5v5ULZUb+glqbI9g+oOsjELB+OWEGDVxN/Y4=";
     }
     .${system} or throwSystem;
 
   # Please backport all compatible updates to the stable release.
   # This is important for the extension ecosystem.
-  version = "1.104.3";
+  version = "1.105.0";
 
   # This is used for VS Code - Remote SSH test
-  rev = "385651c938df8a906869babee516bffd0ddb9829";
+  rev = "03c265b1adee71ac88f833e065f7bb956b60550a";
 in
 callPackage ./generic.nix {
   pname = "vscode" + lib.optionalString isInsiders "-insiders";

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bind";
-  version = "9.20.13";
+  version = "9.20.15";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/bind-${finalAttrs.version}.tar.xz";
-    hash = "sha256-FR+TdurTF+ZGpdDJ8BwGA4bYkRGNdDen+Cm7lyfHs0w=";
+    hash = "sha256-1is4+uSLqD/KYYERLQxxAY2LDyzihdx53GoDZ3Isyrs=";
   };
 
   outputs = [

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bind";
-  version = "9.20.12";
+  version = "9.20.13";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/bind-${finalAttrs.version}.tar.xz";
-    hash = "sha256-3TLW62dQTopDCq9wtO+JTz0CJrRMfgI3DJsNN38ceZk=";
+    hash = "sha256-FR+TdurTF+ZGpdDJ8BwGA4bYkRGNdDen+Cm7lyfHs0w=";
   };
 
   outputs = [

--- a/pkgs/by-name/br/brave/package.nix
+++ b/pkgs/by-name/br/brave/package.nix
@@ -3,24 +3,24 @@
 
 let
   pname = "brave";
-  version = "1.83.118";
+  version = "1.83.120";
 
   allArchives = {
     aarch64-linux = {
       url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_arm64.deb";
-      hash = "sha256-daHMBEGYJBLYu2HP2oY1wYLhVC61DNT6EFlK/PBzqcw=";
+      hash = "sha256-DQX+HKNLakI6G7K53SmcmtmA+h7ZmvkcjUgd/k3C/cc=";
     };
     x86_64-linux = {
       url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-      hash = "sha256-KjcRXDxXAkhgAXgALzCN828+ovp2HURKL+VWT2DIMVI=";
+      hash = "sha256-E1IKc6ftBO88WVXa0RgjAFhtckBNm/hTQgxzMzK17PY=";
     };
     aarch64-darwin = {
       url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-v${version}-darwin-arm64.zip";
-      hash = "sha256-EnCEuLqYdV3gSwvcT19FUtRbPm79TdjUzL39sKpPTd8=";
+      hash = "sha256-aMyTGhxnExd1kaoHHTZu7UU42/WSOkB9PAyc8M0B/xU=";
     };
     x86_64-darwin = {
       url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-v${version}-darwin-x64.zip";
-      hash = "sha256-brj0EvOwX0i82ndPHBS9mqfliq/YnXyxGeiz4nA1qNw=";
+      hash = "sha256-lTxFrmQzWWegmlyBc71fL81iTPqVLB3r8q2gqvrlM3o=";
     };
   };
 

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-dockerfile.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-dockerfile.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "Dockerfile code formatter.";
-  hash = "sha256-gsfMLa4zw8AblOS459ZS9OZrkGCQi5gBN+a3hvOsspk=";
+  description = "Dockerfile code formatter";
+  hash = "sha256-GaK1sYdZPwQWJmz2ULcsGpWDiKjgPhqNRoGgQfGOkqc=";
   initConfig = {
     configExcludes = [ ];
     configKey = "dockerfile";
@@ -9,6 +9,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-dockerfile";
   updateUrl = "https://plugins.dprint.dev/dprint/dockerfile/latest.json";
-  url = "https://plugins.dprint.dev/dockerfile-0.3.2.wasm";
-  version = "0.3.2";
+  url = "https://plugins.dprint.dev/dockerfile-0.3.3.wasm";
+  version = "0.3.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "Ruff (Python) wrapper plugin.";
-  hash = "sha256-15InHQgF9c0Js4yUJxmZ1oNj1O16FBU12u/GOoaSAJ8=";
+  description = "Ruff (Python) wrapper plugin";
+  hash = "sha256-qT+6zPbX3KrONXshwzLoGTWRXM93VKO0lN9ycJujEDM=";
   initConfig = {
     configExcludes = [ ];
     configKey = "ruff";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-ruff";
   updateUrl = "https://plugins.dprint.dev/dprint/ruff/latest.json";
-  url = "https://plugins.dprint.dev/ruff-0.3.9.wasm";
-  version = "0.3.9";
+  url = "https://plugins.dprint.dev/ruff-0.6.1.wasm";
+  version = "0.6.1";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "CSS, SCSS, Sass and Less formatter.";
-  hash = "sha256-mFlhfqtglKtKNls96PO/2AWLL1fNC5msQCd9EgdKauE=";
+  description = "CSS, SCSS, Sass and Less formatter";
+  hash = "sha256-IAIix6c9/GNDZsRk95T/rpvMh7HqFgBoq5KDVYHHOjU=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "malva";
@@ -14,6 +14,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-malva";
   updateUrl = "https://plugins.dprint.dev/g-plane/malva/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/malva-v0.11.2.wasm";
-  version = "0.11.2";
+  url = "https://plugins.dprint.dev/g-plane/malva-v0.14.3.wasm";
+  version = "0.14.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento formatter.";
-  hash = "sha256-fCvurr8f79io/jIjwCfwr/WGjvcKZtptRrx9GFfytSI=";
+  description = "HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento formatter";
+  hash = "sha256-TQxHIw5IXZwFA/WzIJ33ZckJNkHwW67lnh0cCGkgmrs=";
   initConfig = {
     configExcludes = [ ];
     configKey = "markup";
@@ -19,6 +19,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-markup_fmt";
   updateUrl = "https://plugins.dprint.dev/g-plane/markup_fmt/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.19.0.wasm";
-  version = "0.19.0";
+  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.24.0.wasm";
+  version = "0.24.0";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_graphql.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_graphql.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "GraphQL formatter.";
-  hash = "sha256-PlQwpR0tMsghMrOX7is+anN57t9xa9weNtoWpc0E9ec=";
+  description = "GraphQL formatter";
+  hash = "sha256-xEEBnmxxiIPNOePBDS2HG6lfAhR4l53w+QDF2mXdyzg=";
   initConfig = {
     configExcludes = [ ];
     configKey = "graphql";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-pretty_graphql";
   updateUrl = "https://plugins.dprint.dev/g-plane/pretty_graphql/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.1.wasm";
-  version = "0.2.1";
+  url = "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.3.wasm";
+  version = "0.2.3";
 }

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "YAML formatter.";
-  hash = "sha256-6ua021G7ZW7Ciwy/OHXTA1Joj9PGEx3SZGtvaA//gzo=";
+  description = "YAML formatter";
+  hash = "sha256-iSh5SRrjQB1hJoKkkup7R+Durcu+cxePa7GDVjwnexU=";
   initConfig = {
     configExcludes = [ ];
     configKey = "yaml";
@@ -12,6 +12,6 @@ mkDprintPlugin {
   };
   pname = "g-plane-pretty_yaml";
   updateUrl = "https://plugins.dprint.dev/g-plane/pretty_yaml/latest.json";
-  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm";
-  version = "0.5.0";
+  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm";
+  version = "0.5.1";
 }

--- a/pkgs/by-name/dp/dprint/plugins/update-plugins.py
+++ b/pkgs/by-name/dp/dprint/plugins/update-plugins.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python -p nix nixfmt-rfc-style 'python3.withPackages (pp: [ pp.requests ])'
+#!nix-shell -i python3 -p nix 'python3.withPackages (ps: [ ps.requests ])'
 
 import json
 import os
@@ -138,7 +138,7 @@ def update_plugins():
             "updateUrl": update_url,
             "pname": pname,
             "version": e["version"],
-            "description": e["description"],
+            "description": e["description"].rstrip("."),
             "initConfig": {
                 "configKey": e["configKey"],
                 "configExcludes": e["configExcludes"],

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -228,6 +228,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "system_dbus_proxy" (lib.getExe xdg-dbus-proxy))
     (lib.mesonOption "system_fusermount" "/run/wrappers/bin/fusermount3")
     (lib.mesonOption "system_install_dir" "/var/lib/flatpak")
+    (lib.mesonOption "sysconfdir" "/etc")
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "18.5.0";
+  version = "18.5.1";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-kVFO8brtXWWGU2nWTtHR1q5RrTIXy2ssra9YjtWsglU=";
+      hash = "sha256-719FC9+OBX9Li9gkIpusFoZrpMyeDwCsoWxt9pfhI1A=";
     };
 
     vendorHash = "sha256-I2YMn84wEAY+Z02bmkyP/b0eix7FW3hP/noyEKYsEaQ=";

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "18.5.0";
+  version = "18.5.1";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-7jMiKN2L4rF4YyqoJW8pzj5rP5g6ScwZ3qkY+OCZOZ8=";
+    hash = "sha256-UrVH5Ky5aiqquQ2o6bSkqLD4ULl9/vUViOoACantT1Q=";
   };
 
   vendorHash = "sha256-VWD/AXqEVWo7G9p1q1BM2LUNwAFmkPm+Gm2s9EPu6nM=";

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,16 +1,16 @@
 {
-  "version": "18.5.0",
-  "repo_hash": "0r1q6byqv3zziwsw63z7km5jjap7q6222j91lnr048w6cf425n1w",
+  "version": "18.5.1",
+  "repo_hash": "0h80pzsfn6lb8mz8igbpkmazzj3kkdwhrqxazjq6g9zrsqsvydx5",
   "yarn_hash": "16f7r4v4mjjdsfbzy5vy1g18p0l3gnjvfvzrl2xrxdibx7a3b4xs",
   "frontend_islands_yarn_hash": "0kks9hzm5fq3fss9ys8zxls3d3860l1fvsfcrbhf9rccmwvmjn3l",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v18.5.0-ee",
+  "rev": "v18.5.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "18.5.0",
-    "GITLAB_PAGES_VERSION": "18.5.0",
+    "GITALY_SERVER_VERSION": "18.5.1",
+    "GITLAB_PAGES_VERSION": "18.5.1",
     "GITLAB_SHELL_VERSION": "14.45.3",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.9.4",
-    "GITLAB_WORKHORSE_VERSION": "18.5.0"
+    "GITLAB_WORKHORSE_VERSION": "18.5.1"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "18.5.0";
+  version = "18.5.1";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {

--- a/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile
@@ -331,7 +331,8 @@ gem 'js_regex', '~> 3.8', feature_category: :shared
 gem 'device_detector', feature_category: :shared
 
 # Redis
-gem 'redis', '~> 5.4.0', feature_category: :redis
+# Do NOT upgrade until Rails is upgraded with a version that contains https://github.com/rails/rails/pull/55359.
+gem 'redis', '= 5.4.0', feature_category: :redis
 gem 'redis-client', '~> 0.25', feature_category: :redis
 gem 'redis-cluster-client', '~> 0.13', feature_category: :redis
 gem 'redis-clustering', '~> 5.4.0', feature_category: :redis

--- a/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile.lock
@@ -1624,7 +1624,7 @@ GEM
       json
     recursive-open-struct (1.1.3)
     redcarpet (3.6.0)
-    redis (5.4.1)
+    redis (5.4.0)
       redis-client (>= 0.22.0)
     redis-actionpack (5.5.0)
       actionpack (>= 5)
@@ -1634,8 +1634,8 @@ GEM
       connection_pool
     redis-cluster-client (0.13.5)
       redis-client (~> 0.24)
-    redis-clustering (5.4.1)
-      redis (= 5.4.1)
+    redis-clustering (5.4.0)
+      redis (= 5.4.0)
       redis-cluster-client (>= 0.10.0)
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -2364,7 +2364,7 @@ DEPENDENCIES
   rbtrace (~> 0.4)
   re2 (~> 2.15)
   recaptcha (~> 5.12)
-  redis (~> 5.4.0)
+  redis (= 5.4.0)
   redis-actionpack (~> 5.5.0)
   redis-client (~> 0.25)
   redis-cluster-client (~> 0.13)
@@ -2452,4 +2452,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.7.1
+   2.7.2

--- a/pkgs/by-name/gi/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/gemset.nix
@@ -7528,10 +7528,10 @@ src: {
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1bpsh5dbvybsa8qnv4dg11a6f2zn4sndarf7pk4iaayjgaspbrmm";
+      sha256 = "0syhyw1bp9nbb0fvcmm58y1c6iav6xw6b4bzjz1rz2j1d7c012br";
       type = "gem";
     };
-    version = "5.4.1";
+    version = "5.4.0";
   };
   redis-actionpack = {
     dependencies = [
@@ -7579,10 +7579,10 @@ src: {
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1sj4b3j7i3rb5a276g7yyd95kji4j9sl6wmqfgpz39gx06qlni47";
+      sha256 = "0fsnfi15xiy8sal6av11fqfjmdmjpy93amf790i0zwqcf1iq1qbw";
       type = "gem";
     };
-    version = "5.4.1";
+    version = "5.4.0";
   };
   redis-namespace = {
     dependencies = [ "redis" ];

--- a/pkgs/by-name/qq/qq/package.nix
+++ b/pkgs/by-name/qq/qq/package.nix
@@ -37,6 +37,7 @@ let
   pname = "qq";
   inherit (source) version src;
   passthru = {
+    # nixpkgs-update: no auto update
     updateScript = ./update.sh;
   };
   meta = {

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -19,14 +19,14 @@ python3Packages.buildPythonApplication rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2025.10.14";
+  version = "2025.10.22";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "yt-dlp";
     repo = "yt-dlp";
     tag = version;
-    hash = "sha256-x7vpuXUihlC4jONwjmWnPECFZ7xiVAOFSDUgBNvl+aA=";
+    hash = "sha256-jQaENEflaF9HzY/EiMXIHgUehAJ3nnDT9IbaN6bDcac=";
   };
 
   postPatch = ''

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3335,16 +3335,17 @@ self: super:
   }
 )
 
-# cachix: manually maintained
+# Cachix packages
+# Manually maintained
 // (
   let
-    version = "1.7.9";
+    version = "1.9.1";
 
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
       tag = "v${version}";
-      hash = "sha256-R0W7uAg+BLoHjMRMQ8+oiSbTq8nkGz5RDpQ+ZfxxP3A=";
+      hash = "sha256-IwnNtbNVrlZIHh7h4Wz6VP0Furxg9Hh0ycighvL5cZc=";
     };
   in
   {
@@ -3358,12 +3359,9 @@ self: super:
         inherit version;
         src = src + "/cachix";
       })
-      # Fix ambiguous 'show' reference: https://github.com/cachix/cachix/pull/704
-      (overrideCabal (_: {
-        postPatch = ''
-          sed -i 's/<> show i/<> Protolude.show i/' src/Cachix/Client/NixVersion.hs
-        '';
-      }))
+      (addBuildDepends [
+        self.pqueue
+      ])
       (
         drv:
         drv.override {

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -442,6 +442,8 @@ let
             ]
             # Those are annoyingly flaky, but not enough to be marked as such upstream.
             ++ lib.optional (majorVersion == "22") "test-child-process-stdout-flush-exit"
+            # This is failing on newer macOS versions, no fix has yet been provided upstream:
+            ++ lib.optional (majorVersion == "24" && stdenv.buildPlatform.isDarwin) "test-cluster-dgram-1"
           )
         }"
       ];

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -428,6 +428,9 @@ let
 
               # Those are annoyingly flaky, but not enough to be marked as such upstream.
               "test-wasi"
+
+              # This is failing on newer macOS versions, no fix has yet been provided upstream:
+              "test-cluster-dgram-1"
             ]
             ++ lib.optionals (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform.isx86_64) [
               # These tests fail on x86_64-darwin (even without sandbox).
@@ -442,12 +445,9 @@ let
             ]
             # Those are annoyingly flaky, but not enough to be marked as such upstream.
             ++ lib.optional (majorVersion == "22") "test-child-process-stdout-flush-exit"
-            ++ lib.optionals (majorVersion == "22" && stdenv.buildPlatform.isDarwin) [
-              "test-cluster-dgram-1"
-              "test/sequential/test-http-server-request-timeouts-mixed.js"
-            ]
-            # This is failing on newer macOS versions, no fix has yet been provided upstream:
-            ++ lib.optional (majorVersion == "24" && stdenv.buildPlatform.isDarwin) "test-cluster-dgram-1"
+            ++ lib.optional (
+              majorVersion == "22" && stdenv.buildPlatform.isDarwin
+            ) "test/sequential/test-http-server-request-timeouts-mixed.js"
           )
         }"
       ];

--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -17,8 +17,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "24.9.0";
-  sha256 = "f17bc4cb01f59098c34a288c1bb109a778867c14eeb0ebbd608d0617b1193bbf";
+  version = "24.10.0";
+  sha256 = "f17e36cb2cc8c34a9215ba57b55ce791b102e293432ed47ad63cbaf15f78678f";
   patches =
     (
       if (stdenv.hostPlatform.emulatorAvailable buildPackages) then
@@ -57,6 +57,14 @@ buildNodejs {
         url = "https://github.com/nodejs/node/commit/886e4b3b534a9f3ad2facbc99097419e06615900.patch?full_index=1";
         hash = "sha256-dg/wVkD3iFS7RNjmvMDGw+ONScEjynlkRXqVxdF45TM=";
         includes = [ "tools/gyp/pylib/gyp/xcode_emulation.py" ];
+        revert = true;
+      })
+      (fetchpatch2 {
+        url = "https://github.com/nodejs/node/commit/886e4b3b534a9f3ad2facbc99097419e06615900.patch?full_index=1";
+        hash = "sha256-DJTH8wVAAnoCTsUhYjsr1DV/EhFaduDpzETfer7WUL0=";
+        stripLen = 2;
+        extraPrefix = "deps/npm/node_modules/node-gyp/";
+        includes = [ "deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py" ];
         revert = true;
       })
       ./bypass-darwin-xcrun-node16.patch

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -28,23 +28,23 @@ let
   patchGoVersion = ''
     find . -name go.mod -not -path "./.bingo/*" -and -not -path "./devenv/*" -and -not -path "./hack/*" -and -not -path "./scripts/*" -and -not -path "./.citools/*" -print0 | while IFS= read -r -d ''' line; do
       substituteInPlace "$line" \
-        --replace-fail "go 1.24.6" "go 1.24.0"
+        --replace-fail "go 1.25.3" "go 1.25.0"
     done
     find . -name go.mod -path "./.citools/*" -print0 | while IFS= read -r -d ''' line; do
       substituteInPlace "$line" \
-        --replace-fail "go 1.24.5" "go 1.24.0"
+        --replace-fail "go 1.25.3" "go 1.25.0"
     done
     find . -name go.work -print0 | while IFS= read -r -d ''' line; do
       substituteInPlace "$line" \
-        --replace-fail "go 1.24.6" "go 1.24.0"
+        --replace-fail "go 1.25.3" "go 1.25.0"
     done
     substituteInPlace Makefile \
-      --replace-fail "GO_VERSION = 1.24.6" "GO_VERSION = 1.24.0"
+      --replace-fail "GO_VERSION = 1.25.3" "GO_VERSION = 1.25.0"
   '';
 in
 buildGoModule rec {
   pname = "grafana";
-  version = "12.0.5";
+  version = "12.0.6";
 
   subPackages = [
     "pkg/cmd/grafana"
@@ -56,7 +56,7 @@ buildGoModule rec {
     owner = "grafana";
     repo = "grafana";
     rev = "v${version}";
-    hash = "sha256-60E/YOW7jlwss0+lvP5twM5xTBW3NM2FzUAnxZcWTJY=";
+    hash = "sha256-VvySbS5c4jYsSEDRDlifOCNIDgoIQGGobDRHxAASXVY=";
   };
 
   # borrowed from: https://github.com/NixOS/nixpkgs/blob/d70d9425f49f9aba3c49e2c389fe6d42bac8c5b0/pkgs/development/tools/analysis/snyk/default.nix#L20-L22
@@ -70,14 +70,14 @@ buildGoModule rec {
   missingHashes = ./missing-hashes.json;
   offlineCache = yarn-berry_4.fetchYarnBerryDeps {
     inherit src missingHashes;
-    hash = "sha256-qarRn9m12mthKiaTJGpQI4sLadqJm71X9tUfqRbLo2Y=";
+    hash = "sha256-60I2rAdl5KczfvGevkoP2ahmV9r1Hm30zM2mA9jVdl4=";
   };
 
   disallowedRequisites = [ offlineCache ];
 
   postPatch = patchGoVersion;
 
-  vendorHash = "sha256-BtXwPQThXShORrp7TkOfrvcq5ajrkaBxxUceJtjJSNo=";
+  vendorHash = "sha256-x9howXCPl/gSQSm1P5VmDbYzoPP2Nzx5WA0ERNqm4As=";
 
   proxyVendor = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10427,7 +10427,9 @@ with pkgs;
 
   glabels-qt = callPackage ../applications/graphics/glabels-qt { };
 
-  grafana = callPackage ../servers/monitoring/grafana { };
+  grafana = callPackage ../servers/monitoring/grafana {
+    buildGoModule = buildGo125Module;
+  };
   grafanaPlugins = callPackages ../servers/monitoring/grafana/plugins { };
 
   hasura-cli = callPackage ../servers/hasura/cli.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of https://github.com/NixOS/nixpkgs/pull/451788 to address the darwin Hydra failures for nodejs, e.g. https://hydra.nixos.org/build/310882917.

The merge commit was because of the conflicts between `release-25.05` and `staging-next-25.05`, I didn't mean to ping all of you folks, sorry for the noise.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
