### PR TITLE
djv: 2.0.8-unstable-2021-07-31 -> 3.1.1

### DIFF
--- a/pkgs/by-name/dj/djv/package.nix
+++ b/pkgs/by-name/dj/djv/package.nix
@@ -1,187 +1,94 @@
 {
-  stdenv,
-  cmake,
-  fetchFromGitHub,
-  fetchpatch,
   lib,
-  alsa-lib,
-  libGL,
-  libX11,
-  libXinerama,
-  libXi,
-  zlib,
-  rtaudio,
-  rapidjson,
-  ilmbase,
-  glm,
-  glfw3,
-  libpng,
-  opencolorio_1,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  bzip2,
+  feather-tk,
+  ffmpeg,
   freetype,
+  glfw,
+  imath,
+  libGL,
+  libjpeg,
+  libtiff,
+  libpng,
+  lunasvg,
+  minizip-ng,
+  nativefiledialog-extended,
+  nlohmann_json,
+  opencolorio,
   openexr,
+  openssl,
+  opentimelineio,
+  plutovg,
+  SDL2,
+  tlrender,
+  xz,
+  zlib,
+  zstd,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
+  pname = "djv";
+  version = "3.1.1";
 
-  # The way third-party dependencies are packaged has changed
-  # significantly from the 2.0.8 release. This means any packaging
-  # effort for the 2.0.8 release would have to be redone for the next
-  # release. Hence we package the git version for now and can easily
-  # jump onto the next release once it's available.
-  djvVersion = "2.0.8-unstable-2021-07-31";
-
-  djvSrc = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "darbyjohnston";
     repo = "djv";
-    rev = "ae31712c4f2802a874217ac194bde26287993934";
-    sha256 = "1qgia6vqb6fhyfj8w925xl6k6zidrp2gj5f32bpi94lwwhi6p9pd";
+    tag = finalAttrs.version;
+    hash = "sha256-/SakJ23mi/dz8eUt2UtcgfLtFZiCHy1ME+jWdNS8+Fw=";
   };
