### PR TITLE
forgejo-lts: 11.0.6 -> 11.0.7, forgejo: 13.0.1 -> 13.0.2

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -12,7 +12,6 @@
   bash,
   brotli,
   buildGoModule,
-  fetchpatch,
   forgejo,
   git,
   gzip,
@@ -84,14 +83,6 @@ buildGoModule rec {
 
   patches = [
     ./static-root-path.patch
-  ]
-  ++ lib.optionals lts [
-    (fetchpatch {
-      # fix for go 1.25.2 stricter ipv6 parsing, remove for LTS > 11.0.6
-      name = "fix-test-ipv6-go125.patch";
-      url = "https://codeberg.org/forgejo/forgejo/commit/0d9a8e3fa2cf9228290ed1a9a5767e6ba204edd7.patch";
-      hash = "sha256-AM4/kgCXSU5Bj8aOObm6qyeL1SEpeFhmlT42lMJ2o08=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "11.0.6";
-  hash = "sha256-7rX0B1db0HbZa/em3hX+yzAi4rqsDysJPx3dIInGxpY=";
+  version = "11.0.7";
+  hash = "sha256-svNysySAE50rgTXTyPiZDv0lQfYGgdgoc5+9GXxv3Bw=";
   npmDepsHash = "sha256-1lY08jBTx3DRhoaup02076EL9n85y57WCsS/cNcM4aw=";
   vendorHash = "sha256-Jh8u+iCBhYdKcLj4IzcKtJBnzvclvUeYbR/hjMN+cPs=";
   lts = true;

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "13.0.1";
-  hash = "sha256-P8ZIBV0pVo3cn9Yroe67Bt+/7KEdz/gBGSypmUz5V2g=";
+  version = "13.0.2";
+  hash = "sha256-5am/WiRo+ma2ArhnKxQ6cpFl2q7R4g4UwtdnSY/+RIM=";
   npmDepsHash = "sha256-7WjcMsKPtKUWJfDrJc65ZXq2tjK8+8DnqwINj+0XyiQ=";
   vendorHash = "sha256-PHItbU27d9ouykUlhr9owylMpF+3wz2vc8c0UTR1RVU=";
   lts = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://codeberg.org/forgejo/security-announcements/issues/43

Backport will likely need a go 1.25 bump

Relates #455715

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
