### PR TITLE
nixos/clickhouse: tests: Add basic Selenium test

### DIFF
--- a/nixos/tests/clickhouse/default.nix
+++ b/nixos/tests/clickhouse/default.nix
@@ -28,4 +28,10 @@
       inherit package;
     };
   };
+  ui = runTest {
+    imports = [ ./ui.nix ];
+    _module.args = {
+      inherit package;
+    };
+  };
 }

--- a/nixos/tests/clickhouse/ui.nix
+++ b/nixos/tests/clickhouse/ui.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  pkgs,
+  package,
+  ...
+}:
+
+{
+  name = "clickhouse-ui";
+
+  nodes = {
+    browser =
+      {
+        config,
+        pkgs,
+        ...
+      }:
+      {
+        environment.systemPackages =
+          let
+            clickhouseSeleniumScript =
+              pkgs.writers.writePython3Bin "clickhouse-selenium-script"
+                {
+                  libraries = with pkgs.python3Packages; [ selenium ];
+                }
+                ''
+                  from selenium import webdriver
+                  from selenium.webdriver.common.by import By
+                  from selenium.webdriver.firefox.options import Options
+                  from selenium.webdriver.support.ui import WebDriverWait
+
+                  options = Options()
+                  options.add_argument("--headless")
+                  service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
+
+                  driver = webdriver.Firefox(options=options, service=service)
+                  driver.implicitly_wait(10)
+                  driver.get("http://clickhouse:8123/play")
+
+                  wait = WebDriverWait(driver, 60)
+
+                  assert len(driver.find_elements(
+                    By.ID, "query_div")) == 1
+
+                  server_info_element = driver.find_element(
+                    By.XPATH, "//span[@id='server_info']")
+                  assert "${
+                    lib.strings.replaceStrings [ "-stable" "-lts" ] [ "" "" ] package.version
+                  }" in server_info_element.text
+
+                  # Shouldn't show before query done
+                  assert len(driver.find_elements(
+                    By.CSS_SELECTOR, ".row-number")) == 0
+
+                  query_box = driver.find_element(
+                    By.XPATH, "//textarea[@id='query']")
+                  query_box.click()
+                  query_box.send_keys("SELECT 1")
+
+                  query_run_button = driver.find_element(
+                    By.XPATH, "//button[@id='run']").click()
+
+                  # Now verify results shown
+                  assert len(driver.find_elements(
+                    By.XPATH, "//div[@id='check-mark']")) == 1
+
+                  assert len(driver.find_elements(
+                    By.CSS_SELECTOR, ".row-number")) == 2
+
+                  driver.close()
+                '';
+          in
+          with pkgs;
+          [
+            curl
+            firefox-unwrapped
+            geckodriver
+            clickhouseSeleniumScript
+          ];
+      };
+
+    clickhouse =
+      { config, pkgs, ... }:
+      {
+        networking.firewall.allowedTCPPorts = [
+          8123
+          9000
+        ];
+
+        environment.etc = {
+          "clickhouse-server/config.d/listen.xml".text = ''
+            <clickhouse>
+              <listen_host>::</listen_host>
+            </clickhouse>
+          '';
+        };
+
+        services.clickhouse = {
+          enable = true;
+          inherit package;
+        };
+      };
+  };
+
+  testScript = ''
+    clickhouse.wait_for_unit("clickhouse")
+    clickhouse.wait_for_open_port(8123)
+    clickhouse.wait_for_open_port(9000)
+
+    browser.systemctl("start network-online.target")
+    browser.wait_for_unit("network-online.target")
+
+    browser.succeed("curl -kLs http://clickhouse:8123/play | grep 'ClickHouse Query'")
+
+    # Ensure the application is actually rendered by the Javascript
+    browser.succeed("PYTHONUNBUFFERED=1 clickhouse-selenium-script")
+  '';
+}


### PR DESCRIPTION
Adds a basic Selenium test for the ClickHouse UI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