-
-  # DJV's build system tries to automatically pull in FSeq, another
-  # library by the DJV author.
-  #
-  # When updating, check the following file in the DJV source:
-  # etc/SuperBuild/cmake/Modules/BuildFSeq.cmake
-  #
-  # If there is revision or tag specified, DJV wants to use the most
-  # recent master version
-  fseqSrc = fetchFromGitHub {
-    owner = "darbyjohnston";
-    repo = "fseq";
-    rev = "545fac6018100f7fca474b8ee4f1efa7cbf6bf45";
-    sha256 = "0qfhbrzji05hh5kwgd1wvq2lbf81ylbi7v7aqk28aws27f8d2hk0";
-  };
-
-  djv-deps = stdenv.mkDerivation rec {
-    pname = "djv-dependencies";
-    version = djvVersion;
-
-    src = djvSrc;
-
-    sourceRoot = "${src.name}/etc/SuperBuild";
-
-    nativeBuildInputs = [ cmake ];
-    buildInputs = [
-      libGL
-    ];
-
-    postPatch = ''
-      chmod -R +w .
-
-      sed -i 's,GIT_REPOSITORY https://github.com/darbyjohnston/FSeq.git,SOURCE_DIR ${fseqSrc},' \
-          cmake/Modules/BuildFSeq.cmake
-
-      # We pull these projects in as normal Nix dependencies. No need
-      # to build them again here.
-
-      sed -i CMakeLists.txt \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS RapidJSON)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS RtAudio)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS IlmBase)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS GLM)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS GLFW)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS ZLIB)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS PNG)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS FreeType)/d' \
-          -e '/list(APPEND DJV_THIRD_PARTY_DEPS OCIO)/d'
-
-      # The "SuperBuild" wants to build DJV right here. This is
-      # inconvenient, because then the `make install` target is not generated
-      # by CMake. We build DJV in its own derivation below. This also makes
-      # the build a bit more modular.
-
-      sed -i '/include(BuildDJV)/d' \
-          CMakeLists.txt
-    '';
-
-    cmakeFlags = [
-      "-DDJV_THIRD_PARTY_OpenEXR:BOOL=False"
-      "-DDJV_THIRD_PARTY_JPEG:BOOL=False"
-      "-DDJV_THIRD_PARTY_TIFF:BOOL=False"
-    ];
-
-    dontInstall = true;
-    doCheck = true;
-  };
-
-in
-stdenv.mkDerivation {
-  pname = "djv";
-  version = djvVersion;
-
-  src = djvSrc;
-  patches = [
-    # Pull fix ending upstream inclusion for gcc-12+ support:
-    #   https://github.com/darbyjohnston/DJV/pull/477
-    (fetchpatch {
-      name = "gcc-13-cstdint-include.patch";
-      url = "https://github.com/darbyjohnston/DJV/commit/be0dd90c256f30c0305ff7b180fd932a311e66e5.patch";
-      hash = "sha256-x8GAfakhgjBiCKHbfgCukT5iFNad+zqURDJkQr092uk=";
-    })
-    (fetchpatch {
-      name = "gcc-11-limits.patch";
-      url = "https://github.com/darbyjohnston/DJV/commit/0544ffa1a263a6b8e8518b47277de7601b21b4f4.patch";
-      hash = "sha256-x6ye0xMwTlKyNW4cVFb64RvAayvo71kuOooPj3ROn0g=";
-    })
-    (fetchpatch {
-      name = "gcc-11-IO.patch";
-      url = "https://github.com/darbyjohnston/DJV/commit/ce79f2d2cb35d03322648323858834bff942c792.patch";
-      hash = "sha256-oPbXOnN5Y5QL+bs/bL5eJALu45YHnyTBLQcC8XcJi0c=";
-    })
-    (fetchpatch {
-      name = "gcc-11-sleep_for.patch";
-      url = "https://github.com/darbyjohnston/DJV/commit/6989f43db27f66a7691f6048a2eb3299ef43a92e.patch";
-      hash = "sha256-1kiF3VrZiO+FSoR7NHCbduQ8tMq/Uuu6Z+sQII4xBAw=";
-    })
-  ];
-
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [
-    alsa-lib
-    libGL
-    libX11
-    libXinerama
-    libXi
-    rapidjson
-    rtaudio
-    ilmbase
-    glm
-    glfw3
-    zlib
-    libpng
-    freetype
-    opencolorio_1
-    djv-deps
-    openexr
-  ];
 
   postPatch = ''
-    chmod -R +w .
-
-    # When linking opencolorio statically this results in failing to
-    # pull in opencolorio's dependencies (tixml and yaml libraries). Avoid
-    # this by linking it statically instead.
-
-    sed -i cmake/Modules/FindOCIO.cmake \
-        -e 's/PATH_SUFFIXES static//' \
-        -e '/OpenColorIO_STATIC/d'
-
-    # When searching for OpenEXR this looks for Iex.h, which exists in ilmbase,
-    # since it's a secondary inport, to find the correct OpenEXR lib, we search
-    # for something specifically in OpenEXR.
-
-    sed -i cmake/Modules/FindOpenEXR.cmake \
-        -e 's/find_path(OpenEXR_INCLUDE_DIR NAMES Iex.h PATH_SUFFIXES OpenEXR)/find_path(OpenEXR_INCLUDE_DIR NAMES ImfImage.h PATH_SUFFIXES OpenEXR)/'
+    substituteInPlace cmake/Modules/djvPackage.cmake \
+      --replace-fail \
+        ' ''${CMAKE_INSTALL_PREFIX}/etc/tlRender/LICENSE_' \
+        " ${tlrender}/etc/tlRender/LICENSE_"
   '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2
+    feather-tk
+    ffmpeg
+    freetype
+    glfw
+    imath
+    tlrender
+    libjpeg
+    libGL
+    libpng
+    libtiff
+    lunasvg
+    minizip-ng
+    nativefiledialog-extended
+    nlohmann_json
+    opencolorio
+    openexr
+    openssl
+    opentimelineio
+    plutovg
+    SDL2
+    xz
+    zlib
+    zstd
+  ];
 
   # GLFW requires a working X11 session.
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Professional review software for VFX, animation, and film production";
     homepage = "https://darbyjohnston.github.io/DJV/";
-    platforms = platforms.linux;
-    maintainers = [ maintainers.blitz ];
-    license = licenses.bsd3;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ blitz ];
+    license = lib.licenses.bsd3;
+    mainProgram = "djv";
   };
-}
+})

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -94,5 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ liberodark ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    badPlatforms = [
+      # Broken on darwin with latest SDK, see https://github.com/darbyjohnston/feather-tk/issues/1
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 })

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -21,6 +21,7 @@
   enablePython ? false,
   enableTests ? false,
   enableExamples ? false,
