### PR TITLE
waydroid-nftables: init

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -294,6 +294,8 @@
 
 - `forgejo-runner`: The upgrade to version 11 brings a license change from MIT to GPLv3-or-later.
 
+- `waydroid-nftables`: New variant of `waydroid` that supports nftables instead of iptables.
+
 - `lisp-modules` were brought in sync with the [June 2025 Quicklisp release](http://blog.quicklisp.org/2025/07/june-2025-quicklisp-dist-now-available.html).
 
 - `ffmpeg_8`, `ffmpeg_8-headless`, and `ffmpeg_8-full` have been added. The default version of FFmpeg remains ffmpeg_7 for now, though this may change before release.

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -305,6 +305,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `vmalert` now supports multiple instances with the option `services.vmalert.instances."".enable`
 
+- [`virtualisation.waydroid.package`](#opt-virtualisation.waydroid.package) now defaults to `waydroid-nftables` on systems with nftables enabled.
+
 - [`services.victorialogs.package`](#opt-services.victorialogs.package) now defaults to `victorialogs`, as `victoriametrics` no longer contains the VictoriaLogs binaries.
 
 - The `services.traccar.settings` attribute has been reworked. Instead of the previous flat attribute set the new implementation uses nested attribute sets. You need to update you configuration manually. For instance, `services.traccar.settings.loggerConsole` becomes `services.traccar.settings.logger.console`.

--- a/nixos/modules/virtualisation/waydroid.nix
+++ b/nixos/modules/virtualisation/waydroid.nix
@@ -25,7 +25,10 @@ in
 
   options.virtualisation.waydroid = {
     enable = lib.mkEnableOption "Waydroid";
-    package = lib.mkPackageOption pkgs "waydroid" { };
+    package = lib.mkPackageOption pkgs "waydroid" { } // {
+      default = if config.networking.nftables.enable then pkgs.waydroid-nftables else pkgs.waydroid;
+      defaultText = lib.literalExpression ''if config.networking.nftables.enable then pkgs.waydroid-nftables else pkgs.waydroid'';
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/pkgs/by-name/wa/waydroid/package.nix
+++ b/pkgs/by-name/wa/waydroid/package.nix
@@ -12,11 +12,13 @@
   lxc,
   iproute2,
   iptables,
+  nftables,
   util-linux,
   wrapGAppsHook3,
   wl-clipboard,
   runtimeShell,
   nix-update-script,
+  withNftables ? false,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -65,6 +67,10 @@ python3Packages.buildPythonApplication rec {
     "USE_SYSTEMD=0"
     "SYSCONFDIR=$(out)/etc"
   ];
+  postInstall = lib.optionalString withNftables ''
+    substituteInPlace $out/lib/waydroid/data/scripts/waydroid-net.sh \
+      --replace-fail 'LXC_USE_NFT="false"' 'LXC_USE_NFT="true"'
+  '';
 
   preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
@@ -76,7 +82,7 @@ python3Packages.buildPythonApplication rec {
           dnsmasq
           getent
           iproute2
-          iptables
+          (if withNftables then nftables else iptables)
         ]
       }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1133,6 +1133,8 @@ with pkgs;
 
   vprof = with python3Packages; toPythonApplication vprof;
 
+  waydroid-nftables = waydroid.override { withNftables = true; };
+
   winbox = winbox3;
   winbox3 = callPackage ../tools/admin/winbox {
     wine = wineWowPackages.stable;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **waydroid: add nftables support**
  - see https://github.com/waydroid/waydroid/issues/178
  - fixes #455336
  - fixes https://github.com/waydroid/waydroid/issues/2094
- **waydroid-nftables: init**
- **nixos/waydroid: use waydroid-nftables by default if nftables is enabled**
  - reduces the manual effort to resolve the issue
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
