### PR TITLE
xdg-desktop-portal-phosh: drop incorrect `updateScript`

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-phosh/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-phosh/package.nix
@@ -72,10 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     ./cargo_lock_deps_version.patch
   ];
 
-  passthru = {
-    updateScript = lib.updateScript { };
-  };
-
   meta = with lib; {
     description = "A backend implementation for xdg-desktop-portal that is using GTK/GNOME/Phosh to provide interfaces that aren't provided by the GTK portal";
     homepage = "https://gitlab.gnome.org/guidog/xdg-desktop-portal-phosh";


### PR DESCRIPTION
The update script fails to eval:

    $ nix-shell maintainers/scripts/update.nix --argstr package xdg-desktop-portal-phosh
    error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixpkgs-update-script'
         whose name attribute is located at pkgs/stdenv/generic/make-derivation.nix:544:13

       … while evaluating attribute 'shellHook' of derivation 'nixpkgs-update-script'
         at maintainers/scripts/update.nix:275:3:
          274|   '';
          275|   shellHook = ''
             |   ^
          276|     unset shellHook # do not contaminate nested shells

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'updateScript' missing
       at pkgs/by-name/xd/xdg-desktop-portal-phosh/package.nix:76:20:
           75|   passthru = {
           76|     updateScript = lib.updateScript { };
             |                    ^
           77|   };


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
