### PR TITLE
python313Packages.pygls_2: init at 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pygls/1.nix
+++ b/pkgs/development/python-modules/pygls/1.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lsprotocol,
+  poetry-core,
+  pytest-asyncio,
+  pytestCheckHook,
+  pythonOlder,
+  typeguard,
+  websockets,
+}:
+
+buildPythonPackage rec {
+  pname = "pygls";
+  version = "1.3.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "openlawlibrary";
+    repo = "pygls";
+    tag = "v${version}";
+    hash = "sha256-AvrGoQ0Be1xKZhFn9XXYJpt5w+ITbDbj6NFZpaDPKao=";
+  };
+
+  pythonRelaxDeps = [
+    # https://github.com/openlawlibrary/pygls/pull/432
+    "lsprotocol"
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    lsprotocol
+    typeguard
+  ];
+
+  optional-dependencies = {
+    ws = [ websockets ];
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  # Fixes hanging tests on Darwin
+  __darwinAllowLocalNetworking = true;
+
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Darwin issue: OSError: [Errno 24] Too many open files
+    ulimit -n 1024
+  '';
+
+  pythonImportsCheck = [ "pygls" ];
+
+  passthru.skipBulkUpdate = true;
+
+  meta = {
+    description = "Pythonic generic implementation of the Language Server Protocol";
+    homepage = "https://github.com/openlawlibrary/pygls";
+    changelog = "https://github.com/openlawlibrary/pygls/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kira-bruneau ];
+  };
+}

--- a/pkgs/development/python-modules/pygls/2.nix
+++ b/pkgs/development/python-modules/pygls/2.nix
@@ -3,42 +3,36 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  lsprotocol,
   poetry-core,
+  attrs,
+  cattrs,
+  lsprotocol,
+  websockets,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
-  typeguard,
-  websockets,
   nix-update-script,
 }:
 
 buildPythonPackage rec {
   pname = "pygls";
-  version = "1.3.1";
+  version = "2.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "openlawlibrary";
     repo = "pygls";
     tag = "v${version}";
-    hash = "sha256-AvrGoQ0Be1xKZhFn9XXYJpt5w+ITbDbj6NFZpaDPKao=";
+    hash = "sha256-dQLK18EACiN+DpWp81Vgaan0mwtifhrmH4xwkqttKvg=";
   };
-
-  pythonRelaxDeps = [
-    # https://github.com/openlawlibrary/pygls/pull/432
-    "lsprotocol"
-  ];
 
   nativeBuildInputs = [
     poetry-core
   ];
 
   propagatedBuildInputs = [
+    attrs
+    cattrs
     lsprotocol
-    typeguard
   ];
 
   optional-dependencies = {
@@ -68,11 +62,11 @@ buildPythonPackage rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Pythonic generic implementation of the Language Server Protocol";
     homepage = "https://github.com/openlawlibrary/pygls";
     changelog = "https://github.com/openlawlibrary/pygls/blob/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ kira-bruneau ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kira-bruneau ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13130,7 +13130,15 @@ self: super: with self; {
 
   pyglossary = callPackage ../development/python-modules/pyglossary { };
 
-  pygls = callPackage ../development/python-modules/pygls { };
+  pygls = pygls_1;
+
+  pygls_1 = callPackage ../development/python-modules/pygls/1.nix {
+    lsprotocol = lsprotocol_2023;
+  };
+
+  pygls_2 = callPackage ../development/python-modules/pygls/2.nix {
+    lsprotocol = lsprotocol_2025;
+  };
 
   pygltflib = callPackage ../development/python-modules/pygltflib { };
 


### PR DESCRIPTION
The next major release of pygls (v2.0.0) is now available: https://github.com/openlawlibrary/pygls/releases/tag/v2.0.0

It would break everything that depends on pygls if we updated the existing package, so I introduced it as a new attribute.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
