### PR TITLE
sc64deployer: init at 2.20.2

### DIFF
--- a/pkgs/by-name/sc/sc64deployer/package.nix
+++ b/pkgs/by-name/sc/sc64deployer/package.nix
@@ -1,0 +1,41 @@
+{
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sc64deployer";
+  version = "2.20.2";
+
+  src = fetchFromGitHub {
+    owner = "Polprzewodnikowy";
+    repo = "SummerCart64";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nYnZNCE6bie+8eei3tqqkwHfbr9Pj/wMKW9KSEeSZ7k=";
+  };
+
+  cargoHash = "sha256-bE0CuAoZLx6amun+dnrgNavt0AzOS+JLz9sO+2Zf5s0=";
+  sourceRoot = "source/sw/deployer";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux pkg-config;
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    udev
+  ];
+
+  meta = {
+    description = "SummerCart64 loader and control software";
+    homepage = "https://summercart64.dev";
+    license = lib.licenses.gpl3;
+    mainProgram = "sc64deployer";
+    maintainers = with lib.maintainers; [ nadiaholmquist ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the `sc64deployer` tool, the PC program for controlling the SummerCart 64.

The [SummerCart 64](https://summercart64.dev/) is a completely open source flash cartridge for the Nintendo 64 with a focus on game development. `sc64deployer` lets you upload your compiled programs and debug them from a host PC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
