### PR TITLE
dockerTools: fix throw on invalid compressor

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -113,7 +113,7 @@ let
   compressorForImage =
     compressor: imageName:
     compressors.${compressor}
-      or (throw "in docker image ${imageName}: compressor must be one of: [${toString builtins.attrNames compressors}]");
+      or (throw "in docker image ${imageName}: compressor must be one of: [${toString (builtins.attrNames compressors)}]");
 
 in
 rec {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There were some missing parens in a throw expression.

```nix
# before
nix-repl> pkgs.dockerTools.buildImage { name = "bash"; tag = "latest"; compressor = "adsf"; }
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating the derivation attribute 'name'
         at /nix/store/7sdgbmyyyd1avk5azdm9rf8qsjzv3yhp-source/pkgs/stdenv/generic/make-derivation.nix:544:13:
          543|           // {
          544|             ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
             |             ^
          545|               let

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: cannot coerce the built-in function 'attrNames' to a string: «primop attrNames»


# after
nix-repl> pkgs.dockerTools.buildImage { name = "bash"; tag = "latest"; compression = "adsf"; }
error:
       … while calling a functor (an attribute set with a '__functor' attribute)
         at «string»:1:1:
            1| pkgs.dockerTools.buildImage { name = "bash"; tag = "latest"; compression = "adsf"; }
             | ^

       … while evaluating a branch condition
         at /nix/store/29dn4yygghi9dm9r0yzjyhxz4jd6xlvp-source/lib/customisation.nix:182:7:
          181|       in
          182|       if isAttrs result then
             |       ^
          183|         result

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: function 'anonymous lambda' called with unexpected argument 'compression'
       at /nix/store/29dn4yygghi9dm9r0yzjyhxz4jd6xlvp-source/pkgs/build-support/docker/default.nix:605:5:
          604|   buildImage = lib.makeOverridable (
          605|     args@{
             |     ^
          606|       # Image name.
       Did you mean compressor?

nix-repl> pkgs.dockerTools.buildImage { name = "bash"; tag = "latest"; compressor = "adsf"; }
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating the derivation attribute 'name'
         at /nix/store/29dn4yygghi9dm9r0yzjyhxz4jd6xlvp-source/pkgs/stdenv/generic/make-derivation.nix:544:13:
          543|           // {
          544|             ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
             |             ^
          545|               let

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: in docker image bash: compressor must be one of: [gz none zstd]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
