### PR TITLE
python3Packages.ufmt: cleanup, fix build

### DIFF
--- a/pkgs/by-name/uf/ufmt/package.nix
+++ b/pkgs/by-name/uf/ufmt/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication ufmt

--- a/pkgs/development/python-modules/ufmt/default.nix
+++ b/pkgs/development/python-modules/ufmt/default.nix
@@ -37,6 +37,13 @@ buildPythonPackage rec {
     hash = "sha256-oEvvXUju7qne3pCwnrckplMs0kBJavB669qieXJZPKw=";
   };
 
+  # Broken since click was updated to 8.2.1 in https://github.com/NixOS/nixpkgs/pull/448189
+  # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
+  postPatch = ''
+    substituteInPlace ufmt/tests/__init__.py \
+      --replace-fail "from .cli import CliTest" ""
+  '';
+
   build-system = [ flit-core ];
 
   dependencies = [

--- a/pkgs/development/python-modules/ufmt/default.nix
+++ b/pkgs/development/python-modules/ufmt/default.nix
@@ -1,28 +1,34 @@
 {
   lib,
-  black,
   buildPythonPackage,
-  click,
   fetchFromGitHub,
+
+  # build-system
   flit-core,
+
+  # dependencies
+  black,
+  click,
   libcst,
   moreorless,
-  pygls,
-  pythonOlder,
   tomlkit,
   trailrunner,
-  ruff-api,
   typing-extensions,
-  unittestCheckHook,
   usort,
+
+  # optional-dependencies
+  pygls,
+  ruff-api,
+
+  # tests
+  unittestCheckHook,
+  versionCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "ufmt";
   version = "2.8.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "omnilib";
@@ -51,17 +57,19 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     unittestCheckHook
+    versionCheckHook
   ]
   ++ lib.flatten (builtins.attrValues optional-dependencies);
+  versionCheckProgramArg = "--version";
 
   pythonImportsCheck = [ "ufmt" ];
 
-  meta = with lib; {
+  meta = {
     description = "Safe, atomic formatting with black and usort";
     homepage = "https://github.com/omnilib/ufmt";
     changelog = "https://github.com/omnilib/ufmt/blob/${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "ufmt";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4204,8 +4204,6 @@ with pkgs;
     libjpeg_turbo = libjpeg_turbo.override { enableJava = true; };
   };
 
-  ufmt = with python3Packages; toPythonApplication ufmt;
-
   unbound-with-systemd = unbound.override {
     withSystemd = true;
   };


### PR DESCRIPTION
- **python3Packages.ufmt: cleanup**
- **python3Packages.ufmt: skip tests broken by click update**
- **ufmt: move to by-name**


cc @fabaff

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
