### PR TITLE
linux/build: re-expose `config` with its helper functions

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -90,6 +90,8 @@ lib.makeOverridable (
     # Provide defaults. Note that we support `null` so that callers don't need to use optionalAttrs,
     # which can lead to unnecessary strictness and infinite recursions.
     modDirVersion_ = if modDirVersion == null then lib.versions.pad 3 version else modDirVersion;
+
+    config_ = config;
   in
   let
     # Shadow the un-defaulted parameter; don't want null.
@@ -139,29 +141,29 @@ lib.makeOverridable (
     ];
     needsUbootTools = lib.elem stdenv.hostPlatform.linuxArch linuxPlatformsUsingUImage;
 
-    configHelpers =
+    config =
       let
         attrName = attr: "CONFIG_" + attr;
       in
       {
         isSet = attr: hasAttr (attrName attr) config;
 
-        getValue = attr: if configHelpers.isSet attr then getAttr (attrName attr) config else null;
+        getValue = attr: if config.isSet attr then getAttr (attrName attr) config else null;
 
-        isYes = attr: (configHelpers.getValue attr) == "y";
+        isYes = attr: (config.getValue attr) == "y";
 
-        isNo = attr: (configHelpers.getValue attr) == "n";
+        isNo = attr: (config.getValue attr) == "n";
 
-        isModule = attr: (configHelpers.getValue attr) == "m";
+        isModule = attr: (config.getValue attr) == "m";
 
-        isEnabled = attr: (configHelpers.isModule attr) || (configHelpers.isYes attr);
+        isEnabled = attr: (config.isModule attr) || (config.isYes attr);
 
-        isDisabled = attr: (!(configHelpers.isSet attr)) || (configHelpers.isNo attr);
+        isDisabled = attr: (!(config.isSet attr)) || (config.isNo attr);
       }
-      // config;
+      // config_;
 
-    isModular = configHelpers.isYes "MODULES";
-    withRust = configHelpers.isYes "RUST";
+    isModular = config.isYes "MODULES";
+    withRust = config.isYes "RUST";
 
     target = stdenv.hostPlatform.linux-kernel.target or "vmlinux";
 


### PR DESCRIPTION
In #448835 I renamed `config` to `configHelpers` to save a `config_ = config;`, however `config` having the `is*` helpers is kinda public API (as proven by NixOS modules failing to evaluate).

As a result, this commit adds the helpers back to `config` that is exposed by the kernel derivation.

Apologies, I'm pretty sure I fixed that before locally and it just got lost during a rebase :(

cc @magneticflux-


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
