### PR TITLE
pomatez: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22485,6 +22485,12 @@
     githubId = 1387224;
     name = "Richard Szibele";
   };
+  rszyma = {
+    email = "rszyma.dev@gmail.com";
+    github = "rszyma";
+    githubId = 44318430;
+    name = "rszyma";
+  };
   rtburns-jpl = {
     email = "rtburns@jpl.nasa.gov";
     github = "rtburns-jpl";

--- a/pkgs/by-name/po/pomatez/0001-disable-auto-update.patch
+++ b/pkgs/by-name/po/pomatez/0001-disable-auto-update.patch
@@ -1,0 +1,75 @@
+diff --git c/app/electron/src/main.ts i/app/electron/src/main.ts
+index ed9ca0e..5c1fd4c 100644
+--- c/app/electron/src/main.ts
++++ i/app/electron/src/main.ts
+@@ -328,37 +328,39 @@ if (!onlySingleInstance) {
+       },
+     ]);
+ 
+-    const autoUpdater = activateAutoUpdate({
+-      onUpdateAvailable: (info) => {
+-        notify({
+-          title: "NEW UPDATE IS AVAILABLE",
+-          message: `App version ${info.version} ready to be downloaded.`,
+-          actions: ["View Release Notes"],
+-          callback: (err, response) => {
+-            if (!err) {
+-              if (response === "view release notes") {
+-                shell.openExternal(RELEASE_NOTES_LINK);
+-              }
+-            }
+-          },
+-        });
+-      },
+-      onUpdateDownloaded: (info) => {
+-        notify({
+-          title: "READY TO BE INSTALLED",
+-          message: "Update has been successfully downloaded.",
+-          // Temporarily commented out due to an issue with snoretoast https://github.com/mikaelbr/node-notifier/issues/332
+-          actions: ["Quit and Install" /*, "Install it Later"*/],
+-          callback: (err, response) => {
+-            if (!err) {
+-              //if (response === "quit and install") {
+-              autoUpdater.quitAndInstall();
+-              //}
+-            }
+-          },
+-        });
+-      },
+-    });
++    console.info("auto-update disabled by Nix");
++
++    // const autoUpdater = activateAutoUpdate({
++    //   onUpdateAvailable: (info) => {
++    //     notify({
++    //       title: "NEW UPDATE IS AVAILABLE",
++    //       message: `App version ${info.version} ready to be downloaded.`,
++    //       actions: ["View Release Notes"],
++    //       callback: (err, response) => {
++    //         if (!err) {
++    //           if (response === "view release notes") {
++    //             shell.openExternal(RELEASE_NOTES_LINK);
++    //           }
++    //         }
++    //       },
++    //     });
++    //   },
++    //   onUpdateDownloaded: (info) => {
++    //     notify({
++    //       title: "READY TO BE INSTALLED",
++    //       message: "Update has been successfully downloaded.",
++    //       // Temporarily commented out due to an issue with snoretoast https://github.com/mikaelbr/node-notifier/issues/332
++    //       actions: ["Quit and Install" /*, "Install it Later"*/],
++    //       callback: (err, response) => {
++    //         if (!err) {
++    //           //if (response === "quit and install") {
++    //           autoUpdater.quitAndInstall();
++    //           //}
++    //         }
++    //       },
++    //     });
++    //   },
++    // });
+   });
+ }
+ 

