### PR TITLE
sleepwatcher: add new package to nixpkgs at version 2.2.1

### DIFF
--- a/pkgs/os-specific/darwin/sleepwatcher/default.nix
+++ b/pkgs/os-specific/darwin/sleepwatcher/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sleepwatcher";
+  version = "2.2.1";
+
+  src = fetchurl {
+    url = "https://www.bernhard-baehr.de/sleepwatcher_${version}.tgz";
+    sha256 = "0gk4x4x04wz7y0kp19p1jjcxhqqk9n29l4dw3wa72y0n09knbwab";
+  };
+
+  sourceRoot = "sleepwatcher_${version}/sources";
+
+  buildPhase = ''
+    # Modern build: x86_64 and arm64 only (skip obsolete i386)
+    if [ "$(uname -m)" = "arm64" ]; then
+      $CC -O3 -mmacosx-version-min=10.4 -arch arm64 -o sleepwatcher sleepwatcher.c -framework IOKit -framework CoreFoundation
+    else
+      $CC -O3 -mmacosx-version-min=10.4 -arch x86_64 -o sleepwatcher sleepwatcher.c -framework IOKit -framework CoreFoundation
+    fi
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man8
+    install -m 0755 sleepwatcher $out/bin/sleepwatcher
+    install -m 0444 ../sleepwatcher.8 $out/share/man/man8/sleepwatcher.8
+  '';
+
+  meta = {
+    description = "Monitors sleep, wakeup and idleness of a Mac";
+    longDescription = ''
+      SleepWatcher is a command line tool (daemon) for macOS that monitors
+      sleep, wakeup and idleness of a Mac. It can be used to execute a Unix
+      command when the Mac or the display of the Mac goes to sleep mode or wakes
+      up, after a given time without user interaction or when the user resumes
+      activity after a break or when the power supply of a Mac notebook is attached
+      or detached. It also can send the Mac to sleep mode or retrieve the time since
+      last user activity.
+    '';
+    homepage = "https://www.bernhard-baehr.de/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ virusdave ];
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -121,6 +121,8 @@ makeScopeWithSplicing' {
 
         openwith = callPackage ../os-specific/darwin/openwith { };
 
+        sleepwatcher = callPackage ../os-specific/darwin/sleepwatcher { };
+
         trash = callPackage ../os-specific/darwin/trash { };
 
         inherit (self.file_cmds) xattr;


### PR DESCRIPTION
New package `sleepwalker`, developed here: https://github.com/fishman/sleepwatcher

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

