### PR TITLE
nixos/immich: reindex VectorChord indexes on update

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -323,7 +323,11 @@ in
           "vchord"
         ];
         sqlFile = pkgs.writeText "immich-pgvectors-setup.sql" (
+          # save previous version of vectorchord to trigger reindex on update
+          lib.optionalString cfg.database.enableVectorChord ''
+            SELECT COALESCE(installed_version, ''') AS vchord_version_before FROM pg_available_extensions WHERE name = 'vchord' \gset
           ''
+          + ''
             ${lib.concatMapStringsSep "\n" (ext: "CREATE EXTENSION IF NOT EXISTS \"${ext}\";") extensions}
             ${lib.concatMapStringsSep "\n" (ext: "ALTER EXTENSION \"${ext}\" UPDATE;") extensions}
             ALTER SCHEMA public OWNER TO ${cfg.database.user};
@@ -331,6 +335,17 @@ in
           + lib.optionalString cfg.database.enableVectors ''
             ALTER SCHEMA vectors OWNER TO ${cfg.database.user};
             GRANT SELECT ON TABLE pg_vector_index_stat TO ${cfg.database.user};
+          ''
+          # trigger reindex if vectorchord updates
+          # https://docs.immich.app/administration/postgres-standalone/#updating-vectorchord
+          + lib.optionalString cfg.database.enableVectorChord ''
+            SELECT COALESCE(installed_version, ''') AS vchord_version_after FROM pg_available_extensions WHERE name = 'vchord' \gset
+
+            SELECT (:'vchord_version_before' != ''' AND :'vchord_version_before' != :'vchord_version_after') AS has_vchord_updated \gset
+            \if :has_vchord_updated
+              REINDEX INDEX face_index;
+              REINDEX INDEX clip_index;
+            \endif
           ''
         );
       in

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -733,6 +733,7 @@ in
   immich = runTest ./web-apps/immich.nix;
   immich-public-proxy = runTest ./web-apps/immich-public-proxy.nix;
   immich-vectorchord-migration = runTest ./web-apps/immich-vectorchord-migration.nix;
+  immich-vectorchord-reindex = runTest ./web-apps/immich-vectorchord-reindex.nix;
   incron = runTest ./incron.nix;
   incus = pkgs.recurseIntoAttrs (
     handleTest ./incus {

--- a/nixos/tests/web-apps/immich-vectorchord-reindex.nix
+++ b/nixos/tests/web-apps/immich-vectorchord-reindex.nix
@@ -1,0 +1,74 @@
+{ ... }:
+{
+  name = "immich-vectorchord-reindex";
+
+  nodes.machine =
+    { lib, pkgs, ... }:
+    {
+      # These tests need a little more juice
+      virtualisation = {
+        cores = 2;
+        memorySize = 2048;
+        diskSize = 4096;
+      };
+
+      services.immich = {
+        enable = true;
+        environment.IMMICH_LOG_LEVEL = "verbose";
+      };
+
+      services.postgresql.extensions = lib.mkForce (ps: [
+        ps.pgvector
+        # pin vectorchord to an older version simulate version bump
+        (ps.vectorchord.overrideAttrs (prevAttrs': rec {
+          version = "0.5.2";
+          src = pkgs.fetchFromGitHub {
+            owner = "tensorchord";
+            repo = "vectorchord";
+            tag = version;
+            hash = "sha256-KGwiY5t1ivFiYex3D20y3sdiu3CT9LCDd2fPnRE56jM=";
+          };
+
+          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+            inherit src;
+            hash = "sha256-Vn3c/xuUpQzERJ74I0qbvufTZtW3goefPa5B/nOUO48=";
+          };
+        }))
+      ]);
+
+      specialisation."immich-vectorchord-upgraded".configuration = {
+        # needs to be lower than mkForce, otherwise it does not get rid of the previous version
+        services.postgresql.extensions = lib.mkOverride 40 (ps: [
+          ps.pgvector
+          ps.vectorchord
+        ]);
+      };
+
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specBase = "${nodes.machine.system.build.toplevel}/specialisation";
+      vectorchordUpgraded = "${specBase}/immich-vectorchord-upgraded";
+    in
+    ''
+      def immich_works():
+        machine.wait_for_unit("immich-server.service")
+
+        machine.wait_for_open_port(2283) # Server
+        machine.wait_for_open_port(3003) # Machine learning
+        machine.succeed("curl --fail http://localhost:2283/")
+
+      immich_works()
+
+      machine.succeed("${vectorchordUpgraded}/bin/switch-to-configuration test")
+
+      # just tests that reindexing is triggered
+      machine.wait_until_succeeds(
+        "journalctl -o cat -u postgresql-setup.service | grep 'REINDEX'"
+      )
+
+      immich_works()
+    '';
+}

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -251,7 +251,7 @@ stdenv.mkDerivation {
 
   passthru = {
     tests = {
-      inherit (nixosTests) immich immich-vectorchord-migration;
+      inherit (nixosTests) immich immich-vectorchord-migration immich-vectorchord-reindex;
     };
 
     machine-learning = immich-machine-learning;


### PR DESCRIPTION
VectorChord requires its indexes to be reindexed when the extension is updated. [1]
This commit adds functionality to save the current version of the extension before performing an update, and then compare it with the updated version to decide whether it should reindex Immich's indexes. This complexity is needed to avoid reindexing every time PostgreSQL is started, as it is an expensive operation that would slow down startup.

[1]: https://docs.immich.app/administration/postgres-standalone/#updating-vectorchord

Closes #454606

See related discussion in https://github.com/NixOS/nixpkgs/pull/436031#issuecomment-3433297004 and #454606

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
