### PR TITLE
silverfort-client: init at 3.7.5

### DIFF
--- a/pkgs/by-name/si/silverfort-client/dont-delete-envfile.patch
+++ b/pkgs/by-name/si/silverfort-client/dont-delete-envfile.patch
@@ -1,0 +1,17 @@
+diff --git a/build/electron/main.js b/build/electron/main.js
+index ca36c4b..dbea8c6 100644
+--- a/build/electron/main.js
++++ b/build/electron/main.js
+@@ -324,12 +324,6 @@ const readEnvVars = async () => {
+             disableStartup = envVariables.SF_DISABLE_STARTUP;
+         }
+ 
+-        try {
+-            await fsPromises.unlink(configFileName, { force: true });
+-        } catch (err) {
+-            log.error(`failed to delete env file (${configFileName})`, err.toString());
+-        }
+-
+         log.info(`Env vars loaded from file. (${configFileName}) `);
+ 
+         return { url, id };

--- a/pkgs/by-name/si/silverfort-client/package.nix
+++ b/pkgs/by-name/si/silverfort-client/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenvNoCC,
+  requireFile,
+  copyDesktopItems,
+  makeDesktopItem,
+  wrapGAppsHook3,
+  asar,
+  dpkg,
+  electron,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "silverfort-client";
+  version = "3.7.5";
+
+  src = requireFile rec {
+    name = "${finalAttrs.pname}_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-eOkSVoucMiGH4sTnC8/3sWMyT9DpnGEYXX+1y2ULDBg=";
+    message = ''
+      Due to the commercial license of Silverfort, Nix is unable to download
+      Silverfort automatically. Please download ${name} manually and add it
+      to the Nix store using \`nix-prefetch-url file:///\$PWD/${name}\`.
+      It is recommended to add this file to the garbage collector root
+      to prevent grabage collection.
+    '';
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    asar
+    copyDesktopItems
+    dpkg
+    wrapGAppsHook3
+  ];
+
+  # Prevent double wrapping
+  dontWrapGApps = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "silverfort-client";
+      desktopName = "Silverfort Client";
+      genericName = "Multi-factor authentication client";
+      comment = "Silverfort Desktop Messaging Client";
+      icon = "silverfort-client";
+      exec = "silverfort-client";
+      categories = [
+        "Utility"
+        "Security"
+      ];
+      keywords = [
+        "2fa"
+        "authentication"
+        "factor"
+        "mfa"
+        "multi"
+      ];
+      startupWMClass = "Silverfort Client";
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    asar extract "opt/Silverfort Client/resources/app.asar" $TMP/work
+
+    # Remove unneeded files
+    rm $TMP/work/build/{"public assests.zip",robots.txt}
+
+    # Install icons
+    install -Dm444 $TMP/work/build/logo192.png $out/share/icons/hicolor/192x192/apps/silverfort-client.png
+    install -Dm444 $TMP/work/build/favicon.ico $out/share/icons/hicolor/256x256/apps/silverfort-client.png
+    install -Dm444 $TMP/work/build/logo512.png $out/share/icons/hicolor/512x512/apps/silverfort-client.png
+
+    # By default, Silverfort will delete the envfile after it has been read one time.
+    # This file is located at "~/.config/Silverfort Client/config.env" and can be configured
+    # to store environment variables in JSON format.
+    # For example: `{"SF_MESSAGING_URL":"https://example-sdms-server.net"}`
+    patch -d $TMP/work -p1 < ${./dont-delete-envfile.patch}
+
+    asar pack $TMP/work $out/share/silverfort-client/resources/app.asar
+
+    rm -rf $TMP/work
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeBinaryWrapper "${lib.getExe electron}" $out/bin/silverfort-client \
+      --add-flags "$out/share/silverfort-client/resources/app.asar" \
+      --set-default ELECTRON_IS_DEV 0 \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = {
+    description = "Silverfort multi-factor authentication client";
+    homepage = "https://www.silverfort.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "silverfort-client";
+  };
+})


### PR DESCRIPTION
Add Silverfort Client, a program for multi-factor authentication.

Due to the commercial license, I had to use requireFile to package this unfortunately. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
