### PR TITLE
qgnomeplatform: fix build with qt 6.10

### DIFF
--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
     # Backport cursor fix for Qt6 apps
     # Adjusted from https://github.com/FedoraQt/QGnomePlatform/pull/138
     ./qt6-cursor-fix.patch
+
+    # fixing build with Qt>=6.10
+    ./qt6_10.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/qgnomeplatform/qt6_10.patch
+++ b/pkgs/development/libraries/qgnomeplatform/qt6_10.patch
@@ -1,0 +1,140 @@
+diff --git a/src/common/CMakeLists.txt b/src/common/CMakeLists.txt
+index e6dcf06..287824c 100644
+--- a/src/common/CMakeLists.txt
++++ b/src/common/CMakeLists.txt
+@@ -3,6 +3,10 @@ set(common_SRCS
+     gnomesettings.cpp
+ )
+ 
++if(QT_VERSION_MAJOR EQUAL 6)
++    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
++endif()
++
+ add_library(qgnomeplatform${LIBQGNOMEPLATFORM_SUFFIX} SHARED ${common_SRCS})
+ target_link_libraries(qgnomeplatform${LIBQGNOMEPLATFORM_SUFFIX}
+     Qt${QT_VERSION_MAJOR}::Core
+diff --git a/src/decoration/CMakeLists.txt b/src/decoration/CMakeLists.txt
+index a6fb227..7b6647c 100644
+--- a/src/decoration/CMakeLists.txt
++++ b/src/decoration/CMakeLists.txt
+@@ -8,6 +8,11 @@ set(decoration_SRCS
+     qgnomeplatformdecoration.cpp
+ )
+ 
++if(QT_VERSION_MAJOR EQUAL 6)
++    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
++    find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
++endif()
++
+ add_library(qgnomeplatformdecoration MODULE ${decoration_SRCS})
+ target_link_libraries(qgnomeplatformdecoration
+     qgnomeplatform${LIBQGNOMEPLATFORM_SUFFIX}
+diff --git a/src/decoration/qgnomeplatformdecoration.cpp b/src/decoration/qgnomeplatformdecoration.cpp
+index a719cb3..79c0be0 100644
+--- a/src/decoration/qgnomeplatformdecoration.cpp
++++ b/src/decoration/qgnomeplatformdecoration.cpp
+@@ -616,8 +616,12 @@ void QGnomePlatformDecoration::processMouseTop(QWaylandInputDevice *inputDevice,
+         if (local.x() <= margins().left()) {
+             //top left bit
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++            waylandWindow()->applyCursor(inputDevice, Qt::SizeFDiagCursor);
++#else
+             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeFDiagCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+             startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_TOP_LEFT, b);
+ #else
+@@ -626,8 +630,12 @@ void QGnomePlatformDecoration::processMouseTop(QWaylandInputDevice *inputDevice,
+         } else if (local.x() > window()->width() + margins().left()) {
+             //top right bit
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++            waylandWindow()->applyCursor(inputDevice, Qt::SizeBDiagCursor);
++#else
+             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeBDiagCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+             startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_TOP_RIGHT, b);
+ #else
+@@ -636,8 +644,12 @@ void QGnomePlatformDecoration::processMouseTop(QWaylandInputDevice *inputDevice,
+         } else {
+             //top resize bit
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++            waylandWindow()->applyCursor(inputDevice, Qt::SplitVCursor);
++#else
+             waylandWindow()->setMouseCursor(inputDevice, Qt::SplitVCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+             startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_TOP, b);
+ #else
+@@ -682,8 +694,12 @@ void QGnomePlatformDecoration::processMouseBottom(QWaylandInputDevice *inputDevi
+     if (local.x() <= margins().left()) {
+         //bottom left bit
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++        waylandWindow()->applyCursor(inputDevice, Qt::SizeBDiagCursor);
++#else
+         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeBDiagCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+         startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_BOTTOM_LEFT, b);
+ #else
+@@ -692,8 +708,12 @@ void QGnomePlatformDecoration::processMouseBottom(QWaylandInputDevice *inputDevi
+     } else if (local.x() > window()->width() + margins().right()) {
+         //bottom right bit
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++        waylandWindow()->applyCursor(inputDevice, Qt::SizeFDiagCursor);
++#else
+         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeFDiagCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+         startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_BOTTOM_RIGHT, b);
+ #else
+@@ -702,8 +722,12 @@ void QGnomePlatformDecoration::processMouseBottom(QWaylandInputDevice *inputDevi
+     } else {
+         //bottom bit
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++        waylandWindow()->applyCursor(inputDevice, Qt::SplitVCursor);
++#else
+         waylandWindow()->setMouseCursor(inputDevice, Qt::SplitVCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+         startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_BOTTOM, b);
+ #else
+@@ -717,8 +741,12 @@ void QGnomePlatformDecoration::processMouseLeft(QWaylandInputDevice *inputDevice
+     Q_UNUSED(local)
+     Q_UNUSED(mods)
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++    waylandWindow()->applyCursor(inputDevice, Qt::SplitHCursor);
++#else
+     waylandWindow()->setMouseCursor(inputDevice, Qt::SplitHCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+         startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_LEFT, b);
+ #else
+@@ -731,8 +759,12 @@ void QGnomePlatformDecoration::processMouseRight(QWaylandInputDevice *inputDevic
+     Q_UNUSED(local)
+     Q_UNUSED(mods)
+ #if QT_CONFIG(cursor)
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++    waylandWindow()->applyCursor(inputDevice, Qt::SplitHCursor);
++#else
+     waylandWindow()->setMouseCursor(inputDevice, Qt::SplitHCursor);
+ #endif
++#endif
+ #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
+         startResize(inputDevice, WL_SHELL_SURFACE_RESIZE_RIGHT, b);
+ #else
+


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/454910

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
