### PR TITLE
Make callPackage observe `<pkg>.override.argSelectors` and by-name-overlay manage `arg-selectors.nix` and siblings

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -398,6 +398,19 @@ rec {
     else
       mapAttrs mkAttrOverridable pkgs;
 
+  makeCallPackageWithArgSelectors =
+    callPackage: fn: extraArgSelectors:
+    let
+      f = if isFunction fn then fn else import fn;
+      f' = if isAttrs f then f else mirrorFunctionArgs f f;
+    in
+    callPackage (
+      f'
+      // {
+        argSelectors = f.argSelectors or { } // extraArgSelectors;
+      }
+    ) { };
+
   /**
     Add attributes to each output of a derivation without changing
     the derivation itself and check a given condition when evaluating.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -391,6 +391,7 @@ let
         makeOverridable
         callPackageWith
         callPackagesWith
+        makeCallPackageWithArgSelectors
         extendDerivation
         hydraJob
         makeScope

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -138,6 +138,8 @@ in
 
   callPackages = lib.callPackagesWith pkgsForCall;
 
+  callPackageWithArgSelectors = lib.makeCallPackageWithArgSelectors pkgs.callPackage;
+
   newScope = extra: lib.callPackageWith (pkgsForCall // extra);
 
   pkgs = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;


### PR DESCRIPTION
1. Introduce `argSelectors` as a way to specify arguments for the override interface.
   It is an attribute set of functions that takes `pkgs` and return the selected argument.
   ```nix
   {
     stdenv = { clangStdenv, ... }: clangStdenv;
   }
   ```

   The difference between the `argSelectors` and the [`pkgs: { ... }` `args.nix` proposed as an alternative enhancement in Nix RFC 140](https://github.com/NixOS/rfcs/blob/9c85c3d7f7113dc69122e0078dd43170d9b1f7af/rfcs/0140-simple-package-paths.md#allow-callpackage-arguments-to-be-specified-in-argsnix) is that the attribute names of `argSelectors` is strict and accessible without calling the selector functions.

2. Teach `lib.callPackageWith autoArgs f args` and `lib.callPackagesWith autoArgs f args` to observe `f.<argSelectors>`, and attach `argSelectors` to the result as `<pkg>.override.argSelectors` if `args == { }`.

   This ensures that `argSecetors` will be lost after calling `<pkg>.override` directly or after specifying a plain attrset of custom arguments to `callPackage`. The presence of `<pkg>.override.argSelectors` therefore ensures `result == pkgs.callPackage result.override { }`.

   This is useful to short-cut the build tests of staging changes. If the mass-rebuild change of `pkgs.foo` cause its direct dependent `pkgs.bar` to rebuild, and `pkgs.bar.override.argSelectors` is present, its rebuild can be short-cut as
   ```
   pkgsMaster.callPackage pkgsStaging.bar.override {
     inherit (pkgsStaging) foo;
   }
   ```

3. Provide `lib.makeCallPackageWithArgSelectors` and `pkgs.callPackageWithArgSelectors` as a convenient way to add/extend `<pkg>.override.argSelectors`.
4. Teach the `by-name-overlay.nix` to understand an optional file `arg-selector.nix` beside `package.nix`, implementing the "Option 3" of #404946.

   Even though the hard-coded version-specific override interface proposed in #444420 enhances override stability, we sometimes do want override abstraction for interoperability. For example, we may want different versions/variants of a package (e.g. `foo`, `fooMinimal` and `fooFull`) to have the same override interface to make it possible to `bar.override { foo = foo_1; }`. The `sibling.nix` interface proposed below makes it possible to define them in `pkgs/by-name`.

5. Introduce a way to specify "siblings" inn `pkgs/by-name`. One can define a sibling with a `packages.nix` in the following format:
   ```nix
   # pkgs/by-name/fo/foo-minimal
   {
     type = "sibling";
     package = "foo";
     # packagePath = [ "fooSet" "foo" ]; # Alternative to `package`
     transform = # Optionally transform the package
       { lib, package }:
       package.overrideAttrs (finalAttrs: previousAttrs: {
         # Attributes to override
       });
   }
   ```

   A sibling can also have an optional `arg-selectors.nix` for `<pkg>.override` overriding.

   The above example provides `foo-minimal` with the same `<pkg>.override` interface as `pkgs.foo` the following way:
   ```nix
   {
     foo-minimal = transform {
       inherit lib;
       package =
         callPackageWithArgSelectors
           foo.override
           (import /path/to/by-name/fo/foo-minimal/arg-selectors.nix);
     };
   }
   ```

   The sibling design is inspired by #442066
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
