### PR TITLE
home-assistant: support cync component

### DIFF
--- a/pkgs/development/python-modules/pycync/default.nix
+++ b/pkgs/development/python-modules/pycync/default.nix
@@ -1,0 +1,49 @@
+{
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  lib,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pycync";
+  version = "0.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Kinachi249";
+    repo = "pycync";
+    tag = "v${version}";
+    hash = "sha256-PDCS+ucfO5RRvTshGGjxir3ez7L405k5tL5svMxZMsg=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiohttp
+  ];
+
+  pythonImportsCheck = [ "pycync" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    cd tests
+  '';
+
+  meta = {
+    changelog = "https://github.com/Kinachi249/pycync/releases/tag/${src.tag}";
+    description = "Python API library for Cync smart devices";
+    homepage = "https://github.com/Kinachi249/pycync";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1057,7 +1057,8 @@
       ];
     "cync" =
       ps: with ps; [
-      ]; # missing inputs: pycync
+        pycync
+      ];
     "dacia" =
       ps: with ps; [
       ];
@@ -7138,6 +7139,7 @@
     "cpuspeed"
     "crownstone"
     "cups"
+    "cync"
     "daikin"
     "datadog"
     "date"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12828,6 +12828,8 @@ self: super: with self; {
 
   pycycling = callPackage ../development/python-modules/pycycling { };
 
+  pycync = callPackage ../development/python-modules/pycync { };
+
   pycyphal = callPackage ../development/python-modules/pycyphal { };
 
   pydaikin = callPackage ../development/python-modules/pydaikin { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
