### PR TITLE
honeycomb-refinery: 1.19.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/ho/honeycomb-refinery/0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
+++ b/pkgs/by-name/ho/honeycomb-refinery/0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
@@ -1,37 +1,24 @@
-From 301de689a1f7fae8ee6d0d5bbbe155a351b1b927 Mon Sep 17 00:00:00 2001
-From: Jade Lovelace <jadel@mercury.com>
-Date: Wed, 9 Nov 2022 11:02:02 -0800
-Subject: [PATCH] add NO_REDIS_TEST env-var that disables Redis-requiring tests
+From f2d2d869a4aa58430415d0969f5e80ece0142ad2 Mon Sep 17 00:00:00 2001
+From: jkachmar <j@mercury.com>
+Date: Thu, 23 Oct 2025 17:36:48 -0400
+Subject: [PATCH] disable tests that require redis
 
 ---
- internal/peer/peers_test.go | 7 +++++++
- 1 file changed, 7 insertions(+)
+ internal/peer/peers_test.go | 4 ++++
+ 1 file changed, 4 insertions(+), 0 deletions(-)
 
 diff --git a/internal/peer/peers_test.go b/internal/peer/peers_test.go
-index 5ec7f81..c64b1b4 100644
+index dae54067d8..b33ebc4979 100644
 --- a/internal/peer/peers_test.go
 +++ b/internal/peer/peers_test.go
-@@ -2,6 +2,7 @@ package peer
+@@ -86,6 +86,10 @@
+ }
  
- import (
- 	"context"
-+	"os"
- 	"testing"
- 	"time"
- 
-@@ -26,6 +27,12 @@ func TestNewPeers(t *testing.T) {
- 		t.Errorf("received %T expected %T", i, &filePeers{})
- 	}
- 
-+	// Allow skipping test requiring redis, since Nix builds without redis
-+	// available
+ func TestPeerShutdown(t *testing.T) {
++	// Skip tests requiring Redis so that nixpkgs can build & test refinery.
 +	if os.Getenv("NO_REDIS_TEST") != "" {
-+		t.Skip("Skipping redis-requiring test");
++		t.Skip("Skipping Redis-requiring test");
 +	}
-+
- 	c = &config.MockConfig{
+ 	c := &config.MockConfig{
  		GetPeerListenAddrVal: "0.0.0.0:8081",
  		PeerManagementType:   "redis",
--- 
-2.37.1
-

--- a/pkgs/by-name/ho/honeycomb-refinery/package.nix
+++ b/pkgs/by-name/ho/honeycomb-refinery/package.nix
@@ -2,17 +2,19 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "honeycomb-refinery";
-  version = "1.19.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "honeycombio";
     repo = "refinery";
-    rev = "v${version}";
-    hash = "sha256-SU9JbyUuBMqPw4XcoF5s8CgBn7+V/rHBAwpXJk373jg=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-jt8aEqglGXzBL5UDOz8e7qRDmE3RnMb2y+eLFI9jJSE=";
   };
 
   NO_REDIS_TEST = true;
@@ -24,23 +26,33 @@ buildGoModule rec {
     ./0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
   ];
 
-  excludedPackages = [ "cmd/test_redimem" ];
+  excludedPackages = [
+    "LICENSES"
+    "cmd/test_redimem"
+  ];
 
   ldflags = [
     "-s"
     "-w"
-    "-X main.BuildID=${version}"
+    "-X main.BuildID=${finalAttrs.version}"
   ];
 
-  vendorHash = "sha256-0M05JGLdmKivRTN8ZdhAm+JtXTlYAC31wFS82g3NenI=";
+  vendorHash = "sha256-/1IT3GxKANBltetRKxP/jUG05GGbg9mc7aWEcbrwUT0=";
 
   doCheck = true;
 
-  meta = with lib; {
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     homepage = "https://github.com/honeycombio/refinery";
     description = "Tail-sampling proxy for OpenTelemetry";
-    license = licenses.asl20;
-    maintainers = [ ];
     mainProgram = "refinery";
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.mercury ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- updated `1.19.0` -> `3.0.0`
- added `lib.teams.mercury` to the maintainer list
  - unclear if we'll actually end up using this internally so maybe i should just add myself?
- added update script & version check hooks

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
