### PR TITLE
gleam: skip failing tests on x86_64-darwin

### DIFF
--- a/pkgs/by-name/gl/gleam/package.nix
+++ b/pkgs/by-name/gl/gleam/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   git,
@@ -46,6 +47,26 @@ rustPlatform.buildRustPackage (finalAttrs: {
   checkFlags = [
     # Makes a network request
     "--skip=tests::echo::echo_dict"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    # Snapshot tests fail because a warning is shown on stdout
+    # warn: CPU lacks AVX support, strange crashes may occur. Reinstall Bun or use *-baseline build:
+    #   https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-darwin-x64-baseline.zip
+    "--skip=tests::echo::echo_bitarray"
+    "--skip=tests::echo::echo_bool"
+    "--skip=tests::echo::echo_charlist"
+    "--skip=tests::echo::echo_circular_reference"
+    "--skip=tests::echo::echo_custom_type"
+    "--skip=tests::echo::echo_float"
+    "--skip=tests::echo::echo_function"
+    "--skip=tests::echo::echo_importing_module_named_inspect"
+    "--skip=tests::echo::echo_int"
+    "--skip=tests::echo::echo_list"
+    "--skip=tests::echo::echo_nil"
+    "--skip=tests::echo::echo_singleton"
+    "--skip=tests::echo::echo_string"
+    "--skip=tests::echo::echo_tuple"
+    "--skip=tests::echo::echo_with_message"
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Some snapshot tests fail with:

```
---- tests::echo::echo_singleton stdout ----
Snapshots in allow-duplicates block do not match.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Differences in Block ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: test-output/src/tests/snapshots/test_output__tests__echo__echo_singleton.snap
Snapshot: echo_singleton
Source: test-output/src/tests/echo.rs:206
────────────────────────────────────────────────────────────────────────────────
-previous assertion
+current assertion
────────────┬───────────────────────────────────────────────────────────────────
   11    11 │ }
   12    12 │
   13    13 │
   14    14 │ --- gleam run output ----------------
         15 │+warn: CPU lacks AVX support, strange crashes may occur. Reinstall Bun or use *-baseline build:
         16 │+  https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-darwin-x64-baseline.zip
   15    17 │ ␛[90msrc/main.gleam:4␛[39m␊
   16    18 │ #(1, Thing, Thing)
────────────┴───────────────────────────────────────────────────────────────────
```

cc @philtaken @llakala

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
