### PR TITLE
sbcl: remove broken run-program test

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -152,6 +152,23 @@ stdenv.mkDerivation (self: {
       # Fail intermittently
       "gc.impure.lisp"
       "threads.pure.lisp"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+      # This test has a gotcha on Darwin which originally showed up in
+      # 57b36ea5c83a1841b174ec6cd5e423439fe9d7a0, and later again around Oct
+      # 2025 in staging.  The test wants a clean environment (using
+      # run-program, akin to fork & execve), but darwin keeps injecting this
+      # envvar:
+      #
+      #   __CF_USER_TEXT_ENCODING=0x15F:0:0
+      #
+      # It’s not clear to maintainers where the problem lies exactly, but
+      # removing the test at least fixes the build and unblocks others.
+      #
+      # see:
+      # - https://github.com/NixOS/nixpkgs/pull/359214
+      # - https://github.com/NixOS/nixpkgs/pull/453099
+      "run-program.test.sh"
     ];
 
   patches =


### PR DESCRIPTION
From the code:

This test has a gotcha on Darwin which originally showed up in
57b36ea5c83a1841b174ec6cd5e423439fe9d7a0, and later again around Oct
2025 in Hydra in staging.  The test wants a clean environment (using
run-program, akin to fork & execve), but darwin keeps injecting this
envvar:
  
  __CF_USER_TEXT_ENCODING=0x15F:0:0
  
It’s not clear to maintainers where the problem lies exactly, but
removing the test at least fixes Hydra and unblocks others.
  
see:
- https://github.com/NixOS/nixpkgs/pull/359214
- https://github.com/NixOS/nixpkgs/pull/361072
- https://github.com/NixOS/nixpkgs/pull/453099

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
