### PR TITLE
various: lib usage improvements - prefer more specialized functions over folds

### DIFF
--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -7,6 +7,7 @@
 
 let
   inherit (lib)
+    concatMapStringsSep
     concatStringsSep
     flip
     literalMD
@@ -95,9 +96,9 @@ let
     '';
   };
 
-  defaultJmxRolesFile = builtins.foldl' (left: right: left + right) "" (
-    map (role: "${role.username} ${role.password}") cfg.jmxRoles
-  );
+  defaultJmxRolesFile = concatMapStringsSep "" (
+    role: "${role.username} ${role.password}"
+  ) cfg.jmxRoles;
 
   fullJvmOptions =
     cfg.jvmOpts

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -120,7 +120,7 @@ let
     '';
   };
 
-  mailOption = lib.optionalString (lib.foldr (n: a: a || (n.mail or false) != false) false (
+  mailOption = lib.optionalString (lib.any (n: n.mail or true) (
     lib.attrValues cfg.settings
   )) "--mail=${pkgs.mailutils}/bin/mail";
 in
@@ -146,7 +146,7 @@ in
   options = {
     services.logrotate = {
       enable = lib.mkEnableOption "the logrotate systemd service" // {
-        default = lib.foldr (n: a: a || n.enable) false (lib.attrValues cfg.settings);
+        default = lib.any (n: n.enable) (lib.attrValues cfg.settings);
         defaultText = lib.literalExpression "cfg.settings != {}";
       };
 

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -15,7 +15,7 @@ let
     let
       parseAddresses = listeners: lib.flatten (lib.mapAttrsToList (name: value: value.bind) listeners);
       splitAddress = addr: lib.splitString ":" addr;
-      extractPort = addr: lib.toInt (builtins.foldl' (a: b: b) "" (splitAddress addr));
+      extractPort = addr: lib.toInt (lib.last (splitAddress addr));
     in
     map (address: extractPort address) (parseAddresses listeners);
 

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -138,7 +138,7 @@ let
     addresses:
     let
       splitAddress = addr: strings.splitString ":" addr;
-      extractPort = addr: builtins.foldl' (a: b: b) "" (splitAddress addr);
+      extractPort = addr: last (splitAddress addr);
     in
     map (address: strings.toInt (extractPort address)) addresses;
 

--- a/nixos/modules/tasks/encrypted-devices.nix
+++ b/nixos/modules/tasks/encrypted-devices.nix
@@ -23,7 +23,7 @@ let
     else
       filter (dev: dev.encrypted.keyFile == null) encDevs;
 
-  anyEncrypted = foldr (j: v: v || j.encrypted.enable) false encDevs;
+  anyEncrypted = any (j: j.encrypted.enable) encDevs;
 
   encryptedFSOptions = {
 

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -183,7 +183,7 @@ let
           ) { } extensions;
 
           Extensions = {
-            Install = lib.foldr (e: ret: ret ++ [ "${e.outPath}/${e.extid}.xpi" ]) [ ] extensions;
+            Install = map (e: "${e.outPath}/${e.extid}.xpi") extensions;
           };
         }
         // lib.optionalAttrs smartcardSupport {

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -86,9 +86,7 @@ let
 
           mkScript = drv: lib.forEach drv.scripts (script: "/script load ${drv}/share/${script}");
 
-          scripts = builtins.concatStringsSep ";" (
-            lib.foldl (scripts: drv: scripts ++ mkScript drv) [ ] (config.scripts or [ ])
-          );
+          scripts = lib.concatMapStringsSep ";" mkScript (config.scripts or [ ]);
         in
         "${scripts};${init}";
 

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -39,9 +39,13 @@ let
   version_ = lib.splitString "-" crateVersion;
   versionPre = lib.optionalString (lib.tail version_ != [ ]) (lib.elemAt version_ 1);
   version = lib.splitVersion (lib.head version_);
-  rustcOpts = lib.foldl' (opts: opt: opts + " " + opt) (
-    if release then "-C opt-level=3" else "-C debuginfo=2"
-  ) ([ "-C codegen-units=${toString codegenUnits}" ] ++ extraRustcOptsForBuildRs);
+  rustcOpts = lib.concatStringsSep " " (
+    [
+      (if release then "-C opt-level=3" else "-C debuginfo=2")
+      "-C codegen-units=${toString codegenUnits}"
+    ]
+    ++ extraRustcOptsForBuildRs
+  );
   buildDeps = mkRustcDepArgs buildDependencies crateRenames;
   authors = lib.concatStringsSep ":" crateAuthors;
   optLevel = if release then 3 else 0;

--- a/pkgs/build-support/rust/build-rust-crate/helpers.nix
+++ b/pkgs/build-support/rust/build-rust-crate/helpers.nix
@@ -9,12 +9,7 @@
       lib.foldl' (features: fun: fun features) (lib.attrsets.recursiveUpdate f up) functions
     );
   mapFeatures = features: map (fun: fun { features = features; });
-  mkFeatures =
-    feat:
-    lib.foldl (
-      features: featureName:
-      if feat.${featureName} or false then [ featureName ] ++ features else features
-    ) [ ] (lib.attrNames feat);
+  mkFeatures = feat: lib.filter (featureName: feat.${featureName}) (lib.attrNames feat);
   include =
     includedFiles: src:
     builtins.filterSource (

--- a/pkgs/build-support/rust/build-rust-crate/test/brotli-crates.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/brotli-crates.nix
@@ -25,12 +25,7 @@ let
       lib.lists.foldl' (features: fun: fun features) (lib.attrsets.recursiveUpdate f up) functions
     );
   mapFeatures = features: map (fun: fun { features = features; });
-  mkFeatures =
-    feat:
-    lib.lists.foldl (
-      features: featureName:
-      if feat.${featureName} or false then [ featureName ] ++ features else features
-    ) [ ] (builtins.attrNames feat);
+  mkFeatures = feat: lib.filter (featureName: feat.${featureName}) (lib.attrNames feat);
 in
 rec {
   alloc_no_stdlib_1_3_0_ =

--- a/pkgs/build-support/rust/build-rust-crate/test/rcgen-crates.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/rcgen-crates.nix
@@ -4994,7 +4994,7 @@ rec {
       assert (builtins.isList features);
       assert (builtins.all builtins.isString features);
       let
-        outFeaturesSet = lib.foldl (set: feature: set // { "${feature}" = 1; }) { } features;
+        outFeaturesSet = lib.genAttrs features (_: 1);
         outFeaturesUnique = builtins.attrNames outFeaturesSet;
       in
       builtins.sort (a: b: a < b) outFeaturesUnique;

--- a/pkgs/by-name/ty/typst/with-packages.nix
+++ b/pkgs/by-name/ty/typst/with-packages.nix
@@ -13,7 +13,7 @@ lib.makeOverridable (
     inherit (typst) meta;
     name = "${typst.name}-env";
 
-    paths = lib.foldl' (acc: p: acc ++ lib.singleton p ++ p.propagatedBuildInputs) [ ] (f typstPkgs);
+    paths = (f typstPkgs) ++ (lib.concatMap (pkg: pkg.propagatedBuildInputs) (f typstPkgs));
 
     pathsToLink = [ "/lib/typst-packages" ];
 

--- a/pkgs/development/libraries/libint/default.nix
+++ b/pkgs/development/libraries/libint/default.nix
@@ -73,31 +73,19 @@ assert (eri2Deriv >= 0 && eri2Deriv <= 4);
 assert (eri3Deriv >= 0 && eri3Deriv <= 4);
 
 # Ensure valid arguments for generated angular momenta in ERI derivatives are used.
-assert (
-  builtins.length eriAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eriAm)
-);
-assert (
-  builtins.length eri3Am == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri3Am)
-);
-assert (
-  builtins.length eri2Am == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri2Am)
-);
+assert (builtins.length eriAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eriAm);
+assert (builtins.length eri3Am == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri3Am);
+assert (builtins.length eri2Am == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri2Am);
 
 # Ensure valid arguments for generated angular momenta in optimised ERI derivatives are used.
 assert (
-  builtins.length eriOptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eriOptAm)
+  builtins.length eriOptAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eriOptAm
 );
 assert (
-  builtins.length eri3OptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri3OptAm)
+  builtins.length eri3OptAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri3OptAm
 );
 assert (
-  builtins.length eri2OptAm == eriDeriv + 1
-  && builtins.foldl' (a: b: a && b) true (map (a: a <= maxAm && a >= 0) eri2OptAm)
+  builtins.length eri2OptAm == eriDeriv + 1 && builtins.all (a: a <= maxAm && a >= 0) eri2OptAm
 );
 
 # Ensure a valid derivative order for one-electron integrals

