### PR TITLE
sampo: init at 0.12.0

### DIFF
--- a/pkgs/by-name/sa/sampo/package.nix
+++ b/pkgs/by-name/sa/sampo/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  pkg-config,
+  openssl,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sampo";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "bruits";
+    repo = "sampo";
+    tag = "sampo-v${finalAttrs.version}";
+    hash = "sha256-0E9dvyu6mGbuMH8Lf/rVTn3skVq9kaVjQG2eLH8a2IY=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  cargoHash = "sha256-gooShQWJY9UKYq99o7qhyz6ROK+VXYG2PpygdVWG0iM=";
+
+  cargoBuildFlags = [
+    "-p"
+    "sampo"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Automate changelogs, versioning, and publishing—even for monorepos across multiple package registries";
+    homepage = "https://github.com/bruits/sampo";
+    changelog = "https://github.com/bruits/sampo/blob/sampo-v${finalAttrs.version}/crates/sampo/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "sampo";
+  };
+})


### PR DESCRIPTION
[Sampo](https://github.com/bruits/sampo) - automate changelogs, versioning, and publishing—even for monorepos across multiple package registries. Currently supported ecosystems: Rust ([Crates](https://crates.io/)), JavaScript/TypeScript ([npm](https://www.npmjs.com/)), Elixir ([Hex](https://hex.pm/))... And more

CLI for managing changesets, versioning, and publishing

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
