### PR TITLE
nixos/bind: fix listenOnPort option

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -107,8 +107,12 @@ let
       acl badnetworks { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.blockedNetworks} };
 
       options {
-        listen-on { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.listenOn} };
-        listen-on-v6 { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.listenOnIpv6} };
+        listen-on port ${toString cfg.listenOnPort} { ${
+          lib.concatMapStrings (entry: " ${entry}; ") cfg.listenOn
+        } };
+        listen-on-v6 port ${toString cfg.listenOnIpv6Port} { ${
+          lib.concatMapStrings (entry: " ${entry}; ") cfg.listenOnIpv6
+        } };
         allow-query-cache { cachenetworks; };
         blackhole { badnetworks; };
         forward ${cfg.forward};

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -1,30 +1,57 @@
-{ ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  zones = lib.singleton {
+    name = ".";
+    master = true;
+    file = pkgs.writeText "root.zone" ''
+      $TTL 3600
+      . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
+      . IN NS ns.example.org.
+
+      ns.example.org. IN A    192.168.0.1
+      ns.example.org. IN AAAA abcd::1
+
+      1.0.168.192.in-addr.arpa IN PTR ns.example.org.
+    '';
+  };
+in
 {
   name = "bind";
 
-  nodes.machine =
-    { pkgs, lib, ... }:
-    {
-      services.bind.enable = true;
-      services.bind.extraOptions = "empty-zones-enable no;";
-      services.bind.zones = lib.singleton {
-        name = ".";
-        master = true;
-        file = pkgs.writeText "root.zone" ''
-          $TTL 3600
-          . IN SOA ns.example.org. admin.example.org. ( 1 3h 1h 1w 1d )
-          . IN NS ns.example.org.
+  nodes = {
+    machine = {
+      services.bind = {
+        enable = true;
 
-          ns.example.org. IN A    192.168.0.1
-          ns.example.org. IN AAAA abcd::1
-
-          1.0.168.192.in-addr.arpa IN PTR ns.example.org.
-        '';
+        extraOptions = "empty-zones-enable no;";
+        inherit zones;
       };
     };
 
+    machineNonDefaultPort = {
+      services.bind = {
+        enable = true;
+
+        extraOptions = "empty-zones-enable no;";
+        inherit zones;
+
+        listenOnPort = 9053;
+      };
+    };
+  };
+
   testScript = ''
-    machine.wait_for_unit("bind.service")
-    machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
+    with subtest("Bind starts and responds"):
+      machine.wait_for_unit("bind.service")
+      machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
+
+    with subtest("Bind starts and responds on nondefault port"):
+      machineNonDefaultPort.wait_for_unit("bind.service")
+      machineNonDefaultPort.succeed("host -p 9053 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
   '';
 }


### PR DESCRIPTION
PR #389406 removed `listenOnPort` and `listenOnIpv6Port` from the config file.

Readded them in the config and also added a test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

**cc:** @spacekitteh