### PR TITLE
pdfsam-basic: fix

### DIFF
--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -3,63 +3,95 @@
   stdenv,
   makeDesktopItem,
   fetchurl,
-  jdk21,
+  temurin-jre-bin-21,
+  javaPackages,
   wrapGAppsHook3,
-  glib,
+  dpkg,
+  xorg,
+  gtk3,
+  libGL,
+  alsa-lib,
   nix-update-script,
+  desktop-file-utils,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pdfsam-basic";
-  version = "5.3.2";
+  version = "5.4.1";
 
   src = fetchurl {
-    url = "https://github.com/torakiki/pdfsam/releases/download/v${version}/pdfsam-basic_${version}-1_amd64.deb";
-    hash = "sha256-Y0Q9uT6cyxIYTX0JxoS0r3TamPT1iLXr94Zex30AeWo=";
+    url = "https://github.com/torakiki/pdfsam/releases/download/v${finalAttrs.version}/pdfsam-basic_${finalAttrs.version}-1_amd64.deb";
+    hash = "sha256-iM0avC0YwxaB2prWbiKJZ9Fzd/HcdDWJg5IWRmNlVkM=";
   };
 
-  unpackPhase = ''
-    ar vx ${src}
-    tar xvf data.tar.gz
-  '';
-
-  nativeBuildInputs = [ wrapGAppsHook3 ];
-  buildInputs = [ glib ];
-
-  preFixup = ''
-    gappsWrapperArgs+=(--set JAVA_HOME "${jdk21}" --set PDFSAM_JAVA_PATH "${jdk21}")
-  '';
+  nativeBuildInputs = [
+    dpkg
+    wrapGAppsHook3
+    desktop-file-utils
+  ];
 
   installPhase = ''
-    cp -R opt/pdfsam-basic/ $out/
-    mkdir -p "$out"/share/icons
-    cp --recursive ${desktopItem}/share/applications $out/share
-    cp $out/icon.svg "$out"/share/icons/pdfsam-basic.svg
+    runHook preInstall
+    desktop-file-edit usr/share/applications/pdfsam-basic.desktop \
+         --set-key="Exec" --set-value="pdfsam-basic %F" \
+         --set-key="Path" --set-value="$out/share/pdfsam-basic" \
+         --set-icon="pdfsam-basic"
+       mkdir $out
+       cp -r usr/share $out/share
+       mkdir $out/share/pdfsam-basic
+       cp -r opt/pdfsam-basic/lib $out/share/pdfsam-basic/lib
+       install -Dm0644 opt/pdfsam-basic/splash.png $out/share/pdfsam-basic/splash.png
+       install -Dm0644 opt/pdfsam-basic/icon.svg $out/share/icons/hicolor/scalable/apps/pdfsam-basic.svg
+       mkdir $out/bin
+       makeWrapper ${temurin-jre-bin-21}/bin/java $out/bin/pdfsam-basic \
+         "''${gappsWrapperArgs[@]}" \
+         --set JAVA_HOME ${temurin-jre-bin-21} \
+         --set PDFSAM_JAVA_PATH ${temurin-jre-bin-21} \
+         --prefix LD_LIBRARY_PATH : ${
+           lib.makeLibraryPath [
+             javaPackages.openjfx23 # PDFSam Basic requires JDK 21 and JavaFX 23 https://github.com/torakiki/pdfsam/issues/785#issuecomment-3446564717
+             xorg.libXxf86vm
+             xorg.libXtst
+             gtk3
+             libGL
+             alsa-lib
+           ]
+         } \
+         --add-flags ${
+           lib.escapeShellArg (
+             lib.escapeShellArgs [
+               "--enable-preview"
+               "--module-path"
+               "${placeholder "out"}/share/pdfsam-basic/lib"
+               "--module"
+               "org.pdfsam.basic/org.pdfsam.basic.App"
+               "-Xmx512M"
+               "-splash:${placeholder "out"}/share/pdfsam-basic/splash.png"
+               "-Dapp.name=\"pdfsam-basic\""
+               "-Dapp.pid=\"$$\""
+               "-Dapp.home=\"${placeholder "out"}/share/pdfsam-basic\""
+               "-Dbasedir=\"${placeholder "out"}/share/pdfsam-basic\""
+               "-Dprism.lcdtext=false"
+             ]
+           )
+         }
+    runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = meta.description;
-    desktopName = "PDFsam Basic";
-    genericName = "PDF Split and Merge";
-    mimeTypes = [ "application/pdf" ];
-    categories = [ "Office" ];
-  };
+  dontWrapGApps = true;
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/torakiki/pdfsam";
     description = "Multi-platform software designed to extract pages, split, merge, mix and rotate PDF files";
     mainProgram = "pdfsam-basic";
-    sourceProvenance = with sourceTypes; [
+    sourceProvenance = with lib.sourceTypes; [
       binaryBytecode
       binaryNativeCode
     ];
-    license = licenses.agpl3Plus;
+    license = lib.licenses.agpl3Plus;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ _1000101 ];
+    maintainers = with lib.maintainers; [ _1000101 ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11922,9 +11922,7 @@ with pkgs;
     lua = lua5;
   };
 
-  pdfsam-basic = callPackage ../applications/misc/pdfsam-basic {
-    jdk21 = openjdk21.override { enableJavaFX = true; };
-  };
+  pdfsam-basic = callPackage ../applications/misc/pdfsam-basic { };
 
   mupdf-headless = mupdf.override {
     enableX11 = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the package to latest version (5.3.2 -> 5.4.1), closes https://github.com/NixOS/nixpkgs/pull/446319, and fixes https://github.com/NixOS/nixpkgs/issues/453783.
Based on https://github.com/NixOS/nixpkgs/pull/422289 (thanks, `emaryn`). Thanks @kachick for leading me in the right direction.

[PDFSam Basic requires JDK 21 and JavaFX 23 ](https://github.com/torakiki/pdfsam/issues/785#issuecomment-3446564717). Newer version of pdfsam uses functions which were missing in jdk21 with openjfx21, so this fix specifically uses openjfx23.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
