### PR TITLE
edgetx: fix build with CMake 4, 2.11.2 -> 2.11.3

### DIFF
--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -47,14 +47,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "edgetx";
-  version = "2.11.2";
+  version = "2.11.3";
 
   src = fetchFromGitHub {
     owner = "EdgeTX";
     repo = "edgetx";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-F3T1lX0FSSUIQxSlqLQHj7JrfF+20Ndv63zDA0sRzFQ=";
+    hash = "sha256-vlJsfebTWhdh6HDpUEA1QJJSVGMlcL49XFwIx4A9zHs=";
   };
 
   nativeBuildInputs = [
@@ -175,6 +175,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     mainProgram = "companion" + lib.concatStrings (lib.take 2 (lib.splitVersion finalAttrs.version));
     homepage = "https://edgetx.org/";
+    changelog = "https://github.com/EdgeTX/edgetx/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
     platforms = [
       "i686-linux"

--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -15,6 +15,7 @@
   miniz,
   yaml-cpp,
   udevCheckHook,
+  applyPatches,
   # List of targets to build simulators for
   targetsToBuild ? import ./targets.nix,
 }:
@@ -36,6 +37,12 @@ let
       libclang
     ]
   );
+
+  # paches are needed to fix build with CMake 4
+  yaml-cppSrc = applyPatches {
+    inherit (yaml-cpp) src;
+    patches = yaml-cpp.patches or [ ];
+  };
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -93,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Unvendoring these libraries is infeasible. At least lets reuse the same sources.
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MINIZ" "${miniz.src}")
-    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_YAML-CPP" "${yaml-cpp.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_YAML-CPP" "${yaml-cppSrc}")
     # Custom library https://github.com/edgetx/maxLibQt.
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MAXLIBQT" "${maxlibqt}")
     (lib.cmakeFeature "DFU_UTIL_ROOT_DIR" "${lib.getBin dfu-util}/bin")


### PR DESCRIPTION
Diff: https://github.com/EdgeTX/edgetx/compare/v2.11.2...v2.11.3

Changelog: https://github.com/EdgeTX/edgetx/releases/tag/v2.11.3

related: #445447 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
