### PR TITLE
libsForQt5.kdiagram: fix build with cmake 4

### DIFF
--- a/pkgs/development/libraries/kdiagram/cmake-minimum-required.patch
+++ b/pkgs/development/libraries/kdiagram/cmake-minimum-required.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 12dbdbb..22495bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project( kdiagram )
+ 
+diff --git a/src/KChart/CMakeLists.txt b/src/KChart/CMakeLists.txt
+index 676b71f..a9a2928 100644
+--- a/src/KChart/CMakeLists.txt
++++ b/src/KChart/CMakeLists.txt
+@@ -359,6 +359,7 @@ install(EXPORT KChartTargets
+ ecm_generate_pri_file(
+     BASE_NAME KChart
+     LIB_NAME KChart
++    VERSION ${KCHARTLIB_VERSION}
+     DEPS "widgets svg"
+     FILENAME_VAR PRI_FILENAME
+     INCLUDE_INSTALL_DIR ${INCLUDE_INSTALL_DIR}/KChart
+diff --git a/src/KGantt/CMakeLists.txt b/src/KGantt/CMakeLists.txt
+index 107d762..5cbb254 100644
+--- a/src/KGantt/CMakeLists.txt
++++ b/src/KGantt/CMakeLists.txt
+@@ -183,6 +183,7 @@ install(EXPORT KGanttTargets
+ ecm_generate_pri_file(
+     BASE_NAME KGantt
+     LIB_NAME KGantt
++    VERSION ${KGANTTLIB_VERSION}
+     DEPS "widgets printsupport"
+     FILENAME_VAR PRI_FILENAME
+     INCLUDE_INSTALL_DIR ${INCLUDE_INSTALL_DIR}/KGantt

--- a/pkgs/development/libraries/kdiagram/default.nix
+++ b/pkgs/development/libraries/kdiagram/default.nix
@@ -18,6 +18,9 @@ mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-Se131GZE12wqdfN/V4id1pphUvteSrmMaKZ0+lqg1z8=";
   };
+  patches = [
+    ./cmake-minimum-required.patch
+  ];
   nativeBuildInputs = [
     extra-cmake-modules
     qttools


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- #445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
