### PR TITLE
home-assistant: support droplet component

### DIFF
--- a/pkgs/development/python-modules/pydroplet/default.nix
+++ b/pkgs/development/python-modules/pydroplet/default.nix
@@ -1,0 +1,43 @@
+{
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytest-asyncio,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pydroplet";
+  version = "2.3.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Hydrific";
+    repo = "pydroplet";
+    tag = "v${version}";
+    hash = "sha256-cVftXG7sKDpGRRb2jLlFxgCH2+rA6hLYTUqWL1kvh+E=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+  ];
+
+  pythonImportsCheck = [ "pydroplet" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/Hydrific/pydroplet/releases/tag/${src.tag}";
+    description = "Package to connect to a Droplet device";
+    homepage = "https://github.com/Hydrific/pydroplet";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1329,7 +1329,8 @@
       ];
     "droplet" =
       ps: with ps; [
-      ]; # missing inputs: pydroplet
+        pydroplet
+      ];
     "dsmr" =
       ps: with ps; [
         dsmr-parser
@@ -7174,6 +7175,7 @@
     "downloader"
     "dremel_3d_printer"
     "drop_connect"
+    "droplet"
     "dsmr"
     "dsmr_reader"
     "duckdns"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12922,6 +12922,8 @@ self: super: with self; {
 
   pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam { };
 
+  pydroplet = callPackage ../development/python-modules/pydroplet { };
+
   pydruid = callPackage ../development/python-modules/pydruid { };
 
   pydsdl = callPackage ../development/python-modules/pydsdl { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
