### PR TITLE
mackup: 0.8.41 -> 0.9.3

### DIFF
--- a/pkgs/by-name/ma/mackup/package.nix
+++ b/pkgs/by-name/ma/mackup/package.nix
@@ -1,19 +1,20 @@
 {
-  lib,
-  python3Packages,
   fetchFromGitHub,
+  lib,
   procps,
+  python3Packages,
+  stdenv,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "mackup";
-  version = "0.8.41";
+  version = "0.9.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lra";
     repo = "mackup";
     rev = "${version}";
-    hash = "sha256-eWSBl8BTg2FLI21DQcnepBFPF08bfm0V8lYB4mMbAiw=";
+    hash = "sha256-ysVABY/PWwqbWEATpzIrMkppHExOxDcia5HFr+VGQQc=";
   };
 
   postPatch = ''
@@ -21,9 +22,9 @@ python3Packages.buildPythonApplication rec {
       --replace-fail '"/usr/bin/pgrep"' '"${lib.getExe' procps "pgrep"}"' \
   '';
 
-  build-system = with python3Packages; [ poetry-core ];
+  build-system = with python3Packages; [ hatchling ];
 
-  dependencies = with python3Packages; [ docopt ];
+  dependencies = with python3Packages; [ docopt-ng ];
 
   pythonImportsCheck = [ "mackup" ];
 
@@ -32,7 +33,7 @@ python3Packages.buildPythonApplication rec {
   pytestFlagsArray = [ "tests/*.py" ];
 
   # Disabling tests failing on darwin due to a missing pgrep binary on procps
-  disabledTests = [ "test_is_process_running" ];
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [ "test_is_process_running" ];
 
   meta = {
     description = "A tool to keep your application settings in sync (OS X/Linux)";


### PR DESCRIPTION
Updates `mackup` from version 0.8.41 to 0.9.3.

Changes in upstream: https://github.com/lra/mackup/compare/0.8.41...0.9.3

## Things done

* sorted arguments
* updated version and corresponding hash
* changed build system from poetry to hatchling in accordance with upstream
* conditionally disabled test for darwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
