### PR TITLE
rocmPackages.clr: introduce SimpleOpenCLSamples based impureTests

### DIFF
--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -280,6 +280,9 @@ stdenv.mkDerivation (finalAttrs: {
       opencl-example = callPackage ./test-opencl-example.nix {
         clr = finalAttrs.finalPackage;
       };
+      simple-opencl-samples = callPackage ./test-simple-opencl-samples.nix {
+        clr = finalAttrs.finalPackage;
+      };
     };
 
     selectGpuTargets =

--- a/pkgs/development/rocm-modules/6/clr/simple-opencl-samples-system-deps.patch
+++ b/pkgs/development/rocm-modules/6/clr/simple-opencl-samples-system-deps.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3b73eec..304d08e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,18 +18,11 @@ project(SimpleOpenCLSamples VERSION 1.0)
+ 
+ option(SAMPLES_ENABLE_EXCEPTIONS "Enable Exceptions for OpenCL Errors")
+ 
+-set(OpenCL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/OpenCL-Headers CACHE PATH "Path to OpenCL Headers")
+-find_package(OpenCL)
++find_package(OpenCL REQUIRED)
+ 
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+ include_directories(${OpenCL_INCLUDE_DIR})
+ 
+-add_subdirectory(external/OpenCL-Headers)
+-add_subdirectory(external/opencl-icd-loader)
+-set_target_properties(OpenCL PROPERTIES FOLDER "OpenCL-ICD-Loader")
+-set_target_properties(cllayerinfo PROPERTIES FOLDER "OpenCL-ICD-Loader")
+-set(OpenCL_LIBRARIES OpenCL)
+-
+ if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/opencl-extension-loader)
+     add_subdirectory(external/opencl-extension-loader)
+ else()

--- a/pkgs/development/rocm-modules/6/clr/test-simple-opencl-samples.nix
+++ b/pkgs/development/rocm-modules/6/clr/test-simple-opencl-samples.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  stdenv,
+  makeImpureTest,
+  fetchFromGitHub,
+  clr,
+  cmake,
+  pkg-config,
+  opencl-headers,
+  ocl-icd,
+}:
+
+let
+  examples = stdenv.mkDerivation {
+    pname = "simple-opencl-samples";
+    version = "2025-09-29";
+
+    src = fetchFromGitHub {
+      owner = "bashbaug";
+      repo = "SimpleOpenCLSamples";
+      rev = "d58373658308d2f8a10c969fb5e5aa8e3b78ec15";
+      hash = "sha256-7EA8R2IJYjPg0m0StCVmEh/mbWQvJ0zLSGjbx7ql++k=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+    ];
+
+    buildInputs = [
+      opencl-headers
+      ocl-icd
+    ];
+
+    patches = [
+      ./simple-opencl-samples-system-deps.patch
+    ];
+
+    cmakeFlags = [
+      (lib.cmakeFeature "OpenCL_INCLUDE_DIR" "${lib.getInclude opencl-headers}/include")
+      (lib.cmakeFeature "OpenCL_LIBRARY" "${lib.getLib ocl-icd}/lib/libOpenCL.so")
+      (lib.cmakeBool "SAMPLES_ENABLE_EXCEPTIONS" true)
+    ];
+
+    # Samples install to $out/Release instead of CMAKE_INSTALL_BINDIR for some reason
+    postInstall = ''
+      if [ -d $out/Release ]; then
+        mkdir -p $out/bin
+        mv $out/Release/* $out/bin/
+        rmdir $out/Release
+      fi
+    '';
+
+    meta = with lib; {
+      description = "Simple, self-contained OpenCL samples";
+      homepage = "https://github.com/bashbaug/SimpleOpenCLSamples";
+      license = licenses.mit;
+      platforms = platforms.linux;
+      teams = [ teams.rocm ];
+    };
+  };
+
+in
+makeImpureTest {
+  name = "simple-opencl-samples";
+  testedPackage = "rocmPackages_6.clr";
+
+  sandboxPaths = [
+    "/sys"
+    "/dev/dri"
+    "/dev/kfd"
+  ];
+
+  nativeBuildInputs = [ examples ];
+
+  OCL_ICD_VENDORS = "${clr.icd}/etc/OpenCL/vendors";
+  testScript = ''
+    set -euo pipefail
+    export AMD_LOG_LEVEL=2
+    echo "OCL_ICD_VENDORS=$OCL_ICD_VENDORS"
+
+    cd ${examples}/bin
+
+    (set -x
+    # Basic enumeration and queries
+    ./enumopencl
+    ./enumopenclpp
+    ./extendeddevicequeries
+    ./newqueries
+    ./loaderinfo
+
+    # Buffer operations
+    ./copybuffer
+    ./copybufferkernel
+
+    # Kernel compilation tests
+    ./kernelfromfile
+    ./ndrangekernelfromfile
+
+    # Shared Virtual Memory tests
+    ./svmqueries
+    ./fgsvmhelloworld
+    ./cgsvmhelloworld
+
+    # Atomic operations
+    ./floatatomics
+
+    # Queue experiments
+    ./enumqueuefamilies
+    ./queueexperiments
+
+    # Actual compute workloads
+    ./julia
+    ./mandelbrot
+    )
+
+    echo "=== OpenCL tests completed successfully ==="
+  '';
+
+  meta = with lib; {
+    description = "Test that OpenCL works with ROCm";
+    teams = [ teams.rocm ];
+  };
+}


### PR DESCRIPTION
We need a more modern set of OpenCL tests. AMD's official OpenCL samples have not been maintained in 7 years.

I was hoping to find a simpler repro for #448456 - bisecting when OpenCL loads through /run is not fun - but have not succeeded.

Might try to package the [Khronos OpenCL conformance test suite](https://github.com/KhronosGroup/OpenCL-CTS) next.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
