### PR TITLE
 buildPython*: unconditionally add .override 

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -39,7 +39,7 @@ let
       else
         result
     )
-    // lib.optionalAttrs (f ? override) {
+    // {
       # Support overriding `f` itself, e.g. `buildPythonPackage.override { }`.
       # Ensure `makeOverridablePythonPackage` is applied to the result.
       override = lib.mirrorFunctionArgs f.override (fdrv: makeOverridablePythonPackage (f.override fdrv));


### PR DESCRIPTION
Preserve laziness of `buildPython*` build-helper functions, by adding `override` unconditionally instead of via `optionalAttrs (f ? override)`.

Checking if `f` contains `override` causes it to be strictly evaluated. The check is also uneccessary because we know `makeOverridablePythonPackage` is always supplied a `callPackage`-result (either `callPackage ./mk-python-derivation.nix { }` or the python2 equivalent), so `override` should always be present in `f`.

This should resolve issues like `pkgsCross.ghcjs.buildPackages.nixpkgs-openjdk-updater` on staging right now (ff5098e3056110b7d40e49151248f90e43a6c7e1).

<details><summary>Original description</summary>
<p>


This change fixes two kinds of issues:

1. Fixes evaluation if `result` is neither a function nor an attribute set (which the code at least allowed before #366593).
2. Fix evaluation of buildPython* based packages in certain splicing situations by being lazier. An example of this is pkgsCross.ghcjs.buildPackages.nixpkgs-openjdk-updater on staging right now (ff5098e3056110b7d40e49151248f90e43a6c7e1). Apparently, a change that is not part of master, caused this to manifest on staging.

   By moving the addition of the set with .override inwards, we are able generating the outer __spliced set without forcing result, so we can actually access splices that don't throw.


</p>
</details> 

cc @wolfgangwalther @alexfmpe