### PR TITLE
haskellPackages.cabal2nix-unstable: 2025-10-19 -> 2025-10-25

### DIFF
--- a/pkgs/development/haskell-modules/cabal2nix-unstable/cabal2nix.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/cabal2nix.nix
@@ -35,10 +35,10 @@
 }:
 mkDerivation {
   pname = "cabal2nix";
-  version = "2.20.1-unstable-2025-10-19";
+  version = "2.20.1-unstable-2025-10-25";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/26e5dba9259791d1e80ce68a07f6d20adb26c7eb.tar.gz";
-    sha256 = "19y5smq0aji45zak6sxlimzw7ww33zbcmbbrvi2rq40i26mw6kxj";
+    url = "https://github.com/NixOS/cabal2nix/archive/19800f3819e099dba344001d0d0f5c15698bc793.tar.gz";
+    sha256 = "02zxw06d5c9zh63kra9sx3rfcgb8xqaz77b5za0jxvkjxjl9ysyn";
   };
   postUnpack = "sourceRoot+=/cabal2nix; echo source root reset to $sourceRoot";
   isLibrary = true;

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/distribution-nixpkgs.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/distribution-nixpkgs.nix
@@ -18,10 +18,10 @@
 }:
 mkDerivation {
   pname = "distribution-nixpkgs";
-  version = "1.7.1.1-unstable-2025-10-19";
+  version = "1.7.1.1-unstable-2025-10-25";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/26e5dba9259791d1e80ce68a07f6d20adb26c7eb.tar.gz";
-    sha256 = "19y5smq0aji45zak6sxlimzw7ww33zbcmbbrvi2rq40i26mw6kxj";
+    url = "https://github.com/NixOS/cabal2nix/archive/19800f3819e099dba344001d0d0f5c15698bc793.tar.gz";
+    sha256 = "02zxw06d5c9zh63kra9sx3rfcgb8xqaz77b5za0jxvkjxjl9ysyn";
   };
   postUnpack = "sourceRoot+=/distribution-nixpkgs; echo source root reset to $sourceRoot";
   enableSeparateDataOutput = true;

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/hackage-db.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/hackage-db.nix
@@ -17,10 +17,10 @@
 }:
 mkDerivation {
   pname = "hackage-db";
-  version = "2.1.3-unstable-2025-10-19";
+  version = "2.1.3-unstable-2025-10-25";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/26e5dba9259791d1e80ce68a07f6d20adb26c7eb.tar.gz";
-    sha256 = "19y5smq0aji45zak6sxlimzw7ww33zbcmbbrvi2rq40i26mw6kxj";
+    url = "https://github.com/NixOS/cabal2nix/archive/19800f3819e099dba344001d0d0f5c15698bc793.tar.gz";
+    sha256 = "02zxw06d5c9zh63kra9sx3rfcgb8xqaz77b5za0jxvkjxjl9ysyn";
   };
   postUnpack = "sourceRoot+=/hackage-db; echo source root reset to $sourceRoot";
   isLibrary = true;

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/language-nix.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/language-nix.nix
@@ -13,10 +13,10 @@
 }:
 mkDerivation {
   pname = "language-nix";
-  version = "2.3.0-unstable-2025-10-19";
+  version = "2.3.0-unstable-2025-10-25";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/26e5dba9259791d1e80ce68a07f6d20adb26c7eb.tar.gz";
-    sha256 = "19y5smq0aji45zak6sxlimzw7ww33zbcmbbrvi2rq40i26mw6kxj";
+    url = "https://github.com/NixOS/cabal2nix/archive/19800f3819e099dba344001d0d0f5c15698bc793.tar.gz";
+    sha256 = "02zxw06d5c9zh63kra9sx3rfcgb8xqaz77b5za0jxvkjxjl9ysyn";
   };
   postUnpack = "sourceRoot+=/language-nix; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [


### PR DESCRIPTION
cc @jopejoe1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
