### PR TITLE
kubazip: init at 0.3.5; tic-80: use system kubazip

### DIFF
--- a/pkgs/by-name/ku/kubazip/package.nix
+++ b/pkgs/by-name/ku/kubazip/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kubazip";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "kuba--";
+    repo = "zip";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wNkIYuwwXo7v3vNaOnRZt1tcd0RGjDvCUqDGdvJzVdo=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Portable, simple zip library written in C";
+    homepage = "https://github.com/kuba--/zip";
+    changelog = "https://github.com/kuba--/zip/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+  };
+})

--- a/pkgs/by-name/ti/tic-80/package.nix
+++ b/pkgs/by-name/ti/tic-80/package.nix
@@ -7,6 +7,7 @@
   rake,
   curl,
   fetchFromGitHub,
+  kubazip,
   libGL,
   libGLU,
   libX11,
@@ -37,7 +38,7 @@ stdenv.mkDerivation {
     hash = "sha256-UjBnXxYZ5gfk58sI1qek5fkKpJ7LzOVmrxdjVgONcXc=";
     # TIC-80 vendors its dependencies as submodules. For the following dependencies,
     # there are no (or no compatible) packages in nixpkgs yet, so we use the vendored
-    # ones as a fill-in: kubazip, wasm, squirrel, pocketpy, argparse, naett,
+    # ones as a fill-in: wasm, squirrel, pocketpy, argparse, naett,
     # sdlgpu, mruby.
     fetchSubmodules = true;
   };
@@ -90,6 +91,7 @@ stdenv.mkDerivation {
     rake
   ];
   buildInputs = [
+    kubazip
     libGL
     libGLU
     libX11


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes https://github.com/NixOS/nixpkgs/issues/452776

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
