### PR TITLE
pkgs/buffybox: 3.3.0 -> 3.4.2-unstable-2025-10-25

### DIFF
--- a/nixos/modules/services/hardware/buffyboard.nix
+++ b/nixos/modules/services/hardware/buffyboard.nix
@@ -132,7 +132,6 @@ in
         ))
       ];
       wantedBy = [ "getty.target" ];
-      before = [ "getty.target" ];
     };
   };
 }

--- a/nixos/modules/services/hardware/buffyboard.nix
+++ b/nixos/modules/services/hardware/buffyboard.nix
@@ -109,6 +109,22 @@ in
               This has a negative performance impact.
             '';
           };
+          options.quirks.ignore_unused_terminals = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              If true, buffyboard won't automatically update the layout of a new terminal and
+              draw the keyboard, if the terminal is not opened by any process. In this case
+              SIGUSR1 should be sent to buffyboard to update the layout. This quirk was introduced
+              to resolve a race between buffyboard and systemd-logind according to the following scenario:
+              - A user switches to a new virtual terminal
+              - Buffyboard opens the terminal and changes the number of rows
+              - systemd-logind sees that the terminal is opened by some other process and don't start getty@.service
+
+              The race is resolved by enabling this option and installing a drop-in file
+              for getty@.service that sends SIGUSR1 to buffyboard.
+            '';
+          };
         };
         default = { };
       };

--- a/pkgs/by-name/bu/buffybox/package.nix
+++ b/pkgs/by-name/bu/buffybox/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitLab,
-  fetchpatch2,
   inih,
   lib,
   libdrm,
@@ -16,29 +15,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "buffybox";
-  version = "3.3.0";
+  version = "3.4.2-unstable-2025-10-25";
+  # 3.4.2 would be preferred but there are 3 commits past 3.4.2 that are really nice to have
 
   src = fetchFromGitLab {
     domain = "gitlab.postmarketos.org";
     owner = "postmarketOS";
     repo = "buffybox";
     fetchSubmodules = true; # to use its vendored lvgl
-    rev = "dce41a6f07a2b63c3136409b7bcd0078299fadf9";
-    hash = "sha256-n5RQg7kGS+lg7sRe5Defl3nDEha0vhc/FbwywD5wBsg=";
+    rev = "437ff2cbd7fd35ba6ca2d46624e7fcf8c5f3f954";
+    hash = "sha256-1GRsntNc3byHmZKLG/ZRXvbo96DjmLrA0bVYtMAlKsQ=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      # This fixes a bug that might annoy you if you use something like PKCS#11
-      url = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/commit/d8214b522a3cc72cd4639a1dd114103a02e9218c.patch";
-      hash = "sha256-WxKuioJ1Fo5ARRYF/R4yULDVB4pq11phljzVGdWTV6s=";
-    })
-    (fetchpatch2 {
-      # Fixes up UB
-      url = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/commit/4e13c312241420cbb3e5cc7d4f0dd3e5d17449be.patch";
-      hash = "sha256-7yX6gGsptwijx+ZedSJWJKhwaoBVpxIbGK+ZiMLsIhc=";
-    })
-  ];
 
   depsBuildBuild = [
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bumps unl0kr to current master as of PR. Many nice to haves, also adds f0rmz which might be useful for somebody who wants to make a 100% touchscreen installer.

Changelog: https://gitlab.postmarketos.org/postmarketOS/buffybox/-/blob/437ff2cbd7fd35ba6ca2d46624e7fcf8c5f3f954/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
