### PR TITLE
cmake: drop outdated flags from setupHook

### DIFF
--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -39,10 +39,6 @@ cmakeConfigurePhase() {
     prependToVar cmakeFlags "-DCMAKE_RANLIB=$(command -v $RANLIB)"
     prependToVar cmakeFlags "-DCMAKE_STRIP=$(command -v $STRIP)"
 
-    # on macOS we want to prefer Unix-style headers to Frameworks
-    # because we usually do not package the framework
-    prependToVar cmakeFlags "-DCMAKE_FIND_FRAMEWORK=LAST"
-
     # correctly detect our clang compiler
     prependToVar cmakeFlags "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
 

--- a/pkgs/by-name/cm/cmake/setup-hook.sh
+++ b/pkgs/by-name/cm/cmake/setup-hook.sh
@@ -39,9 +39,6 @@ cmakeConfigurePhase() {
     prependToVar cmakeFlags "-DCMAKE_RANLIB=$(command -v $RANLIB)"
     prependToVar cmakeFlags "-DCMAKE_STRIP=$(command -v $STRIP)"
 
-    # correctly detect our clang compiler
-    prependToVar cmakeFlags "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
-
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the
     # basename as the install name, which means that, on Darwin, they


### PR DESCRIPTION
Drop outdated CMake flags from the setup hook.

The first (`CMAKE_FIND_FRAMEWORK=LAST`) is actively wrong now that we include the SDK and all its component frameworks in the Darwin stdenv by default (see #455458, which this PR supersedes).

The second (`CMAKE_POLICY_DEFAULT_CMP0025=NEW`) is just irrelevant with a `cmake_minimum_required` of 3.0 or higher (the minimum version supported by the version of CMake in nixpkgs is above this), and the policy was entirely dropped in CMake 4.0, so it can no longer even be set to the `OLD` behavior. We probably wouldn't bother removing this on its own, but since I'm causing a world-rebuild anyway, here we are.

Closes #455059.
Supersedes #455458.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
