### PR TITLE
nixos/wireguard-networkd: fix `fwMark` type error

### DIFF
--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -29,6 +29,13 @@ let
 
   escapeCredentialName = input: replaceStrings [ "\\" ] [ "_" ] input;
 
+  fwMarkFromHexOrNum =
+    fwMark:
+    if (lib.hasPrefix "0x" fwMark) then
+      lib.fromHexString fwMark
+    else
+      (builtins.fromTOML "v=${fwMark}").v;
+
   privateKeyCredential = interfaceName: escapeCredentialName "wireguard-${interfaceName}-private-key";
   presharedKeyCredential =
     interfaceName: peer: escapeCredentialName "wireguard-${interfaceName}-${peer.name}-preshared-key";
@@ -52,7 +59,7 @@ let
       wireguardConfig = removeNulls {
         PrivateKey = "@${privateKeyCredential name}";
         ListenPort = interface.listenPort;
-        FirewallMark = interface.fwMark;
+        FirewallMark = if interface.fwMark == null then null else (fwMarkFromHexOrNum interface.fwMark);
         RouteTable = if interface.allowedIPsAsRoutes then interface.table else null;
         RouteMetric = interface.metric;
       };

--- a/nixos/tests/wireguard/networkd.nix
+++ b/nixos/tests/wireguard/networkd.nix
@@ -27,6 +27,7 @@ in
               "fc00::1/128"
             ];
             listenPort = 23542;
+            fwMark = "0x6e6978";
 
             # !!! Don't do this with real keys. The /nix store is world-readable!
             privateKeyFile = toString (pkgs.writeText "privateKey" wg-snakeoil-keys.peer0.privateKey);
@@ -60,6 +61,7 @@ in
               "fc00::2/128"
             ];
             listenPort = 23542;
+            fwMark = "30567";
 
             # !!! Don't do this with real keys. The /nix store is world-readable!
             privateKeyFile = toString (pkgs.writeText "privateKey" wg-snakeoil-keys.peer1.privateKey);
@@ -97,5 +99,9 @@ in
     with subtest("Has PSK set"):
       peer0.succeed("wg | grep 'preshared key'")
       peer1.succeed("wg | grep 'preshared key'")
+
+    with subtest("Has FwMark set"):
+      peer0.succeed("wg | grep '0x6e6978'")
+      peer1.succeed("wg | grep '0x7767'")
   '';
 }


### PR DESCRIPTION
Fixes #454334

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

ping @Majiir

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
