### PR TITLE
ducker: init at 0.5.4

### DIFF
--- a/pkgs/by-name/du/ducker/package.nix
+++ b/pkgs/by-name/du/ducker/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "ducker";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "robertpsoane";
+    repo = "ducker";
+    tag = "v${version}";
+    sha256 = "sha256-I2lAJY+lB7COwo1Sk70/CUl6xfAGGy7qEl4U69Tx4wI";
+  };
+
+  cargoHash = "sha256-lvIKIkPIFz3RKyoEFCCH9u5yBSC8Q1QocfGfQvqBUYI=";
+
+  meta = {
+    description = "Terminal app for managing docker containers, inspired by K9s";
+    homepage = "https://github.com/robertpsoane/ducker";
+    changelog = "https://github.com/robertpsoane/ducker/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "ducker";
+    platforms = with lib.platforms; unix ++ windows;
+    maintainers = with lib.maintainers; [ anas ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added package for Ducker: A terminal app for managing docker containers, inspired by [K9s](https://k9scli.io/)
Homepage: https://github.com/robertpsoane/ducker

This PR rebases and updates the package to the newer upstream release and fixes the build for the new version.

Supersedes NixOS/nixpkgs#323004 (original PR by @0x61nas).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
