### PR TITLE
various: lib usage improvements - remove arg-skipping uses of lib.const

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -21,7 +21,6 @@ let
     substring
     attrValues
     concatLists
-    const
     elem
     generators
     id
@@ -221,7 +220,7 @@ rec {
         else
           v;
       noQuotes = str: v: {
-        __pretty = const str;
+        __pretty = _: str;
         val = v;
       };
       modify =
@@ -231,7 +230,7 @@ rec {
         else if isList v then
           map (modify (n - 1) fn) v
         else if isAttrs v then
-          mapAttrs (const (modify (n - 1) fn)) v
+          mapAttrs (_: modify (n - 1) fn) v
         else
           v;
     in

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2443,7 +2443,7 @@ runTests {
           # float = 42.23; # floats are strange
         };
       in
-      mapAttrs (const (generators.mkValueStringDefault { })) vals;
+      mapAttrs (_: generators.mkValueStringDefault { }) vals;
     expected = {
       int = "42";
       string = ''fo"o'';
@@ -2684,7 +2684,7 @@ runTests {
       };
     in
     {
-      expr = mapAttrs (const (generators.toPretty { multiline = false; })) rec {
+      expr = mapAttrs (_: generators.toPretty { multiline = false; }) rec {
         int = 42;
         float = 0.1337;
         bool = true;
@@ -2782,7 +2782,7 @@ runTests {
     };
 
   testToPrettyMultiline = {
-    expr = mapAttrs (const (generators.toPretty { })) {
+    expr = mapAttrs (_: generators.toPretty { }) {
       list = [
         3
         4
@@ -2844,7 +2844,7 @@ runTests {
   };
 
   testToPlistUnescaped = {
-    expr = mapAttrs (const (generators.toPlist { })) {
+    expr = mapAttrs (_: generators.toPlist { }) {
       value = {
         nested.values = {
           int = 42;
@@ -2876,7 +2876,7 @@ runTests {
   };
 
   testToPlistEscaped = {
-    expr = mapAttrs (const (generators.toPlist { escape = true; })) {
+    expr = mapAttrs (_: generators.toPlist { escape = true; }) {
       value = {
         nested.values = {
           int = 42;

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -15,7 +15,6 @@ let
     concatMapStrings
     concatStrings
     concatStringsSep
-    const
     elem
     elemAt
     filter
@@ -284,15 +283,15 @@ rec {
       # We're applied at the top-level type (attrsOf unitOption), so the actual
       # unit options might contain attributes from mkOverride and mkIf that we need to
       # convert into single values before checking them.
-      defs = mapAttrs (const (
-        v:
+      defs = mapAttrs (
+        _: v:
         if v._type or "" == "override" then
           v.content
         else if v._type or "" == "if" then
           v.content
         else
           v
-      )) attrs;
+      ) attrs;
       errors = concatMap (c: c group defs) checks;
     in
     if errors == [ ] then true else trace (concatStringsSep "\n" errors) false;

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -45,7 +45,7 @@ in
         example = lib.literalExpression "with pkgs.ibus-engines; [ mozc hangul ]";
         description =
           let
-            enginesDrv = lib.filterAttrs (lib.const lib.isDerivation) pkgs.ibus-engines;
+            enginesDrv = lib.filterAttrs (_: lib.isDerivation) pkgs.ibus-engines;
             engines = lib.concatStringsSep ", " (map (name: "`${name}`") (lib.attrNames enginesDrv));
           in
           "Enabled IBus engines. Available engines are: ${engines}.";

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -11,7 +11,6 @@ let
     attrValues
     concatMapStrings
     concatStringsSep
-    const
     elem
     escapeShellArgs
     filter
@@ -57,7 +56,7 @@ let
   # The main PostgreSQL configuration file.
   configFile = pkgs.writeTextDir "postgresql.conf" (
     concatStringsSep "\n" (
-      mapAttrsToList (n: v: "${n} = ${toStr v}") (filterAttrs (const (x: x != null)) cfg.settings)
+      mapAttrsToList (n: v: "${n} = ${toStr v}") (filterAttrs (_: x: x != null) cfg.settings)
     )
   );
 
@@ -731,7 +730,7 @@ in
     '';
 
     services.postgresql.systemCallFilter = mkMerge [
-      (mapAttrs (const mkDefault) {
+      (mapAttrs (_: mkDefault) {
         "@system-service" = true;
         "~@privileged" = true;
         "~@resources" = true;

--- a/nixos/modules/services/mail/mailpit.nix
+++ b/nixos/modules/services/mail/mailpit.nix
@@ -10,7 +10,6 @@ let
   inherit (lib)
     cli
     concatStringsSep
-    const
     filterAttrs
     getExe
     mapAttrs'
@@ -22,7 +21,7 @@ let
 
   isNonNull = v: v != null;
   genCliFlags =
-    settings: concatStringsSep " " (cli.toCommandLineGNU { } (filterAttrs (const isNonNull) settings));
+    settings: concatStringsSep " " (cli.toCommandLineGNU { } (filterAttrs (_: isNonNull) settings));
 in
 {
   options.services.mailpit.instances = mkOption {

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -235,7 +235,7 @@ let
         ""
       ];
 
-      masterCf = lib.mapAttrsToList (lib.const (lib.getAttr "rawEntry")) cfg.settings.master;
+      masterCf = lib.mapAttrsToList (_: lib.getAttr "rawEntry") cfg.settings.master;
 
       # A list of the maximum width of the columns across all lines and labels
       maxWidths =

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -1071,15 +1071,18 @@ in
                 url_preview_url_blacklist = mkOption {
                   # FIXME revert to just `listOf (attrsOf str)` after some time(tm).
                   type = types.listOf (
-                    types.coercedTo types.str (const (throw ''
-                      Setting `config.services.matrix-synapse.settings.url_preview_url_blacklist`
-                      to a list of strings has never worked. Due to a bug, this was the type accepted
-                      by the module, but in practice it broke on runtime and as a result, no URL
-                      preview worked anywhere if this was set.
+                    types.coercedTo types.str (
+                      _:
+                      throw ''
+                        Setting `config.services.matrix-synapse.settings.url_preview_url_blacklist`
+                        to a list of strings has never worked. Due to a bug, this was the type accepted
+                        by the module, but in practice it broke on runtime and as a result, no URL
+                        preview worked anywhere if this was set.
 
-                      See https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#url_preview_url_blacklist
-                      on how to configure it properly.
-                    '')) (types.attrsOf types.str)
+                        See https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#url_preview_url_blacklist
+                        on how to configure it properly.
+                      ''
+                    ) (types.attrsOf types.str)
                   );
                   default = [ ];
                   example = literalExpression ''
@@ -1417,7 +1420,7 @@ in
     # default them, so they are additive
     services.matrix-synapse.extras = defaultExtras;
 
-    services.matrix-synapse.log = mapAttrsRecursive (const mkDefault) defaultCommonLogConfig;
+    services.matrix-synapse.log = mapAttrsRecursive (_: mkDefault) defaultCommonLogConfig;
 
     users.users.matrix-synapse = {
       group = "matrix-synapse";

--- a/nixos/modules/services/monitoring/grafana-image-renderer.nix
+++ b/nixos/modules/services/monitoring/grafana-image-renderer.nix
@@ -127,7 +127,7 @@ in
     services.grafana-image-renderer.chromium = lib.mkDefault pkgs.chromium;
 
     services.grafana-image-renderer.settings = {
-      rendering = lib.mapAttrs (lib.const lib.mkDefault) {
+      rendering = lib.mapAttrs (_: lib.mkDefault) {
         chromeBin = "${cfg.chromium}/bin/chromium";
         verboseLogging = cfg.verbose;
         timezone = config.time.timeZone;

--- a/nixos/modules/services/networking/anubis.nix
+++ b/nixos/modules/services/networking/anubis.nix
@@ -264,7 +264,7 @@ in
         after = [ "network-online.target" ];
         wants = [ "network-online.target" ];
 
-        environment = lib.mapAttrs (lib.const (lib.generators.mkValueStringDefault { })) (
+        environment = lib.mapAttrs (_: (lib.generators.mkValueStringDefault { })) (
           lib.filterAttrs (_: v: v != null) (
             instance.settings
             // {

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -274,6 +274,6 @@ in
 {
   config.systemd = mkIf cfg.enable {
     inherit sockets timers paths;
-    services = lib.mapAttrs (lib.const hardenService) (services // modemServices);
+    services = lib.mapAttrs (_: hardenService) (services // modemServices);
   };
 }

--- a/nixos/modules/services/web-apps/kanboard.nix
+++ b/nixos/modules/services/web-apps/kanboard.nix
@@ -8,7 +8,7 @@
 let
   cfg = config.services.kanboard;
 
-  toStringAttrs = lib.mapAttrs (lib.const toString);
+  toStringAttrs = lib.mapAttrs (_: toString);
 in
 {
   meta.maintainers = with lib.maintainers; [ yzx9 ];

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1082,7 +1082,7 @@ in
         );
 
         services.nextcloud.phpOptions = lib.mkMerge [
-          (lib.mapAttrs (lib.const lib.mkOptionDefault) defaultPHPSettings)
+          (lib.mapAttrs (_: lib.mkOptionDefault) defaultPHPSettings)
           {
             upload_max_filesize = cfg.maxUploadSize;
             post_max_size = cfg.maxUploadSize;

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -537,7 +537,7 @@ let
                 ip link add name "${n}" type bond \
                 ${
                   let
-                    opts = (mapAttrs (const toString) (bondDeprecation.filterDeprecated v)) // v.driverOptions;
+                    opts = (mapAttrs (_: toString) (bondDeprecation.filterDeprecated v)) // v.driverOptions;
                   in
                   concatStringsSep "\n" (mapAttrsToList (set: val: "  ${set} ${val} \\") opts)
                 }

--- a/nixos/tests/kernel-rust.nix
+++ b/nixos/tests/kernel-rust.nix
@@ -6,7 +6,6 @@
 
 let
   inherit (pkgs.lib)
-    const
     filterAttrs
     mapAttrs
     meta
@@ -49,8 +48,8 @@ let
   kernels = {
     inherit (pkgs.linuxKernel.packages) linux_testing;
   }
-  // filterAttrs (const (
-    x:
+  // filterAttrs (
+    _: x:
     let
       inherit (builtins.tryEval (x.rust-out-of-tree-module or null != null))
         success
@@ -59,6 +58,6 @@ let
       available = meta.availableOn pkgs.stdenv.hostPlatform x.rust-out-of-tree-module;
     in
     success && value && available
-  )) pkgs.linuxKernel.vanillaPackages;
+  ) pkgs.linuxKernel.vanillaPackages;
 in
-mapAttrs (const kernelRustTest) kernels
+mapAttrs (_: kernelRustTest) kernels

--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -1449,8 +1449,8 @@ let
   };
 
 in
-lib.mapAttrs (lib.const (
-  attrs:
+lib.mapAttrs (
+  _: attrs:
   makeTest (
     attrs
     // {
@@ -1458,4 +1458,4 @@ lib.mapAttrs (lib.const (
       meta.maintainers = with lib.maintainers; [ rnhmjoj ];
     }
   )
-)) testCases
+) testCases

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -182,8 +182,8 @@ let
     };
   };
 in
-lib.mapAttrs (lib.const (
-  attrs:
+lib.mapAttrs (
+  _: attrs:
   makeTest (
     attrs
     // {
@@ -194,4 +194,4 @@ lib.mapAttrs (lib.const (
 
     }
   )
-)) testCases
+) testCases

--- a/nixos/tests/postgresql/default.nix
+++ b/nixos/tests/postgresql/default.nix
@@ -11,7 +11,6 @@ let
     recurseIntoAttrs
     filterAttrs
     mapAttrs
-    const
     ;
   genTests =
     {
@@ -19,7 +18,7 @@ let
       filter ? (_: _: true),
     }:
     recurseIntoAttrs (
-      mapAttrs (const makeTestFor) (filterAttrs filter pkgs.postgresqlVersions)
+      mapAttrs (_: makeTestFor) (filterAttrs filter pkgs.postgresqlVersions)
       // {
         passthru.override = makeTestFor;
       }

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -47,7 +47,7 @@ let
           --config-file="${pkgs.dbus}/share/dbus-1/system.conf"
 
         ${guestAdditions}/bin/VBoxService
-        ${(attrs.vmScript or (const "")) pkgs}
+        ${(attrs.vmScript or (_: "")) pkgs}
 
         i=0
         while [ ! -e /mnt-root/shutdown ]; do
@@ -90,7 +90,7 @@ let
       boot.initrd.extraUtilsCommands = ''
         copy_bin_and_libs "${guestAdditions}/bin/mount.vboxsf"
         copy_bin_and_libs "${pkgs.util-linux}/bin/unshare"
-        ${(attrs.extraUtilsCommands or (const "")) pkgs}
+        ${(attrs.extraUtilsCommands or (_: "")) pkgs}
       '';
 
       boot.initrd.postMountCommands = ''

--- a/pkgs/by-name/te/television/package.nix
+++ b/pkgs/by-name/te/television/package.nix
@@ -96,4 +96,4 @@ let
   });
 in
 
-if extraPackages == null then television else television.withPackages (lib.const extraPackages)
+if extraPackages == null then television else television.withPackages (_: extraPackages)

--- a/pkgs/by-name/xr/xremap/package.nix
+++ b/pkgs/by-name/xr/xremap/package.nix
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-NZNLO+wmzEdIZPp5Zu81m/ux8Au+8EMq31QpuZN9l5w=";
 
-  passthru = lib.mapAttrs (name: lib.const (xremap.override { withVariant = name; })) variants;
+  passthru = lib.mapAttrs (name: _: xremap.override { withVariant = name; }) variants;
 
   meta = {
     description = "Key remapper for X11 and Wayland (${variant.descriptionSuffix} support)";

--- a/pkgs/servers/nextcloud/notify_push.nix
+++ b/pkgs/servers/nextcloud/notify_push.nix
@@ -48,9 +48,7 @@ rustPlatform.buildRustPackage rec {
       };
     };
     tests =
-      lib.filterAttrs (
-        key: lib.const (lib.hasPrefix "with-postgresql-and-redis" key)
-      ) nixosTests.nextcloud
+      lib.filterAttrs (key: _: lib.hasPrefix "with-postgresql-and-redis" key) nixosTests.nextcloud
       // {
         inherit test_client;
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from #445357


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
