### PR TITLE
libbluray: 1.3.4 -> 1.4.0

### DIFF
--- a/pkgs/by-name/li/libbluray-full/package.nix
+++ b/pkgs/by-name/li/libbluray-full/package.nix
@@ -1,0 +1,8 @@
+{
+  callPackage,
+}:
+callPackage ../libbluray/package.nix {
+  withAACS = true;
+  withBDplus = true;
+  withJava = true;
+}

--- a/pkgs/by-name/li/libbluray-full/package.nix
+++ b/pkgs/by-name/li/libbluray-full/package.nix
@@ -1,8 +1,0 @@
-{
-  callPackage,
-}:
-callPackage ../libbluray/package.nix {
-  withAACS = true;
-  withBDplus = true;
-  withJava = true;
-}

--- a/pkgs/by-name/li/libbluray-full/package.nix
+++ b/pkgs/by-name/li/libbluray-full/package.nix
@@ -1,4 +1,4 @@
-{libbluray}:
+{ libbluray }:
 libbluray.override {
   withAACS = true;
   withBDplus = true;

--- a/pkgs/by-name/li/libbluray-full/package.nix
+++ b/pkgs/by-name/li/libbluray-full/package.nix
@@ -1,0 +1,6 @@
+{libbluray}:
+libbluray.override {
+  withAACS = true;
+  withBDplus = true;
+  withJava = true;
+}

--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -71,9 +71,16 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
+    variants = {
+      full = callPackage ./package.nix {
+        withAACS = true;
+        withBDplus = true;
+        withJava = true;
+      };
+    };
     tests = {
       # Verify the "full" package when verifying changes to this package
-      full = callPackage ../libbluray-full/package.nix { };
+      full = passthru.variants.full;
     };
   };
 }

--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -19,6 +19,7 @@
   libxml2,
   withFonts ? true,
   freetype,
+  libbluray-full, # Used for tests
 }:
 
 # Info on how to use:
@@ -71,16 +72,9 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    variants = {
-      full = callPackage ./package.nix {
-        withAACS = true;
-        withBDplus = true;
-        withJava = true;
-      };
-    };
     tests = {
       # Verify the "full" package when verifying changes to this package
-      full = passthru.variants.full;
+      inherit libbluray-full;
     };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7284,6 +7284,8 @@ with pkgs;
       }
   );
 
+  libbluray-full = libbluray.variants.full;
+
   mtrace = callPackage ../development/libraries/glibc/mtrace.nix { };
 
   # Provided by libc on Operating Systems that use the Extensible Linker Format.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7284,8 +7284,6 @@ with pkgs;
       }
   );
 
-  libbluray-full = libbluray.variants.full;
-
   mtrace = callPackage ../development/libraries/glibc/mtrace.nix { };
 
   # Provided by libc on Operating Systems that use the Extensible Linker Format.


### PR DESCRIPTION
This updates libbluray from version 1.3.4 to the latest v1.4.0. This change is a bit more consequential than a typical version bump because the underlying project switched from building with autotools to building with meson in this release. Also, the underlying project is now compatible with JDK 21, so the JDK version has been bumped. Unfortunately, stable libbluray is not yet compatible with JDK 25 (changes that should hopefully make this work have been merged to their mainline branch, but as of yet, no release has been made).

This change also introduces a new alternate version of libbluray into nixpkgs, `libbluray-full`, which adds in all of the optional dependencies, such as Java and libaacs. Nearly ten years ago, these dependencies were removed from the default version of the package because eelco didn't appreciate that a JDK was being installed on his system, thus inflating his closure. Although it is outside the scope of this change, adding a "full" version of libbluray to nixpkgs should allow downstream packages to consume it in the future and provide users with full blu-ray support without having to build many of their packages from scratch.

Because libbluray sits upstream of several media libraries, including ffmpeg, I'm expecting that this change will create a lot of rebuilds. Therefore, I'm making my PR into `staging`. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
