### PR TITLE
various: lib usage improvements - prefer `removeAttrs` over `filterAttrs`

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -12,7 +12,7 @@ let
   ]
   ++ lib.pipe config.i18n.extraLocaleSettings [
     # See description of extraLocaleSettings for why is this ignored here.
-    (lib.filterAttrs (n: v: n != "LANGUAGE"))
+    (x: lib.removeAttrs x [ "LANGUAGE" ])
     (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
     (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
   ]

--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -101,14 +101,12 @@ let
   # removes NixOS special and unused attributes
   sensorToConf =
     { type, query, ... }@args:
-    (lib.filterAttrs (
-      k: v:
-      v != null
-      && !(lib.elem k [
+    (lib.filterAttrs (k: v: v != null) (
+      lib.removeAttrs args [
         "type"
         "query"
-      ])
-    ) args)
+      ]
+    ))
     // {
       "${type}" = query;
     };

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -403,7 +403,7 @@ in
       }
     ];
     services.public-inbox.settings = filterAttrsRecursive (n: v: v != null) {
-      publicinbox = mapAttrs (n: filterAttrs (n: v: n != "description")) cfg.inboxes;
+      publicinbox = mapAttrs (n: v: removeAttrs v [ "description" ]) cfg.inboxes;
     };
     users = {
       users.public-inbox = {

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -126,7 +126,7 @@ let
       '';
 
   # Get a submodule without any embedded metadata:
-  _filter = x: filterAttrs (k: v: k != "_module") x;
+  _filter = x: removeAttrs x [ "_module" ];
 
   # https://grafana.com/docs/grafana/latest/administration/provisioning/#datasources
   grafanaTypes.datasourceConfig = types.submodule {

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail.nix
@@ -15,6 +15,7 @@ let
     nameValuePair
     toLower
     filterAttrs
+    removeAttrs
     escapeShellArg
     literalExpression
     mkIf
@@ -41,7 +42,7 @@ let
           )
         else
           nameValuePair (toLower name) value
-      ) (filterAttrs (n: _: !(n == "_module")) cfg.configuration)
+      ) (removeAttrs cfg.configuration [ "_module" ])
     )
   );
 

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -270,7 +270,7 @@ let
     lib.updateManyAttrsByPath [
       {
         path = lib.init pathList;
-        update = old: lib.filterAttrs (n: v: n != (lib.last pathList)) old;
+        update = old: lib.removeAttrs old [ (lib.last pathList) ];
       }
     ] set;
 in

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -592,7 +592,7 @@ in
             '';
 
         enabledUpstreamSystemUnits = filter (n: !elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
-        enabledUnits = filterAttrs (n: v: !elem n cfg.suppressedSystemUnits) cfg.units;
+        enabledUnits = removeAttrs cfg.units cfg.suppressedSystemUnits;
 
       in
       {

--- a/pkgs/by-name/qu/quartus-prime-lite/quartus.nix
+++ b/pkgs/by-name/qu/quartus-prime-lite/quartus.nix
@@ -35,9 +35,7 @@ let
       }) supportedDevices
     );
 
-  unsupportedDeviceIds = lib.filterAttrs (
-    name: value: !(lib.hasAttr name supportedDeviceIds)
-  ) deviceIds;
+  unsupportedDeviceIds = lib.removeAttrs deviceIds (lib.attrNames supportedDeviceIds);
 
   componentHashes = {
     "arria_lite" = "sha256-ASvi9YX15b4XXabGjkuR5wl9wDwCijl8s750XTR/4XU=";

--- a/pkgs/development/python-modules/dramatiq-abort/default.nix
+++ b/pkgs/development/python-modules/dramatiq-abort/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     gevent = [ gevent ];
     redis = [ redis ];
   };

