### PR TITLE
various: lib usage improvements - prefer `elem` over `any` for list inclusion conditions

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -30,12 +30,12 @@ in
       glibcLocales = lib.mkOption {
         type = lib.types.path;
         default = pkgs.glibcLocales.override {
-          allLocales = lib.any (x: x == "all") config.i18n.supportedLocales;
+          allLocales = lib.elem "all" config.i18n.supportedLocales;
           locales = config.i18n.supportedLocales;
         };
         defaultText = lib.literalExpression ''
           pkgs.glibcLocales.override {
-            allLocales = lib.any (x: x == "all") config.i18n.supportedLocales;
+            allLocales = lib.elem "all" config.i18n.supportedLocales;
             locales = config.i18n.supportedLocales;
           }
         '';

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -149,7 +149,7 @@ in
         (
           !(
             (lib.subtractLists config.i18n.supportedLocales aggregatedLocales) == [ ]
-            || lib.any (x: x == "all") config.i18n.supportedLocales
+            || lib.elem "all" config.i18n.supportedLocales
           )
         )
         ''

--- a/nixos/modules/services/audio/mpdscribble.nix
+++ b/nixos/modules/services/audio/mpdscribble.nix
@@ -130,7 +130,7 @@ in
     passwordFile = lib.mkOption {
       default =
         if localMpd then
-          (lib.findFirst (c: lib.any (x: x == "read") c.permissions) {
+          (lib.findFirst (c: lib.elem "read" c.permissions) {
             passwordFile = null;
           } mpdCfg.credentials).passwordFile
         else

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -13,11 +13,11 @@ let
     types
     concatStringsSep
     concatMapStringsSep
-    any
+    elem
     optionals
     ;
-  collectorIsEnabled = final: any (collector: (final == collector)) cfg.enabledCollectors;
-  collectorIsDisabled = final: any (collector: (final == collector)) cfg.disabledCollectors;
+  collectorIsEnabled = final: elem final cfg.enabledCollectors;
+  collectorIsDisabled = final: elem final cfg.disabledCollectors;
 in
 {
   port = 9100;

--- a/nixos/modules/services/networking/ifstate.nix
+++ b/nixos/modules/services/networking/ifstate.nix
@@ -198,7 +198,7 @@ in
         {
           assertion =
             initrdCfg.package.passthru.features.withWireguard
-            || !(builtins.any (kind: kind == "wireguard") initrdInterfaceTypes);
+            || !(builtins.elem "wireguard" initrdInterfaceTypes);
           message = "IfState initrd package is configured without the `wireguard` feature, but wireguard interfaces are configured. Please see the `boot.initrd.network.ifstate.package` option.";
         }
         {

--- a/nixos/modules/services/web-apps/dolibarr.nix
+++ b/nixos/modules/services/web-apps/dolibarr.nix
@@ -6,9 +6,9 @@
 }:
 let
   inherit (lib)
-    any
     boolToString
     concatStringsSep
+    elem
     isBool
     isString
     mapAttrsToList
@@ -46,7 +46,7 @@ let
 
       toStr =
         k: v:
-        if (any (str: k == str) secretKeys) then
+        if (elem k secretKeys) then
           v
         else if isString v then
           "'${v}'"

--- a/nixos/modules/services/web-apps/librespeed.nix
+++ b/nixos/modules/services/web-apps/librespeed.nix
@@ -338,10 +338,10 @@ in
                 proxy_buffering off;
                 proxy_request_buffering off;
               ''
-              + lib.optionalString (lib.any (m: m.name == "brotli") config.services.nginx.additionalModules) ''
+              + lib.optionalString (lib.elem "brotli" config.services.nginx.additionalModules) ''
                 brotli off;
               ''
-              + lib.optionalString (lib.any (m: m.name == "zstd") config.services.nginx.additionalModules) ''
+              + lib.optionalString (lib.elem "zstd" config.services.nginx.additionalModules) ''
                 zstd off;
               '';
             };

--- a/nixos/modules/system/boot/kernel_config.nix
+++ b/nixos/modules/system/boot/kernel_config.nix
@@ -6,7 +6,7 @@ let
     locs: defs:
     if defs == [ ] then
       abort "This case should never happen."
-    else if any (x: x == false) (getValues defs) then
+    else if elem false (getValues defs) then
       false
     else
       true;

--- a/nixos/tests/kubernetes/base.nix
+++ b/nixos/tests/kubernetes/base.nix
@@ -18,9 +18,7 @@ let
     }:
     let
       masterName = head (
-        filter (machineName: any (role: role == "master") machines.${machineName}.roles) (
-          attrNames machines
-        )
+        filter (machineName: lib.elem "master" machines.${machineName}.roles) (attrNames machines)
       );
       master = machines.${masterName};
       extraHosts = ''

--- a/nixos/tests/sftpgo.nix
+++ b/nixos/tests/sftpgo.nix
@@ -25,7 +25,7 @@ let
     groupName:
     # users.users attrset
     user:
-    lib.any (x: x == user.name) config.users.groups.${groupName}.members;
+    lib.elem user.name config.users.groups.${groupName}.members;
 
   # Generates a valid SFTPGo user configuration for a given user
   # Will be converted to JSON and loaded on application startup.

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -48,7 +48,7 @@
   ctestCheckHook,
 }:
 
-assert builtins.any (g: guiModule == g) [
+assert builtins.elem guiModule [
   "fltk"
   "ntk"
   "zest"

--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -62,7 +62,7 @@ in
                 "logo64"
                 "extraPaths"
               ];
-              kernel = lib.filterAttrs (n: v: (lib.any (x: x == n) allowedKernelKeys)) unfilteredKernel;
+              kernel = lib.filterAttrs (n: v: (lib.elem n allowedKernelKeys)) unfilteredKernel;
               config = builtins.toJSON (
                 kernel
                 // {

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -142,14 +142,12 @@ stdenv.mkDerivation (finalAttrs: {
         # the following are distributed with calibre, but we use upstream instead
         odfpy
       ]
-      ++
-        lib.optionals (lib.lists.any (p: p == stdenv.hostPlatform.system) pyqt6-webengine.meta.platforms)
-          [
-            # much of calibre's functionality is usable without a web
-            # browser, so we enable building on platforms which qtwebengine
-            # does not support by simply omitting qtwebengine.
-            pyqt6-webengine
-          ]
+      ++ lib.optionals (lib.lists.elem stdenv.hostPlatform.system pyqt6-webengine.meta.platforms) [
+        # much of calibre's functionality is usable without a web
+        # browser, so we enable building on platforms which qtwebengine
+        # does not support by simply omitting qtwebengine.
+        pyqt6-webengine
+      ]
       ++ lib.optional unrarSupport unrardll
     ))
     piper-tts

--- a/pkgs/by-name/di/distrho-ports/package.nix
+++ b/pkgs/by-name/di/distrho-ports/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
 
   env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
 
-  postFixup = lib.optionalString (lib.any (x: x == "vitalium") plugins || plugins == [ ]) ''
+  postFixup = lib.optionalString (lib.elem "vitalium" plugins || plugins == [ ]) ''
     for file in \
       $out/lib/lv2/vitalium.lv2/vitalium.so \
       $out/lib/vst/vitalium.so \

--- a/pkgs/by-name/in/inspircd/package.nix
+++ b/pkgs/by-name/in/inspircd/package.nix
@@ -24,7 +24,7 @@ let
   # libcs in nixpkgs (musl and glibc).
   compatible =
     lib: drv:
-    lib.any (lic: lic == (drv.meta.license or { })) [
+    lib.elem (drv.meta.license or { }) [
       lib.licenses.mit # musl
       lib.licenses.lgpl2Plus # glibc
     ];

--- a/pkgs/by-name/li/libvgm/package.nix
+++ b/pkgs/by-name/li/libvgm/package.nix
@@ -106,9 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "More modular rewrite of most components from VGMPlay";
     homepage = "https://github.com/ValleyBell/libvgm";
     license =
-      if
-        (enableEmulation && (withAllEmulators || (lib.lists.any (core: core == "WSWAN_ALL") emulators)))
-      then
+      if (enableEmulation && (withAllEmulators || (lib.lists.elem "WSWAN_ALL" emulators))) then
         lib.licenses.unfree # https://github.com/ValleyBell/libvgm/issues/43
       else
         lib.licenses.gpl2Only;

--- a/pkgs/by-name/ot/otb/package.nix
+++ b/pkgs/by-name/ot/otb/package.nix
@@ -59,7 +59,7 @@ let
     # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2454#note_112821
     "fftw"
   ];
-  itkIsInDepsToRemove = dep: builtins.any (d: d == dep.name) itkDepsToRemove;
+  itkIsInDepsToRemove = dep: builtins.elem dep.name itkDepsToRemove;
 
   # remove after https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2451
   otbSwig = swig.overrideAttrs (oldArgs: {

--- a/pkgs/by-name/sl/sleek-grub-theme/package.nix
+++ b/pkgs/by-name/sl/sleek-grub-theme/package.nix
@@ -6,7 +6,7 @@
   withStyle ? "light", # use override to specify one of "dark" / "orange" / "bigSur"
 }:
 
-assert builtins.any (s: withStyle == s) [
+assert builtins.elem withStyle [
   "light"
   "dark"
   "orange"

--- a/pkgs/by-name/uw/uwsgi/package.nix
+++ b/pkgs/by-name/uw/uwsgi/package.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # this is a hack to make the php plugin link with session.so (which on nixos is a separate package)
   # the hack works in coordination with ./additional-php-ldflags.patch
-  UWSGICONFIG_PHP_LDFLAGS = lib.optionalString (builtins.any (x: x.name == "php") needed) (
+  UWSGICONFIG_PHP_LDFLAGS = lib.optionalString (lib.elem "php" needed) (
     lib.concatStringsSep "," [
       "-Wl"
       "-rpath=${php-embed.extensions.session}/lib/php/extensions/"
@@ -176,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postFixup = lib.optionalString (builtins.any (x: x.name == "php") needed) ''
+  postFixup = lib.optionalString (lib.elem "php" needed) ''
     wrapProgram $out/bin/uwsgi --set PHP_INI_SCAN_DIR ${php-embed}/lib
   '';
 

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
   ]
   ++
     lib.optionals
-      (lib.any (l: l == optimizationLevel) [
+      (lib.elem optimizationLevel [
         "0"
         "1"
         "2"

--- a/pkgs/development/ruby-modules/testing/stubs.nix
+++ b/pkgs/development/ruby-modules/testing/stubs.nix
@@ -14,7 +14,7 @@ let
         builtins.toJSON (
           lib.filterAttrs (
             n: v:
-            builtins.any (x: x == n) [
+            builtins.elem n [
               "name"
               "system"
             ]

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -57,7 +57,7 @@ let
 
     let
       inherit (lib)
-        any
+        elem
         optionalString
         optionals
         optional
@@ -66,11 +66,11 @@ let
 
       smartmon = smartmontools.override { inherit enableMail; };
 
-      buildKernel = any (n: n == configFile) [
+      buildKernel = elem configFile [
         "kernel"
         "all"
       ];
-      buildUser = any (n: n == configFile) [
+      buildUser = elem configFile [
         "user"
         "all"
       ];

--- a/pkgs/servers/web-apps/wordpress/packages/default.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/default.nix
@@ -43,7 +43,7 @@ let
           license,
           ...
         }@args:
-        assert lib.any (x: x == type) [
+        assert lib.elem type [
           "plugin"
           "theme"
           "language"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -426,7 +426,7 @@ let
 
       concretizeFlagImplications =
         flag: impliesFlags: list:
-        if any (x: x == flag) list then (list ++ impliesFlags) else list;
+        if builtins.elem flag list then (list ++ impliesFlags) else list;
 
       hardeningDisable' = unique (
         pipe hardeningDisable [

--- a/pkgs/tools/networking/maubot/plugins/generated.nix
+++ b/pkgs/tools/networking/maubot/plugins/generated.nix
@@ -69,7 +69,7 @@ lib.flip builtins.mapAttrs json (
             );
           in
           spdxLicenses.${spdx};
-        broken = builtins.any (x: x == null) reqDeps;
+        broken = builtins.elem null reqDeps;
       };
     }
     // lib.optionalAttrs (entry.isPoetry or false) {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from #445357

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> before</summary>


```json
{
  "cpuTime": 7.045458793640137,
  "envs": {
    "bytes": 277566552,
    "elements": 20557892,
    "number": 14137927
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376646688
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14944556,
  "nrExprs": 2241977,
  "nrFunctionCalls": 12182654,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17829336,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 7.045458793640137,
    "gc": 0.127,
    "gcFraction": 0.01802579558262999
  },
  "values": {
    "bytes": 398413968,
    "number": 24900873
  }
}
```

</details>

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> after</summary>

```json
{
  "cpuTime": 6.7508931159973145,
  "envs": {
    "bytes": 277542552,
    "elements": 20556392,
    "number": 14136427
  },
  "gc": {
    "cycles": 6,
    "heapSize": 587464704,
    "totalBytes": 1376587392
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14945929,
  "nrExprs": 2241940,
  "nrFunctionCalls": 12181154,
  "nrLookups": 7874611,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17827963,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 6.7508931159973145,
    "gc": 0.114,
    "gcFraction": 0.016886654556840616
  },
  "values": {
    "bytes": 398392000,
    "number": 24899500
  }
}
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
