### PR TITLE
stellarium, kdePackages.qxlsx: fix build with QT 6.10

### DIFF
--- a/pkgs/applications/science/astronomy/stellarium/default.nix
+++ b/pkgs/applications/science/astronomy/stellarium/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   perl,
   wrapGAppsHook3,
@@ -36,6 +37,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-9uQ6u1+dSszmKG8eY6kSXhqsCPRGw6tulCTCrLByIxc=";
   };
+
+  # patch from fedora to allow building with Qt 6.10
+  patches = [
+    (fetchpatch2 {
+      url = "https://src.fedoraproject.org/rpms/stellarium/raw/27b05de4be4fa44630c38ffed7f19fe6297e0236/f/stellarium-fix-build-against-qt-6-10.patch";
+      hash = "sha256-VYGaXdokTGOK4pa6WBncdJiVmNQFCaFyRa9r3qXHvY0=";
+    })
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/development/libraries/qxlsx/default.nix
+++ b/pkgs/development/libraries/qxlsx/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   qtbase,
 }:
@@ -16,6 +17,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-twOlAiLE0v7+9nWo/Gd+oiKT1umL3UnG1Xa0zDG7u7s=";
   };
+
+  # patch to fix build with Qt 6.10
+  # picked from master
+  # remove with next release
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/QtExcel/QXlsx/commit/90d762625750c6b2c73f6cd96b633e9158aed72e.patch?full_index=1";
+      hash = "sha256-0Roo/r7aV/ldNz9u6P1NtWzZMF0DFEj1bNjUA3qlnoI=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qtbase ];


### PR DESCRIPTION
For qxlsx: Added patch from master to fix building against Qt 6.10
For stellarium I used a Fedora patch for Qt 6.10

Hydra failure: https://hydra.nixos.org/build/310403475

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 455785`
Commit: `91b81ed32817b72b0d31f5931b4689cf81a7cbed`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>kdePackages.qxlsx (qt6Packages.qxlsx)</li>
    <li>libsForQt5.qxlsx (plasma5Packages.qxlsx)</li>
    <li>stellarium</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
