### PR TITLE
postgres-lsp: 0.15.0 -> 0.16.1

### DIFF
--- a/pkgs/by-name/po/postgres-language-server/package.nix
+++ b/pkgs/by-name/po/postgres-language-server/package.nix
@@ -7,7 +7,7 @@
   nodejs,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "postgres-lsp";
+  pname = "postgres-language-server";
   version = "0.16.1";
 
   src = fetchgit {

--- a/pkgs/by-name/po/postgres-lsp/package.nix
+++ b/pkgs/by-name/po/postgres-lsp/package.nix
@@ -3,22 +3,29 @@
   rustPlatform,
   fetchgit,
   rust-jemalloc-sys,
+  tree-sitter,
+  nodejs,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "postgres-lsp";
-  version = "0.15.0";
+  version = "0.16.1";
 
   src = fetchgit {
     url = "https://github.com/supabase-community/postgres-language-server";
     tag = finalAttrs.version;
-    hash = "sha256-ZintjrSeNsYR6A8tlEfSetse7d79jgLdCpdu+sMe3Zk=";
+    hash = "sha256-zdFgfZ9GtZObn839kkAIT71bBt7YHs28qkAWlp3k7kw=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-x/Wbx3noH6YOQIis1sN8ylQApjhSy4/mrxX6jvZFs6A=";
+  cargoHash = "sha256-psgo5/tDHaQd0dkiD/3uhrKuxlOBLi/xG4x3gVPLZbw=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
+
+    # Required to build the custom tree-sitter grammar
+    # https://github.com/supabase-community/postgres-language-server/blob/main/crates/pgt_treesitter_grammar/grammar.js
+    tree-sitter
+    nodejs
   ];
 
   buildInputs = [
@@ -44,12 +51,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Tools and language server for Postgres";
-    homepage = "https://pgtools.dev";
+    homepage = "https://pg-language-server.com";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       figsoda
       myypo
     ];
-    mainProgram = "postgrestools";
+    mainProgram = "postgres-language-server";
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1214,6 +1214,7 @@ mapAliases {
   posterazor = throw "posterazor was removed due to numerous vulnerabilities in freeimage"; # Added 2025-10-23
   postfixadmin = throw "'postfixadmin' has been removed due to lack of maintenance and missing support for PHP >8.1"; # Added 2025-10-03
   postgis = throw "'postgis' has been removed. Use 'postgresqlPackages.postgis' instead."; # Added 2025-07-19
+  postgres-lsp = lib.warnOnInstantiate "'postgres-lsp' has been renamed to 'postgres-language-server'" postgres-language-server; # Added 2025-10-28
   postgresql13JitPackages = throw "'postgresql13JitPackages' has been renamed to/replaced by 'postgresql13Packages'"; # Converted to throw 2025-10-27
   postgresql14JitPackages = throw "'postgresql14JitPackages' has been renamed to/replaced by 'postgresql14Packages'"; # Converted to throw 2025-10-27
   postgresql15JitPackages = throw "'postgresql15JitPackages' has been renamed to/replaced by 'postgresql15Packages'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
The upstream is deprecating `pgtools` binary and and moving on to `postgres-language-server`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
