### PR TITLE
luajitPackages.lux-lua: symlink to 5.1 directory

### DIFF
--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -16,7 +16,8 @@
 }:
 let
   luaMajorMinor = lib.take 2 (lib.splitVersion lua.version);
-  luaVersionDir = if isLuaJIT then "jit" else lib.concatStringsSep "." luaMajorMinor;
+  luxLuaVersionDir = if isLuaJIT then "jit" else lib.concatStringsSep "." luaMajorMinor;
+  luaVersionDir = if isLuaJIT then "5.1" else lib.concatStringsSep "." luaMajorMinor;
   luaFeature = if isLuaJIT then "luajit" else "lua${lib.concatStringsSep "" luaMajorMinor}";
 in
 toLuaModule (
@@ -75,7 +76,7 @@ toLuaModule (
       cp -r target/dist/share $out
       cp -r target/dist/lib $out
       mkdir -p $out/lib/lua
-      ln -s $out/share/lux-lua/${luaVersionDir} $out/lib/lua/${luaVersionDir}
+      ln -s $out/share/lux-lua/${luxLuaVersionDir} $out/lib/lua/${luaVersionDir}
       runHook postInstall
     '';
 


### PR DESCRIPTION
The lux-lua crate for LuaJIT installs the package into `share/lua/jit/lux.so`, and we create a symlink in `lib/lua/<luaVersionDir>/lux.so`, where `luaVersionDir` is `jit` in the case of LuaJIT.
But the `package.cpath` for LuaJIT is configured to search a `lib/lua/5.1` directory.

To make sure LuaJIT can find lux-lua without relying on lux-cli to configure the search path, we have to symlink `share/lua/jit` to `lib/lua/5.1` in the `luajitPackages.lux-lua` package. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
