### PR TITLE
nanotts: fix build with cmake4, unbreak

### DIFF
--- a/pkgs/by-name/na/nanotts/package.nix
+++ b/pkgs/by-name/na/nanotts/package.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation {
   ];
 
   patchPhase = ''
+    # fix 64-bit compilation error in picoapi.c: picoos_uint32 vs picoos_objsize_t
+    substituteInPlace svoxpico/picoapi.c \
+      --replace-fail 'picoos_uint32 rest_mem_size;' 'picoos_objsize_t rest_mem_size;'
+
     substituteInPlace "src/main.cpp" --replace "/usr/share/pico/lang" "$out/share/lang"
     echo "" > update_build_version.sh
   '';
@@ -44,6 +48,11 @@ stdenv.mkDerivation {
     install -Dm644 -t $out/share/lang $src/lang/*
     wrapProgram $out/bin/nanotts \
       --set ALSA_PLUGIN_DIR ${alsa-plugins}/lib/alsa-lib
+  '';
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 3.3)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
   meta = {


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

This PR also attempts to unbreak the package, its last successful build on Hydra was in 2024:
https://hydra.nixos.org/build/310418412
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
