### PR TITLE
python3Packages.yamlfix: skip tests broken by click update

### DIFF
--- a/pkgs/by-name/ya/yamlfix/package.nix
+++ b/pkgs/by-name/ya/yamlfix/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication yamlfix

--- a/pkgs/development/python-modules/yamlfix/default.nix
+++ b/pkgs/development/python-modules/yamlfix/default.nix
@@ -52,6 +52,12 @@ buildPythonPackage rec {
     "-Wignore::ResourceWarning"
   ];
 
+  disabledTestPaths = [
+    # Broken since click was updated to 8.2.1 in https://github.com/NixOS/nixpkgs/pull/448189
+    # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
+    "tests/e2e/test_cli.py"
+  ];
+
   meta = {
     description = "Python YAML formatter that keeps your comments";
     homepage = "https://github.com/lyz-code/yamlfix";

--- a/pkgs/development/python-modules/yamlfix/default.nix
+++ b/pkgs/development/python-modules/yamlfix/default.nix
@@ -1,16 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  click,
   fetchFromGitHub,
-  maison,
+
+  # build-system
   pdm-backend,
+  setuptools,
+
+  # dependencies
+  click,
+  maison,
   pydantic,
+  ruyaml,
+
+  # tests
   pytest-freezegun,
   pytest-xdist,
   pytestCheckHook,
-  ruyaml,
-  setuptools,
+  versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
@@ -27,8 +34,8 @@ buildPythonPackage rec {
   };
 
   build-system = [
-    setuptools
     pdm-backend
+    setuptools
   ];
 
   dependencies = [
@@ -43,7 +50,9 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     writableTmpDirAsHomeHook
+    versionCheckHook
   ];
+  versionCheckProgramArg = "--version";
 
   pythonImportsCheck = [ "yamlfix" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4307,8 +4307,6 @@ with pkgs;
     fixup_yarn_lock
     ;
 
-  yamlfix = with python3Packages; toPythonApplication yamlfix;
-
   yamllint = with python3Packages; toPythonApplication yamllint;
 
   # To expose more packages for Yi, override the extraPackages arg.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Broken since click was updated to 8.2.1 in https://github.com/NixOS/nixpkgs/pull/448189

cc @koozz

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
