### PR TITLE
libsForQt5.kproperty: fix build with cmake 4

### DIFF
--- a/pkgs/development/libraries/kproperty/cmake-minimum-required.patch
+++ b/pkgs/development/libraries/kproperty/cmake-minimum-required.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d589d5..0e1390f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ set(KPROPERTY_GENERATE_PRI TRUE)
+-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+ find_package(ECM 1.8.0 REQUIRED NO_MODULE)
+ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+ include(SetKPropertyCMakePolicies NO_POLICY_SCOPE)
+diff --git a/cmake/modules/SetKPropertyCMakePolicies.cmake b/cmake/modules/SetKPropertyCMakePolicies.cmake
+index bc28d8a..85370c2 100644
+--- a/cmake/modules/SetKPropertyCMakePolicies.cmake
++++ b/cmake/modules/SetKPropertyCMakePolicies.cmake
+@@ -9,7 +9,7 @@ cmake_policy(SET CMP0053 NEW) # TODO remove, temporary fix for a bug in Qt 5.8's
+                               # "Simplify variable reference and escape sequence evaluation"
+ 
+ if(POLICY CMP0059) # Don’t treat DEFINITIONS as a built-in directory property.
+-    cmake_policy(SET CMP0059 OLD)
++    cmake_policy(SET CMP0059 NEW)
+ endif()
+ if(POLICY CMP0063) # Honor visibility properties for all target types (since cmake 3.3)
+     cmake_policy(SET CMP0063 NEW)

--- a/pkgs/development/libraries/kproperty/default.nix
+++ b/pkgs/development/libraries/kproperty/default.nix
@@ -20,6 +20,10 @@ mkDerivation rec {
     sha256 = "1yldfsdamk4dag8dyryjn5n9j2pzi42s79kkafymfnbifhnhrbv7";
   };
 
+  patches = [
+    ./cmake-minimum-required.patch
+  ];
+
   nativeBuildInputs = [ extra-cmake-modules ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- #445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
