### PR TITLE
honeycomb-refinery: fix redis test timeout

### DIFF
--- a/pkgs/by-name/ho/honeycomb-refinery/0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
+++ b/pkgs/by-name/ho/honeycomb-refinery/0001-add-NO_REDIS_TEST-env-var-that-disables-Redis-requir.patch
@@ -1,11 +1,12 @@
-From f2d2d869a4aa58430415d0969f5e80ece0142ad2 Mon Sep 17 00:00:00 2001
+From ce22aed5afa89c9b591d865bdfcc84a739929a01 Mon Sep 17 00:00:00 2001
 From: jkachmar <j@mercury.com>
-Date: Thu, 23 Oct 2025 17:36:48 -0400
+Date: Fri, 24 Oct 2025 17:56:22 -0400
 Subject: [PATCH] disable tests that require redis
 
 ---
  internal/peer/peers_test.go | 4 ++++
- 1 file changed, 4 insertions(+), 0 deletions(-)
+ pubsub/pubsub_test.go       | 1 -
+ 2 files changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/internal/peer/peers_test.go b/internal/peer/peers_test.go
 index dae54067d8..b33ebc4979 100644
@@ -22,3 +23,15 @@ index dae54067d8..b33ebc4979 100644
  	c := &config.MockConfig{
  		GetPeerListenAddrVal: "0.0.0.0:8081",
  		PeerManagementType:   "redis",
+diff --git a/pubsub/pubsub_test.go b/pubsub/pubsub_test.go
+index 4ad630ff96..dff6981926 100644
+--- a/pubsub/pubsub_test.go
++++ b/pubsub/pubsub_test.go
+@@ -17,7 +17,6 @@
+ )
+ 
+ var types = []string{
+-	"goredis",
+ 	"local",
+ }
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

https://github.com/NixOS/nixpkgs/pull/455258 passed tests on macOS but failed on Linux; looks like the issue is that Linux tests against the Redis backend for their pubsub impl and that will just straight-up timeout.

updated the patch to skip testing the `goredis` pubsub backend & only test the local one; verified that this successfully builds on `x86_64-linux` as well as `aarch64-darwin`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