--- a/pkgs/by-name/po/pomatez/0002-insecure-enable-node-integration.patch
+++ b/pkgs/by-name/po/pomatez/0002-insecure-enable-node-integration.patch
@@ -1,0 +1,12 @@
+diff --git c/app/electron/src/main.ts i/app/electron/src/main.ts
+index ed9ca0e..f3fe08b 100644
+--- c/app/electron/src/main.ts
++++ i/app/electron/src/main.ts
+@@ -97,6 +97,7 @@ function createMainWindow() {
+     backgroundColor: store.safeGet("isDarkMode") ? "#141e25" : "#fff",
+     webPreferences: {
+       contextIsolation: true,
++      nodeIntegration: true,
+       backgroundThrottling: false,
+       preload: path.join(__dirname, "preload.js"),
+     },

--- a/pkgs/by-name/po/pomatez/package.nix
+++ b/pkgs/by-name/po/pomatez/package.nix
@@ -1,0 +1,120 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  electron,
+  yarnConfigHook,
+  yarnBuildHook,
+  makeWrapper,
+  imagemagick,
+  applyPatches,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pomatez";
+  version = "1.9.0";
+
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "zidoro";
+      repo = "pomatez";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-IHzdd9iamK14MFEEbJch3YTWE0nFGQWoinu/d0Tr6ls=";
+    };
+    patches = [
+      # Checking for updates is broken somehow due to a missing file (an issue with packaging),
+      # but the related code also provides a self-update feature, which we want to disable anyway.
+      ./0001-disable-auto-update.patch
+      # XXX: This enables nodeIntegration which is insecure, as it disables sandboxing.
+      # Pomatez upstream pins archaic electron version v18, where node integration is still allowed by default.
+      # Without this patch, latest electron (which we use) fails loading @pomatez/shareables node module, completely breaking rendering.
+      ./0002-insecure-enable-node-integration.patch
+    ];
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-y3BAsd6ACcGLH+6X+MCEQMS9wNZJR6SBTFJmyUnoL0w=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    makeWrapper
+    imagemagick
+    yarnConfigHook
+    yarnBuildHook
+    copyDesktopItems
+  ];
+
+  # FIXME: These scripts unnecessarily build 2 systems at once (x86_64 and aarch64).
+  yarnBuildScript = if stdenv.hostPlatform.isDarwin then "build:mac" else "build:linux";
+
+  yarnBuildFlags = [
+    "--" # Additional 2 "--" are needed so lerna passes the flags to electron-builder.
+    "--"
+    "--dir"
+    "-c.electronDist=${electron.dist}"
+    "-c.electronVersion=${electron.version}"
+  ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  installPhase =
+    let
+      electronBuilderOutputDirBySystem = {
+        "x86_64-linux" = "linux-unpacked";
+        "aarch64-linux" = "linux-arm64-unpacked";
+        "x86_64-darwin" = "mac";
+        "aarch64-darwin" = "mac-arm64";
+      };
+    in
+    ''
+      runHook preInstall
+
+      for size in 16 24 32 48 64 128 256; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        magick convert -background none -resize "$size"x"$size" snap/gui/icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/pomatez.png
+      done
+
+      cd app/electron/dist/${electronBuilderOutputDirBySystem.${stdenv.hostPlatform.system}}
+      mkdir -p $out/share/pomatez
+      cp -r ./* $out/share/pomatez
+
+      makeWrapper '${electron}/bin/electron' "$out/bin/pomatez" \
+        --add-flags "$out/share/pomatez/resources/app.asar" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+        --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+        --set-default ELECTRON_IS_DEV 0 \
+
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "pomatez";
+      exec = "pomatez";
+      icon = "pomatez";
+      desktopName = "Pomatez";
+      genericName = "Pomodoro timer";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Office"
+        "Utility"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Elegant multi-platform Pomodoro desktop app, built with Electron";
+    homepage = "https://zidoro.github.io/pomatez/";
+    changelog = "https://github.com/zidoro/pomatez/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "pomatez";
+    maintainers = with lib.maintainers; [ rszyma ];
+    inherit (electron.meta) platforms;
+  };
+})


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/377326

Packaged pomatez - https://github.com/zidoro/pomatez, a pomodoro timer app, build with Electron. 

The upstream also provides alternative frontend using tauri, but it's not stable yet judging from "beta" in release names of that version, and so this package doesn't build it.

Tested on x86_64-linux, both wayland and x11, probably doesn't work for other systems.
Especially for macOS, I don't have apple device to test on.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
