### PR TITLE
calibre: skip crashing test on aarch64-linux

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -221,29 +221,39 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckInputs = with python3Packages; [
     psutil
   ];
-  installCheckPhase = ''
-    runHook preInstallCheck
+  installCheckPhase =
+    let
+      excludedTestNames = [
+        "test_7z" # we don't include 7z support
+        "test_zstd" # we don't include zstd support
+        "test_qt" # we don't include svg or webp support
+        "test_import_of_all_python_modules" # explores actual file paths, gets confused
+        "test_websocket_basic" # flaky
 
-    ETN='--exclude-test-name'
-    EXCLUDED_FLAGS=(
-      $ETN 'test_7z'  # we don't include 7z support
-      $ETN 'test_zstd'  # we don't include zstd support
-      $ETN 'test_qt'  # we don't include svg or webp support
-      $ETN 'test_import_of_all_python_modules'  # explores actual file paths, gets confused
-      $ETN 'test_websocket_basic'  # flakey
-      # hangs with cuda enabled, also:
-      # eglInitialize: Failed to get system egl display
-      # Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-      $ETN 'test_recipe_browser_webengine'
+        # hangs with cuda enabled, also:
+        # eglInitialize: Failed to get system egl display
+        # Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+        "test_recipe_browser_webengine"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+        # https://github.com/microsoft/onnxruntime/issues/10038
+        "test_piper"
+      ]
+      ++ lib.optionals (!unrarSupport) [
+        "test_unrar"
+      ];
 
-      ${lib.optionalString stdenv.hostPlatform.isAarch64 "$ETN 'test_piper'"} # https://github.com/microsoft/onnxruntime/issues/10038
-      ${lib.optionalString (!unrarSupport) "$ETN 'test_unrar'"}
-    )
+      testFlags = lib.concatStringsSep " " (
+        lib.map (testName: "--exclude-test-name ${testName}") excludedTestNames
+      );
+    in
+    ''
+      runHook preInstallCheck
 
-    python setup.py test ''${EXCLUDED_FLAGS[@]}
+      python setup.py test ${testFlags}
 
-    runHook postInstallCheck
-  '';
+      runHook postInstallCheck
+    '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--url=https://github.com/kovidgoyal/calibre" ];

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -238,6 +238,12 @@ stdenv.mkDerivation (finalAttrs: {
       ++ lib.optionals stdenv.hostPlatform.isAarch64 [
         # https://github.com/microsoft/onnxruntime/issues/10038
         "test_piper"
+
+        # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+        #  what():  /build/source/include/onnxruntime/core/common/logging/logging.h:371
+        # static const onnxruntime::logging::Logger& onnxruntime::logging::LoggingManager::DefaultLogger()
+        # Attempt to use DefaultLogger but none has been registered.
+        "test_plugins"
       ]
       ++ lib.optionals (!unrarSupport) [
         "test_unrar"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **calibre refactor test skipping code**
- **calibre: skip crashing test on aarch64-linux**

```
test_plugins (calibre.test_build.BuildTest.test_plugins) ... Error in cpuinfo: failed to parse the list of possible processors in /sys/devices/system/cpu/possible
Error in cpuinfo: failed to parse the list of present processors in /sys/devices/system/cpu/present
Error in cpuinfo: failed to parse both lists of possible and present processors
terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
  what():  /build/source/include/onnxruntime/core/common/logging/logging.h:371 static const onnxruntime::logging::Logger& onnxruntime::logging::LoggingManager::DefaultLogger() Attempt to use DefaultLogger but none has been registered.

/nix/store/rcsp4mykd4d0cnxdcjh2qcn865ad793l-stdenv-linux/setup: line 1774: 18297 Aborted                    (core dumped) python setup.py test ${EXCLUDED_FLAGS[@]}
```

cc @pSub

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
