### PR TITLE
lxqt.qlipper: 5.1.2-unstable-2025-07-04 -> 5.1.2-unstable-2025-10-29, fix build

### DIFF
--- a/pkgs/desktops/lxqt/qlipper/default.nix
+++ b/pkgs/desktops/lxqt/qlipper/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation {
   pname = "qlipper";
-  version = "5.1.2-unstable-2025-07-04";
+  version = "5.1.2-unstable-2025-10-29";
 
   src = fetchFromGitHub {
     owner = "pvanek";
     repo = "qlipper";
-    rev = "d3e605fb9d44c523a95e3aac53c7d179a560c85f";
-    hash = "sha256-9V9s0oxWKqd9MHKlkZF3SetrAjHX4cAenAg7as4TLn0=";
+    rev = "4e9fcfe6684c465944baa153aeb7603ec27728b1";
+    hash = "sha256-7qaLY3F67uBtX1wI667MaqtrKLDfeG9jKwlC1pUOteQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Broken with Qt 6.10

https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes

"Usage of a private Qt module Foo now requires a call to find_package(Qt6 COMPONENTS FooPrivate) to make the Qt6::FooPrivate target available."
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
