### PR TITLE
boxfort: 0.1.4 -> 0.1.5; criterion: 2.4.2 -> 2.4.3

### DIFF
--- a/pkgs/by-name/bo/boxfort/package.nix
+++ b/pkgs/by-name/bo/boxfort/package.nix
@@ -2,25 +2,29 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  pkg-config,
   meson,
   ninja,
   python3Packages,
+  gitMinimal,
 }:
 
 stdenv.mkDerivation rec {
   pname = "boxfort";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "BoxFort";
     rev = "v${version}";
-    sha256 = "jmtWTOkOlqVZ7tFya3IrQjr714Y8TzAVY5Cq+RzDuRs=";
+    hash = "sha256-fgX2Ilb01qa9myuz6yiC67WKeai2m/csncS6u5and3o=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
+    pkg-config
+    gitMinimal
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/bo/boxfort/package.nix
+++ b/pkgs/by-name/bo/boxfort/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Snaipe/BoxFort";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      sigmanificient
       thesola10
       Yumasi
     ];

--- a/pkgs/by-name/bo/boxfort/package.nix
+++ b/pkgs/by-name/bo/boxfort/package.nix
@@ -9,14 +9,14 @@
   gitMinimal,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "boxfort";
   version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "BoxFort";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-fgX2Ilb01qa9myuz6yiC67WKeai2m/csncS6u5and3o=";
   };
 
@@ -51,4 +51,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/cr/criterion/package.nix
+++ b/pkgs/by-name/cr/criterion/package.nix
@@ -9,6 +9,7 @@
   cmake,
   ninja,
   protobuf,
+  gitMinimal,
   libffi,
   libgit2,
   dyncall,
@@ -38,14 +39,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "criterion";
-  version = "2.4.2";
+  version = "2.4.3";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "Criterion";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-5GH7AYjrnBnqiSmp28BoaM1Xmy8sPs1atfqJkGy3Yf0=";
+    hash = "sha256-X4m/uCyanS7HLtf6GyK4XuaT5i+HQt1PZC7gd813IVQ=";
   };
 
   nativeBuildInputs = [
@@ -54,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     protobuf
+    gitMinimal
   ];
 
   buildInputs = [


### PR DESCRIPTION
- https://github.com/Snaipe/BoxFort/compare/v0.1.4...v0.1.5
- https://github.com/Snaipe/Criterion/compare/v2.4.2...v2.4.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
