### PR TITLE
buildPython*: simplify overrideStdenvCompat and add nested-override support

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -45,16 +45,16 @@ let
 
   overrideStdenvCompat =
     f:
-    lib.setFunctionArgs (
+    lib.mirrorFunctionArgs f (
       args:
       if !(lib.isFunction args) && (args ? stdenv) then
         lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511) ''
           Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
             buildPythonPackage.override { stdenv = customStdenv; } { }
-        '' (f.override { stdenv = args.stdenv; } args)
+        '' (f.override { inherit (args) stdenv; } args)
       else
         f args
-    ) (removeAttrs (lib.functionArgs f) [ "stdenv" ])
+    )
     // {
       # Intentionally drop the effect of overrideStdenvCompat when calling `buildPython*.override`.
       inherit (f) override;

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -51,7 +51,7 @@ let
         lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511) ''
           Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
             buildPythonPackage.override { stdenv = customStdenv; } { }
-        '' (f.override { inherit (args) stdenv; } args)
+        '' (f.override { inherit (args) stdenv; } (removeAttrs args [ "stdenv" ]))
       else
         f args
     )

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -45,20 +45,23 @@ let
 
   overrideStdenvCompat =
     f:
-    lib.mirrorFunctionArgs f (
-      args:
-      if !(lib.isFunction args) && (args ? stdenv) then
-        lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511) ''
-          Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
-            buildPythonPackage.override { stdenv = customStdenv; } { }
-        '' (f.override { inherit (args) stdenv; } (removeAttrs args [ "stdenv" ]))
-      else
-        f args
-    )
-    // {
-      # Intentionally drop the effect of overrideStdenvCompat when calling `buildPython*.override`.
-      inherit (f) override;
-    };
+    lib.fix (
+      f':
+      lib.mirrorFunctionArgs f (
+        args:
+        if !(lib.isFunction args) && (args ? stdenv) then
+          lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511) ''
+            Passing `stdenv` directly to `buildPythonPackage` or `buildPythonApplication` is deprecated. You should use their `.override` function instead, e.g:
+              buildPythonPackage.override { stdenv = customStdenv; } { }
+          '' (f'.override { inherit (args) stdenv; } (removeAttrs args [ "stdenv" ]))
+        else
+          f args
+      )
+      // {
+        # Preserve the effect of overrideStdenvCompat when calling `buildPython*.override`.
+        override = lib.mirrorFunctionArgs f.override (newArgs: overrideStdenvCompat (f.override newArgs));
+      }
+    );
 
   mkPythonDerivation =
     if python.isPy3k then ./mk-python-derivation.nix else ./python2/mk-python-derivation.nix;

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -38,7 +38,9 @@ let
     // {
       # Support overriding `f` itself, e.g. `buildPythonPackage.override { }`.
       # Ensure `makeOverridablePythonPackage` is applied to the result.
-      override = lib.mirrorFunctionArgs f.override (fdrv: makeOverridablePythonPackage (f.override fdrv));
+      override = lib.mirrorFunctionArgs f.override (
+        newArgs: makeOverridablePythonPackage (f.override newArgs)
+      );
     };
 
   overrideStdenvCompat =

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -453,6 +453,13 @@ let
           })).stdenv;
         expected = pkgs.clangStdenv;
       };
+      overridePythonAttrs-override-clangStdenv-deprecated-nested = {
+        expr =
+          (package-stub-gcc.overridePythonAttrs {
+            stdenv = pkgs.clangStdenv;
+          }).stdenv;
+        expected = pkgs.clangStdenv;
+      };
 
       overridePythonAttrs = {
         expr = (applyOverridePythonAttrs package-stub).overridePythonAttrsFlag;


### PR DESCRIPTION

- We don't need `setFunctionArgs` now `stdenv` is dropped as an explicit parameter from the underlying `mk-python-derivation.nix` files
- Instead, we can `removeAttrs args [ "stdenv "]` to ensure the arg isn't needlessly applied
- While it may be nice to "drop" the compatibility layer from already-overridden build-helpers, this will break in unexpected ways (including `.overridePythonAttrs { stdenv }`)

With this change, the `overridePythonAttrs-override-clangStdenv-deprecated-nested` test I suggested in https://github.com/NixOS/nixpkgs/pull/455462#issuecomment-3448165963 now passes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    - `nix-build -A tests.overriding`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
