### PR TITLE
lzham: 1.0 -> 1.0-unstable-2023-05-14

### DIFF
--- a/pkgs/by-name/lz/lzham/package.nix
+++ b/pkgs/by-name/lz/lzham/package.nix
@@ -5,29 +5,38 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "lzham";
-  version = "1.0";
+  version = "1.0-unstable-2023-05-14";
 
   src = fetchFromGitHub {
     owner = "richgel999";
-    repo = "lzham_codec";
-    rev = "v${lib.replaceStrings [ "." ] [ "_" ] version}_release";
-    sha256 = "14c1zvzmp1ylp4pgayfdfk1kqjb23xj4f7ll1ra7b18wjxc9ja1v";
+    repo = "lzham_codec_devel";
+    rev = "d09fc6676a0313c3814457fbc76351a68f653092";
+    hash = "sha256-zKzz4gEB2dkIIAuDhKGWeV1hn8tCMVILsiQ/gu6aAEE=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ../bin_linux/lzhamtest $out/bin
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  postPatch = ''
+    substituteInPlace {./,lzhamcomp/,lzhamdecomp/,lzhamdll/,lzhamtest/}CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
-  meta = with lib; {
+  postInstall = ''
+    mkdir -p $out/bin
+    cp lzhamtest/lzhamtest $out/bin/
+  '';
+
+  meta = {
     description = "Lossless data compression codec with LZMA-like ratios but 1.5x-8x faster decompression speed";
     mainProgram = "lzhamtest";
     homepage = "https://github.com/richgel999/lzham_codec";
-    license = with licenses; [ mit ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

Updated `lzham` to latest unstable devel, according to upstream is improved and 100% backwards compatible with lzham v1.0.

I changed the installPhase so it installs the `lib` and `include` and then move lzhamtest `bin` to correct place.
result folder look like this:
```
.
└── result
    ├── bin
    │   └── lzhamtest
    ├── include
    │   ├── lzham_dynamic_lib.h
    │   ├── lzham_exports.inc
    │   ├── lzham.h
    │   ├── lzham_static_lib.h
    │   └── zlib.h
    └── lib
        ├── liblzhamcomp.so
        ├── liblzhamdecomp.so
        └── liblzhamdll.so
```
Result from `lzhamtest`:
```
LZHAM Codec - x64 Command Line Test App - Compiled Jan  1 1980 00:00:00
Expecting LZHAM DLL Version 0x1011
Using static libraries.
Loaded LZHAM DLL version 0x1011

Usage: [options] [mode] inpath/infile [outfile]

Modes:
c - Compress "infile" to "outfile"
d - Decompress "infile" to "outfile"
a - Recursively compress all files under "inpath"

Options:
-m[0-4] - Compression level: 0=fastest, 1=faster, 2=default, 3=better, 4=uber
          Default is uber (4).
-d[15-29] - Set log2 dictionary size, max. is 26 on x86 platforms, 29 on x64.
          Default is 26 (64MB) on x86, 28 (256MB) on x64.
-c - Do not compute or verify adler32 checksum during decompression (faster).
-u - Use unbuffered decompression on files that can fit into memory.
     Unbuffered decompression is faster, but may have more I/O overhead.
-t[0-64] - Number of extra compression helper threads. Default=# CPU's-1.
           Note: The total number of threads will be 1 + num_helper_threads,
           because the main thread is counted separately.
-v - Immediately decompress compressed file after compression for verification.
-x - Extreme parsing, for slight compression gain (Uber only, MUCH slower).
-x# - Same as -x, except sets the max # of best arrivals (2-8), higher=better compression
-o - Permit the compressor to trade off decompression rate for higher ratios.
     Note: This flag can drop the decompression rate by 30% or more.
-e - Enable deterministic parsing for slightly higher compression and
     predictable output files when enabled, but less scalability.
     The default is disabled, so the generated output data may slightly vary
     between runs when multithreaded compression is enabled.
-afilename Enable delta compression using the specified seed file.
           The same seed file MUST be used for compression/decompression.
-r - Use randomized parameters for each file.
-h[0-20] - Set Huffman table update frequency. 0=Internal def, Def=8, higher=faster.
 Lower settings=slower decompression, but higher ratio. Note 1=impractically slow.
-b - Force single threaded parsing for higher compression ratios (slower).
-F - Use low memory hash finder (16-bit vs. 24-bit hashing)
-f# - Set extreme parser's "fast bytes" setting (16-257, default=128, lower=faster)

LZHAM simple memory to memory compression test
Uncompressed size: 88
Compressed size: 39
Decompress time: 0.000014 secs
Compression test succeeded.
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
