### PR TITLE
pods: 2.1.2 -> 2.2.0, fix CVE-2025-62518, add versionCheckHook

### DIFF
--- a/pkgs/by-name/po/pods/cve-2025-62516.patch
+++ b/pkgs/by-name/po/pods/cve-2025-62516.patch
@@ -1,0 +1,200 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e799bfd1..efd6601a 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -86,6 +86,21 @@ dependencies = [
+  "zbus",
+ ]
+ 
++[[package]]
++name = "astral-tokio-tar"
++version = "0.5.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
++dependencies = [
++ "filetime",
++ "futures-core",
++ "libc",
++ "portable-atomic",
++ "rustc-hash",
++ "tokio",
++ "tokio-stream",
++]
++
+ [[package]]
+ name = "async-broadcast"
+ version = "0.7.2"
+@@ -147,12 +162,6 @@ version = "0.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+ 
+-[[package]]
+-name = "bitflags"
+-version = "1.3.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+-
+ [[package]]
+ name = "bitflags"
+ version = "2.9.0"
+@@ -213,7 +222,7 @@ version = "0.20.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "ae50b5510d86cf96ac2370e66d8dc960882f3df179d6a5a1e52bd94a1416c0f7"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+  "cairo-sys-rs",
+  "glib",
+  "libc",
+@@ -833,7 +842,7 @@ version = "0.20.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+  "futures-channel",
+  "futures-core",
+  "futures-executor",
+@@ -1368,9 +1377,9 @@ version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+  "libc",
+- "redox_syscall 0.5.10",
++ "redox_syscall",
+ ]
+ 
+ [[package]]
+@@ -1488,7 +1497,7 @@ version = "0.29.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+  "cfg-if",
+  "cfg_aliases",
+  "libc",
+@@ -1842,6 +1851,7 @@ version = "2.2.0"
+ dependencies = [
+  "anyhow",
+  "ashpd",
++ "astral-tokio-tar",
+  "futures",
+  "gettext-rs",
+  "gtk4",
+@@ -1860,11 +1870,16 @@ dependencies = [
+  "syslog",
+  "tokio",
+  "tokio-stream",
+- "tokio-tar",
+  "vte",
+  "vte4",
+ ]
+ 
++[[package]]
++name = "portable-atomic"
++version = "1.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
++
+ [[package]]
+ name = "powerfmt"
+ version = "0.2.0"
+@@ -1973,22 +1988,13 @@ dependencies = [
+  "getrandom 0.3.2",
+ ]
+ 
+-[[package]]
+-name = "redox_syscall"
+-version = "0.3.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+-dependencies = [
+- "bitflags 1.3.2",
+-]
+-
+ [[package]]
+ name = "redox_syscall"
+ version = "0.5.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+ ]
+ 
+ [[package]]
+@@ -2026,6 +2032,12 @@ version = "0.1.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+ 
++[[package]]
++name = "rustc-hash"
++version = "2.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
++
+ [[package]]
+ name = "rustc_version"
+ version = "0.4.1"
+@@ -2041,7 +2053,7 @@ version = "1.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+  "errno",
+  "libc",
+  "linux-raw-sys",
+@@ -2434,20 +2446,6 @@ dependencies = [
+  "tokio",
+ ]
+ 
+-[[package]]
+-name = "tokio-tar"
+-version = "0.3.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+-dependencies = [
+- "filetime",
+- "futures-core",
+- "libc",
+- "redox_syscall 0.3.5",
+- "tokio",
+- "tokio-stream",
+-]
+-
+ [[package]]
+ name = "toml"
+ version = "0.8.20"
+@@ -2862,7 +2860,7 @@ version = "0.39.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+ dependencies = [
+- "bitflags 2.9.0",
++ "bitflags",
+ ]
+ 
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index 9a0b95d7..7d818fbf 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -8,6 +8,7 @@ edition = "2024"
+ adw = { version = "0.7", package = "libadwaita", features = ["v1_7"] }
+ anyhow = "1"
+ ashpd = { version = "0.11", default-features = false, features = ["gtk4", "tokio"] }
++astral-tokio-tar = { version = "0.5.6", default-features = false }
+ futures = { version = "0.3", default-features = false }
+ gettext-rs = { version = "=0.7.0", features = ["gettext-system"] }
+ gtk = { version = "0.9", package = "gtk4", features = ["gnome_47"] }
+@@ -25,7 +26,6 @@ sourceview5 = { version = "0.9" }
+ syslog = "7"
+ tokio = "1"
+ tokio-stream = { version = "0.1", default-features = false }
+-tokio-tar = { version = "0.3", default-features = false }
+ vte = { version = "0.15", default-features = false }
+ vte4 = "0.8"
+ 

--- a/pkgs/by-name/po/pods/package.nix
+++ b/pkgs/by-name/po/pods/package.nix
@@ -16,6 +16,7 @@
   libadwaita,
   libpanel,
   vte-gtk4,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -54,6 +55,10 @@ stdenv.mkDerivation rec {
     libpanel
     vte-gtk4
   ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Podman desktop application";

--- a/pkgs/by-name/po/pods/package.nix
+++ b/pkgs/by-name/po/pods/package.nix
@@ -21,18 +21,18 @@
 
 stdenv.mkDerivation rec {
   pname = "pods";
-  version = "2.1.2";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "marhkb";
     repo = "pods";
     tag = "v${version}";
-    hash = "sha256-S84Qb+hySjIxcznuA7Sh8n9XFvdZpf32Yznb1Sj+owY=";
+    hash = "sha256-m+0XjxY0nDAJbVX3r/Jfg+G+RU8Q51e0ZXxkdH69SiQ=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-UBInZdoluWXq1jm2rhS5wBwXQ/zYFPSEeWhpSmkc2aY=";
+    hash = "sha256-ssLiGYBz8fh0oci/pVaeEEIruA691tdEOUyEFssNUXU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/po/pods/package.nix
+++ b/pkgs/by-name/po/pods/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  applyPatches,
+  fetchpatch2,
   cargo,
   desktop-file-utils,
   glib,
@@ -23,16 +25,24 @@ stdenv.mkDerivation rec {
   pname = "pods";
   version = "2.2.0";
 
-  src = fetchFromGitHub {
-    owner = "marhkb";
-    repo = "pods";
-    tag = "v${version}";
-    hash = "sha256-m+0XjxY0nDAJbVX3r/Jfg+G+RU8Q51e0ZXxkdH69SiQ=";
+  src = applyPatches {
+    name = "pods-patched";
+    src = fetchFromGitHub {
+      owner = "marhkb";
+      repo = "pods";
+      tag = "v${version}";
+      hash = "sha256-m+0XjxY0nDAJbVX3r/Jfg+G+RU8Q51e0ZXxkdH69SiQ=";
+    };
+
+    # Based on upstream PR: https://github.com/marhkb/pods/pull/895
+    # which cannot be merged into 2.2.0 because dependencies were bumped since its release.
+    # Hopefully 2.2.1 will be released soon
+    patches = [ ./cve-2025-62516.patch ];
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-ssLiGYBz8fh0oci/pVaeEEIruA691tdEOUyEFssNUXU=";
+    hash = "sha256-GBWaGCNXYCiT/favrIYB30VGMMoQQk1iUh4GTNPerK8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/po/pods/package.nix
+++ b/pkgs/by-name/po/pods/package.nix
@@ -18,6 +18,7 @@
   libadwaita,
   libpanel,
   vte-gtk4,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -65,6 +66,10 @@ stdenv.mkDerivation rec {
     libpanel
     vte-gtk4
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Tracking Issue: https://github.com/NixOS/nixpkgs/issues/455265

Patch has to be vendored, as upstream has since bumped dependencies (not including tokio-tar).
Therefore a separate PR has been submitted upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
