### PR TITLE
nixos/nfs-client: add dns_resolver entry to request-key.conf

### DIFF
--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -60,10 +60,6 @@ let
     else
       pkgs.writeText "nfs.conf" nfsConfDeprecated;
 
-  requestKeyConfFile = pkgs.writeText "request-key.conf" ''
-    create id_resolver * * ${pkgs.nfs-utils}/bin/nfsidmap -t 600 %k %d
-  '';
-
   cfg = config.services.nfs;
 
 in
@@ -162,7 +158,10 @@ in
         environment.etc = {
           "idmapd.conf".source = idmapdConfFile;
           "nfs.conf".source = nfsConfFile;
-          "request-key.conf".source = requestKeyConfFile;
+          "request-key.conf".text = ''
+            create id_resolver * * ${pkgs.nfs-utils}/bin/nfsidmap -t 600 %k %d
+            create dns_resolver * * ${pkgs.keyutils}/bin/key.dns_resolver %k
+          '';
         };
 
         systemd.services.nfs-blkmap = {


### PR DESCRIPTION
A dns_resolver entry is needed for a NFSv4 client to resolve hostnames of NFS referrals and replicas.

When an NFS client discovers a referral, the target is mounted directly by the kernel. However, 
for the hostname resolution, a user space helper is required.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
