### PR TITLE
nixos/prometheus: tests: Improve Selenium clickthrough test

### DIFF
--- a/nixos/tests/prometheus/ui.nix
+++ b/nixos/tests/prometheus/ui.nix
@@ -7,6 +7,8 @@
     browser =
       { config, pkgs, ... }:
       {
+        virtualisation.memorySize = 1024 * 2;
+
         environment.systemPackages =
           let
             prometheusSeleniumScript =
@@ -18,20 +20,87 @@
                   from selenium import webdriver
                   from selenium.webdriver.common.by import By
                   from selenium.webdriver.firefox.options import Options
+                  from selenium.webdriver.support.relative_locator import locate_with
                   from selenium.webdriver.support.ui import WebDriverWait
 
                   options = Options()
                   options.add_argument("--headless")
-                  service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
+                  service = webdriver.FirefoxService(
+                    executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
 
                   driver = webdriver.Firefox(options=options, service=service)
                   driver.implicitly_wait(10)
-                  driver.get("http://prometheus:9090/")
 
+                  driver.get("http://prometheus:9090/")
                   wait = WebDriverWait(driver, 60)
 
-                  assert len(driver.find_elements(By.CLASS_NAME, "mantine-AppShell-header")) > 0  # noqa: E501
-                  assert len(driver.find_elements(By.CLASS_NAME, "mantine-AppShell-main")) > 0  # noqa: E501
+                  # There should have been a redirect
+                  url = driver.current_url
+                  assert url == "http://prometheus:9090/query"
+
+                  assert len(driver.find_elements(
+                    By.CLASS_NAME, "mantine-AppShell-header")) > 0
+                  assert len(driver.find_elements(
+                    By.CLASS_NAME, "mantine-AppShell-main")) > 0
+
+                  # Do a Prometheus query
+                  query_box = driver.find_element(
+                    By.XPATH, "//div[@role='textbox']")
+                  query_box.click()
+                  query_box.send_keys("up")
+
+                  # Run query with execute button
+                  driver.find_element(
+                    By.XPATH, "//span[contains(text(),'Execute')]").click()
+
+                  # Find query result table
+                  table_tr_elements = driver.find_elements(
+                    By.CLASS_NAME, "mantine-Table-tr")
+                  assert len(table_tr_elements) == 1
+
+                  # Navigate to target health page
+                  driver.find_element(
+                    By.XPATH, "//span[text()='Status']").click()
+
+                  driver.find_element(
+                    By.LINK_TEXT, "Target health").click()
+
+                  url = driver.current_url
+                  assert url == "http://prometheus:9090/targets"
+
+                  # Click on the prometheus job dropdown button
+                  prometheus_job_dropdown = driver.find_element(
+                    By.CLASS_NAME, "mantine-Accordion-chevron").click()
+
+                  targets_healthy = len(driver.find_elements(
+                    By.CSS_SELECTOR, "div[class^='_healthOk']"))
+                  assert targets_healthy == 1
+
+                  targets_errored = len(driver.find_elements(
+                    By.CSS_SELECTOR, "div[class^='_healthErr']"))
+                  assert targets_errored == 0
+
+                  # Go back to homepage
+                  driver.find_element(
+                    By.XPATH, "//span[text()='Query']").click()
+
+                  # Navigate to build info section and verify correct version
+                  # number shown
+                  driver.find_element(
+                    By.XPATH, "//span[text()='Status']").click()
+
+                  driver.find_element(
+                    By.LINK_TEXT, "Runtime & build information").click()
+
+                  url = driver.current_url
+                  assert url == "http://prometheus:9090/status"
+
+                  # Find table
+                  version_th_element = driver.find_element(
+                    By.XPATH, "//th[text()='version']")
+                  version_td_element = driver.find_element(
+                    locate_with(By.TAG_NAME, "td").near(version_th_element))
+                  assert version_td_element.text == "${pkgs.prometheus.version}"
 
                   driver.close()
                 '';
@@ -59,8 +128,7 @@
               static_configs = [
                 {
                   targets = [
-                    "prometheus1:${toString config.services.prometheus.port}"
-                    "prometheus2:${toString config.services.prometheus.port}"
+                    "prometheus:${toString config.services.prometheus.port}"
                   ];
                 }
               ];


### PR DESCRIPTION
Improve the Selenium clickthrough test

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
