### PR TITLE
codex: 0.47.0 -> 0.50.0

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -14,18 +14,18 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.47.0";
+  version = "0.50.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-5AyatNXgHuia656OuSDozQzQv80bNHncgLN1X23bfM4=";
+    hash = "sha256-8qNQ92VV0aog3USzeAMqWXws7kaQ//6/A/M85USTTXY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-PQ1NxwNBaI48gQ4GGoricA/j7vpsnaLlL6st5P+CTHk=";
+  cargoHash = "sha256-T6Zt5U2aCJWflwKzTbJXwK+BeE7L6IP4WAmISitrpRg=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Automatic update generated by [nixpkgs-update-gha](https://github.com/delafthi/nixpkgs-update-gha). This update was made based on information from `passthru.updatScript`.

meta.description for codex is: Lightweight coding agent that runs in your terminal

meta.homepage for codex is: https://github.com/openai/codex

meta.changelog for codex is: https://raw.githubusercontent.com/openai/codex/refs/tags/rust-v0.50.0/CHANGELOG.md

###### Updates performed

- Ran `passthru.updateScript`

###### To inspect upstream changes

https://raw.githubusercontent.com/openai/codex/refs/tags/rust-v0.50.0/CHANGELOG.md

###### Impact

<b>Checks done</b>

---

- built on NixOS



- found 0.50.0 with grep in /nix/store/w54hmd52a360gdwm47c3k4c3sns63slc-codex-0.50.0
- found 0.50.0 in filename of file in /nix/store/w54hmd52a360gdwm47c3k4c3sns63slc-codex-0.50.0

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
Build logs: https://github.com/delafthi/nixpkgs-update-gha/actions/runs/18816822199
```

</details>

### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review wip`

---
### `x86_64-linux`


:information_source: No packages were built

---

###### Maintainer pings



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.com/blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc