### PR TITLE
git-cola: 4.15.0 -> 4.16.0

### DIFF
--- a/pkgs/by-name/gi/git-cola/package.nix
+++ b/pkgs/by-name/gi/git-cola/package.nix
@@ -5,7 +5,7 @@
   python3Packages,
   gettext,
   git,
-  qt5,
+  qt6,
   versionCheckHook,
   copyDesktopItems,
   imagemagick,
@@ -14,33 +14,36 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "git-cola";
-  version = "4.15.0";
+  version = "4.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "git-cola";
     repo = "git-cola";
     tag = "v${version}";
-    hash = "sha256-h3W7CsdJK1hid8Nmp1bvFwiHVS4UV/gziwtyZuxSxHY=";
+    hash = "sha256-gBqMwqmpu0+gMeffiFdwy/kBdCUQRpJr+3vzUkBCRSk=";
   };
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ qt5.qtwayland ];
+  build-system = with python3Packages; [
+    setuptools-scm
+  ];
 
-  propagatedBuildInputs = [
+  buildInputs = [
     git
+    qt6.qtbase
   ]
-  ++ (with python3Packages; [
-    setuptools
-    pyqt5
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ qt6.qtwayland ];
+
+  dependencies = with python3Packages; [
+    polib
+    pyqt6
     qtpy
     send2trash
-    polib
-  ]);
+  ];
 
   nativeBuildInputs = [
     gettext
-    qt5.wrapQtAppsHook
-    python3Packages.setuptools-scm
+    qt6.wrapQtAppsHook
     imagemagick
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ copyDesktopItems ];


### PR DESCRIPTION
This PR updates git-cola to the latest release ([v4.16.0](https://github.com/git-cola/git-cola/releases/tag/v4.16.0)) and switches the build from Qt5 to Qt6, which has been supported upstream for some time.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
