### PR TITLE
ponyc: 0.59.0 -> 0.60.3

### DIFF
--- a/pkgs/by-name/po/ponyc/package.nix
+++ b/pkgs/by-name/po/ponyc/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nix-update-script,
   stdenv,
   fetchFromGitHub,
   apple-sdk_13,
@@ -24,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ponyc";
-  version = "0.59.0";
+  version = "0.60.3";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     tag = version;
-    hash = "sha256-4gDv8UWTk0RWVNC4PU70YKSK9fIMbWBsQbHboVls2BA=";
+    hash = "sha256-VlmIy2i7BZ8jK96KVnTzdjyXWTyOuWE5M3yNp7gcVCA=";
     fetchSubmodules = true;
   };
 
@@ -42,12 +43,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-5xDg1duixLoWIuy59WT0r5ZBAvTR6RPP7YrhBYkMxc8=";
   };
 
-  googletestRev = "1.15.2";
+  googletestRev = "1.17.0";
   googletest = fetchFromGitHub {
     owner = "google";
     repo = "googletest";
     rev = "v${googletestRev}";
-    hash = "sha256-1OJ2SeSscRBNr7zZ/a8bJGIqAnhkg45re0j3DtPfcXM=";
+    hash = "sha256-HIHMxAUR4bjmFLoltJeIAVSulVQ6kVuIT2Ku+lwAx/4=";
   };
 
   nativeBuildInputs = [
@@ -99,7 +100,7 @@ stdenv.mkDerivation rec {
     # Replace downloads with local copies.
     substituteInPlace lib/CMakeLists.txt \
         --replace-fail "https://github.com/google/benchmark/archive/v$benchmarkRev.tar.gz" "$NIX_BUILD_TOP/deps/benchmark-$benchmarkRev.tar" \
-        --replace-fail "https://github.com/google/googletest/archive/refs/tags/v$googletestRev.tar.gz" "$NIX_BUILD_TOP/deps/googletest-$googletestRev.tar"
+        --replace-fail "https://github.com/google/googletest/releases/download/v$googletestRev/googletest-$googletestRev.tar.gz" "$NIX_BUILD_TOP/deps/googletest-$googletestRev.tar"
   '';
 
   preBuild = ''
@@ -115,6 +116,8 @@ stdenv.mkDerivation rec {
     make configure "''${extraFlags[@]}"
   '';
 
+  enableParallelBuilding = true;
+
   makeFlags = [
     "PONYC_VERSION=${version}"
     "prefix=${placeholder "out"}"
@@ -127,6 +130,8 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+
+  enableParallelChecking = true;
 
   nativeCheckInputs = [ procps ];
 
@@ -156,7 +161,10 @@ stdenv.mkDerivation rec {
   # Stripping breaks linking for ponyc
   dontStrip = true;
 
-  passthru.tests.pony-corral = pony-corral;
+  passthru = {
+    tests.pony-corral = pony-corral;
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";


### PR DESCRIPTION
Enabling parallel building and checking takes the compile time down by 7 minutes on my 24 core EPYC 4.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
