### PR TITLE
python3Packages.gmpy2: handle Python 3.13.8's new to_bytes behavior

### DIFF
--- a/pkgs/development/python-modules/gmpy2/default.nix
+++ b/pkgs/development/python-modules/gmpy2/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   isPyPy,
   setuptools,
   gmp,
@@ -29,6 +30,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-wrMN3kqLnjItoybKYeo4Pp2M0uma7Kg0JEQM8lr6OI0=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "fix-to_bytes-tests.patch";
+      url = "https://github.com/aleaxit/gmpy/commit/1903841667e7a6842bdead90bd7798b99de5b7be.patch?full_index=1";
+      hash = "sha256-rlssUIkQ1RCRSu5eCXKJ2lNa/oIoLzf9sxJuNfDrVmk=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
From https://docs.python.org/release/3.13.8/whatsnew/changelog.html#python-3-13-8:

[gh-71810](https://github.com/python/cpython/issues/71810): Raise [OverflowError](https://docs.python.org/release/3.13.8/library/exceptions.html#OverflowError) for (-1).to_bytes() for signed conversions when bytes count is zero. Patch by Sergey B Kirpichev.]

This breaks gmpy2 (https://cache.nixos.org/log/05yhrd3hw62yyanvqqs24n4kbsy7qn15-python3.13-gmpy2-2.2.1.drv), so I imported a patch from https://github.com/aleaxit/gmpy/pull/593 to fix it.

Fixes #455853. Fixes #456220.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
