### PR TITLE
xen: patch with XSA-476

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -225,6 +225,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://xenbits.xen.org/xsa/xsa475-2.patch";
       hash = "sha256-7MKtDAJpihpfcBK+hyBFGCP6gHWs2cdgTks8B439b2s=";
     })
+
+    # XSA 476
+    (fetchpatch {
+      url = "https://xenbits.xen.org/xsa/xsa476-4.20.patch";
+      hash = "sha256-nZUHcMr9RpQqrazG+RtTw+/s1gzqN1D565RuQjuALTQ=";
+    })
   ];
 
   outputs = [


### PR DESCRIPTION
## Xen Security Advisory CVE-2025-58149 / XSA-476

### Incorrect removal of permissions on PCI device unplug

When passing through PCI devices, the detach logic in libxl won't remove access permissions to any 64bit memory BARs the device might have.  As a result a domain can still have access any 64bit memory BAR when such device is no longer assigned to the domain.

For PV domains the permission leak allows the domain itself to map the memory in the page-tables.  For HVM it would require a compromised device model or stubdomain to map the leaked memory into the HVM domain p2m.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
