### PR TITLE
python313Packages.traittypes: 0.2.1-unstable-2020-07-17 -> 0.2.3

### DIFF
--- a/pkgs/development/python-modules/traittypes/default.nix
+++ b/pkgs/development/python-modules/traittypes/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jupyter-widgets";
     repo = "traittypes";
-    rev = version;
+    tag = version;
     hash = "sha256-RwEZs4QFK+IrPFPBI7+jnQSFQryQFzEbrnOF8OyExuk=";
   };
 

--- a/pkgs/development/python-modules/traittypes/default.nix
+++ b/pkgs/development/python-modules/traittypes/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  isPy27,
   pytestCheckHook,
   setuptools,
   numpy,
@@ -11,24 +10,17 @@
   traitlets,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "traittypes";
-  version = "0.2.1-unstable-2020-07-17";
+  version = "0.2.3";
   pyproject = true;
-
-  disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "jupyter-widgets";
     repo = "traittypes";
-    rev = "af2ebeec9e58b73a12d4cf841bd506d6eadb8868";
-    hash = "sha256-q7kt8b+yDHsWML/wCeND9PrZMVjemhzG7Ih1OtHbnTw=";
+    rev = version;
+    hash = "sha256-RwEZs4QFK+IrPFPBI7+jnQSFQryQFzEbrnOF8OyExuk=";
   };
-
-  postPatch = ''
-    substituteInPlace traittypes/tests/test_traittypes.py \
-      --replace-fail "np.int" "int"
-  '';
 
   build-system = [ setuptools ];
 
@@ -39,6 +31,11 @@ buildPythonPackage {
     pandas
     xarray
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError; see https://github.com/jupyter-widgets/traittypes/issues/55
+    "test_initial_values"
   ];
 
   pythonImportsCheck = [ "traittypes" ];


### PR DESCRIPTION
Routine update ([diff](https://github.com/jupyter-widgets/traittypes/compare/af2ebeec9e5...0.2.3)). Supersedes #451206.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
