### PR TITLE
python3Packages.backports-zstd: fix hash

### DIFF
--- a/pkgs/development/python-modules/backports-zstd/default.nix
+++ b/pkgs/development/python-modules/backports-zstd/default.nix
@@ -17,10 +17,16 @@ buildPythonPackage rec {
     repo = "backports.zstd";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-MRtj40vjCPtV9/RDgun/APzva4lv+TnXeBKD9RNlkII=";
+    postFetch = ''
+      rm -r "$out/src/c/zstd"
+    '';
+    hash = "sha256-5t5ET8b65v4ArV9zrmu+kDXLG3QQRpMMZPSG+RRaCLk=";
   };
 
   postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'ROOT_PATH / "src" / "c" / "zstd"' 'Path("${zstd.src}")'
+
     # need to preserve $PYTHONPATH when calling sys.executable
     substituteInPlace tests/test/support/script_helper.py \
       --replace-fail "return __cached_interp_requires_environment" "return True"


### PR DESCRIPTION


The old hash was invalid because of a problem with line ending
normalization in the zstd module:

    $ file /nix/store/3v178rjmmyxlb5s9bn0nvq5xzcixlali-source/src/c/zstd/build/VS2008/fullbench/fullbench.vcproj /nix/store/qagxczby82d2pvwsv9nancayx2ywfr51-source/src/c/zstd/build/VS2008/fullbench/fullbench.vcproj
    /nix/store/3v178rjmmyxlb5s9bn0nvq5xzcixlali-source/src/c/zstd/build/VS2008/fullbench/fullbench.vcproj: XML 1.0 document, ASCII text
    /nix/store/qagxczby82d2pvwsv9nancayx2ywfr51-source/src/c/zstd/build/VS2008/fullbench/fullbench.vcproj: XML 1.0 document, ASCII text, with CRLF line terminators

We don't need that module so let's remove it from `src`.


closes https://github.com/NixOS/nixpkgs/pull/455143 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
