### PR TITLE
opencolorio_1: fix build with cmake4, yaml-cpp_0_3: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ya/yaml-cpp_0_3/package.nix
+++ b/pkgs/by-name/ya/yaml-cpp_0_3/package.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jbeder/yaml-cpp";
     license = licenses.mit;
     platforms = platforms.all;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with maintainers; [ iedame ];
   };
 }

--- a/pkgs/by-name/ya/yaml-cpp_0_3/package.nix
+++ b/pkgs/by-name/ya/yaml-cpp_0_3/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yaml-cpp_0_3";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jbeder";
+    repo = "yaml-cpp";
+    rev = "release-${version}";
+    hash = "sha256-pmgcULTXhl83+Wc8ZsGebnJ1t0XybHhUEJxDnEZE5x8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DYAML_CPP_BUILD_TOOLS=${lib.boolToString doCheck}"
+    "-DBUILD_SHARED_LIBS=${lib.boolToString (!stdenv.hostPlatform.isStatic)}"
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required(VERSION 3.10)" \
+      --replace-fail "cmake_policy(SET CMP0015 OLD)" "cmake_policy(SET CMP0015 NEW)" \
+      --replace-fail "cmake_policy(SET CMP0012 OLD)" "cmake_policy(SET CMP0012 NEW)"
+  '';
+
+  meta = with lib; {
+    description = "YAML parser and emitter for C++";
+    homepage = "https://github.com/jbeder/yaml-cpp";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ iedame ];
+  };
+}

--- a/pkgs/development/libraries/opencolorio/1.x.nix
+++ b/pkgs/development/libraries/opencolorio/1.x.nix
@@ -89,5 +89,6 @@ stdenv.mkDerivation (finalAtts: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ yzx9 ];
     platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/development/libraries/opencolorio/1.x.nix
+++ b/pkgs/development/libraries/opencolorio/1.x.nix
@@ -8,6 +8,7 @@
   lcms2,
   tinyxml,
   boost,
+  yaml-cpp_0_3,
 }:
 
 stdenv.mkDerivation (finalAtts: {
@@ -37,19 +38,28 @@ stdenv.mkDerivation (finalAtts: {
   buildInputs = [
     lcms2
     tinyxml
+    yaml-cpp_0_3
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin boost;
 
   postPatch = ''
     substituteInPlace src/core/CMakeLists.txt --replace "-Werror" ""
     substituteInPlace src/pyglue/CMakeLists.txt --replace "-Werror" ""
+
+    substituteInPlace src/core/CMakeLists.txt \
+      --replace-fail "add_dependencies(OpenColorIO_STATIC TINYXML_LIB YAML_CPP_LIB)" ""
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
+    substituteInPlace share/cmake/ParseArguments.cmake \
+      --replace-fail "cmake_minimum_required(VERSION 2.4.7)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
   cmakeFlags = [
     "-DUSE_EXTERNAL_LCMS=ON"
     "-DUSE_EXTERNAL_TINYXML=ON"
     # External yaml-cpp 0.6.* not compatible: https://github.com/imageworks/OpenColorIO/issues/517
-    "-DUSE_EXTERNAL_YAML=OFF"
+    "-DUSE_EXTERNAL_YAML=ON"
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin "-DOCIO_USE_BOOST_PTR=ON"
   ++ lib.optional (!stdenv.hostPlatform.isx86) "-DOCIO_USE_SSE=OFF"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2868,7 +2868,6 @@ mapAliases {
   ### Y ###
 
   yacc = throw "'yacc' has been renamed to/replaced by 'bison'"; # Converted to throw 2024-10-17
-  yaml-cpp_0_3 = throw "yaml-cpp_0_3 has been removed, as it was unused"; # Added 2025-09-16
   yesplaymusic = throw "YesPlayMusic has been removed as it was broken, unmaintained, and used deprecated Node and Electron versions"; # Added 2024-12-13
   yafaray-core = libyafaray; # Added 2022-09-23
   yamlpath = throw "'yamlpath' has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-01


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

Edit: Marked as draft to be closed by #455551

Re-introduces yaml-cpp_0_3, that is needed patched for cmake4.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
