### PR TITLE
kide: init at 1.0.40

### DIFF
--- a/pkgs/by-name/ki/kide/package.nix
+++ b/pkgs/by-name/ki/kide/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  cargo-tauri,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  wrapGAppsHook4,
+  openssl,
+  webkitgtk_4_1,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kide";
+  version = "1.0.40";
+
+  src = fetchFromGitHub {
+    owner = "openobserve";
+    repo = "kide";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lRkFPS+hkACj3CxWde4B7phHUMh+2643Jgd0Wt3nUSo=";
+  };
+
+  cargoHash = "sha256-/PdUaSW7YMFDgMFqA+7ePNPraPhMSNqFaONIEFubtNc=";
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-1BY2oEnpldl+m8hUg9bszAyR67M8ErbcNaNE676c9hU=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    webkitgtk_4_1
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast and lightweight Kubernetes IDE";
+    homepage = "https://github.com/openobserve/kide";
+    changelog = "https://github.com/openobserve/kide/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    inherit (cargo-tauri.hook.meta) platforms;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "kide";
+  };
+})


### PR DESCRIPTION
[Kide](https://github.com/openobserve/kide) - fast and lightweight Kubernetes IDE

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
