### PR TITLE
workflows/eval: fix eval report with formatting changes

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -279,12 +279,11 @@ jobs:
                         const diff = JSON.parse(
                           readFileSync(path.join(artifact, system, 'diff.json'), 'utf-8'),
                         )
-                        const attrs = [].concat(
-                          diff.added,
-                          diff.removed,
-                          diff.changed,
-                          diff.rebuilds
-                        )
+                        const attrs = []
+                          .concat(diff.added, diff.removed, diff.changed, diff.rebuilds)
+                          // There are some special attributes, which are ignored for rebuilds.
+                          // These only have a single path component, because they lack the `.<system>` suffix.
+                          .filter((attr) => attr.split('.').length > 1)
                         if (attrs.length > 0) {
                           core.setFailed(
                             `${version} on ${system} has changed outpaths!\nNote: Please make sure to update ci/pinned.json separately from changes to other packages.`,


### PR DESCRIPTION
The Eval report which tests performance between Nix/Lix versions on update of `ci/pinned` wrongly returned errors, when only the special attribute `release-checks` changed. Since this reads in all of Nixpkgs, it will change with any formatting change that is introduced at the same time via update of any of `treefmt`'s formatters.

Should help with https://github.com/NixOS/nixpkgs/pull/450451#issuecomment-3442458959.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