--- a/pkgs/development/ruby-modules/testing/tap-support.nix
+++ b/pkgs/development/ruby-modules/testing/tap-support.nix
@@ -21,7 +21,7 @@ in
     ''
       TAP version 13
       1..${toString (length reports)}''
-    + (foldl' (l: r: l + "\n" + r) "" (map testLine (withIndexes reports)))
+    + (concatStringsSep "\n" (map testLine (withIndexes reports)))
     + ''
 
       # Finished at ${toString currentTime}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from #445357

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> before</summary>

```json
{
  "cpuTime": 7.045458793640137,
  "envs": {
    "bytes": 277566552,
    "elements": 20557892,
    "number": 14137927
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376646688
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14944556,
  "nrExprs": 2241977,
  "nrFunctionCalls": 12182654,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17829336,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 7.045458793640137,
    "gc": 0.127,
    "gcFraction": 0.01802579558262999
  },
  "values": {
    "bytes": 398413968,
    "number": 24900873
  }
}
```

</details>

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> after</summary>

```json
{
  "cpuTime": 11.73483943939209,
  "envs": {
    "bytes": 277566472,
    "elements": 20557887,
    "number": 14137922
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376649840
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14944553,
  "nrExprs": 2241947,
  "nrFunctionCalls": 12182650,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17829335,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 11.73483943939209,
    "gc": 0.178,
    "gcFraction": 0.015168507495933927
  },
  "values": {
    "bytes": 398413952,
    "number": 24900872
  }
}
```

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
