### PR TITLE
python313Packages.colcon-cd: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1466,6 +1466,12 @@
     githubId = 37040543;
     name = "Wroclaw";
   };
+  amronos = {
+    email = "aarav@spikonado.com";
+    github = "Amronos";
+    githubId = 134804732;
+    name = "Aarav Gupta";
+  };
   amuckstot30 = {
     github = "amuckstot30";
     githubId = 157274630;

--- a/pkgs/development/python-modules/colcon-cd/default.nix
+++ b/pkgs/development/python-modules/colcon-cd/default.nix
@@ -1,0 +1,49 @@
+{
+  buildPythonPackage,
+  colcon,
+  colcon-argcomplete,
+  colcon-package-information,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "colcon-cd";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = "colcon-cd";
+    tag = "${version}";
+    hash = "sha256-eOo1DqTvYazr+wWraG9PZe0tTCgaAvhWtELG5rlaGSs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    colcon
+    colcon-package-information
+  ];
+
+  optional-dependencies = [ colcon-argcomplete ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # Skip the linter tests that require additional dependencies
+    "test/test_flake8.py"
+    "test/test_spell_check.py"
+  ];
+
+  pythonImportCheck = [ "colcon_cd" ];
+
+  meta = {
+    description = "A shell function for colcon-core to change the current working directory.";
+    homepage = "https://github.com/colcon/colcon-cd";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ amronos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2811,6 +2811,8 @@ self: super: with self; {
 
   colcon-cargo = callPackage ../development/python-modules/colcon-cargo { };
 
+  colcon-cd = callPackage ../development/python-modules/colcon-cd { };
+
   colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };
 
   colcon-installed-package-information =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

``colcon-cd`` is an extension for [``colcon``](https://github.com/colcon/colcon-core) included in the [``colcon-common-extensions``](https://github.com/colcon/colcon-common-extensions) package. It offers a command to change to the directory where a colcon package specified by its name is. This command is offered through shell functions, which one needs to manually source. More info is available [here](https://colcon.readthedocs.io/en/released/user/installation.html#quick-directory-changes).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
