### PR TITLE
various: lib usage improvements - misc

### DIFF
--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -46,7 +46,6 @@ let
     concatStringsSep
     head
     isAttrs
-    listToAttrs
     tail
     ;
 in
@@ -152,15 +151,7 @@ rec {
           else if done ? ${entry} then
             f done (tail todo)
           else
-            f (
-              done
-              // listToAttrs [
-                {
-                  name = entry;
-                  value = 1;
-                }
-              ]
-            ) ([ predefined.${entry} ] ++ tail todo);
+            f (done // { ${entry} = 1; }) ([ predefined.${entry} ] ++ tail todo);
     in
     (f { } arg).result;
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -25,7 +25,6 @@ let
     hasAttr
     id
     length
-    listToAttrs
     literalExpression
     mapAttrs'
     mapAttrsToList
@@ -584,14 +583,9 @@ let
         let
           id = toString (getAttr idAttr (getAttr name set));
           exists = hasAttr id acc;
-          newAcc =
-            acc
-            // (listToAttrs [
-              {
-                name = id;
-                value = true;
-              }
-            ]);
+          newAcc = acc // {
+            ${id} = true;
+          };
         in
         if dup then
           args

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -167,19 +167,15 @@ in
     # from other packages will be used by neovim.
     environment.pathsToLink = [ "/share/nvim" ];
 
