### PR TITLE
ocamlPackages.ninja_utils: 0.9.0 -> 1.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ninja_utils/default.nix
+++ b/pkgs/development/ocaml-modules/ninja_utils/default.nix
@@ -1,19 +1,21 @@
 {
   lib,
-  fetchzip,
+  fetchFromGitHub,
   buildDunePackage,
   re,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ninja_utils";
-  version = "0.9.0";
+  version = "1.0.0";
 
   minimalOCamlVersion = "4.12";
 
-  src = fetchzip {
-    url = "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/${version}.tar.gz";
-    hash = "sha256-VSj1IXfczoI3lSAtOqQPIqsxX+HgyxKzlssKd7By/Lo=";
+  src = fetchFromGitHub {
+    owner = "CatalaLang";
+    repo = "ninja_utils";
+    tag = finalAttrs.version;
+    hash = "sha256-2OYsZVk7/KYHXHTqAAEyVEHzcUCC+vBRU1s1XdfnWaE=";
   };
 
   propagatedBuildInputs = [ re ];
@@ -22,6 +24,6 @@ buildDunePackage rec {
     description = "Small library used to generate Ninja build files";
     homepage = "https://github.com/CatalaLang/ninja_utils";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.stepbrobd ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

supersedes https://github.com/NixOS/nixpkgs/pull/454190

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
