### PR TITLE
kraft: 0.11.6 -> 0.12.3 and improvements

### DIFF
--- a/pkgs/by-name/kr/kraft/package.nix
+++ b/pkgs/by-name/kr/kraft/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule rec {
   pname = "kraftkit";
-  version = "0.11.6";
+  version = "0.12.5";
 
   src = fetchFromGitHub {
     owner = "unikraft";
     repo = "kraftkit";
     rev = "v${version}";
-    hash = "sha256-a6c7g2cxrawE7BRpcrsefCQ7xQ56wVOGjFexdkOKnv0=";
+    hash = "sha256-/ReHXxvn/6dDJVxk5BOvxSZrlkDkZEfr+qM5raf2a3A=";
   };
 
   nativeBuildInputs = [
@@ -31,7 +31,7 @@ buildGoModule rec {
     btrfs-progs
   ];
 
-  vendorHash = "sha256-lwgxedKLcuV6RucbU26sDO+9j+8uWkignJDomFHaSXU=";
+  vendorHash = "sha256-1rdpyOJVeyzYT0WHJbeqO3aH15FN1/9iQ9bEsjWwn4c=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/kr/kraft/package.nix
+++ b/pkgs/by-name/kr/kraft/package.nix
@@ -65,6 +65,17 @@ buildGoModule rec {
   ]
   ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [ "tools/genman" ];
 
+  excludedPackages = [
+    "test/e2e"
+    "initrd"
+    "tools"
+  ];
+
+  preCheck = ''
+    # Run all tests.
+    unset subPackages
+  '';
+
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/genman generate ./docs/man/
     rm $out/bin/genman

--- a/pkgs/by-name/kr/kraft/package.nix
+++ b/pkgs/by-name/kr/kraft/package.nix
@@ -8,6 +8,8 @@
   pkg-config,
   btrfs-progs,
   gpgme,
+  xen,
+  yajl,
   nix-update-script,
 }:
 
@@ -33,6 +35,8 @@ buildGoModule rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     btrfs-progs
+    xen
+    yajl
   ];
 
   vendorHash = "sha256-1rdpyOJVeyzYT0WHJbeqO3aH15FN1/9iQ9bEsjWwn4c=";
@@ -40,7 +44,20 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
+    "-X kraftkit.sh/internal/cli/kraft.sentryDsn="
+    "-X kraftkit.sh/internal/version.buildTime=1970-01-01T00:00:00Z"
+    "-X kraftkit.sh/internal/version.commit=nixpkgs"
     "-X kraftkit.sh/internal/version.version=${version}"
+  ];
+
+  tags = [
+    "containers_image_storage_stub"
+    "containers_image_openpgp"
+    "netgo"
+    "osusergo"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "xen"
   ];
 
   subPackages = [


### PR DESCRIPTION
Various improvements for the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
