### PR TITLE
all-packages: do not export lib functions from pkgs

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -14,10 +14,15 @@
 # where said tests are unsupported.
 # Example callTest that just extracts the derivation from the test:
 #   callTest = t: t.test;
-
-with pkgs.lib;
-
 let
+  inherit (pkgs.lib)
+    isAttrs
+    isFunction
+    mapAttrs
+    elem
+    recurseIntoAttrs
+    ;
+
   # TODO: remove when handleTest is gone (make sure nixosTests and nixos/release.nix#tests are unaffected)
   # TODO: when removing, also deprecate `test` attribute in ../lib/testing/run.nix
   discoverTests =
@@ -667,7 +672,7 @@ in
   guacamole-server = runTest ./guacamole-server.nix;
   guix = handleTest ./guix { };
   gvisor = runTest ./gvisor.nix;
-  h2o = import ./web-servers/h2o { inherit recurseIntoAttrs runTest; };
+  h2o = import ./web-servers/h2o { inherit runTest; };
   hadoop = import ./hadoop {
     inherit handleTestOn;
     package = pkgs.hadoop;
@@ -737,13 +742,13 @@ in
   immich-vectorchord-migration = runTest ./web-apps/immich-vectorchord-migration.nix;
   immich-vectorchord-reindex = runTest ./web-apps/immich-vectorchord-reindex.nix;
   incron = runTest ./incron.nix;
-  incus = pkgs.recurseIntoAttrs (
+  incus = recurseIntoAttrs (
     handleTest ./incus {
       lts = false;
       inherit system pkgs;
     }
   );
-  incus-lts = pkgs.recurseIntoAttrs (handleTest ./incus { inherit system pkgs; });
+  incus-lts = recurseIntoAttrs (handleTest ./incus { inherit system pkgs; });
   influxdb = runTest ./influxdb.nix;
   influxdb2 = runTest ./influxdb2.nix;
   initrd-luks-empty-passphrase = runTest ./initrd-luks-empty-passphrase.nix;
@@ -754,7 +759,7 @@ in
   initrdNetwork = runTest ./initrd-network.nix;
   input-remapper = runTest ./input-remapper.nix;
   inspircd = runTest ./inspircd.nix;
-  installed-tests = pkgs.recurseIntoAttrs (handleTest ./installed-tests { });
+  installed-tests = recurseIntoAttrs (handleTest ./installed-tests { });
   installer = handleTest ./installer.nix { };
   installer-systemd-stage-1 = handleTest ./installer-systemd-stage-1.nix { };
   intune = runTest ./intune.nix;
@@ -808,7 +813,7 @@ in
   ksm = runTest ./ksm.nix;
   kthxbye = runTest ./kthxbye.nix;
   kubernetes = handleTestOn [ "x86_64-linux" ] ./kubernetes { };
-  kubo = import ./kubo { inherit recurseIntoAttrs runTest; };
+  kubo = import ./kubo { inherit runTest; };
   lact = runTest ./lact.nix;
   ladybird = runTest ./ladybird.nix;
   languagetool = runTest ./languagetool.nix;
@@ -891,7 +896,7 @@ in
   man = runTest ./man.nix;
   mariadb-galera = handleTest ./mysql/mariadb-galera.nix { };
   marytts = runTest ./marytts.nix;
-  mastodon = pkgs.recurseIntoAttrs (handleTest ./web-apps/mastodon { inherit handleTestOn; });
+  mastodon = recurseIntoAttrs (handleTest ./web-apps/mastodon { inherit handleTestOn; });
   mate = runTest ./mate.nix;
   mate-wayland = runTest ./mate-wayland.nix;
   matomo = runTest ./matomo.nix;
@@ -953,7 +958,7 @@ in
   mopidy = runTest ./mopidy.nix;
   morph-browser = runTest ./morph-browser.nix;
   mosquitto = runTest ./mosquitto.nix;
-  movim = import ./web-apps/movim { inherit recurseIntoAttrs runTest; };
+  movim = import ./web-apps/movim { inherit runTest; };
   mpd = runTest ./mpd.nix;
   mpv = runTest ./mpv.nix;
   mtp = runTest ./mtp.nix;
@@ -1410,7 +1415,7 @@ in
   suricata = runTest ./suricata.nix;
   suwayomi-server = import ./suwayomi-server.nix {
     inherit runTest;
-    lib = pkgs.lib;
+    inherit (pkgs) lib;
   };
   svnserve = runTest ./svnserve.nix;
   swap-file-btrfs = runTest ./swap-file-btrfs.nix;

--- a/nixos/tests/kubo/default.nix
+++ b/nixos/tests/kubo/default.nix
@@ -1,5 +1,5 @@
-{ recurseIntoAttrs, runTest }:
-recurseIntoAttrs {
+{ lib, runTest }:
+lib.recurseIntoAttrs {
   kubo = runTest ./kubo.nix;
   kubo-fuse = runTest ./kubo-fuse.nix;
 }

--- a/nixos/tests/web-apps/movim/default.nix
+++ b/nixos/tests/web-apps/movim/default.nix
@@ -1,6 +1,5 @@
-{ recurseIntoAttrs, runTest }:
-
-recurseIntoAttrs {
+{ lib, runTest }:
+lib.recurseIntoAttrs {
   ejabberd-h2o = runTest ./ejabberd-h2o.nix;
   prosody-nginx = runTest ./prosody-nginx.nix;
 }

--- a/nixos/tests/web-servers/h2o/default.nix
+++ b/nixos/tests/web-servers/h2o/default.nix
@@ -1,6 +1,5 @@
-{ recurseIntoAttrs, runTest }:
-
-recurseIntoAttrs {
+{ lib, runTest }:
+lib.recurseIntoAttrs {
   basic = runTest ./basic.nix;
   mruby = runTest ./mruby.nix;
   tls-recommendations = runTest ./tls-recommendations.nix;

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -53,7 +53,6 @@
   ncurses,
   nixosTests,
   pkg-config,
-  recurseIntoAttrs,
   sigtool,
   sqlite,
   replaceVars,
@@ -496,7 +495,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit withNativeCompilation;
     inherit withTreeSitter;
     inherit withXwidgets;
-    pkgs = recurseIntoAttrs (emacsPackagesFor finalAttrs.finalPackage);
+    pkgs = lib.recurseIntoAttrs (emacsPackagesFor finalAttrs.finalPackage);
     tests = {
       inherit (nixosTests) emacs-daemon;
       withPackages = callPackage ./build-support/wrapper-test.nix {

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -128,7 +128,7 @@ let
     }
   );
 in
-pkgs.recurseIntoAttrs rec {
+pkgs.lib.recurseIntoAttrs rec {
 
   inherit nmt;
 

--- a/pkgs/applications/graphics/tesseract/default.nix
+++ b/pkgs/applications/graphics/tesseract/default.nix
@@ -1,9 +1,10 @@
 {
+  lib,
   callPackage,
-  lowPrio,
 }:
 
 let
+  inherit (lib) lowPrio;
   base3 = callPackage ./tesseract3.nix { };
   base4 = callPackage ./tesseract4.nix { };
   base5 = callPackage ./tesseract5.nix { };

--- a/pkgs/build-support/fetchpypi/default.nix
+++ b/pkgs/build-support/fetchpypi/default.nix
@@ -1,7 +1,7 @@
 # `fetchPypi` function for fetching artifacts from PyPI.
 {
+  lib,
   fetchurl,
-  makeOverridable,
 }:
 
 let
@@ -46,7 +46,7 @@ let
     compute (removeAttrs attrs [ "format" ]);
 
 in
-makeOverridable (
+lib.makeOverridable (
   {
     format ? "setuptools",
     sha256 ? "",

--- a/pkgs/by-name/la/lammps-mpi/package.nix
+++ b/pkgs/by-name/la/lammps-mpi/package.nix
@@ -1,10 +1,10 @@
 {
+  lib,
   lammps,
   mpi,
-  lowPrio,
 }:
 
-lowPrio (
+lib.lowPrio (
   lammps.override {
     extraBuildInputs = [
       mpi

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -8,7 +8,6 @@
 {
   lib,
   config,
-  recurseIntoAttrs,
   generateSplicesForMkScope,
   makeScopeWithSplicing',
   writeScriptBin,
@@ -92,9 +91,9 @@ let
         mkNugetDeps = callPackage ../../../build-support/dotnet/make-nuget-deps { };
         addNuGetDeps = callPackage ../../../build-support/dotnet/add-nuget-deps { };
 
-        dotnet_8 = recurseIntoAttrs (callPackage ./8 { });
-        dotnet_9 = recurseIntoAttrs (callPackage ./9 { });
-        dotnet_10 = recurseIntoAttrs (callPackage ./10 { });
+        dotnet_8 = lib.recurseIntoAttrs (callPackage ./8 { });
+        dotnet_9 = lib.recurseIntoAttrs (callPackage ./9 { });
+        dotnet_10 = lib.recurseIntoAttrs (callPackage ./10 { });
       }
     );
   };

--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -19,7 +19,6 @@
   nugetPackageHook,
   xmlstarlet,
   pkgs,
-  recurseIntoAttrs,
 }:
 type: unwrapped:
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -282,7 +281,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         };
       }
       // lib.optionalAttrs (type == "sdk") {
-        buildDotnetModule = recurseIntoAttrs (
+        buildDotnetModule = lib.recurseIntoAttrs (
           (pkgs.appendOverlays [
             (self: super: {
               dotnet-sdk = finalAttrs.finalPackage;

--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -6,7 +6,6 @@
   callPackage,
   isl_0_20,
   noSysDirs,
-  lowPrio,
   wrapCC,
 }@args:
 
@@ -18,7 +17,7 @@ let
       majorVersion = lib.versions.major majorMinorVersion;
       atLeast = lib.versionAtLeast majorMinorVersion;
       attrName = "gcc${lib.replaceStrings [ "." ] [ "" ] majorMinorVersion}";
-      pkg = lowPrio (
+      pkg = lib.lowPrio (
         wrapCC (
           callPackage ./default.nix {
             inherit noSysDirs;

--- a/pkgs/development/compilers/gcc/ng/default.nix
+++ b/pkgs/development/compilers/gcc/ng/default.nix
@@ -3,7 +3,6 @@
   callPackage,
   stdenv,
   stdenvAdapters,
-  recurseIntoAttrs,
   gccVersions ? { },
   patchesFn ? lib.id,
   buildPackages,
@@ -44,7 +43,7 @@ let
         args.name or (if (gitRelease != null) then "git" else lib.versions.major release_version);
     in
     lib.nameValuePair attrName (
-      recurseIntoAttrs (
+      lib.recurseIntoAttrs (
         callPackage ./common (
           {
             inherit (stdenvAdapters) overrideCC;

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -1,5 +1,4 @@
 {
-  lowPrio,
   pkgs,
   targetPackages,
   lib,
@@ -190,14 +189,14 @@ makeScopeWithSplicing' {
 
       clang-unwrapped = self.libclang;
 
-      llvm-manpages = lowPrio (
+      llvm-manpages = lib.lowPrio (
         self.libllvm.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
         }
       );
 
-      clang-manpages = lowPrio (
+      clang-manpages = lib.lowPrio (
         self.libclang.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot
@@ -261,7 +260,7 @@ makeScopeWithSplicing' {
 
       lldb = callPackage ./lldb { };
 
-      lldb-manpages = lowPrio (
+      lldb-manpages = lib.lowPrio (
         self.lldb.override {
           enableManpages = true;
           python3 = pkgs.python3; # don't use python-boot

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -6,7 +6,6 @@
   targetPackages,
   stdenv,
   pkgs,
-  recurseIntoAttrs,
   # This is the default binutils, but with *this* version of LLD rather
   # than the default LLVM version's, if LLD is the choice. We use these for
   # the `useLLVM` bootstrapping below.
@@ -56,7 +55,7 @@ let
         args.name or (if (gitRelease != null) then "git" else lib.versions.major release_version);
     in
     lib.nameValuePair attrName (
-      recurseIntoAttrs (
+      lib.recurseIntoAttrs (
         callPackage ./common (
           {
             inherit (stdenvAdapters) overrideCC;

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -58,7 +58,7 @@ let
       ";./?.lua;${lua}/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;${lua}/share/lua/5.1/?.lua;${lua}/share/lua/5.1/?/init.lua;";
   };
 in
-pkgs.recurseIntoAttrs {
+lib.recurseIntoAttrs {
 
   checkInterpreterPath =
     let

--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -3,7 +3,6 @@
   config,
   callPackage,
   newScope,
-  recurseIntoAttrs,
   symlinkJoin,
   fetchFromGitHub,
   boost179,
@@ -33,7 +32,7 @@ let
       rocmUpdateScript = self.callPackage ./update.nix { };
 
       ## ROCm ##
-      llvm = recurseIntoAttrs (
+      llvm = lib.recurseIntoAttrs (
         callPackage ./llvm/default.nix {
           # rocm-device-libs is used for .src only
           # otherwise would cause infinite recursion

--- a/pkgs/development/tools/continuous-integration/buildbot/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/default.nix
@@ -2,7 +2,6 @@
   lib,
   newScope,
   python3,
-  recurseIntoAttrs,
 }:
 # Take packages from self first, then python.pkgs (and secondarily pkgs)
 lib.makeScope (self: newScope (self.python.pkgs // self)) (self: {
@@ -14,7 +13,7 @@ lib.makeScope (self: newScope (self.python.pkgs // self)) (self: {
 
   buildbot = self.callPackage ./master.nix { };
 
-  buildbot-plugins = recurseIntoAttrs (self.callPackage ./plugins.nix { });
+  buildbot-plugins = lib.recurseIntoAttrs (self.callPackage ./plugins.nix { });
 
   buildbot-ui = self.buildbot.withPlugins (with self.buildbot-plugins; [ www ]);
 

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -3,7 +3,6 @@
   stdenvNoCC,
   gccStdenv,
   lib,
-  recurseIntoAttrs,
   libsForQt5,
   newScope,
   perlPackages,

--- a/pkgs/games/openra_2019/default.nix
+++ b/pkgs/games/openra_2019/default.nix
@@ -49,7 +49,7 @@ let
   callWithName = name: value: if lib.isFunction value then value name else value;
   buildOpenRASet =
     f: args:
-    pkgs.recurseIntoAttrs (
+    lib.recurseIntoAttrs (
       lib.mapAttrs callWithName (
         f (
           {
@@ -65,7 +65,7 @@ let
     );
 
 in
-pkgs.recurseIntoAttrs rec {
+lib.recurseIntoAttrs rec {
   # The whole attribute set is destructered to ensure those (and only those) attributes are given
   # and to provide defaults for those that are optional.
   buildOpenRAEngine =

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -28,7 +28,6 @@
   multipath-tools,
   nixosTests,
   buildFHSEnv,
-  recurseIntoAttrs,
 }:
 
 # configure: error: --enable-dmeventd requires --enable-cmdlib to be used as well
@@ -224,7 +223,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     installer = nixosTests.installer.lvm;
-    lvm2 = recurseIntoAttrs nixosTests.lvm2;
+    lvm2 = lib.recurseIntoAttrs nixosTests.lvm2;
 
     # https://github.com/NixOS/nixpkgs/issues/369732
     lvm2-fhs-env = buildFHSEnv {

--- a/pkgs/servers/web-apps/pingvin-share/default.nix
+++ b/pkgs/servers/web-apps/pingvin-share/default.nix
@@ -1,7 +1,7 @@
 {
+  lib,
   callPackage,
   fetchFromGitHub,
-  recurseIntoAttrs,
 }:
 
 let
@@ -14,7 +14,7 @@ let
   };
 in
 
-recurseIntoAttrs {
+lib.recurseIntoAttrs {
   backend = callPackage ./backend.nix { inherit src version; };
 
   frontend = callPackage ./frontend.nix { inherit src version; };

--- a/pkgs/servers/web-apps/szurubooru/default.nix
+++ b/pkgs/servers/web-apps/szurubooru/default.nix
@@ -1,7 +1,7 @@
 {
   callPackage,
   fetchFromGitHub,
-  recurseIntoAttrs,
+  lib,
 }:
 
 let
@@ -14,7 +14,7 @@ let
   };
 in
 
-recurseIntoAttrs {
+lib.recurseIntoAttrs {
   client = callPackage ./client.nix { inherit src version; };
   server = callPackage ./server.nix { inherit src version; };
 }

--- a/pkgs/test/cuda/default.nix
+++ b/pkgs/test/cuda/default.nix
@@ -1,17 +1,16 @@
 {
   lib,
   pkgs,
-  recurseIntoAttrs,
 }:
 let
   getTests =
     cps:
-    recurseIntoAttrs {
+    lib.recurseIntoAttrs {
       inherit (cps) saxpy;
       inherit (cps.tests) cuda-library-samples;
     };
 in
-recurseIntoAttrs (
+lib.recurseIntoAttrs (
   lib.mapAttrs (_: getTests) {
     inherit (pkgs)
       cudaPackages

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -22,7 +22,7 @@ let
   };
 in
 lib.optionalAttrs (stdenv.hostPlatform.isLinux) (
-  pkgs.recurseIntoAttrs {
+  lib.recurseIntoAttrs {
     nixos-test =
       (pkgs.nixos {
         system.nixos = dummyVersioning;

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -1,8 +1,8 @@
 {
+  lib,
   vimUtils,
   vim-full,
   vimPlugins,
-  pkgs,
 }:
 let
   inherit (vimUtils) buildVimPlugin;
@@ -10,7 +10,7 @@ let
   packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
 
 in
-pkgs.recurseIntoAttrs {
+lib.recurseIntoAttrs {
   vim_empty_config = vimUtils.vimrcFile {
     beforePlugins = "";
     customRC = "";

--- a/pkgs/tools/games/minecraft/optifine/default.nix
+++ b/pkgs/tools/games/minecraft/optifine/default.nix
@@ -1,5 +1,4 @@
 {
-  recurseIntoAttrs,
   callPackage,
   lib,
 }:
@@ -11,6 +10,6 @@
 # To do so, change directory to nixpkgs root, and do:
 # $ nix-shell ./maintainers/scripts/update.nix --argstr package optifinePackages.optifine-latest --argstr commit true
 
-recurseIntoAttrs (
+lib.recurseIntoAttrs (
   lib.mapAttrs (name: value: callPackage ./generic.nix value) (lib.importJSON ./versions.json)
 )

--- a/pkgs/tools/text/gawk/gawkextlib.nix
+++ b/pkgs/tools/text/gawk/gawkextlib.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  recurseIntoAttrs,
   fetchgit,
   pkg-config,
   autoreconfHook,
@@ -212,7 +211,7 @@ let
     };
   };
 in
-recurseIntoAttrs (
+lib.recurseIntoAttrs (
   libs
   // {
     inherit gawkextlib buildExtension;

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -42,7 +42,6 @@
   makeFontsConf,
   useFixedHashes ? true,
   extraMirrors ? [ ],
-  recurseIntoAttrs,
   nixfmt,
   luajit,
 }:
@@ -543,7 +542,7 @@ let
     license = licenses.scheme-infraonly;
   };
 
-  combined = recurseIntoAttrs (
+  combined = lib.recurseIntoAttrs (
     lib.genAttrs
       [
         "scheme-basic"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -246,8 +246,8 @@ mapAliases {
   llvmPackages_latest = llvmPackages_21;
   llvmPackages_git = (callPackages ../development/compilers/llvm { }).git;
   # these are for convenience, not for backward compat., and shouldn't expire until the package is deprecated.
-  clang18Stdenv = lowPrio llvmPackages_18.stdenv;
-  clang19Stdenv = lowPrio llvmPackages_19.stdenv;
+  clang18Stdenv = lib.lowPrio llvmPackages_18.stdenv;
+  clang19Stdenv = lib.lowPrio llvmPackages_19.stdenv;
 
   # Various to preserve
   autoReconfHook = throw "You meant 'autoreconfHook', with a lowercase 'r'."; # preserve, reason: common typo
@@ -497,6 +497,7 @@ mapAliases {
   docker_27 = throw "'docker_27' has been removed because it has been unmaintained since May 2025. Use docker_28 or newer instead."; # Added 2025-06-15
   dockerfile-language-server-nodejs = warnAlias "'dockerfile-language-server-nodejs' has been renamed to 'dockerfile-language-server'" dockerfile-language-server; # Added 2025-09-12
   dolphin-emu-beta = throw "'dolphin-emu-beta' has been renamed to/replaced by 'dolphin-emu'"; # Converted to throw 2025-10-27
+  dontRecurseIntoAttrs = warnAlias "dontRecurseIntoAttrs has been removed from pkgs, use `lib.dontRecurseIntoAttrs` instead" lib.dontRecurseIntoAttrs; # Added 2025-10-30
   dotnetenv = throw "'dotnetenv' has been removed because it was unmaintained in Nixpkgs"; # Added 2025-07-11
   dotty = throw "'dotty' has been renamed to/replaced by 'scala_3'"; # Converted to throw 2025-10-27
   dovecot_fts_xapian = throw "'dovecot_fts_xapian' has been removed because it was unmaintained in Nixpkgs. Consider using dovecot-fts-flatcurve instead"; # Added 2025-08-16
@@ -687,6 +688,7 @@ mapAliases {
   hibernate = throw "hibernate has been removed due to lack of maintenance"; # Added 2025-09-10
   hiddify-app = throw "hiddify-app has been removed, since it is unmaintained"; # added 2025-08-20
   himitsu-firefox = throw "himitsu-firefox has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-11
+  hiPrio = warnAlias "'hiPrio' has been removed from pkgs, use `lib.hiPrio` instead" lib.hiPrio; # Added 2025-10-30
   hobbes = throw "hobbes has been removed, as it does not build with supported LLVM versions"; # Added 2025-08-20
   hostPlatform = warnAlias "'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'" stdenv.hostPlatform; # Converted to warning 2025-10-28
   hpmyroom = throw "hpmyroom has been removed because it has been marked as broken since May 2024."; # Added 2025-10-11
@@ -925,6 +927,7 @@ mapAliases {
   llvmPackages_16 = throw "llvmPackages_16 has been removed, as it is unmaintained and obsolete"; # Added 2025-08-09
   llvmPackages_17 = throw "llvmPackages_17 has been removed, as it is unmaintained and obsolete"; # Added 2025-08-09
   loco-cli = throw "'loco-cli' has been renamed to/replaced by 'loco'"; # Converted to throw 2025-10-27
+  lowPrio = warnAlias "'lowPrio' has been removed from pkgs, use `lib.lowPrio` instead" lib.lowPrio; # Added 2025-10-30
   LPCNet = throw "'LPCNet' has been renamed to/replaced by 'lpcnet'"; # Converted to throw 2025-10-27
   luci-go = throw "luci-go has been removed since it was unused and failing to build for 5 months"; # Added 2025-08-27
   lxd = throw "
@@ -968,6 +971,7 @@ mapAliases {
   mailcore2 = throw "'mailcore2' has been removed due to lack of upstream maintenance."; # Added 2025-06-09
   mailnag = throw "mailnag has been removed because it has been marked as broken since 2022."; # Added 2025-10-12
   mailnagWithPlugins = throw "mailnagWithPlugins has been removed because mailnag has been marked as broken since 2022."; # Added 2025-10-12
+  makeOverridable = warnAlias "'makeOverridable' has been removed from pkgs, use `lib.makeOverridable` instead" lib.makeOverridable; # Added 2025-10-30
   manaplus = throw "manaplus has been removed, as it was broken"; # Added 2025-08-25
   mariadb-client = throw "mariadb-client has been renamed to mariadb.client"; # Converted to throw 2025-10-26
   marwaita-manjaro = throw "'marwaita-manjaro' has been renamed to/replaced by 'marwaita-teal'"; # Converted to throw 2025-10-27
@@ -1290,6 +1294,7 @@ mapAliases {
   railway-travel = throw "'railway-travel' has been renamed to/replaced by 'diebahn'"; # Converted to throw 2025-10-27
   rambox-pro = throw "'rambox-pro' has been renamed to/replaced by 'rambox'"; # Converted to throw 2025-10-27
   rapidjson-unstable = throw "'rapidjson-unstable' has been renamed to/replaced by 'rapidjson'"; # Converted to throw 2025-10-27
+  recurseIntoAttrs = warnAlias "'recurseIntoAttrs' has been removed from pkgs, use `lib.recurseIntoAttrs` instead" lib.recurseIntoAttrs; # Added 2025-10-30
   redict = throw "'redict' has been removed due to lack of nixpkgs maintenance and a slow upstream development pace. Consider using 'valkey'."; # Added 2025-10-16
   redoc-cli = throw "'redoc-cli' been removed because it has been marked as broken since at least November 2024. Consider using 'redocly' instead."; # Added 2025-10-01
   redocly-cli = throw "'redocly-cli' has been renamed to/replaced by 'redocly'"; # Converted to throw 2025-10-27
@@ -1406,6 +1411,7 @@ mapAliases {
   StormLib = throw "'StormLib' has been renamed to/replaced by 'stormlib'"; # Converted to throw 2025-10-27
   strawberry-qt5 = throw "strawberry-qt5 has been replaced by strawberry"; # Converted to throw 2025-07-19
   strawberry-qt6 = throw "strawberry-qt6 has been replaced by strawberry"; # Added 2025-07-19
+  stringsWithDeps = warnAlias "'stringsWithDeps' has been removed from pkgs, use `lib.stringsWithDeps` instead" lib.stringsWithDeps; # Added 2025-10-30
   subberthehut = throw "'subberthehut' has been removed as it was unmaintained upstream"; # Added 2025-05-17
   sublime-music = throw "`sublime-music` has been removed because upstream has announced it is no longer maintained. Upstream suggests using `supersonic` instead."; # Added 2025-09-20
   substituteAll = throw "`substituteAll` has been removed. Use `replaceVars` instead."; # Added 2025-05-23

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12,6 +12,17 @@
   config,
   overlays,
 }:
+let
+  # Add inherited lib functions only here, so they are not exported from pkgs
+  inherit (lib)
+    lowPrio
+    hiPrio
+    recurseIntoAttrs
+    dontRecurseIntoAttrs
+    makeOverridable
+    ;
+in
+
 res: pkgs: super:
 
 with pkgs;
@@ -31,6 +42,12 @@ with pkgs;
   # (earlier stages being the various `super` variables that precede
   # all-packages.nix)
   _type = "pkgs";
+
+  ### Helper functions.
+  inherit lib config overlays;
+
+  # For convenience, allow callers to get the path to Nixpkgs.
+  path = ../..;
 
   # A stdenv capable of building 32-bit binaries.
   # On x86_64-linux, it uses GCC compiled with multilib support; on i686-linux,
@@ -91,35 +108,13 @@ with pkgs;
   gccStdenvNoLibs = mkStdenvNoLibs gccStdenv;
   clangStdenvNoLibs = mkStdenvNoLibs clangStdenv;
 
-  # For convenience, allow callers to get the path to Nixpkgs.
-  path = ../..;
-
-  ### Helper functions.
-  inherit lib config overlays;
-
-  # do not import 'appendToName' to get consistent package-names with the same
-  # set of package-parameters: https://github.com/NixOS/nixpkgs/issues/68519
-  inherit (lib) lowPrio hiPrio makeOverridable;
-
-  inherit (lib) recurseIntoAttrs;
-
-  # This is intended to be the reverse of recurseIntoAttrs, as it is
-  # defined now it exists mainly for documentation purposes, but you
-  # can also override this with recurseIntoAttrs to recurseInto all
-  # the Attrs which is useful for testing massive changes. Ideally,
-  # every package subset not marked with recurseIntoAttrs should be
-  # marked with this.
-  inherit (lib) dontRecurseIntoAttrs;
-
-  stringsWithDeps = lib.stringsWithDeps;
-
   ### Evaluating the entire Nixpkgs naively will likely fail, make failure fast
   AAAAAASomeThingsFailToEvaluate = throw ''
     This pseudo-package is likely not the only part of Nixpkgs that fails to evaluate.
     You should not evaluate entire Nixpkgs without measures to handle failing packages.
   '';
 
-  tests = lib.recurseIntoAttrs (callPackages ../test { });
+  tests = recurseIntoAttrs (callPackages ../test { });
 
   defaultPkgConfigPackages =
     # We don't want nix-env -q to enter this, because all of these are aliases.
@@ -2185,7 +2180,7 @@ with pkgs;
 
   mpd-sima = python3Packages.callPackage ../tools/audio/mpd-sima { };
 
-  nltk-data = lib.recurseIntoAttrs (callPackage ../tools/text/nltk-data { });
+  nltk-data = recurseIntoAttrs (callPackage ../tools/text/nltk-data { });
 
   seabios-coreboot = seabios.override { ___build-type = "coreboot"; };
   seabios-csm = seabios.override { ___build-type = "csm"; };
@@ -5555,7 +5550,7 @@ with pkgs;
   cbqn-standalone-replxx = cbqn-bootstrap.phase0-replxx;
 
   # Below, the classic self-bootstrapping process
-  cbqn-bootstrap = lib.dontRecurseIntoAttrs {
+  cbqn-bootstrap = dontRecurseIntoAttrs {
     # Use clang to compile CBQN if we aren't already.
     # CBQN's upstream primarily targets and tests clang which means using gcc
     # will result in slower binaries and on some platforms failing/broken builds.
@@ -8170,7 +8165,7 @@ with pkgs;
     nvidia-docker
     ;
 
-  nvidia-vaapi-driver = lib.hiPrio (callPackage ../development/libraries/nvidia-vaapi-driver { });
+  nvidia-vaapi-driver = hiPrio (callPackage ../development/libraries/nvidia-vaapi-driver { });
 
   nvidia-system-monitor-qt = libsForQt5.callPackage ../tools/system/nvidia-system-monitor-qt { };
 
@@ -9263,13 +9258,13 @@ with pkgs;
   home-assistant = callPackage ../servers/home-assistant { };
 
   buildHomeAssistantComponent = callPackage ../servers/home-assistant/build-custom-component { };
-  home-assistant-custom-components = lib.recurseIntoAttrs (
+  home-assistant-custom-components = recurseIntoAttrs (
     lib.packagesFromDirectoryRecursive {
       inherit (home-assistant.python.pkgs) callPackage;
       directory = ../servers/home-assistant/custom-components;
     }
   );
-  home-assistant-custom-lovelace-modules = lib.recurseIntoAttrs (
+  home-assistant-custom-lovelace-modules = recurseIntoAttrs (
     lib.packagesFromDirectoryRecursive {
       inherit callPackage;
       directory = ../servers/home-assistant/custom-lovelace-modules;
@@ -10939,7 +10934,7 @@ with pkgs;
   emacsPackagesFor =
     emacs:
     import ./emacs-packages.nix {
-      inherit (lib) makeScope makeOverridable dontRecurseIntoAttrs;
+      inherit lib;
       emacs' = emacs;
       pkgs' = pkgs; # default pkgs used for bootstrapping the emacs package set
     };
@@ -11003,7 +10998,7 @@ with pkgs;
       python = python3;
     };
   };
-  gnuradioPackages = lib.recurseIntoAttrs gnuradio.pkgs;
+  gnuradioPackages = recurseIntoAttrs gnuradio.pkgs;
 
   goldendict = libsForQt5.callPackage ../applications/misc/goldendict { };
   goldendict-ng = qt6Packages.callPackage ../applications/misc/goldendict-ng { };
@@ -11681,7 +11676,7 @@ with pkgs;
 
   magic-wormhole = with python3Packages; toPythonApplication magic-wormhole;
 
-  magnetophonDSP = lib.recurseIntoAttrs {
+  magnetophonDSP = recurseIntoAttrs {
     CharacterCompressor = callPackage ../applications/audio/magnetophonDSP/CharacterCompressor { };
     CompBus = callPackage ../applications/audio/magnetophonDSP/CompBus { };
     ConstantDetuneChorus = callPackage ../applications/audio/magnetophonDSP/ConstantDetuneChorus { };
@@ -11937,7 +11932,7 @@ with pkgs;
     inherit (darwin) DarwinTools;
   };
 
-  open-music-kontrollers = lib.recurseIntoAttrs {
+  open-music-kontrollers = recurseIntoAttrs {
     eteroj = callPackage ../applications/audio/open-music-kontrollers/eteroj.nix { };
     jit = callPackage ../applications/audio/open-music-kontrollers/jit.nix { };
     mephisto = callPackage ../applications/audio/open-music-kontrollers/mephisto.nix { };
@@ -12568,7 +12563,7 @@ with pkgs;
   # more usecases when wrapping neovim. The interface is being actively worked on
   # so expect breakage. use wrapNeovim instead if you want a stable alternative
   wrapNeovimUnstable = callPackage ../applications/editors/neovim/wrapper.nix { };
-  wrapNeovim = neovim-unwrapped: lib.makeOverridable (neovimUtils.legacyWrapper neovim-unwrapped);
+  wrapNeovim = neovim-unwrapped: makeOverridable (neovimUtils.legacyWrapper neovim-unwrapped);
   neovim-unwrapped = callPackage ../by-name/ne/neovim-unwrapped/package.nix {
     lua = if lib.meta.availableOn stdenv.hostPlatform luajit then luajit else lua5_1;
   };

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -5,7 +5,6 @@
   fetchzip,
   callPackage,
   newScope,
-  recurseIntoAttrs,
   ocamlPackages_4_09,
   ocamlPackages_4_10,
   ocamlPackages_4_12,
@@ -42,7 +41,7 @@ let
       };
       mkCoqDerivation = lib.makeOverridable (callPackage ../build-support/coq { });
 
-      contribs = recurseIntoAttrs (callPackage ../development/coq-modules/contribs { });
+      contribs = lib.recurseIntoAttrs (callPackage ../development/coq-modules/contribs { });
 
       aac-tactics = callPackage ../development/coq-modules/aac-tactics { };
       addition-chains = callPackage ../development/coq-modules/addition-chains { };
@@ -337,6 +336,6 @@ rec {
   coqPackages_9_0 = mkCoqPackages coq_9_0;
   coqPackages_9_1 = mkCoqPackages coq_9_1;
 
-  coqPackages = recurseIntoAttrs coqPackages_9_0;
+  coqPackages = lib.recurseIntoAttrs coqPackages_9_0;
   coq = coqPackages.coq;
 }

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -15,11 +15,9 @@
 */
 
 {
+  lib,
   pkgs',
   emacs',
-  makeScope,
-  makeOverridable,
-  dontRecurseIntoAttrs,
 }:
 
 let
@@ -73,9 +71,9 @@ let
     };
 
 in
-makeScope pkgs'.newScope (
+lib.makeScope pkgs'.newScope (
   self:
-  makeOverridable (
+  lib.makeOverridable (
     {
       pkgs ? pkgs',
       lib ? pkgs.lib,
@@ -122,7 +120,7 @@ makeScope pkgs'.newScope (
         # Propagate overridden scope
         emacs = emacs'.overrideAttrs (old: {
           passthru = (old.passthru or { }) // {
-            pkgs = dontRecurseIntoAttrs self;
+            pkgs = lib.dontRecurseIntoAttrs self;
           };
         });
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -217,7 +217,7 @@ in
             pkgs.lib.attrNames compiler
           );
         in
-        pkgs.recurseIntoAttrs (
+        pkgs.lib.recurseIntoAttrs (
           pkgs.lib.genAttrs nativeBignumGhcNames (
             name: compiler.${name}.override { enableNativeBignum = true; }
           )

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -1,10 +1,14 @@
 { pkgs }:
-
-with pkgs;
-
+let
+  inherit (pkgs)
+    stdenv
+    callPackage
+    config
+    lib
+    ;
+in
 {
   inherit (pkgs) openjfx17 openjfx21 openjfx23;
-
   compiler = lib.recurseIntoAttrs (
     let
       # merge meta.platforms of both packages so that dependent packages and hydra build them
@@ -56,7 +60,7 @@ with pkgs;
       openjdk11-bootstrap = temurin-bin.jdk-11;
       openjdk17-bootstrap = temurin-bin.jdk-17;
 
-      temurin-bin = recurseIntoAttrs (
+      temurin-bin = lib.recurseIntoAttrs (
         let
           temurinLinux = import ../development/compilers/temurin-bin/jdk-linux.nix {
             inherit (pkgs) lib callPackage stdenv;
@@ -68,7 +72,7 @@ with pkgs;
         lib.mapAttrs (name: drv: mkLinuxDarwin drv temurinDarwin.${name}) temurinLinux
       );
 
-      semeru-bin = recurseIntoAttrs (
+      semeru-bin = lib.recurseIntoAttrs (
         let
           semeruLinux = import ../development/compilers/semeru-bin/jdk-linux.nix {
             inherit (pkgs) lib callPackage;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -5,9 +5,6 @@
   config,
   buildPackages,
   callPackage,
-  makeOverridable,
-  recurseIntoAttrs,
-  dontRecurseIntoAttrs,
   stdenv,
   stdenvNoCC,
   newScope,
@@ -22,6 +19,7 @@
 with linuxKernel;
 
 let
+  inherit (lib) recurseIntoAttrs dontRecurseIntoAttrs;
   markBroken =
     drv:
     drv.overrideAttrs (

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -16,10 +16,20 @@
 # - Update packageAliases.linux_latest to the latest version
 # - Update linux_latest_hardened when the patches become available
 
-with linuxKernel;
-
 let
   inherit (lib) recurseIntoAttrs dontRecurseIntoAttrs;
+  inherit (linuxKernel)
+    kernels
+    kernelPatches
+    manualConfig
+    packages
+    packagesFor
+    packageAliases
+    vanillaPackages
+    rtPackages
+    rpiPackages
+    ;
+
   markBroken =
     drv:
     drv.overrideAttrs (

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -9,7 +9,7 @@
   packageOverrides =
     super:
     with super;
-    lib.mapAttrs (_: set: recurseIntoAttrs set) {
+    lib.mapAttrs (_: set: lib.recurseIntoAttrs set) {
       inherit (super)
         rPackages
         sourceHanPackages

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20051,7 +20051,7 @@ self: super: with self; {
     wasmer-compiler-singlepass
     ;
 
-  wasmerPackages = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });
+  wasmerPackages = lib.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });
 
   wasserstein = callPackage ../development/python-modules/wasserstein { };
 

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -5,7 +5,6 @@
   fetchzip,
   callPackage,
   newScope,
-  recurseIntoAttrs,
   ocamlPackages_4_14,
   fetchpatch,
   makeWrapper,
@@ -93,6 +92,6 @@ rec {
   rocqPackages_9_0 = mkRocqPackages rocq-core_9_0;
   rocqPackages_9_1 = mkRocqPackages rocq-core_9_1;
 
-  rocqPackages = recurseIntoAttrs rocqPackages_9_0;
+  rocqPackages = lib.recurseIntoAttrs rocqPackages_9_0;
   rocq-core = rocqPackages.rocq-core;
 }


### PR DESCRIPTION
This is a preparation for some larger cleanups

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