--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     code_syntax_highlighting = [ pygments ];
     wavedrom = [ wavedrom ];
     latex = [ latex2mathml ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   meta = {

--- a/pkgs/development/python-modules/odc-loader/default.nix
+++ b/pkgs/development/python-modules/odc-loader/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     botocore = [ botocore ];
     zarr = [ zarr ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pettingzoo/default.nix
+++ b/pkgs/development/python-modules/pettingzoo/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     atari = [
       # multi-agent-ale-py
       pygame

--- a/pkgs/development/python-modules/planetary-computer/default.nix
+++ b/pkgs/development/python-modules/planetary-computer/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     adlfs = [ adlfs ];
     azure = [ azure-storage-blob ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pulsar-client/default.nix
+++ b/pkgs/development/python-modules/pulsar-client/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
       ratelimit
     ];
     avro = [ fastavro ];
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyproject-parser/default.nix
+++ b/pkgs/development/python-modules/pyproject-parser/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     cli = [
       click
       consolekit

--- a/pkgs/development/python-modules/tianshou/default.nix
+++ b/pkgs/development/python-modules/tianshou/default.nix
@@ -92,7 +92,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
 
     argparse = [
       docstring-parser

--- a/pkgs/development/python-modules/whey/default.nix
+++ b/pkgs/development/python-modules/whey/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "whey" ];
 
   optional-dependencies = {
-    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    all = lib.flatten (lib.attrValues (lib.removeAttrs optional-dependencies [ "all" ]));
     editable = [
       editables
     ];

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -99,7 +99,7 @@ let
     let
       # only formatters that were not requested
       unwanted = lib.pipe knownFormatters [
-        (lib.filterAttrs (fmt: _: !(lib.elem fmt supportedFormatters)))
+        (fmts: lib.removeAttrs fmts supportedFormatters)
         lib.attrsToList
       ];
       # all flags to disable

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,7 +57,7 @@
         in
         {
           name = lib.removeSuffix ".patch" src.name;
-          patch = fetchurl (lib.filterAttrs (k: v: k != "extra") src);
+          patch = fetchurl (lib.removeAttrs src [ "extra" ]);
           extra = src.extra;
           inherit version sha256;
         };

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -737,7 +737,10 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           (disallowedPackages prevStage)
           # Only cctools and ld64 are rebuilt from `bintoolsPackages` to avoid rebuilding their dependencies
           # again in this stage after building them in stage 1.
-          (lib.filterAttrs (name: _: name != "ld64" && name != "cctools") (bintoolsPackages prevStage))
+          (lib.removeAttrs (bintoolsPackages prevStage) [
+            "ld64"
+            "cctools"
+          ])
           (llvmToolsDeps prevStage)
           (sdkPackages prevStage)
           (sdkPackagesNoCC prevStage)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from #445357

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> before</summary>

```json
{
  "cpuTime": 7.045458793640137,
  "envs": {
    "bytes": 277566552,
    "elements": 20557892,
    "number": 14137927
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376646688
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14944556,
  "nrExprs": 2241977,
  "nrFunctionCalls": 12182654,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17829336,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 7.045458793640137,
    "gc": 0.127,
    "gcFraction": 0.01802579558262999
  },
  "values": {
    "bytes": 398413968,
    "number": 24900873
  }
}
```

</details>

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> after</summary>

```json
{
  "cpuTime": 7.139747142791748,
  "envs": {
    "bytes": 277563392,
    "elements": 20557695,
    "number": 14137729
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376659616
  },
  "list": {
    "bytes": 29509984,
    "concats": 529173,
    "elements": 3688748
  },
  "nrAvoided": 14944424,
  "nrExprs": 2241942,
  "nrFunctionCalls": 12182456,
  "nrLookups": 7873896,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575522,
  "nrThunks": 17829201,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051622,
    "number": 90282
  },
  "time": {
    "cpu": 7.139747142791748,
    "gc": 0.131,
    "gcFraction": 0.018347988714454255
  },
  "values": {
    "bytes": 398411808,
    "number": 24900738
  }
}
```

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