+  enableShared ? !stdenv.hostPlatform.isStatic,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,7 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "darbyjohnston";
     repo = "feather-tk";
     tag = finalAttrs.version;
-    fetchSubmodules = true;
     hash = "sha256-hcV99y14o3YFUtKDLEKaR7MxBB3pBdd3sferrYvtvYw=";
   };
 
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
     (lib.cmakeBool "feather_tk_UI_LIB" true)
     (lib.cmakeFeature "feather_tk_API" "GL_4_1")
     (lib.cmakeBool "feather_tk_nfd" enableNFD)

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -11,13 +11,13 @@
   libGL,
   libpng,
   lunasvg,
+  nativefiledialog-extended,
   nlohmann_json,
   plutovg,
   xorg,
   zlib,
-  nativeFileDialog ? null,
   python3Packages ? null,
-  enableNFD ? false,
+  enableNFD ? true,
   enablePython ? false,
   enableTests ? false,
   enableExamples ? false,
@@ -51,8 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     libGL
   ]
-  ++ lib.optionals (enableNFD && nativeFileDialog != null) [
-    nativeFileDialog
+  ++ lib.optionals enableNFD [
+    nativefiledialog-extended
   ]
   ++ lib.optionals (enableNFD && stdenv.isLinux) [
     gtk3

--- a/pkgs/by-name/na/nativefiledialog-extended/package.nix
+++ b/pkgs/by-name/na/nativefiledialog-extended/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  SDL2,
+  SDL2_ttf,
+  gtk3,
+  testers,
+  enableShared ? !stdenv.hostPlatform.isStatic,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nativefiledialog-extended";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "btzy";
+    repo = "nativefiledialog-extended";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GwT42lMZAAKSJpUJE6MYOpSLKUD5o9nSe9lcsoeXgJY=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_ttf
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    gtk3
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
+    (lib.cmakeBool "nfd_ROOT_PROJECT" true)
+    (lib.cmakeBool "NFD_BUILD_TESTS" true)
+    (lib.cmakeBool "NFD_BUILD_SDL2_TESTS" true)
+    (lib.cmakeBool "NFD_INSTALL" true)
+  ];
+
+  # NOTE: Although the tests have been compiled, they still require GUI
+  # interactions. Let's disable running them for now.
+  doCheck = false;
+
+  passthru.tests = {
+    cmake-config = testers.hasCmakeConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "nfd" ];
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/btzy/nativefiledialog-extended";
+    description = "Cross platform native file dialog library with C and C++ bindings";
+    longDescription = ''
+      A small C library with that portably invokes native file open, folder
+      select and file save dialogs. Write dialog code once and have it pop up
+      native dialogs on all supported platforms. Avoid linking large
+      dependencies like wxWidgets and Qt.
+    '';
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ yzx9 ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})

