### PR TITLE
bazarr-sync: init at 0.4

### DIFF
--- a/pkgs/by-name/ba/bazarr-sync/package.nix
+++ b/pkgs/by-name/ba/bazarr-sync/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule rec {
+  pname = "bazarr-sync";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "ajmandourah";
+    repo = "bazarr-sync";
+    rev = "v${version}";
+    hash = "sha256-WyZmuXq0LVyT/6zpIfWyC+i6KIKGVryC1kaCNiQtG64=";
+  };
+
+  vendorHash = "sha256-0K5uBgJ4/QXGd17iNuenB6nXiY2DZn5PIs1jdd10sCs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bulk sync your subtitles via Bazarr";
+    homepage = "https://github.com/ajmandourah/bazarr-sync";
+    # fix once upstream has a LICENSE
+    # https://github.com/ajmandourah/bazarr-sync/issues/15
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ eyjhb ];
+    mainProgram = "bazarr-sync";
+  };
+}


### PR DESCRIPTION
Adds bazarr-sync to nixpkgs. There is no upstream license yet, so it is just added as unfree for the moment being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
