### PR TITLE
scilab-bin: 6.1.1 -> 2026.0.0

### DIFF
--- a/pkgs/by-name/sc/scilab-bin/package.nix
+++ b/pkgs/by-name/sc/scilab-bin/package.nix
@@ -8,24 +8,34 @@
   alsa-lib,
   ncurses5,
   xorg,
+  libgbm,
+  expat,
+  libxkbcommon,
+  pango,
+  cairo,
+  systemd,
+  at-spi2-core,
+  nss,
+  nspr,
+  cups,
 }:
 
 let
   pname = "scilab-bin";
-  version = "6.1.1";
+  version = "2026.0.0";
 
   srcs = {
     aarch64-darwin = fetchurl {
-      url = "https://www.utc.fr/~mottelet/scilab/download/${version}/scilab-${version}-accelerate-arm64.dmg";
-      sha256 = "sha256-L4dxD8R8bY5nd+4oDs5Yk0LlNsFykLnAM+oN/O87SRI=";
+      url = "https://www.scilab.org/download/${version}/scilab-${version}-arm64.dmg";
+      sha256 = "sha256-omfxtzQfkwmApDxbGlTKnzcptfdhjFJRlwW9oGWw1Ko=";
     };
     x86_64-darwin = fetchurl {
-      url = "https://www.utc.fr/~mottelet/scilab/download/${version}/scilab-${version}-x86_64.dmg";
-      sha256 = "sha256-tBeqzllMuogrGcJxGqEl2DdNXaiwok3yhzWSdlWY5Fc=";
+      url = "https://www.scilab.org/download/${version}/scilab-${version}-x86_64.dmg";
+      sha256 = "sha256-avnob3gFVS/6yMQnb6NBeKeQogX8n6hJIWijSQEGbxs=";
     };
     x86_64-linux = fetchurl {
-      url = "https://www.scilab.org/download/${version}/scilab-${version}.bin.linux-x86_64.tar.gz";
-      sha256 = "sha256-PuGnz2YdAhriavwnuf5Qyy0cnCeRHlWC6dQzfr7bLHk=";
+      url = "https://www.scilab.org/download/${version}/scilab-${version}.bin.x86_64-linux-gnu.tar.xz";
+      sha256 = "sha256-gAtaj1weThztFhjiRbfmqdQg0XMquU6LX5E/BeG+ilc=";
     };
   };
   src =
@@ -80,25 +90,35 @@ let
       meta
       ;
 
-    nativeBuildInputs = [
-      autoPatchelfHook
-    ];
+    nativeBuildInputs = [ autoPatchelfHook ];
 
     buildInputs = [
       alsa-lib
       ncurses5
       stdenv.cc.cc
+      # for JCEF
+      libgbm
+      expat
+      libxkbcommon
+      pango
+      cairo
+      systemd
+      at-spi2-core
+      nss
+      nspr
+      cups
     ]
     ++ (with xorg; [
       libX11
-      libXcursor
       libXext
-      libXft
       libXi
-      libXrandr
       libXrender
       libXtst
       libXxf86vm
+      libXrandr
+      libXcursor
+      libXcomposite
+      libXdamage
     ]);
 
     installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates scilab-bin from 6.1.1 to 2026.0.0.

**Changes:**
- Updated version to 2026.0.0
- Updated source URLs and hashes for all platforms (x86_64-linux,
x86_64-darwin, aarch64-darwin)
- Added additional dependencies required for JCEF (Chromium Embedded
Framework) support

**Known Issue:**
It looks like GUI has a known upstream crash issue on some linux distributions. I wasn't able to launch gui, but built was successful and cli seems to work fine. Related issue might be:
- https://gitlab.com/scilab/scilab/-/issues/17323
- https://gitlab.com/scilab/scilab/-/issues/17324

scilab-bin wasn't updated for a while (6.1.1 was released in 2021), and the current version from nixpkgs had longstanding [issues](https://github.com/NixOS/nixpkgs/issues/51173). I hope this pr could raise some discussion about those issues. To make scilab finally work on nixos, as my knowledge isn't enough to fix this


**Release notes:** https://help.scilab.org/docs/2026.0.0/en_US/CHANGES.html


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
