### PR TITLE
netlify-cli: add shell completions

### DIFF
--- a/pkgs/by-name/ne/netlify-cli/package.nix
+++ b/pkgs/by-name/ne/netlify-cli/package.nix
@@ -7,6 +7,7 @@
   nodejs,
   pkg-config,
   vips,
+  installShellFiles,
 }:
 
 buildNpmPackage rec {
@@ -22,9 +23,25 @@ buildNpmPackage rec {
 
   # Prevent postinstall script from running before package is built
   # See https://github.com/netlify/cli/blob/v23.9.2/scripts/postinstall.js#L70
-  # This currently breaks completions: https://github.com/NixOS/nixpkgs/issues/455005
   postPatch = ''
     touch .git
+  '';
+
+  # Completions instalation CLI depends on an interactive user prompt for shell and confirmation
+  # Use @pnpm/tabtab API to generate them in separate files without trying to install them.
+  postInstall = ''
+    completer="$out/lib/node_modules/netlify-cli/dist/lib/completion/script.js"
+    chmod a+x "$completer"
+    node <<EOF
+    import { writeFile } from 'node:fs/promises';
+    import { getCompletionScript } from '@pnpm/tabtab';
+    const name = 'netlify';
+    const completer = '$completer';
+    await Promise.all(["bash", "zsh", "fish"].map(async shell =>
+      await writeFile('netlify.' + shell, await getCompletionScript({name, completer, shell}))
+    ));
+    EOF
+    installShellCompletion netlify.{bash,fish,zsh}
   '';
 
   npmDepsHash = "sha256-itzEmCOBXxspGiwxt8t6di7/EuCo2Qkl5JVSkMfUemI=";
@@ -32,7 +49,10 @@ buildNpmPackage rec {
   inherit nodejs;
 
   buildInputs = [ vips ];
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
 
   passthru = {
     tests.test = callPackage ./test.nix { };


### PR DESCRIPTION
Available CLIs only install completions in $HOME and *rc files, prompting the user interactively for some choices, so use a short script using @pnpm/tabtab API to generate completion files directly.

Fixes https://github.com/NixOS/nixpkgs/issues/455005


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
