### PR TITLE
t4kcommon: fix build with cmake4

### DIFF
--- a/pkgs/by-name/t4/t4kcommon/linebreak-fix.patch
+++ b/pkgs/by-name/t4/t4kcommon/linebreak-fix.patch
@@ -1,0 +1,17 @@
+--- a/src/linebreak/CMakeLists.txt
++++ b/src/linebreak/CMakeLists.txt
+@@ -72,12 +72,12 @@
+   ${LINEBREAK_BINARY_DIR} 
+   ${LINEBREAK_SOURCE_DIR} 
+   ${CMAKE_CURRENT_BINARY_DIR})
+-  
++add_library(linebreak STATIC ${LINEBREAK_SOURCES} ${LINEBREAK_HEADERS})
+ if (ICONV_FOUND)
+   include_directories(${ICONV_INCLUDE_DIR})
+   target_link_libraries(linebreak ${ICONV_LIBRARY})
+ endif (ICONV_FOUND)
+-add_library(linebreak STATIC ${LINEBREAK_SOURCES} ${LINEBREAK_HEADERS})
++
+ 
+ #project_source_group("${GROUP_CODE}" LINEBREAK_SOURCES LINEBREAK_HEADERS)
+ 

--- a/pkgs/by-name/t4/t4kcommon/package.nix
+++ b/pkgs/by-name/t4/t4kcommon/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/tux4kids-pkg-team/t4kcommon/raw/f7073fa384f5a725139f54844e59b57338b69dc7/debian/patches/libpng16.patch";
       hash = "sha256-auQ8VvOyvLE1PD2dfeHZJV+MzIt1OtUa7OcOqsXTAYI=";
     })
+    # Fix "Cannot specify link libraries for target "linebreak" which is not built by this project."
+    ./linebreak-fix.patch
   ];
 
   # Workaround build failure on -fno-common toolchains like upstream
@@ -54,6 +56,11 @@ stdenv.mkDerivation rec {
     librsvg
     libxml2
   ];
+
+  postPatch = ''
+    substituteInPlace {src/,./}CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required(VERSION 3.10)"
+  '';
 
   meta = with lib; {
     description = "Library of code shared between tuxmath and tuxtype";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

This derivation builds successfully on x86_64-linux. I also verified the success by testing the build dependency against tuxtype, which also works as expected.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
