### PR TITLE
treewide: remove myself as maintainer from most packages

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1260,7 +1260,6 @@ with lib.maintainers;
       samasaur
       stephank
       trepetti
-      trundle
     ];
     scope = "Maintain Swift compiler suite for NixOS.";
     shortName = "Swift";

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -3,7 +3,6 @@
   name = "aesmd";
   meta = {
     maintainers = with lib.maintainers; [
-      trundle
       veehaitch
     ];
   };

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -187,7 +187,6 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     mainProgram = "pulumi";
     maintainers = with lib.maintainers; [
-      trundle
       veehaitch
       tie
     ];

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-aws-native/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-aws-native/package.nix
@@ -33,7 +33,6 @@ mkPulumiPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       veehaitch
-      trundle
     ];
   };
 }

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-azure-native/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-azure-native/package.nix
@@ -38,7 +38,6 @@ mkPulumiPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       veehaitch
-      trundle
     ];
   };
 }

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-command/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-command/package.nix
@@ -32,7 +32,6 @@ mkPulumiPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       veehaitch
-      trundle
     ];
   };
 }

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-random/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-random/package.nix
@@ -22,7 +22,6 @@ mkPulumiPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       veehaitch
-      trundle
     ];
   };
 }

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-yandex-unofficial/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-yandex-unofficial/package.nix
@@ -25,7 +25,6 @@ mkPulumiPackage rec {
     maintainers = with maintainers; [
       tie
       veehaitch
-      trundle
     ];
     mainProgram = cmdRes;
   };

--- a/pkgs/by-name/sg/sgx-azure-dcap-client/package.nix
+++ b/pkgs/by-name/sg/sgx-azure-dcap-client/package.nix
@@ -90,7 +90,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/microsoft/azure-dcap-client";
     maintainers = with lib.maintainers; [
       phlip9
-      trundle
       veehaitch
     ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/sg/sgx-ssl/package.nix
+++ b/pkgs/by-name/sg/sgx-ssl/package.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/intel/intel-sgx-ssl";
     maintainers = with lib.maintainers; [
       phlip9
-      trundle
       veehaitch
     ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
This mostly has been reality for a while now. I still use some of the packages, but don't have the capacity to maintain them.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
