### PR TITLE
tests.overriding: buildPythonPackage: test `stdenv` customisation via `buildPythonPackage.override`

### DIFF
--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -402,6 +402,23 @@ let
           src = emptyDirectory;
         }
       ) { };
+
+      package-stub-gcc = package-stub.override (previousArgs: {
+        buildPythonPackage = previousArgs.buildPythonPackage.override {
+          stdenv = pkgs.gccStdenv;
+        };
+      });
+      package-stub-clang = package-stub-gcc.override (previousArgs: {
+        buildPythonPackage = previousArgs.buildPythonPackage.override {
+          stdenv = pkgs.clangStdenv;
+        };
+      });
+      package-stub-libcxx = package-stub-clang.override (previousArgs: {
+        buildPythonPackage = previousArgs.buildPythonPackage.override {
+          stdenv = pkgs.libcxxStdenv;
+        };
+      });
+
       applyOverridePythonAttrs =
         p:
         p.overridePythonAttrs (previousAttrs: {
@@ -417,6 +434,19 @@ let
         );
     in
     {
+      buildPythonPackage-override-gccStdenv = {
+        expr = package-stub-gcc.stdenv;
+        expected = pkgs.gccStdenv;
+      };
+      buildPythonPackage-override-clangStdenv = {
+        expr = package-stub-clang.stdenv;
+        expected = pkgs.clangStdenv;
+      };
+      buildPythonPackage-override-libcxxStdenv = {
+        expr = package-stub-libcxx.stdenv;
+        expected = pkgs.libcxxStdenv;
+      };
+
       overridePythonAttrs = {
         expr = (applyOverridePythonAttrs package-stub).overridePythonAttrsFlag;
         expected = 1;

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -390,7 +390,7 @@ let
 
   tests-python =
     let
-      python-package-stub = pkgs.python3Packages.callPackage (
+      package-stub = pkgs.python3Packages.callPackage (
         {
           buildPythonPackage,
           emptyDirectory,
@@ -418,17 +418,17 @@ let
     in
     {
       overridePythonAttrs = {
-        expr = (applyOverridePythonAttrs python-package-stub).overridePythonAttrsFlag;
+        expr = (applyOverridePythonAttrs package-stub).overridePythonAttrsFlag;
         expected = 1;
       };
       overridePythonAttrs-nested = {
         expr =
-          (applyOverridePythonAttrs (applyOverridePythonAttrs python-package-stub)).overridePythonAttrsFlag;
+          (applyOverridePythonAttrs (applyOverridePythonAttrs package-stub)).overridePythonAttrsFlag;
         expected = 2;
       };
       overrideAttrs-overridePythonAttrs-test-overrideAttrs = {
         expr = {
-          inherit (applyOverridePythonAttrs (overrideAttrsFooBar python-package-stub))
+          inherit (applyOverridePythonAttrs (overrideAttrsFooBar package-stub))
             FOO
             BAR
             ;
@@ -440,15 +440,15 @@ let
       };
       overrideAttrs-overridePythonAttrs-test-overridePythonAttrs = {
         expr =
-          (applyOverridePythonAttrs (overrideAttrsFooBar python-package-stub)) ? overridePythonAttrsFlag;
+          (applyOverridePythonAttrs (overrideAttrsFooBar package-stub)) ? overridePythonAttrsFlag;
         expected = true;
       };
       overrideAttrs-overridePythonAttrs-test-commutation = {
-        expr = overrideAttrsFooBar (applyOverridePythonAttrs python-package-stub);
-        expected = applyOverridePythonAttrs (overrideAttrsFooBar python-package-stub);
+        expr = overrideAttrsFooBar (applyOverridePythonAttrs package-stub);
+        expected = applyOverridePythonAttrs (overrideAttrsFooBar package-stub);
       };
       chain-of-overrides = rec {
-        expr = lib.pipe python-package-stub [
+        expr = lib.pipe package-stub [
           (p: p.overrideAttrs { inherit (expected) a; })
           (p: p.overridePythonAttrs { inherit (expected) b; })
           (p: p.overrideAttrs { inherit (expected) c; })

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -446,14 +446,20 @@ let
         expr = package-stub-libcxx.stdenv;
         expected = pkgs.libcxxStdenv;
       };
+      overridePythonAttrs-stdenv-deprecated = {
+        expr =
+          (package-stub.overridePythonAttrs (_: {
+            stdenv = pkgs.clangStdenv;
+          })).stdenv;
+        expected = pkgs.clangStdenv;
+      };
 
       overridePythonAttrs = {
         expr = (applyOverridePythonAttrs package-stub).overridePythonAttrsFlag;
         expected = 1;
       };
       overridePythonAttrs-nested = {
-        expr =
-          (applyOverridePythonAttrs (applyOverridePythonAttrs package-stub)).overridePythonAttrsFlag;
+        expr = (applyOverridePythonAttrs (applyOverridePythonAttrs package-stub)).overridePythonAttrsFlag;
         expected = 2;
       };
       overrideAttrs-overridePythonAttrs-test-overrideAttrs = {
@@ -469,8 +475,7 @@ let
         };
       };
       overrideAttrs-overridePythonAttrs-test-overridePythonAttrs = {
-        expr =
-          (applyOverridePythonAttrs (overrideAttrsFooBar package-stub)) ? overridePythonAttrsFlag;
+        expr = (applyOverridePythonAttrs (overrideAttrsFooBar package-stub)) ? overridePythonAttrsFlag;
         expected = true;
       };
       overrideAttrs-overridePythonAttrs-test-commutation = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds overriding tests for PR #271762
* #271762

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
