### PR TITLE
rustowl: init at 0.3.4

### DIFF
--- a/pkgs/by-name/ru/rustowl/package.nix
+++ b/pkgs/by-name/ru/rustowl/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rustowl";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "cordx56";
+    repo = "rustowl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pCeVLTiZk2Pv00AK2JlZ1kHrOX1V9iGNaJCdx7hIL+8=";
+  };
+
+  postPatch = ''
+    substituteInPlace lua/rustowl/config.lua \
+      --replace-fail \
+        "cmd = { 'rustowl' }," \
+        "cmd = { '${placeholder "out"}/bin/rustowl' }," \
+  '';
+
+  cargoHash = "sha256-Y8ZBwW2UKp0lVJm54vs9Ll9rEJcNqrEBE5pWH1nTjrM=";
+
+  env = {
+    RUSTUP_TOOLCHAIN = "stable";
+
+    # Bypass rust nightly features not being available on rust stable
+    RUSTC_BOOTSTRAP = 1;
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Visualize Ownership and Lifetimes in Rust";
+    homepage = "https://github.com/cordx56/rustowl";
+    changelog = "https://github.com/cordx56/rustowl/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "rustowl";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [RustOwl](https://github.com/cordx56/rustowl), an editor plugin to visualize ownership and lifetimes in Rust for debugging and optimization.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
