### PR TITLE
cubyz: init at 0.3.0

### DIFF
--- a/pkgs/by-name/cu/cubyz/libs.nix
+++ b/pkgs/by-name/cu/cubyz/libs.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  callPackage,
+  zig_0_16,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "12";
+  pname = "cubyz-libs";
+  src = fetchFromGitHub {
+    owner = "pixelguys";
+    repo = "cubyz-libs";
+    tag = finalAttrs.version;
+    hash = "sha256-ATOsUY2RWKXremtgqoNQb4FEhIXdm1h076ChiriyyUE=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  zigDeps = zig_0_16.fetchDeps {
+    inherit (finalAttrs) src pname version;
+    fetchAll = true;
+    hash = "sha256-5I3KM9yWJlE8ivVjXlVSKSrlMcBk9f09yQnCNVaml8U=";
+  };
+
+  postConfigure = ''
+    ln -s ${finalAttrs.zigDeps} $ZIG_GLOBAL_CACHE_DIR/p
+  '';
+
+  nativeBuildInputs = [
+    zig_0_16.hook
+  ];
+
+  zigBuildFlags = [
+    "-Doptimize=ReleaseSafe"
+  ];
+
+  meta = {
+    homepage = "https://github.com/PixelGuys/Cubyz-libs";
+    description = "Contains libraries used in Cubyz";
+    platforms = lib.platforms.linux;
+    mainProgram = "cubyz";
+    maintainers = with lib.maintainers; [ leha44581 ];
+  };
+})

--- a/pkgs/by-name/cu/cubyz/package.nix
+++ b/pkgs/by-name/cu/cubyz/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  callPackage,
+  makeWrapper,
+  libx11,
+  libxcursor,
+  libGL,
+  alsa-lib,
+  vulkan-loader,
+  vulkan-validation-layers,
+  vulkan-tools,
+  makeDesktopItem,
+  copyDesktopItems,
+  zig_0_16,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "0.3.0";
+  pname = "cubyz";
+  src = fetchFromGitHub {
+    owner = "pixelguys";
+    repo = "cubyz";
+    tag = finalAttrs.version;
+    hash = "sha256-dqxtASlOGWqSXXKIsCYnNyLz1WFJ7qYHhnMe0blWjLc=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  cubAssets = fetchFromGitHub {
+    owner = "PixelGuys";
+    repo = "Cubyz-Assets";
+    tag = "0.3.5";
+    hash = "sha256-rTisqHPvVvZmmsG44Z+860keaDu+cS3lLRBNm+uYT0w=";
+  };
+
+  zigDeps = zig_0_16.fetchDeps {
+    inherit (finalAttrs) src pname version;
+    fetchAll = true;
+    hash = "sha256-bp+fhqp33q/xqPZgpiIenmKIF0ivTCMlV5JPQVnSxhI=";
+  };
+
+  postConfigure = ''
+    ln -s ${finalAttrs.zigDeps} $ZIG_GLOBAL_CACHE_DIR/p
+  '';
+
+  preBuild = "
+    mkdir -p ../Cubyz-libs/zig-out
+    ln -s ${callPackage ./libs.nix { }}/* ../Cubyz-libs/zig-out/
+  ";
+
+  nativeBuildInputs = [
+    zig_0_16.hook
+    makeWrapper # Needed for env variables
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libx11
+    libGL
+    vulkan-loader
+    vulkan-validation-layers
+    vulkan-tools
+    libxcursor
+    alsa-lib
+  ];
+
+  zigBuildFlags = [
+    "-Doptimize=ReleaseSafe"
+  ];
+
+  postBuild = ''
+    mkdir -p $out/assets/cubyz
+    cp -r $cubAssets/* $out/assets/cubyz/.
+    cp -r $src/assets/cubyz/* $out/assets/cubyz/.
+
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    cp -r $src/assets/cubyz/logo.png $out/share/icons/hicolor/256x256/apps/cubyz.png
+
+    cat <<'EOF' > $out/launchConfig.zon
+    .{
+      .cubyzDir = "",
+      .autoEnterWorld = "",
+      .headlessServer = false,
+    }
+    EOF
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cubyz";
+      desktopName = "Cubyz";
+      comment = finalAttrs.meta.description;
+      exec = "Cubyz";
+      icon = "cubyz";
+      categories = [ "Game" ];
+    })
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/Cubyz \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
+      --prefix VK_LAYER_PATH : "${vulkan-validation-layers}/share/vulkan/explicit_layer.d" \
+      --run "
+        cd $out/.
+      "
+  '';
+
+  meta = {
+    homepage = "https://github.com/PixelGuys/Cubyz";
+    description = "Voxel sandbox game with a large render distance, procedurally generated content and some cool graphical effects";
+    changelog = "https://github.com/PixelGuys/Cubyz/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    broken = stdenv.hostPlatform.isAarch64;
+    mainProgram = "cubyz";
+    maintainers = with lib.maintainers; [ leha44581 ];
+  };
+})


### PR DESCRIPTION
Added Cubyz package, because running it on nixos is a pain, solves https://github.com/PixelGuys/Cubyz/pull/1967 https://github.com/NixOS/nixpkgs/issues/363653
Cubyz is a 3D voxel sandbox game.
https://github.com/PixelGuys/Cubyz
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
