### PR TITLE
python3Packages.ufmt: fix cli tests by fetching upstream patch

### DIFF
--- a/pkgs/development/python-modules/ufmt/default.nix
+++ b/pkgs/development/python-modules/ufmt/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   flit-core,
@@ -37,12 +38,16 @@ buildPythonPackage rec {
     hash = "sha256-oEvvXUju7qne3pCwnrckplMs0kBJavB669qieXJZPKw=";
   };
 
-  # Broken since click was updated to 8.2.1 in https://github.com/NixOS/nixpkgs/pull/448189
-  # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
-  postPatch = ''
-    substituteInPlace ufmt/tests/__init__.py \
-      --replace-fail "from .cli import CliTest" ""
-  '';
+  patches = [
+    # Fix click 8.2.x incompatibility
+    # TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'
+    # https://github.com/omnilib/ufmt/pull/260
+    (fetchpatch2 {
+      name = "fix-click-incompatibility.patch";
+      url = "https://github.com/omnilib/ufmt/pull/260/commits/7980d7cd0a29fbd287e10d939248ef7c9d38a660.patch";
+      hash = "sha256-97/jQVGCC+PXk8uxyF/M7XlLuVqJ5SgQZd/MXkaiO70=";
+    })
+  ];
 
   build-system = [ flit-core ];
 


### PR DESCRIPTION
## Things done

Fetch fix from https://github.com/omnilib/ufmt/issues/260 instead of skipping the broken test.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
