### PR TITLE
qjackctl: 0.9.91 -> 1.0.4

### DIFF
--- a/pkgs/by-name/qj/qjackctl/package.nix
+++ b/pkgs/by-name/qj/qjackctl/package.nix
@@ -7,28 +7,25 @@
   alsa-lib,
   libjack2,
   dbus,
-  libsForQt5,
+  qt6,
   # Enable jack session support
   jackSession ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.9.91";
+  version = "1.0.4";
   pname = "qjackctl";
-
-  # some dependencies such as killall have to be installed additionally
 
   src = fetchFromGitHub {
     owner = "rncbc";
     repo = "qjackctl";
-    tag = "qjackctl_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
-    hash = "sha256-YfdRyylU/ktFvsh18FjpnG9MkV1HxHJBhRnHWQ7I+hY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eZ3PBacRdMJCHHwE0qYi4jgSb7G7uS2Q+j02EdnSYqA=";
   };
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qtx11extras
-    libsForQt5.qttools
+    qt6.qtbase
+    qt6.qttools
     alsa-lib
     libjack2
     dbus
@@ -37,12 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   cmakeFlags = [
-    "-DCONFIG_JACK_VERSION=1"
-    "-DCONFIG_JACK_SESSION=${toString jackSession}"
+    (lib.cmakeFeature "CONFIG_JACK_VERSION" "1")
+    (lib.cmakeFeature "CONFIG_JACK_SESSION" (toString jackSession))
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/rncbc/qjackctl/compare/v0.9.91...v1.0.4
https://github.com/rncbc/qjackctl/releases/tag/v1.0.4
https://github.com/rncbc/qjackctl/blob/71c1729497b0ced0233a5f5512ffb9781603665a/ChangeLog#L7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