-    environment.etc = builtins.listToAttrs (
-      builtins.attrValues (
-        builtins.mapAttrs (name: value: {
-          name = "xdg/nvim/${name}";
-          value = builtins.removeAttrs (
-            value
-            // {
-              target = "xdg/nvim/${value.target}";
-            }
-          ) (lib.optionals (builtins.isNull value.source) [ "source" ]);
-        }) cfg.runtime
-      )
-    );
+    environment.etc = lib.mapAttrs' (name: value: {
+      name = "xdg/nvim/${name}";
+      value = lib.removeAttrs (
+        value
+        // {
+          target = "xdg/nvim/${value.target}";
+        }
+      ) (lib.optionals (builtins.isNull value.source) [ "source" ]);
+    }) cfg.runtime;
 
     programs.neovim.finalPackage = pkgs.wrapNeovim cfg.package {
       inherit (cfg)

--- a/nixos/modules/services/backup/sanoid.nix
+++ b/nixos/modules/services/backup/sanoid.nix
@@ -250,7 +250,7 @@ in
   config = lib.mkIf cfg.enable {
     services.sanoid.settings = lib.mkMerge [
       (lib.mapAttrs' (d: v: lib.nameValuePair ("template_" + d) v) cfg.templates)
-      (lib.mapAttrs (d: v: v) cfg.datasets)
+      cfg.datasets
     ];
 
     systemd.services.sanoid = {

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -69,7 +69,7 @@ let
 
   # Filter null values from the configuration, so that we can still advertise
   # optional options in the config attribute.
-  filteredConfig = converge (filterAttrsRecursive (_: v: !elem v [ null ])) (
+  filteredConfig = converge (filterAttrsRecursive (_: v: v != null)) (
     recursiveUpdate customLovelaceModulesResources (cfg.config or { })
   );
   configFile = renderYAMLFile "configuration.yaml" filteredConfig;

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -181,8 +181,7 @@ let
   isUnixSocket = socket: hasPrefix "/" (if (isString socket) then socket else socket.socket);
 
   mkBindSockets =
-    enabled: socks:
-    concatStringsSep "\n  " (flatten (map (each: "bind_socket = \"${each.rawEntry}\";") socks));
+    enabled: socks: concatMapStringsSep "\n  " (each: "bind_socket = \"${each.rawEntry}\";") socks;
 
   rspamdConfFile = pkgs.writeText "rspamd.conf" ''
     .include "$CONFDIR/common.conf"

--- a/nixos/modules/services/networking/ncdns.nix
+++ b/nixos/modules/services/networking/ncdns.nix
@@ -20,8 +20,8 @@ let
   };
 
   # if all keys are the default value
-  needsKeygen = lib.all lib.id (
-    lib.flip lib.mapAttrsToList cfg.dnssec.keys (n: v: v == lib.getAttr n defaultFiles)
+  needsKeygen = lib.all (n: cfg.dnssec.keys.${n} == defaultFiles.${n}) (
+    builtins.attrNames defaultFiles
   );
 
   mkDefaultAttrs = lib.mapAttrs (_n: v: lib.mkDefault v);

--- a/nixos/modules/services/networking/wgautomesh.nix
+++ b/nixos/modules/services/networking/wgautomesh.nix
@@ -13,7 +13,10 @@ let
     # if value is null
     settingsFormat.generate "wgautomesh-config.toml" (
       filterAttrs (k: v: v != null) (
-        mapAttrs (k: v: if k == "peers" then map (e: filterAttrs (k: v: v != null) e) v else v) cfg.settings
+        cfg.settings
+        // {
+          peers = map (filterAttrs (k: v: v != null)) cfg.settings.peers;
+        }
       )
     );
   runtimeConfigFile =

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -29,7 +29,7 @@ let
 
   format = pkgs.formats.yaml { };
 
-  filteredConfig = converge (filterAttrsRecursive (_: v: !elem v [ null ])) cfg.settings;
+  filteredConfig = converge (filterAttrsRecursive (_: v: v != null)) cfg.settings;
 
   configFileUnchecked = format.generate "frigate.yaml" filteredConfig;
   configFileChecked =

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -912,7 +912,7 @@ in
     systemd.services.httpd = {
       description = "Apache HTTPD";
       wantedBy = [ "multi-user.target" ];
-      wants = concatLists (map (certName: [ "acme-${certName}.service" ]) vhostCertNames);
+      wants = map (certName: "acme-${certName}.service") vhostCertNames;
       after = [
         "network.target"
       ]

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -33,7 +33,7 @@ let
           c.plugins or cfg.plugins;
       plugins = unique plugins';
 
-      hasPython3 = filter (n: n == "python3") plugins != [ ];
+      hasPython3 = elem "python3" plugins;
       python = if hasPython3 then cfg.package.python3 else null;
 
       pythonEnv = python.withPackages (c.pythonPackages or (self: [ ]));

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1866,8 +1866,12 @@ in
               wlanListDeviceFirst =
                 device: interfaces:
                 if hasAttr device interfaces then
-                  mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n == device) interfaces)
-                  ++ mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n != device) interfaces)
+                  pipe interfaces [
+                    (mapAttrs (n: v: v // { _iName = n; }))
+                    attrsToList
+                    (partition ({ name, ... }: name == device))
+                    ({ right, wrong }: right ++ wrong)
+                  ]
                 else
                   mapAttrsToList (n: v: v // { _iName = n; }) interfaces;
 

--- a/pkgs/by-name/po/pomerium-cli/package.nix
+++ b/pkgs/by-name/po/pomerium-cli/package.nix
@@ -7,8 +7,7 @@
 let
   inherit (lib)
     concatStringsSep
-    concatMap
-    id
+    concatLists
     mapAttrsToList
     ;
 in
@@ -41,7 +40,7 @@ buildGoModule rec {
         };
       };
       concatStringsSpace = list: concatStringsSep " " list;
-      mapAttrsToFlatList = fn: list: concatMap id (mapAttrsToList fn list);
+      mapAttrsToFlatList = fn: list: concatLists (mapAttrsToList fn list);
       varFlags = concatStringsSpace (
         mapAttrsToFlatList (
           package: packageVars:

--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -12,8 +12,7 @@
 let
   inherit (lib)
     concatStringsSep
-    concatMap
-    id
+    concatLists
     mapAttrsToList
     ;
 in
@@ -78,7 +77,7 @@ buildGoModule rec {
         };
       };
       concatStringsSpace = list: concatStringsSep " " list;
-      mapAttrsToFlatList = fn: list: concatMap id (mapAttrsToList fn list);
+      mapAttrsToFlatList = fn: list: concatLists (mapAttrsToList fn list);
       varFlags = concatStringsSpace (
         mapAttrsToFlatList (
           package: packageVars:

--- a/pkgs/development/ruby-modules/testing/assertions.nix
+++ b/pkgs/development/ruby-modules/testing/assertions.nix
@@ -20,7 +20,7 @@
 
   haveKeys =
     expected: actual:
-    if builtins.all (ex: builtins.any (ac: ex == ac) (builtins.attrNames actual)) expected then
+    if builtins.all (ex: actual ? ${ex}) expected then
       (test.passed "has expected keys")
     else
       (test.failed "keys differ: expected: [${lib.concatStringsSep ";" expected}] actual: [${lib.concatStringsSep ";" (builtins.attrNames actual)}]");

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -71,7 +71,7 @@ let
     x86_64-linux.target = "i386"; # Xen PVH is only i386 on x86.
   };
 
-  inPCSystems = lib.any (system: stdenv.hostPlatform.system == system) (lib.attrNames pcSystems);
+  inPCSystems = lib.hasAttr stdenv.hostPlatform.system pcSystems;
 
   gnulib = fetchgit {
     url = "https://https.git.savannah.gnu.org/git/gnulib.git";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from #445357

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> before</summary>

```json
{
  "cpuTime": 7.045458793640137,
  "envs": {
    "bytes": 277566552,
    "elements": 20557892,
    "number": 14137927
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376646688
  },
  "list": {
    "bytes": 29510496,
    "concats": 529173,
    "elements": 3688812
  },
  "nrAvoided": 14944556,
  "nrExprs": 2241977,
  "nrFunctionCalls": 12182654,
  "nrLookups": 7873959,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575591,
  "nrThunks": 17829336,
  "sets": {
    "bytes": 540057136,
    "elements": 28229185,
    "number": 3682924
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 7.045458793640137,
    "gc": 0.127,
    "gcFraction": 0.01802579558262999
  },
  "values": {
    "bytes": 398413968,
    "number": 24900873
  }
}
```

</details>

<details>
<summary><code>NIX_SHOW_STATS=1 nix flake check</code> after</summary>

```json
{
  "cpuTime": 6.978033065795898,
  "envs": {
    "bytes": 277566536,
    "elements": 20557890,
    "number": 14137927
  },
  "gc": {
    "cycles": 6,
    "heapSize": 621019136,
    "totalBytes": 1376639744
  },
  "list": {
    "bytes": 29509800,
    "concats": 529173,
    "elements": 3688725
  },
  "nrAvoided": 14944469,
  "nrExprs": 2241915,
  "nrFunctionCalls": 12182654,
  "nrLookups": 7873957,
  "nrOpUpdateValuesCopied": 14882399,
  "nrOpUpdates": 1729836,
  "nrPrimOpCalls": 5575504,
  "nrThunks": 17829160,
  "sets": {
    "bytes": 540052264,
    "elements": 28229011,
    "number": 3682837
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 24,
    "Env": 8,
    "Value": 16
  },
  "symbols": {
    "bytes": 1051614,
    "number": 90281
  },
  "time": {
    "cpu": 6.978033065795898,
    "gc": 0.122,
    "gcFraction": 0.017483436786507253
  },
  "values": {
    "bytes": 398411152,
    "number": 24900697
  }
}
```

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
