### PR TITLE
various: lib usage improvements - prefer `concatMap` over `flatten`/`concatLists` + `map`

### DIFF
--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -10,6 +10,7 @@ let
     addErrorContext
     attrNames
     concatLists
+    concatMap
     const
     filter
     genericClosure
@@ -56,7 +57,7 @@ let
     else if isDerivation x then
       optional (canEval x.drvPath) x
     else if isList x then
-      concatLists (map derivationsIn' x)
+      concatMap derivationsIn' x
     else if isAttrs x then
       concatLists (
         mapAttrsToList (n: v: addErrorContext "while finding tarballs in '${n}':" (derivationsIn' v)) x
@@ -95,7 +96,7 @@ let
     else if isDerivation x then
       optional (canEval x.drvPath) x
     else if isList x then
-      concatLists (map derivationsIn x)
+      concatMap derivationsIn x
     else
       [ ];
 

--- a/nixos/modules/security/doas.nix
+++ b/nixos/modules/security/doas.nix
@@ -279,7 +279,7 @@ in
               # `environment.etc."doas.conf"`.
 
               # extraRules
-              ${lib.concatStringsSep "\n" (lib.lists.flatten (map mkRule cfg.extraRules))}
+              ${lib.concatStringsSep "\n" (lib.lists.concatMap mkRule cfg.extraRules)}
 
               # extraConfig
               ${cfg.extraConfig}

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -182,7 +182,7 @@ let
 
   mkBindSockets =
     enabled: socks:
-    concatStringsSep "\n  " (flatten (map (each: "bind_socket = \"${each.rawEntry}\";") socks));
+    concatStringsSep "\n  " (concatMap (each: "bind_socket = \"${each.rawEntry}\";") socks);
 
   rspamdConfFile = pkgs.writeText "rspamd.conf" ''
     .include "$CONFDIR/common.conf"

--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -234,7 +234,7 @@ in
               type:
               if builtins.hasAttr type interfaceKernelModules then interfaceKernelModules."${type}" else [ ];
           in
-          lib.flatten (builtins.map enableModule initrdInterfaceTypes);
+          lib.concatMap enableModule initrdInterfaceTypes;
 
         systemd = {
           storePaths = [

--- a/nixos/modules/services/networking/keepalived/default.nix
+++ b/nixos/modules/services/networking/keepalived/default.nix
@@ -143,8 +143,8 @@ let
         message = "services.keepalived.vrrpInstances.${i.name}.vmacXmitBase has no effect when services.keepalived.vrrpInstances.${i.name}.useVmac is not set.";
       }
     ]
-    ++ flatten (map (virtualIpAssertions i.name) i.virtualIps)
-    ++ flatten (map (vrrpScriptAssertion i.name) i.trackScripts);
+    ++ concatMap (virtualIpAssertions i.name) i.virtualIps
+    ++ concatMap (vrrpScriptAssertion i.name) i.trackScripts;
 
   virtualIpAssertions = vrrpName: ip: [
     {
@@ -323,7 +323,7 @@ in
 
   config = mkIf cfg.enable {
 
-    assertions = flatten (map vrrpInstanceAssertions vrrpInstances);
+    assertions = concatMap vrrpInstanceAssertions vrrpInstances;
 
     networking.firewall = lib.mkIf cfg.openFirewall {
       extraCommands = ''

--- a/nixos/modules/services/networking/rosenpass.nix
+++ b/nixos/modules/services/networking/rosenpass.nix
@@ -161,7 +161,7 @@ in
             ...
           }:
           filter (x: x != null) (flatten (concatMap (x: (map key (peer x))) (attrValues root)));
-        configuredKeys = flatten (map extract relevantExtractions);
+        configuredKeys = concatMap extract relevantExtractions;
         itemize = xs: concatLines (map (x: " - ${x}") xs);
         descriptions = map (x: "`${x.description}`");
         missingKeys = filter (key: !builtins.elem key configuredKeys) (map (x: x.peer) cfg.settings.peers);

--- a/nixos/modules/services/web-apps/glance.nix
+++ b/nixos/modules/services/web-apps/glance.nix
@@ -9,6 +9,7 @@ let
 
   inherit (lib)
     catAttrs
+    concatMap
     concatMapStrings
     getExe
     mkEnableOption
@@ -19,7 +20,6 @@ let
     ;
 
   inherit (builtins)
-    concatLists
     isAttrs
     isList
     attrNames
@@ -184,9 +184,9 @@ in
                 if data ? _secret then
                   [ data ]
                 else
-                  concatLists (map (attr: findSecrets (getAttr attr data)) (attrNames data))
+                  concatMap (attr: findSecrets (getAttr attr data)) (attrNames data)
               else if isList data then
-                concatLists (map findSecrets data)
+                concatMap findSecrets data
               else
                 [ ];
             secretPaths = catAttrs "_secret" (findSecrets cfg.settings);

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -912,7 +912,7 @@ in
     systemd.services.httpd = {
       description = "Apache HTTPD";
       wantedBy = [ "multi-user.target" ];
-      wants = concatLists (map (certName: [ "acme-${certName}.service" ]) vhostCertNames);
+      wants = concatMap (certName: [ "acme-${certName}.service" ]) vhostCertNames;
       after = [
         "network.target"
       ]

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -434,7 +434,7 @@ in
     systemd.services.h2o = {
       description = "H2O HTTP server";
       wantedBy = [ "multi-user.target" ];
-      wants = lib.concatLists (map (certName: [ "acme-${certName}.service" ]) acmeCertNames.all);
+      wants = lib.concatMap (certName: [ "acme-${certName}.service" ]) acmeCertNames.all;
       # Since H2O will be hosting the challenges, H2O must be started
       before = builtins.map (certName: "acme-order-renew-${certName}.service") acmeCertNames.all;
       after = [

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -1484,7 +1484,7 @@ in
         description = "Nginx Web Server";
         wantedBy = [ "multi-user.target" ];
         wants = lib.optionals (!cfg.enableReload) (
-          concatLists (map (certName: [ "acme-${certName}.service" ]) vhostCertNames)
+          concatMap (certName: [ "acme-${certName}.service" ]) vhostCertNames
         );
         after = [
           "network.target"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -488,8 +488,7 @@ in
           ) "${name}.${typeStr} is ordered after 'network-online.target' but doesn't depend on it";
         mkNetOnlineWarns =
           typeStr: defs: lib.concatLists (lib.mapAttrsToList (mkOneNetOnlineWarn typeStr) defs);
-        mkMountNetOnlineWarns =
-          typeStr: defs: lib.concatLists (map (m: mkOneNetOnlineWarn typeStr m.what m) defs);
+        mkMountNetOnlineWarns = typeStr: defs: lib.concatMap (m: mkOneNetOnlineWarn typeStr m.what m) defs;
       in
       concatLists (
         mapAttrsToList (

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -333,7 +333,7 @@ let
           n: v:
           nameValuePair "${n}-netdev" (
             let
-              deps = concatLists (map deviceDependency v.interfaces);
+              deps = concatMap deviceDependency v.interfaces;
             in
             {
               description = "Bridge Interface ${n}";
@@ -432,8 +432,8 @@ let
           n: v:
           nameValuePair "${n}-netdev" (
             let
-              deps = concatLists (
-                map deviceDependency (attrNames (filterAttrs (_: config: config.type != "internal") v.interfaces))
+              deps = concatMap deviceDependency (
+                attrNames (filterAttrs (_: config: config.type != "internal") v.interfaces)
               );
               internalConfigs = map (i: "network-addresses-${i}.service") (
                 attrNames (filterAttrs (_: config: config.type == "internal") v.interfaces)
@@ -511,7 +511,7 @@ let
           n: v:
           nameValuePair "${n}-netdev" (
             let
-              deps = concatLists (map deviceDependency v.interfaces);
+              deps = concatMap deviceDependency v.interfaces;
             in
             {
               description = "Bond Interface ${n}";

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -21,8 +21,8 @@ let
   dhcpStr = useDHCP: if useDHCP == true || useDHCP == null then "yes" else "no";
 
   slaves =
-    concatLists (map (bond: bond.interfaces) (attrValues cfg.bonds))
-    ++ concatLists (map (bridge: bridge.interfaces) (attrValues cfg.bridges))
+    concatMap (bond: bond.interfaces) (attrValues cfg.bonds)
+    ++ concatMap (bridge: bridge.interfaces) (attrValues cfg.bridges)
     ++ map (sit: sit.dev) (attrValues cfg.sits)
     ++ map (ipip: ipip.dev) (attrValues cfg.ipips)
     ++ map (gre: gre.dev) (attrValues cfg.greTunnels)

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/cask/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/cask/package.nix
@@ -22,7 +22,7 @@ let
     pkg:
     let
       direct = builtins.filter (x: x != null) (pkg.packageRequires or [ ]);
-      indirect = builtins.concatLists (map getAllDependenciesOfPkg direct);
+      indirect = builtins.concatMap getAllDependenciesOfPkg direct;
     in
     lib.unique (direct ++ indirect);
 in

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/package.nix
@@ -36,7 +36,7 @@ let
     )
   ]
   ++ appPythonDeps;
-  pythonPkgs = ps: builtins.concatLists (map (f: f ps) pythonPackageLists);
+  pythonPkgs = ps: builtins.concatMap (f: f ps) pythonPackageLists;
   pythonEnv = python3.withPackages pythonPkgs;
 
   wmctrlExe = lib.getExe wmctrl;

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -158,8 +158,7 @@ let
   # transitive closure of plugin dependencies (plugin needs to be a derivation)
   transitiveClosure =
     plugin:
-    [ plugin ]
-    ++ (lib.unique (builtins.concatLists (map transitiveClosure plugin.dependencies or [ ])));
+    [ plugin ] ++ (lib.unique (builtins.concatMap transitiveClosure (plugin.dependencies or [ ])));
 
   findDependenciesRecursively = plugins: lib.concatMap transitiveClosure plugins;
 

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -202,7 +202,7 @@ let
           startWithDeps = findDependenciesRecursively start;
           allPlugins = lib.unique (startWithDeps ++ depsOfOptionalPlugins);
           allPython3Dependencies =
-            ps: lib.flatten (map (plugin: (plugin.python3Dependencies or (_: [ ])) ps) allPlugins);
+            ps: lib.concatMap (plugin: (plugin.python3Dependencies or (_: [ ])) ps) allPlugins;
           python3Env = python3.withPackages allPython3Dependencies;
 
           packdirStart = vimFarm "pack/${packageName}/start" "packdir-start" allPlugins;

--- a/pkgs/applications/emulators/wine/util.nix
+++ b/pkgs/applications/emulators/wine/util.nix
@@ -1,6 +1,6 @@
 { lib }:
 rec {
   toPackages = pkgNames: pkgs: map (pn: lib.getAttr pn pkgs) pkgNames;
-  toBuildInputs = pkgArches: archPkgs: lib.concatLists (map archPkgs pkgArches);
+  toBuildInputs = pkgArches: archPkgs: lib.concatMap archPkgs pkgArches;
   mkBuildInputs = pkgArches: pkgNames: toBuildInputs pkgArches (toPackages pkgNames);
 }

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -166,8 +166,8 @@ assert builtins.elem variant [
 
 let
   inherit (lib)
-    flatten
     flip
+    concatMap
     concatMapStrings
     concatStringsSep
     getDev
@@ -249,8 +249,8 @@ let
   # See `postPatch` for details
   kdeDeps = symlinkJoin {
     name = "libreoffice-kde-dependencies-${version}";
-    paths = flatten (
-      map
+    paths =
+      concatMap
         (e: [
           (getDev e)
           (getLib e)
@@ -263,8 +263,7 @@ let
           kdePackages.ki18n
           kdePackages.kio
           kdePackages.kwindowsystem
-        ]
-    );
+        ];
   };
   tarballPath = "external/tarballs";
 

--- a/pkgs/applications/video/vdr/wrapper.nix
+++ b/pkgs/applications/video/vdr/wrapper.nix
@@ -9,7 +9,7 @@ let
 
   makeXinePluginPath = l: lib.concatStringsSep ":" (map (p: "${p}/lib/xine/plugins") l);
 
-  requiredXinePlugins = lib.flatten (map (p: p.passthru.requiredXinePlugins or [ ]) plugins);
+  requiredXinePlugins = lib.concatMap (p: p.passthru.requiredXinePlugins or [ ]) plugins;
 
 in
 symlinkJoin {

--- a/pkgs/by-name/ag/ags/package.nix
+++ b/pkgs/by-name/ag/ags/package.nix
@@ -62,7 +62,7 @@ buildGoModule rec {
       depsOf = pkg: [ (pkg.dev or pkg) ] ++ (map depsOf (pkg.propagatedBuildInputs or [ ]));
       girDirs = symlinkJoin {
         name = "gir-dirs";
-        paths = lib.flatten (map depsOf buildInputs);
+        paths = lib.concatMap depsOf buildInputs;
       };
     in
     ''

--- a/pkgs/by-name/ca/cantata/package.nix
+++ b/pkgs/by-name/ca/cantata/package.nix
@@ -210,7 +210,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.wrapQtAppsHook
   ];
 
-  cmakeFlags = lib.flatten (map (e: map (f: fstat e.enable f) e.names) options);
+  cmakeFlags = lib.concatMap (e: map (f: fstat e.enable f) e.names) options;
 
   qtWrapperArgs = lib.optionals (withHttpStream && !withLibVlc) [
     "--prefix GST_PLUGIN_PATH : ${lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gst}"

--- a/pkgs/by-name/fa/factorio/utils.nix
+++ b/pkgs/by-name/fa/factorio/utils.nix
@@ -3,7 +3,7 @@
 { lib, stdenv }:
 let
   inherit (lib)
-    flatten
+    concatMap
     head
     optionals
     optionalString
@@ -18,7 +18,7 @@ in
     mods: modsDatFile: # a list of mod derivations
     let
       recursiveDeps = modDrv: [ modDrv ] ++ map recursiveDeps modDrv.deps;
-      modDrvs = unique (flatten (map recursiveDeps mods));
+      modDrvs = unique (concatMap recursiveDeps mods);
     in
     stdenv.mkDerivation {
       name = "factorio-mod-directory";

--- a/pkgs/by-name/re/retroarch-bare/wrapper.nix
+++ b/pkgs/by-name/re/retroarch-bare/wrapper.nix
@@ -24,12 +24,10 @@ let
   # but let's be safe here
   coresPath = lib.lists.unique (map (c: c.libretroCore) cores);
   wrapperArgs = lib.strings.escapeShellArgs (
-    (lib.lists.flatten (
-      map (p: [
-        "--add-flags"
-        "-L ${placeholder "out" + p}"
-      ]) coresPath
-    ))
+    (lib.concatMap (p: [
+      "--add-flags"
+      "-L ${placeholder "out" + p}"
+    ]) coresPath)
     ++ [
       "--add-flags"
       "--appendconfig=${settingsPath}"

--- a/pkgs/by-name/sa/sage/sage-with-env.nix
+++ b/pkgs/by-name/sa/sage/sage-with-env.nix
@@ -70,13 +70,13 @@ let
       [ dep ]
       ++ (
         if builtins.hasAttr "propagatedBuildInputs" dep then
-          lib.unique (builtins.concatLists (map transitiveClosure dep.propagatedBuildInputs))
+          lib.unique (builtins.concatMap transitiveClosure dep.propagatedBuildInputs)
         else
           [ ]
       );
 
   allInputs = lib.remove null (nativeBuildInputs ++ buildInputs ++ pythonEnv.extraLibs);
-  transitiveDeps = lib.unique (builtins.concatLists (map transitiveClosure allInputs));
+  transitiveDeps = lib.unique (builtins.concatMap transitiveClosure allInputs);
   # fix differences between spkg and sage names
   # (could patch sage instead, but this is more lightweight and also works for packages depending on sage)
   patch_names =

--- a/pkgs/development/compilers/factor-lang/wrapper.nix
+++ b/pkgs/development/compilers/factor-lang/wrapper.nix
@@ -53,7 +53,7 @@ let
     defaultLibs
     ++ extraLibs
     ++ binPackages
-    ++ (lib.flatten (map (v: v.extraLibs or [ ]) extraVocabs))
+    ++ (lib.concatMap (v: v.extraLibs or [ ]) extraVocabs)
     ++ optionals guiSupport [
       cairo
       freealut
@@ -65,7 +65,7 @@ let
       libGLU
       pango
     ];
-  bins = binPackages ++ defaultBins ++ (lib.flatten (map (v: v.extraPaths or [ ]) extraVocabs));
+  bins = binPackages ++ defaultBins ++ (lib.concatMap (v: v.extraPaths or [ ]) extraVocabs);
   vocabTree = buildEnv {
     name = "${factor-unwrapped.pname}-vocabs";
     ignoreCollisions = true;

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -52,7 +52,7 @@ let
   expandSingleDep =
     dep: lib.optionals (lib.isDerivation dep) ([ dep ] ++ map (output: dep.${output}) dep.outputs);
 
-  expandDeps = deps: lib.flatten (map expandSingleDep deps);
+  expandDeps = deps: lib.concatMap expandSingleDep deps;
 
   constants = callPackage ./constants.nix { platform = stdenv.targetPlatform; };
 

--- a/pkgs/development/ruby-modules/testing/driver.nix
+++ b/pkgs/development/ruby-modules/testing/driver.nix
@@ -21,6 +21,6 @@ let
 
   tap = import ./tap-support.nix;
 
-  results = builtins.concatLists (map (file: callPackage file testTools) testFiles);
+  results = builtins.concatMap (file: callPackage file testTools) testFiles;
 in
 writeText "test-results.tap" (tap.output results)

--- a/pkgs/development/ruby-modules/testing/testing.nix
+++ b/pkgs/development/ruby-modules/testing/testing.nix
@@ -42,16 +42,14 @@ let
   run =
     name: under: tests:
     if isList tests then
-      (concatLists (map (run name under) tests))
+      (concatMap (run name under) tests)
     else if isAttrs tests then
-      (concatLists (
-        map (
-          subName:
-          run (name + "." + subName) (if hasAttr subName under then getAttr subName under else "<MISSING!>") (
-            getAttr subName tests
-          )
-        ) (attrNames tests)
-      ))
+      (concatMap (
+        subName:
+        run (name + "." + subName) (if hasAttr subName under then getAttr subName under else "<MISSING!>") (
+          getAttr subName tests
+        )
+      ) (attrNames tests))
     else if isFunction tests then
       let
         res = tests under;

--- a/pkgs/development/tools/yarn2nix-moretea/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/default.nix
@@ -333,7 +333,7 @@ rec {
       baseName = unlessNull name "${safeName}-${version}";
 
       workspaceDependenciesTransitive = lib.unique (
-        (lib.flatten (map (dep: dep.workspaceDependencies) workspaceDependencies)) ++ workspaceDependencies
+        (lib.concatMap (dep: dep.workspaceDependencies) workspaceDependencies) ++ workspaceDependencies
       );
 
       deps = mkYarnModules {

--- a/pkgs/os-specific/bsd/freebsd/lib/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/lib/default.nix
@@ -81,7 +81,7 @@
         else if (builtins.isPath patches) then
           (if (isDir patches) then (lib.filesystem.listFilesRecursive patches) else [ patches ])
         else if (builtins.isList patches) then
-          (lib.flatten (map consolidatePatches patches))
+          (lib.concatMap consolidatePatches patches)
         else
           throw "Bad patches - must be path or derivation or list thereof";
       consolidated = consolidatePatches patches;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -754,7 +754,7 @@ stdenv.mkDerivation (finalAttrs: {
       mesonFlagsArray+=(-Dntp-servers="0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org")
       export LC_ALL="en_US.UTF-8";
 
-      ${lib.concatStringsSep "\n" (lib.flatten (map mkSubstitute binaryReplacements))}
+      ${lib.concatStringsSep "\n" (lib.concatMap mkSubstitute binaryReplacements)}
       ${lib.concatMapStringsSep "\n" mkEnsureSubstituted binaryReplacements}
 
       substituteInPlace src/libsystemd/sd-journal/catalog.c \

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -33,7 +33,7 @@ symlinkJoin {
       --suffix XDG_DATA_DIRS : "$out/share" \
       --suffix PATH : "$out/bin" \
       --suffix LD_LIBRARY_PATH : "${
-        lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or [ ]) addons))
+        lib.makeLibraryPath (lib.concatMap (x: x.extraLdLibraries or [ ]) addons)
       }"
 
     ${lib.optionalString withConfigtool ''

--- a/pkgs/tools/networking/maubot/wrapper.nix
+++ b/pkgs/tools/networking/maubot/wrapper.nix
@@ -16,7 +16,7 @@ let
     }:
     let
       plugins' = plugins unwrapped.plugins;
-      extraPythonPackages = builtins.concatLists (map (p: p.propagatedBuildInputs or [ ]) plugins');
+      extraPythonPackages = builtins.concatMap (p: p.propagatedBuildInputs or [ ]) plugins';
     in
     symlinkJoin {
       name = "${unwrapped.pname}-with-plugins-${unwrapped.version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from #445357

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> before</summary>

```json
{
  "cpuTime": 7.045458793640137,
  "envs": {
    "bytes": 277566552,
    "elements": 20557892,
    "number": 14137927
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376646688
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14944556,
  "nrExprs": 2241977,
  "nrFunctionCalls": 12182654,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17829336,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 7.045458793640137,
    "gc": 0.127,
    "gcFraction": 0.01802579558262999
  },
  "values": {
    "bytes": 398413968,
    "number": 24900873
  }
}
```

</details>

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> after</summary>

```json
{
  "cpuTime": 7.28170919418335,
  "envs": {
    "bytes": 277563352,
    "elements": 20557692,
    "number": 14137727
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376634736
  },
  "list": {
    "bytes": 29509168,
    "concats": 529171,
    "elements": 3688646
  },
  "nrAvoided": 14944254,
  "nrExprs": 2241938,
  "nrFunctionCalls": 12182454,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575451,
  "nrThunks": 17829294,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 7.28170919418335,
    "gc": 0.131,
    "gcFraction": 0.01799028174657719
  },
  "values": {
    "bytes": 398412752,
    "number": 24900797
  }
}
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
