### PR TITLE
python3Packages.tilequant: fix build, cleanup

### DIFF
--- a/pkgs/development/python-modules/setuptools-dso/default.nix
+++ b/pkgs/development/python-modules/setuptools-dso/default.nix
@@ -1,10 +1,15 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # tests
   nose2,
   pytestCheckHook,
-  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -12,10 +17,11 @@ buildPythonPackage rec {
   version = "2.12.2";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "setuptools_dso";
-    inherit version;
-    hash = "sha256-evt2+T0Tzp2iRQJnbY8tTbw9o1xiRflfJ9+fp0RQeaQ=";
+  src = fetchFromGitHub {
+    owner = "epics-base";
+    repo = "setuptools_dso";
+    tag = version;
+    hash = "sha256-YYm3mTA443vcD/4vHa7EgPzvDDzBic64NWWJDQYQHKs=";
   };
 
   build-system = [ setuptools ];
@@ -25,10 +31,16 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  meta = with lib; {
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # distutils.compilers.C.errors.CompileError: command '/nix/store/...-clang-wrapper-21.1.2/bin/clang' failed with exit code 1
+    # fatal error: 'string' file not found
+    "test_cxx"
+  ];
+
+  meta = {
     description = "Setuptools extension for building non-Python Dynamic Shared Objects";
     homepage = "https://github.com/mdavidsaver/setuptools_dso";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ marius851000 ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ marius851000 ];
   };
 }

--- a/pkgs/development/python-modules/tilequant/default.nix
+++ b/pkgs/development/python-modules/tilequant/default.nix
@@ -1,13 +1,16 @@
 {
   lib,
   buildPythonPackage,
-  click,
-  fetchPypi,
-  ordered-set,
-  pillow,
-  pythonOlder,
+  fetchFromGitHub,
+
+  # build-system
   setuptools,
   setuptools-dso,
+
+  # dependencies
+  click,
+  ordered-set,
+  pillow,
   sortedcollections,
 }:
 
@@ -16,19 +19,23 @@ buildPythonPackage rec {
   version = "1.2.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-0i7brL/hn8SOj3q/rpOcOQ9QW/4Mew2fr0Y42k4K9UI=";
+  src = fetchFromGitHub {
+    owner = "SkyTemple";
+    repo = "tilequant";
+    tag = version;
+    # Fetch tilequant source files
+    fetchSubmodules = true;
+    hash = "sha256-MgyKLwVdL2DRR8J88q7Q57rQiX4FTOlQ5rTY3UuhaJM=";
   };
-
-  pythonRelaxDeps = [ "pillow" ];
 
   build-system = [
     setuptools
+    setuptools-dso
   ];
 
+  pythonRelaxDeps = [
+    "click"
+  ];
   dependencies = [
     click
     ordered-set
@@ -41,12 +48,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "tilequant" ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool for quantizing image colors using tile-based palette restrictions";
     homepage = "https://github.com/SkyTemple/tilequant";
     changelog = "https://github.com/SkyTemple/tilequant/releases/tag/${version}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ marius851000 ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ marius851000 ];
     mainProgram = "tilequant";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @marius851000

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
