### PR TITLE
python3Packages.trezor: 0.13.10 -> 0.20.0

### DIFF
--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -3,53 +3,73 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  hatchling,
+  pytestCheckHook,
+  pytest-random-order,
+  # dependencies
   click,
   construct,
   construct-classes,
   cryptography,
-  ecdsa,
+  keyring,
   libusb1,
   mnemonic,
+  noiseprotocol,
+  platformdirs,
   requests,
-  setuptools,
   shamir-mnemonic,
   slip10,
   typing-extensions,
-  trezor-udev-rules,
-  pytestCheckHook,
+  # optional-dependencies
+  bleak,
+  pillow,
+  hidapi,
+  web3,
+  pyqt5,
 }:
 
 buildPythonPackage rec {
   pname = "trezor";
-  version = "0.13.10";
+  version = "0.20.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-egtq5GKN0MMaXOtRJYkY2bvdOthROIg3IlgmsijuUE8=";
+    hash = "sha256-TAmOIDFbJxZnOr3vQCgi5xiRAVmMfAPyN0ndIBDuJQQ=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     click
     construct
     construct-classes
     cryptography
-    ecdsa
+    keyring
     libusb1
     mnemonic
+    noiseprotocol
+    platformdirs
     requests
     shamir-mnemonic
     slip10
     typing-extensions
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ trezor-udev-rules ];
+  ];
 
-  # fix "click<8.2,>=7 not satisfied by version 8.3.1"
-  pythonRelaxDeps = [ "click" ];
+  optional-dependencies = {
+    ble = [ bleak ];
+    extra = [ pillow ];
+    hidapi = [ hidapi ];
+    ethereum = [ web3 ];
+    qt-widgets = [ pyqt5 ];
+    # stellar = [ stellar-sdk ]; # missing in nixpkgs
+    full = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "full" ]));
+  };
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-random-order
+  ];
 
   disabledTestPaths = [
     "tests/test_stellar.py" # requires stellar-sdk

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3575,7 +3575,13 @@ with pkgs;
 
   trackma-qt = trackma.override { withQT = true; };
 
-  trezorctl = with python3Packages; toPythonApplication trezor;
+  trezorctl =
+    with python3Packages;
+    toPythonApplication (
+      trezor.overridePythonAttrs (oldAttrs: {
+        dependencies = oldAttrs.dependencies ++ oldAttrs.optional-dependencies.full;
+      })
+    );
 
   trezor-agent = with python3Packages; toPythonApplication trezor-agent;
 


### PR DESCRIPTION
- version update
- upstream is going to release 0.20.0 stable soon, but let's update to dev version which fixes the build failure with python3.13 - https://github.com/NixOS/nixpkgs/issues/455538

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
