### PR TITLE
[Backport release-25.05] python3Packages.ecdsa: mark insecure; python3Packages.python-jose: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/by-name/du/duplicity/package.nix
+++ b/pkgs/by-name/du/duplicity/package.nix
@@ -79,16 +79,10 @@ let
       [
         b2sdk
         boto3
-        cffi
-        cryptography
-        ecdsa
         idna
         pygobject3
         fasteners
-        lockfile
         paramiko
-        pyasn1
-        pycrypto
         # Currently marked as broken.
         # pydrive2
         future

--- a/pkgs/by-name/ki/killerbee/package.nix
+++ b/pkgs/by-name/ki/killerbee/package.nix
@@ -22,6 +22,7 @@ python3.pkgs.buildPythonApplication rec {
   buildInputs = [ libgcrypt ];
 
   dependencies = with python3.pkgs; [
+    pycrypto
     pyserial
     pyusb
     rangeparser

--- a/pkgs/development/python-modules/ecdsa/default.nix
+++ b/pkgs/development/python-modules/ecdsa/default.nix
@@ -24,5 +24,12 @@ buildPythonPackage rec {
     description = "ECDSA cryptographic signature library";
     homepage = "https://github.com/warner/python-ecdsa";
     license = licenses.mit;
+    knownVulnerabilities = [
+      # "I don't want people to use this library in production environments.
+      # It's a teaching tool, it's a testing tool, it's absolutely not an
+      # production grade implementation."
+      # https://github.com/tlsfuzzer/python-ecdsa/issues/330
+      "CVE-2024-23342"
+    ];
   };
 }

--- a/pkgs/development/python-modules/ecdsa/default.nix
+++ b/pkgs/development/python-modules/ecdsa/default.nix
@@ -1,29 +1,48 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  pkgs,
+  fetchFromGitHub,
+  gitUpdater,
+  hypothesis,
+  openssl,
+  pytestCheckHook,
+  setuptools,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "ecdsa";
   version = "0.19.1";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-R4y6e2JVWGb8s7s/6YXgbey9to71VxPE5auYxX1QjmE=";
+  src = fetchFromGitHub {
+    owner = "tlsfuzzer";
+    repo = "python-ecdsa";
+    tag = "python-ecdsa-${version}";
+    hash = "sha256-PjOjHQziQ9ohXH82Ocaowj/AtsXHMHDhatFPQNccyC8=";
   };
 
-  propagatedBuildInputs = [ six ];
-  # Only needed for tests
-  nativeCheckInputs = [ pkgs.openssl ];
+  build-system = [ setuptools ];
 
-  meta = with lib; {
+  dependencies = [ six ];
+
+  pythonImportsCheck = [ "ecdsa" ];
+
+  nativeCheckInputs = [
+    hypothesis
+    openssl # Only needed for tests
+    pytestCheckHook
+  ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "python-ecdsa-";
+  };
+
+  meta = {
+    changelog = "https://github.com/tlsfuzzer/python-ecdsa/blob/${src.tag}/NEWS";
     description = "ECDSA cryptographic signature library";
     homepage = "https://github.com/warner/python-ecdsa";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     knownVulnerabilities = [
       # "I don't want people to use this library in production environments.
       # It's a teaching tool, it's a testing tool, it's absolutely not an

--- a/pkgs/development/python-modules/home-assistant-chip-core/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-core/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   aenum,
   home-assistant-chip-wheels,
   coloredlogs,
@@ -9,7 +8,6 @@
   cryptography,
   dacite,
   deprecation,
-  ecdsa,
   ipdb,
   mobly,
   pygobject3,
@@ -22,8 +20,6 @@ buildPythonPackage rec {
   inherit (home-assistant-chip-wheels) version;
   format = "wheel";
 
-  disabled = pythonOlder "3.7";
-
   src = home-assistant-chip-wheels;
 
   # format=wheel needs src to be a wheel not a folder of wheels
@@ -31,13 +27,12 @@ buildPythonPackage rec {
     src=($src/home_assistant_chip_core*.whl)
   '';
 
-  propagatedBuildInputs = [
+  dependencies = [
     aenum
     coloredlogs
     construct
     cryptography
     dacite
-    ecdsa
     rich
     pyyaml
     ipdb

--- a/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
@@ -138,6 +138,9 @@ stdenv.mkDerivation rec {
       patch -p1 < $patch
     done
 
+    # ecdsa is insecure and only used in tests
+    patch -p1 < ${./dont-import-ecdsa.patch}
+
     # unpin dependencies
     # there are many files to modify, in different formats
     sed -i 's/==.*$//' third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/virtualenv_setup/python_base_requirements.txt

--- a/pkgs/development/python-modules/home-assistant-chip-wheels/dont-import-ecdsa.patch
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/dont-import-ecdsa.patch
@@ -1,0 +1,44 @@
+diff --git a/src/controller/python/chip/crypto/p256keypair.py b/src/controller/python/chip/crypto/p256keypair.py
+index 30198eabee..926f55318e 100644
+--- a/src/controller/python/chip/crypto/p256keypair.py
++++ b/src/controller/python/chip/crypto/p256keypair.py
+@@ -22,7 +22,6 @@ from ctypes import (CFUNCTYPE, POINTER, _Pointer, c_bool, c_char, c_size_t, c_ui
+ from typing import TYPE_CHECKING
+ 
+ from chip import native
+-from ecdsa import ECDH, NIST256p, SigningKey  # type: ignore
+ 
+ # WORKAROUND: Create a subscriptable pointer type (with square brackets) to ensure compliance of type hinting with ctypes
+ if not TYPE_CHECKING:
+@@ -133,31 +132,3 @@ class P256Keypair:
+         format of section 2.3.3 of the SECG SEC 1 standard.
+         '''
+         raise NotImplementedError()
+-
+-
+-class TestP256Keypair(P256Keypair):
+-    ''' The P256Keypair for testing purpose. It is not safe for any productions use
+-    '''
+-
+-    def __init__(self, private_key: SigningKey = None):
+-        super().__init__()
+-
+-        if private_key is None:
+-            self._key = SigningKey.generate(NIST256p)
+-        else:
+-            self._key = private_key
+-
+-        self._pubkey = self._key.verifying_key.to_string(encoding='uncompressed')
+-
+-    @property
+-    def public_key(self) -> bytes:
+-        return self._pubkey
+-
+-    def ECDSA_sign_msg(self, message: bytes) -> bytes:
+-        return self._key.sign_deterministic(message, hashfunc=hashlib.sha256)
+-
+-    def ECDH_derive_secret(self, remote_pubkey: bytes) -> bytes:
+-        ecdh = ECDH(curve=NIST256p)
+-        ecdh.load_private_key(self._key)
+-        ecdh.load_received_public_key_bytes(remote_pubkey[1:])
+-        return ecdh.ecdh1.generate_sharedsecret_bytes()

--- a/pkgs/development/python-modules/okta/default.nix
+++ b/pkgs/development/python-modules/okta/default.nix
@@ -6,7 +6,6 @@
   fetchPypi,
   flatdict,
   jwcrypto,
-  pycryptodome,
   pycryptodomex,
   pydash,
   pyfakefs,
@@ -15,7 +14,6 @@
   pytest-mock,
   pytest-recording,
   pytestCheckHook,
-  python-jose,
   pythonOlder,
   pyyaml,
   setuptools,
@@ -42,11 +40,9 @@ buildPythonPackage rec {
     aiohttp
     flatdict
     jwcrypto
-    pycryptodome
     pycryptodomex
     pydash
     pyjwt
-    python-jose
     pyyaml
     xmltodict
     yarl

--- a/pkgs/development/python-modules/plugp100/default.nix
+++ b/pkgs/development/python-modules/plugp100/default.nix
@@ -9,11 +9,10 @@
   aiohttp,
   jsons,
   requests,
+  cryptography,
   # Test inputs
   pytestCheckHook,
-  pyyaml,
   pytest-asyncio,
-  async-timeout,
 }:
 
 buildPythonPackage rec {
@@ -33,15 +32,14 @@ buildPythonPackage rec {
     requests
     aiohttp
     semantic-version
+    cryptography
     scapy
     urllib3
-    pyyaml
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
-    async-timeout
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "python-jose";
-  version = "3.4.0";
+  version = "3.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mpdavis";
     repo = "python-jose";
     tag = version;
-    hash = "sha256-rPtOZ25aKIN+g3cyv8n6cNejoj3yKk4zpjdLDyEG1e4=";
+    hash = "sha256-8DQ0RBQ4ZgEIwcosgX3dzr928cYIQoH0obIOgk0+Ozs=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -2,14 +2,11 @@
   lib,
   buildPythonPackage,
   cryptography,
-  ecdsa,
   fetchFromGitHub,
   fetchpatch,
-  pyasn1,
   pycrypto,
   pycryptodome,
   pytestCheckHook,
-  rsa,
   setuptools,
 }:
 
@@ -34,17 +31,18 @@ buildPythonPackage rec {
     })
   ];
 
-  pythonRelaxDeps = [
-    # https://github.com/mpdavis/python-jose/pull/376
+  pythonRemoveDeps = [
+    # These aren't needed if the cryptography backend is used:
+    # https://github.com/mpdavis/python-jose/blob/3.5.0/README.rst#cryptographic-backends
+    "ecdsa"
     "pyasn1"
+    "rsa"
   ];
 
   build-system = [ setuptools ];
 
   dependencies = [
-    ecdsa
-    pyasn1
-    rsa
+    cryptography
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/python-jose/default.nix
+++ b/pkgs/development/python-modules/python-jose/default.nix
@@ -4,6 +4,7 @@
   cryptography,
   ecdsa,
   fetchFromGitHub,
+  fetchpatch,
   pyasn1,
   pycrypto,
   pycryptodome,
@@ -23,6 +24,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-8DQ0RBQ4ZgEIwcosgX3dzr928cYIQoH0obIOgk0+Ozs=";
   };
+
+  patches = [
+    # https://github.com/mpdavis/python-jose/pull/393
+    (fetchpatch {
+      name = "fix-test_incorrect_public_key_hmac_signing.patch";
+      url = "https://github.com/mpdavis/python-jose/commit/7c0e4c6640bdc9cd60ac66d96d5d90f4377873db.patch";
+      hash = "sha256-bCzxZEWKYD20TLqzVv6neZlpU41otbVqaXc7C0Ky9BQ=";
+    })
+  ];
 
   pythonRelaxDeps = [
     # https://github.com/mpdavis/python-jose/pull/376

--- a/pkgs/development/python-modules/scapy/default.nix
+++ b/pkgs/development/python-modules/scapy/default.nix
@@ -4,25 +4,15 @@
   stdenv,
   lib,
   isPyPy,
-  pycrypto,
-  ecdsa, # TODO
   mock,
   python-can,
   brotli,
-  withOptionalDeps ? true,
-  tcpdump,
   ipython,
-  withCryptography ? true,
   cryptography,
   withVoipSupport ? true,
   sox,
-  withPlottingSupport ? true,
   matplotlib,
-  withGraphicsSupport ? false,
   pyx,
-  texliveBasic,
-  graphviz,
-  imagemagick,
   withManufDb ? false,
   wireshark,
   libpcap,
@@ -63,22 +53,15 @@ buildPythonPackage rec {
 
   buildInputs = lib.optional withVoipSupport sox;
 
-  propagatedBuildInputs = [
-    pycrypto
-    ecdsa
-  ]
-  ++ lib.optionals withOptionalDeps [
-    tcpdump
-    ipython
-  ]
-  ++ lib.optional withCryptography cryptography
-  ++ lib.optional withPlottingSupport matplotlib
-  ++ lib.optionals withGraphicsSupport [
-    pyx
-    texliveBasic
-    graphviz
-    imagemagick
-  ];
+  optional-dependencies = {
+    all = [
+      cryptography
+      ipython
+      matplotlib
+      pyx
+    ];
+    cli = [ ipython ];
+  };
 
   # Running the tests seems too complicated:
   doCheck = false;

--- a/pkgs/development/python-modules/sshpubkeys/default.nix
+++ b/pkgs/development/python-modules/sshpubkeys/default.nix
@@ -2,31 +2,36 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   cryptography,
-  ecdsa,
 }:
 
 buildPythonPackage rec {
   version = "3.3.1";
-  format = "setuptools";
   pname = "sshpubkeys";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ojarva";
-    repo = "python-${pname}";
-    rev = version;
-    sha256 = "1qsixmqg97kyvg1naw76blq4314vaw4hl5f9wi0v111mcmdia1r4";
+    repo = "python-sshpubkeys";
+    # https://github.com/ojarva/python-sshpubkeys/issues/94
+    tag = "v3.2.0";
+    hash = "sha256-2OJatnQuCt9XQ797F5nEmgEZl5/tu9lrAry5yBGW61g=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     cryptography
-    ecdsa
   ];
 
-  meta = with lib; {
+  pythonImportsCheck = [ "sshpubkeys" ];
+
+  meta = {
+    changelog = "https://github.com/ojarva/python-sshpubkeys/releases/tag/${src.tag}";
     description = "OpenSSH Public Key Parser for Python";
     homepage = "https://github.com/ojarva/python-sshpubkeys";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Manual backport of #412738 #454433 #454346 to `release-25.05`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
