### PR TITLE
qovery-cli: 1.2.6 -> 1.52.0

### DIFF
--- a/pkgs/by-name/qo/qovery-cli/package.nix
+++ b/pkgs/by-name/qo/qovery-cli/package.nix
@@ -4,43 +4,56 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  qovery-cli,
-  testers,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "qovery-cli";
-  version = "1.2.6";
+  version = "1.52.0";
 
   src = fetchFromGitHub {
     owner = "Qovery";
     repo = "qovery-cli";
-    tag = "v${version}";
-    hash = "sha256-NxrhZmRbkQNj2K4b6Em4cAdssJRdwEKbdGy8EThN4JY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-m6NdZ4K0FAZvTloworoK3Lluu9ySCGfS4L216ImByb8=";
   };
 
-  vendorHash = "sha256-GKW89qzyuvwCUvN0i+LgU36Vtr5XuvgXIxwnMlGSTFg=";
+  vendorHash = "sha256-9rAAeJVKBndb4w3LNJLLBvkX5me/Y3GnA55SYGOxqi4=";
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [ "-X github.com/qovery/qovery-cli/utils.Version=v${finalAttrs.version}" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd ${pname} \
-      --bash <($out/bin/${pname} completion bash) \
-      --fish <($out/bin/${pname} completion fish) \
-      --zsh <($out/bin/${pname} completion zsh)
+    installShellCompletion --cmd qovery-cli \
+      --bash <($out/bin/qovery-cli completion bash) \
+      --fish <($out/bin/qovery-cli completion fish) \
+      --zsh <($out/bin/qovery-cli completion zsh)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = qovery-cli;
-    command = "HOME=$(mktemp -d); ${pname} version";
-  };
+  # need network
+  doCheck = false;
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Qovery Command Line Interface";
     homepage = "https://github.com/Qovery/qovery-cli";
-    changelog = "https://github.com/Qovery/qovery-cli/releases/tag/v${version}";
+    changelog = "https://github.com/Qovery/qovery-cli/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "qovery-cli";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/Qovery/qovery-cli/compare/v1.2.6...v1.52.0

Changelog: https://github.com/Qovery/qovery-cli/releases/tag/v1.52.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
