### PR TITLE
sunvox: added desktop entry for application launchers

### DIFF
--- a/pkgs/by-name/su/sunvox/package.nix
+++ b/pkgs/by-name/su/sunvox/package.nix
@@ -4,14 +4,15 @@
   fetchzip,
   alsa-lib,
   autoPatchelfHook,
+  copyDesktopItems,
   libglvnd,
   libjack2,
   libX11,
   libXi,
+  makeDesktopItem,
   makeWrapper,
   SDL2,
 }:
-
 let
   platforms = {
     "x86_64-linux" = "linux_x86_64";
@@ -41,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
+      copyDesktopItems
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       makeWrapper
@@ -56,6 +58,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
     libjack2
+  ];
+
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "sunvox";
+      exec = "sunvox";
+      desktopName = "SunVox";
+      genericName = "Modular Synthesizer";
+      comment = "Modular synthesizer with pattern-based sequencer";
+      categories = [
+        "AudioVideo"
+        "Audio"
+        "Midi"
+      ];
+    })
   ];
 
   dontConfigure = true;


### PR DESCRIPTION
Hello!

I've added a `.desktop` file for SunVox on Linux so it appears in application launchers.

Currently, SunVox installs the binary but doesn't provide a desktop entry, making it invisible to graphical launchers. I believe this would be a small QoL improvement at no additional cost. 

Please note that I could not find a proper icon file, so I haven't added one.

### Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality (appears in fuzzel)