--- a/pkgs/by-name/tl/tlrender/minizip-ng-4.patch
+++ b/pkgs/by-name/tl/tlrender/minizip-ng-4.patch
@@ -1,0 +1,95 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95a03bbd..9ce32264 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -123,7 +123,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+ find_package(Imath REQUIRED)
+ find_package(nlohmann_json REQUIRED)
+ find_package(ZLIB REQUIRED)
+-find_package(minizip REQUIRED)
++find_package(minizip-ng REQUIRED)
+ find_package(OpenTimelineIO REQUIRED)
+ 
+ # OpenColorIO dependencies
+diff --git a/etc/SuperBuild/tests/OpenColorIOTest/CMakeLists.txt b/etc/SuperBuild/tests/OpenColorIOTest/CMakeLists.txt
+index 513e7351..2db48491 100644
+--- a/etc/SuperBuild/tests/OpenColorIOTest/CMakeLists.txt
++++ b/etc/SuperBuild/tests/OpenColorIOTest/CMakeLists.txt
+@@ -1,10 +1,10 @@
+ find_package(ZLIB REQUIRED)
+-find_package(minizip REQUIRED)
++find_package(minizip-ng REQUIRED)
+ find_package(OpenColorIO REQUIRED)
+ 
+ set(source main.cpp)
+ 
+ add_executable(OpenColorIOTest ${header} ${source})
+-target_link_libraries(OpenColorIOTest OpenColorIO::OpenColorIO MINIZIP::minizip ZLIB::ZLIB)
++target_link_libraries(OpenColorIOTest OpenColorIO::OpenColorIO MINIZIP::minizip-ng ZLIB::ZLIB)
+ 
+ add_test(OpenColorIOTest OpenColorIOTest)
+diff --git a/lib/tlCore/CMakeLists.txt b/lib/tlCore/CMakeLists.txt
+index d02fa96a..877c8462 100644
+--- a/lib/tlCore/CMakeLists.txt
++++ b/lib/tlCore/CMakeLists.txt
+@@ -40,7 +40,7 @@ else()
+ endif()
+ 
+ set(LIBRARIES tlResource feather-tk::feather-tk-core OTIO::opentimelineio Imath::Imath nlohmann_json::nlohmann_json)
+-set(LIBRARIES_PRIVATE Freetype::Freetype MINIZIP::minizip ZLIB::ZLIB)
++set(LIBRARIES_PRIVATE Freetype::Freetype MINIZIP::minizip-ng ZLIB::ZLIB)
+ if(TLRENDER_OCIO)
+     list(APPEND LIBRARIES OpenColorIO::OpenColorIO)
+ endif()
+diff --git a/lib/tlTimeline/CMakeLists.txt b/lib/tlTimeline/CMakeLists.txt
+index ad384749..82a6aacb 100644
+--- a/lib/tlTimeline/CMakeLists.txt
++++ b/lib/tlTimeline/CMakeLists.txt
+@@ -49,7 +49,7 @@ set(SOURCE
+     Video.cpp)
+ 
+ add_library(tlTimeline ${HEADERS} ${PRIVATE_HEADERS} ${SOURCE})
+-target_link_libraries(tlTimeline tlIO)
++target_link_libraries(tlTimeline tlIO MINIZIP::minizip-ng)
+ set_target_properties(tlTimeline PROPERTIES FOLDER lib)
+ set_target_properties(tlTimeline PROPERTIES PUBLIC_HEADER "${HEADERS}")
+ 
+diff --git a/lib/tlTimeline/TimelineCreate.cpp b/lib/tlTimeline/TimelineCreate.cpp
+index 9596ab21..c8884435 100644
+--- a/lib/tlTimeline/TimelineCreate.cpp
++++ b/lib/tlTimeline/TimelineCreate.cpp
+@@ -99,7 +99,7 @@ namespace tl
+         public:
+             ZipReader(const std::string& fileName)
+             {
+-                mz_zip_reader_create(&reader);
++                reader = mz_zip_reader_create();
+                 if (!reader)
+                 {
+                     throw std::runtime_error(feather_tk::Format(
+diff --git a/lib/tlTimeline/Util.cpp b/lib/tlTimeline/Util.cpp
+index 611f02ad..338df840 100644
+--- a/lib/tlTimeline/Util.cpp
++++ b/lib/tlTimeline/Util.cpp
+@@ -662,7 +662,7 @@ namespace tl
+                 }
+ 
+                 // Open the output file.
+-                mz_zip_writer_create(&_writer);
++                _writer = mz_zip_writer_create();
+                 if (!_writer)
+                 {
+                     throw std::runtime_error(feather_tk::Format("Cannot create writer: \"{0}\"").arg(fileName));
+diff --git a/tlRenderConfig.cmake.in b/tlRenderConfig.cmake.in
+index 11312d32..e6ec1184 100644
+--- a/tlRenderConfig.cmake.in
++++ b/tlRenderConfig.cmake.in
+@@ -9,7 +9,7 @@ include(CMakeFindDependencyMacro)
+ find_package(Imath REQUIRED)
+ find_package(nlohmann_json REQUIRED)
+ find_package(ZLIB REQUIRED)
+-find_package(minizip REQUIRED)
++find_package(minizip-ng REQUIRED)
+ find_package(OpenTimelineIO REQUIRED)
+ 
+ # OpenColorIO dependencies

--- a/pkgs/by-name/tl/tlrender/package.nix
+++ b/pkgs/by-name/tl/tlrender/package.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  pkg-config,
+
+  bzip2,
+  feather-tk,
+  ffmpeg,
+  freetype,
+  glfw,
+  imath,
+  libGL,
+  libjpeg,
+  libtiff,
+  libpng,
+  lunasvg,
+  minizip-ng,
+  nasm,
+  nativefiledialog-extended,
+  nlohmann_json,
+  opencolorio,
+  openexr,
+  openssl,
+  opentimelineio,
+  openusd,
+  plutovg,
+  SDL2,
+  sdl3,
+  xz,
+  zlib,
+  zstd,
+
+  # optional dependencies
+  enableNet ? false,
+  enableOcio ? true,
+  enableSdl2 ? true,
+  enableSdl3 ? false,
+  enableJpeg ? true,
+  enableTiff ? true,
+  enableStb ? true,
+  enablePng ? true,
+  enableOpenexr ? true,
+  enableFfmpeg ? true,
+  enableUsd ? false,
+
+  # build options
+  enableShared ? !stdenv.hostPlatform.isStatic,
+  enableProgram ? true,
+  enableExamples ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tlrender";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "darbyjohnston";
+    repo = "tlRender";
+    tag = finalAttrs.version;
+    hash = "sha256-TxiDZtMvNmrV1FKXZnekCZHnr/eCWZlsP6VJRnaoWg4=";
+  };
+
+  patches = [
+    # Minizip-ng 4 support: https://github.com/darbyjohnston/tlRender/pull/145
+    ./minizip-ng-4.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "include(Package)" ""
+
+    substituteInPlace lib/tlCore/CMakeLists.txt \
+      --replace-fail "SDL2::SDL2-static" "SDL2::SDL2" \
+      --replace-fail "SDL3::SDL3-static" "SDL3::SDL3" \
+
+    substituteInPlace lib/tlIO/CMakeLists.txt \
+      --replace-fail \
+        "list(APPEND LIBRARIES_PRIVATE libjpeg-turbo::turbojpeg-static)" \
+        "list(APPEND LIBRARIES_PRIVATE libjpeg-turbo::jpeg libjpeg-turbo::turbojpeg)"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2 # required by minizip-ng
+    feather-tk
+    freetype # required by feather-tk
+    glfw
+    libGL
+    lunasvg # required by feather-tk
+    imath
+    minizip-ng
+    nativefiledialog-extended
+    nlohmann_json
+    openssl # required by minizip-ng
+    opentimelineio
+    plutovg # required by feather-tk -> lunasvg
+    xz # libLZMA, required by minizip-ng
+    zlib # required by minizip-ng
+    zstd # required by minizip-ng
+  ]
+  ++ lib.optionals enableNet [ nasm ]
+  ++ lib.optionals enableOcio [ opencolorio ]
+  ++ lib.optionals enableSdl2 [ SDL2 ]
+  ++ lib.optionals enableSdl3 [ sdl3 ]
+  ++ lib.optionals enableJpeg [ libjpeg ]
+  ++ lib.optionals enableTiff [ libtiff ]
+  ++ lib.optionals enablePng [ libpng ]
+  ++ lib.optionals enableOpenexr [ openexr ]
+  ++ lib.optionals enableFfmpeg [ ffmpeg ]
+  ++ lib.optionals enableUsd [ openusd ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "TLRENDER_NET" enableNet)
+    (lib.cmakeBool "TLRENDER_OCIO" enableOcio)
+    (lib.cmakeBool "TLRENDER_SDL2" enableSdl2)
+    (lib.cmakeBool "TLRENDER_SDL3" enableSdl3)
+    (lib.cmakeBool "TLRENDER_JPEG" enableJpeg)
+    (lib.cmakeBool "TLRENDER_TIFF" enableTiff)
+    (lib.cmakeBool "TLRENDER_STB" enableStb)
+    (lib.cmakeBool "TLRENDER_PNG" enablePng)
+    (lib.cmakeBool "TLRENDER_EXR" enableOpenexr)
+    (lib.cmakeBool "TLRENDER_FFMPEG" enableFfmpeg)
+    (lib.cmakeBool "TLRENDER_USD" enableUsd)
+
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
+    (lib.cmakeBool "TLRENDER_PROGRAMS" enableProgram)
+    (lib.cmakeBool "TLRENDER_EXAMPLES" enableExamples)
+    (lib.cmakeBool "TLRENDER_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  # GLFW requires a working X11 session.
+  doCheck = false;
+
+  meta = {
+    description = "Open source library for building playback and review applications";
+    longDescription = ''
+      An open source library for building playback and review applications for
+      visual effects, film, and animation.
+
+      The library can render and playback timelines with multiple video clips,
+      image sequences, audio clips, and transitions. Examples are provided for
+      integrating the library with Qt and OpenGL applications.
+    '';
+    homepage = "https://github.com/darbyjohnston/tlRender";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ yzx9 ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
- `djv` has outdated and broken with CMake 4: https://hydra.nixos.org/build/310538595
- drop `opencolorio_1`

Tracking: #445447

close #426523

close #455325

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
