### PR TITLE
python3Packages.aiotarfile: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/python-modules/aiotarfile/default.nix
+++ b/pkgs/development/python-modules/aiotarfile/default.nix
@@ -1,10 +1,8 @@
 {
   lib,
   fetchFromGitHub,
-  nix-update-script,
   buildPythonPackage,
   unittestCheckHook,
-  pythonOlder,
   cargo,
   rustc,
   rustPlatform,
@@ -12,21 +10,19 @@
 
 buildPythonPackage rec {
   pname = "aiotarfile";
-  version = "0.5.1";
+  version = "0.5.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "rhelmot";
     repo = "aiotarfile";
     tag = "v${version}";
-    hash = "sha256-DslG+XxIYb04I3B7m0fmRmE3hFCczF039QhSVdHGPL8=";
+    hash = "sha256-V88cvVw6ss7iiojhlqDd2frG/gCEH0YKTP0IpgeFASw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-e3NbFlBQu9QkGnIwqy2OmlQFVHjlfpMVRFWD2ADGGSc=";
+    hash = "sha256-Yf6N615X9ZB+HDp3xehMc3kjKbdsSbIJrqARRXwCRDQ=";
   };
 
   nativeBuildInputs = [
@@ -42,12 +38,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiotarfile" ];
 
-  passthru.updateScript = nix-update-script { };
-
   meta = {
     description = "Stream-based, asynchronous tarball processing";
     homepage = "https://github.com/rhelmot/aiotarfile";
-    changelog = "https://github.com/rhelmot/aiotarfile/commits/v{version}";
+    changelog = "https://github.com/rhelmot/aiotarfile/commits/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nicoo ];
   };


### PR DESCRIPTION
Diff: https://github.com/rhelmot/aiotarfile/compare/v0.5.1...v0.5.2

Changelog: https://github.com/rhelmot/aiotarfile/commits/v0.5.2

part of
* https://github.com/NixOS/nixpkgs/issues/455265

closes https://github.com/NixOS/nixpkgs/pull/455298
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
