### PR TITLE
fetchgit, fetchFromGitHub: preserve attributes through overrideAttrs

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -68,7 +68,11 @@ lib.makeOverridable (
       rootDir ? "",
       # GIT_CONFIG_GLOBAL (as a file)
       gitConfigFile ? config.gitConfigFile,
-    }:
+      # Passthrough attributes
+      passthru ? { },
+      # Allow other attributes to pass through
+      ...
+    }@args:
 
     /*
       NOTE:
@@ -195,7 +199,8 @@ lib.makeOverridable (
         passthru = {
           gitRepoUrl = url;
           inherit tag;
-        };
+        }
+        // passthru;
       }
   )
 )

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -70,9 +70,7 @@ lib.makeOverridable (
       gitConfigFile ? config.gitConfigFile,
       # Passthrough attributes
       passthru ? { },
-      # Allow other attributes to pass through
-      ...
-    }@args:
+    }:
 
     /*
       NOTE:

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -124,6 +124,16 @@ lib.makeOverridable (
               fetchLFS
               ;
             url = gitRepoUrl;
+            passthru = (args.passthru or { }) // {
+              inherit
+                gitRepoUrl
+                owner
+                repo
+                tag
+                ;
+              rev = revWithTag;
+            };
+            meta = newMeta;
           }
           // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
         else
@@ -146,9 +156,16 @@ lib.makeOverridable (
                 "${baseUrl}/archive/${revWithTag}.tar.gz";
             extension = "tar.gz";
 
-            passthru = {
-              inherit gitRepoUrl;
+            passthru = (args.passthru or { }) // {
+              inherit
+                gitRepoUrl
+                owner
+                repo
+                tag
+                ;
+              rev = revWithTag;
             };
+            meta = newMeta;
           }
       )
       // privateAttrs


### PR DESCRIPTION
Taking a stab at this after seeing it, hopefully fixes #444503.

When using `overrideAttrs` on a derivation from `fetchFromGitHub`, attributes like `owner`, `repo`, and  `rev` were lost. This particularly affected derivations using the fetchgit backend (when`leaveDotGit = true`, `fetchSubmodules = true`, etc.).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Following the idea from @ConnorBaker to have the fetcher implementation accept variable arguments and pass through those which are not explicitly used:
 1. **fetchgit**: Now accepts `passthru` parameter and arbitrary arguments via `...`, matching fetchzip's behavior
 2. **fetchFromGitHub**: Passes GitHub-specific attributes through `passthru` to ensure they survive `overrideAttrs`
 
 ## Testing
  Tests passed:
  - `nix-build . -A tests.fetchFromGitHub --no-out-link`
  - `nix-build . -A tests.fetchgit --no-out-link`
  - Custom test showing extremely minimal recreation of `overrideAttrs` issue
  <details>
     <summary>Expand for custom test</summary>

  ```nix
  # test.nix
  { pkgs }:

  let
    # Test 1: fetchzip path (default)
    srcZip = pkgs.fetchFromGitHub {
      owner = "NixOS";
      repo = "nix";
      rev = "2.3.16";
      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
    };

    srcZipOverridden = srcZip.overrideAttrs (old: {
      sha256 = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
    });

    # Test 2: fetchgit path (with leaveDotGit)
    srcGit = pkgs.fetchFromGitHub {
      owner = "NixOS";
      repo = "nix";
      rev = "2.3.16";
      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
      leaveDotGit = true;
    };

    srcGitOverridden = srcGit.overrideAttrs (old: {
      sha256 = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
    });
  in
  {
    fetchzip = {
      before = { inherit (srcZip) owner repo rev; };
      after = {
        owner = srcZipOverridden.owner or "MISSING";
        repo = srcZipOverridden.repo or "MISSING";
        rev = srcZipOverridden.rev or "MISSING";
      };
    };

    fetchgit = {
      before = { inherit (srcGit) owner repo rev; };
      after = {
        owner = srcGitOverridden.owner or "MISSING";
        repo = srcGitOverridden.repo or "MISSING";
        rev = srcGitOverridden.rev or "MISSING";
      };
    };
  }
```

  Before this PR:
  ```
$ nix eval --impure --expr 'import ./test.nix { pkgs = import <nixpkgs> {}; }'
{ fetchgit = { after = { owner = "MISSING"; repo = "MISSING"; rev = "2.3.16"; }; before = { owner = "NixOS"; repo = "nix"; rev = "2.3.16"; }; }; fetchzip = { after = { owner = "MISSING"; repo = "MISSING"; rev = "MISSING"; }; before = { owner ="NixOS"; repo = "nix"; rev = "2.3.16"; }; }; }
```
After this PR:
```
$ nix eval --impure --expr 'import ./test.nix { pkgs = import ./. {}; }'
{ fetchgit = { after = { owner = "NixOS"; repo = "nix"; rev = "2.3.16"; }; before = { owner = "NixOS"; repo = "nix"; rev = "2.3.16"; }; }; fetchzip = { after = { owner = "NixOS"; repo = "nix"; rev = "2.3.16"; }; before = { owner = "NixOS"; repo = "nix"; rev = "2.3.16"; }; }; }
 ```
 </details>
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
