### PR TITLE
go-freeze: Init at 0.2.2

### DIFF
--- a/pkgs/by-name/go/go-freeze/package.nix
+++ b/pkgs/by-name/go/go-freeze/package.nix
@@ -1,0 +1,32 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "go-freeze";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "charmbracelet";
+    repo = "freeze";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1zc62m1uS8Bl6x54SG2///PWfiKbZood6VBibbsFX7I=";
+  };
+
+  vendorHash = "sha256-BEMVjPexJ3Y4ScXURu7lbbmrrehc6B09kfr03b/SPg8=";
+
+  postInstall = ''
+    ## Avoid conflicting with `pkgs.freeze`
+    mv $out/bin/{freeze,go-freeze}
+  '';
+
+  meta = {
+    homepage = "https://github.com/charmbracelet/freeze";
+    description = "Generate images of code and terminal output";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/charmbracelet/freeze/releases/tag/v${finalAttrs.version}";
+    mainProgram = finalAttrs.pname;
+    maintainers = with lib.maintainers; [ S0AndS0 ];
+  };
+})


### PR DESCRIPTION
Packages `freeze` from [charmbracelet](https://github.com/charmbracelet/freeze/) as `go-freeze` to avoid name collision with preexisting package `pkgs.freeze` that does other things.

`go-freeze` provides a CLI tool for generating images, often with syntax highlighting, from files or Standard In (STDIN)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
    > Docs link for how to?
  - [ ] Module update: when the change is significant.
- [¿?] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

