### PR TITLE
[release-25.05] zed-editor: fix CVE-2025-62518

### DIFF
--- a/pkgs/by-name/ze/zed-editor/0003-cve-2025-62518.patch
+++ b/pkgs/by-name/ze/zed-editor/0003-cve-2025-62518.patch
@@ -1,0 +1,29 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index bb1e8d9516..92fd68cbbc 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1021,9 +1021,9 @@ dependencies = [
+
+ [[package]]
+ name = "async-tar"
+-version = "0.5.0"
++version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
++checksum = "d1937db2d56578aa3919b9bdb0e5100693fd7d1c0f145c53eb81fbb03e217550"
+ dependencies = [
+  "async-std",
+  "filetime",
+diff --git a/Cargo.toml b/Cargo.toml
+index 9152dfd23c..5687b08b65 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -398,7 +398,7 @@ async-dispatcher = "0.1"
+ async-fs = "2.1"
+ async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
+ async-recursion = "1.0.0"
+-async-tar = "0.5.0"
++async-tar = "0.5.1"
+ async-trait = "0.1"
+ async-tungstenite = "0.29.1"
+ async-watch = "0.3.1

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -124,6 +124,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoPatches = [
     ./0002-fix-duplicate-reqwest.patch
+    # Upstream commit doesn't apply cleanly to 0.189.5 and we can't upgrade to newer
+    # releases on 25.05 as they require a newer version of the Rust compiler.
+    # https://github.com/zed-industries/zed/commit/4a93719b6b5666fd04cbe63fd90aba28c3547f0d
+    ./0003-cve-2025-62518.patch
   ];
 
   postPatch =
@@ -138,7 +142,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         --replace-fail "inner.redirect(policy)" "inner.redirect_policy(policy)"
     '';
 
-  cargoHash = "sha256-YhdwCNTbBphWugguoWQqrGf2fRB5Jv40MElW6hbcxtk=";
+  cargoHash = "sha256-86Y2fyeiCYPWdg2ygt7RbUFrHVIc53yDeqvT7Unmndo=";
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tracking issue: #455265 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
