### PR TITLE
fishPlugins.kubectl-aliases: init at unstable-2025-05-11

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -3,7 +3,6 @@
   newScope,
   config,
 }:
-
 lib.makeScope newScope (
   self:
   with self;
@@ -64,6 +63,8 @@ lib.makeScope newScope (
     humantime-fish = callPackage ./humantime-fish.nix { };
 
     hydro = callPackage ./hydro.nix { };
+
+    kubectl-aliases = callPackage ./kubectl-aliases.nix { };
 
     macos = callPackage ./macos.nix { };
 

--- a/pkgs/shells/fish/plugins/kubectl-aliases.nix
+++ b/pkgs/shells/fish/plugins/kubectl-aliases.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+}:
+buildFishPlugin {
+  pname = "kubectl-aliases";
+  version = "unstable-2025-05-11";
+
+  src = fetchFromGitHub {
+    owner = "ahmetb";
+    repo = "kubectl-aliases";
+    rev = "7549fa45bbde7499b927c74cae13bfb9169c9497";
+    hash = "sha256-NkprSk55aRVHiq9JXduQl6AGZv5pBLHznRToOdm9OUw=";
+  };
+
+  postInstall = ''
+    mkdir -p $out/share/fish/vendor_conf.d/
+    cp .kubectl_aliases.fish $out/share/fish/vendor_conf.d/
+  '';
+
+  meta = {
+    description = "Programmatically generated handy kubectl aliases.";
+    homepage = "https://github.com/ahmetb/kubectl-aliases";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mattfield ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds new `fishPlugins.kubectl-aliases` package containing Fish abbreviations from https://github.com/ahmetb/kubectl-aliases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
