### PR TITLE
sbcl: disable on darwin (tests failure)

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -286,19 +286,26 @@ stdenv.mkDerivation (self: {
     ''
   );
 
-  meta = with lib; {
+  meta = {
     description = "Common Lisp compiler";
     homepage = "https://sbcl.org";
-    license = licenses.publicDomain; # and FreeBSD
+    license = lib.licenses.publicDomain; # and FreeBSD
     mainProgram = "sbcl";
     teams = [ lib.teams.lisp ];
-    platforms = attrNames bootstrapBinaries ++ [
+    platforms = lib.attrNames bootstrapBinaries ++ [
       # These aren’t bootstrapped using the binary distribution but compiled
       # using a separate (lisp) host
       "x86_64-darwin"
       "x86_64-linux"
       "aarch64-darwin"
       "aarch64-linux"
+    ];
+    badPlatforms = [
+      # Several tests fail:
+      # Invalid exit status: run-program.test.sh
+      # (71 tests skipped for this combination of platform and features)
+      # test failed, expected 104 return code, got 1
+      lib.systems.inspect.patterns.isDarwin
     ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I think that `sbcl` has been broken on darwin for several weeks.

```
Finished running tests.
Status:
 Skipped (broken):   compiler.pure.lisp / FULL-WARNING-FOR-UNDEFINED-TYPE-IN-CL
 Skipped (broken):   compiler.pure.lisp / SINGLE-WARNING-FOR-SINGLE-UNDEFINED-TYPE
 Skipped (broken):   debug.pure.lisp / FAST-VALID-TAGGED-POINTER-P
 Expected failure:   dynamic-extent.pure.lisp / (DX-LIST MAKE-LIST)
 Expected failure:   dynamic-extent.pure.lisp / COPY-STRUCTURE-DX
 Expected failure:   dynamic-extent.pure.lisp / AUTO-DX-RECURSIVE-REF.STACK-ALLOCATES
 Expected failure:   dynamic-extent.pure.lisp / AUTO-DX-RECURSIVE-REF-2.STACK-ALLOCATES
 Skipped (broken):   dynamic-extent.pure.lisp / PUSH+DX+MV-CALL
 Skipped (broken):   gethash-concurrency.pure.lisp / (HASH-TABLE UNSYNCHRONIZED)
 Skipped (broken):   hash.pure.lisp / (HASH-TABLE GC-SMASHED-CELL-LIST)
 Expected failure:   hash.pure.lisp / SXHASH-ON-DISPLACED-STRING
 Skipped (broken):   map-refs.pure.lisp / MAP-REFERENCING-OBJS
 Expected failure:   selfbuild-output.pure.lisp / MAKE-LIST-%MAKE-LIST-NOT-CALLED
 Skipped (broken):   type.pure.lisp / (TYPE-DERIVATION LOGICAL-OPERATIONS SCALING)
 Expected failure:   block-compile.impure.lisp / BLOCK-COMPILE-TOP-LEVEL-CLOSURES.SAME-ENVIRONMENT.LOCAL-CALLS
 Expected failure:   compiler-2.impure.lisp / TOP-LEVEL-CLOSURE-SEPARATE-COMPONENT
 Expected failure:   compiler-2.impure.lisp / TOP-LEVEL-CLOSURE-SEPARATE-COMPONENT.2
 Expected failure:   full-eval.impure.lisp / INLINE-FUN-CAPTURES-DECL
 Expected failure:   reader.impure.lisp / (SHARP= EQUALP HASH-TABLE KEY)
 Expected failure:   reader.impure.lisp / (SHARP= MAKE-ARRAY DISPLACED-TO)
 Skipped (broken):   run-program.impure.lisp / (RUN-PROGRAM AUTOCLOSE-STREAMS)
 Skipped (broken):   run-program.impure.lisp / (RUN-PROGRAM PTY-STREAM)
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / INET-SOCKET-BIND
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SOCKOPT-CLOSE-WAIT-LISTEN-EOF
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / INTERRUPT-IO
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.SERVER.CHARACTER.OUTPUT
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.SERVER.UB8.OUTPUT
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.CLIENT.CHARACTER.OUTPUT
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.CLIENT.UB8.OUTPUT
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.SERVER.CHARACTER.IO
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.SERVER.UB8.IO
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.CLIENT.CHARACTER.IO
 Failure:            ../contrib/sb-bsd-sockets/tests.lisp / SHUTDOWN.CLIENT.UB8.IO
 Failure:            ../contrib/sb-posix/posix-tests.lisp / PWENT.NON-EXISTING
 Failure:            ../contrib/sb-posix/posix-tests.lisp / GRENT.NON-EXISTING
 Failure:            ../contrib/sb-simple-streams/simple-stream-tests.lisp / WRITE-READ-INET
 Failure:            ../contrib/sb-simple-streams/simple-stream-tests.lisp / WRITE-READ-LARGE-DC-1
 Expected failure:   traceroot.impure.lisp / (SEARCH-ROOTS STACK-INDIRECT)
 Expected failure:   traceroot.impure.lisp / TRACEROOT-COLLAPSE-LISTS
 Expected failure:   traceroot.impure.lisp / (SEARCH-ROOTS SIMPLE-FUN)
 Expected failure:   traceroot.impure.lisp / SEARCH-FOR-SYMBOL-NAME
 Invalid exit status: run-program.test.sh
 (71 tests skipped for this combination of platform and features)
test failed, expected 104 return code, got 1
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
