### PR TITLE
surge-XT: fix build; add build options, mrtnvgr to maintainers; no with lib; in meta

### DIFF
--- a/pkgs/by-name/su/surge-XT/clap-option.diff
+++ b/pkgs/by-name/su/surge-XT/clap-option.diff
@@ -1,0 +1,21 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 31bee8d5..834ee6f6 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -12,6 +12,8 @@ if (NOT SURGE_COMPILE_BLOCK_SIZE)
+   set(SURGE_COMPILE_BLOCK_SIZE 32)
+ endif()
+ 
++option(SURGE_BUILD_CLAP "Build Surge as a CLAP" ON)
++
+ set(SURGE_JUCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../libs/JUCE" CACHE STRING "Path to JUCE library source tree")
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+@@ -29,7 +31,6 @@ if(${CMAKE_VERSION} VERSION_LESS 3.21)
+   set(SURGE_BUILD_CLAP FALSE)
+ else()
+   message(STATUS "CMake version ${CMAKE_VERSION} allows CLAP build")
+-  set(SURGE_BUILD_CLAP TRUE)
+ endif()
+ 
+ if(SURGE_BUILD_CLAP)

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -71,12 +71,12 @@ stdenv.mkDerivation rec {
     export XDG_DOCUMENTS_DIR=$(mktemp -d)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";
     homepage = "https://surge-synthesizer.github.io";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       magnetophon
       orivej
     ];

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -13,6 +13,11 @@
   libXext,
   libXinerama,
   libXrandr,
+
+  buildVST3 ? true,
+  buildLV2 ? true,
+  buildCLAP ? true,
+  buildStandalone ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,6 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
     hash = "sha256-4b0H3ZioiXFc4KCeQReobwQZJBl6Ep2/8JlRIwvq/hQ=";
   };
+
+  patches = [
+    # NOTE: merged in upstream, remove on package update
+    #     (https://github.com/surge-synthesizer/surge/pull/8202)
+    ./clap-option.diff
+  ];
 
   postPatch = ''
     # see https://github.com/NixOS/nixpkgs/pull/149487#issuecomment-991747333
@@ -47,18 +58,21 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     freetype
     libjack2
-    lv2
     libX11
     libXcursor
     libXext
     libXinerama
     libXrandr
-  ];
+  ]
+  ++ lib.optionals buildLV2 [ lv2 ];
 
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DSURGE_BUILD_LV2=TRUE"
+    (lib.cmakeBool "SURGE_SKIP_STANDALONE" (!buildStandalone))
+    (lib.cmakeBool "SURGE_SKIP_VST3" (!buildVST3))
+    (lib.cmakeBool "SURGE_SKIP_LV2" buildLV2)
+    (lib.cmakeBool "SURGE_BUILD_CLAP" buildCLAP)
   ];
 
   # JUCE dlopen's these at runtime, crashes without them

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       magnetophon
       orivej
+      mrtnvgr
     ];
   };
 }

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  gitUpdater,
   cmake,
   pkg-config,
   alsa-lib,
@@ -27,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = "surge";
-    tag = "release_xt_${finalAttrs.version}";
+    tag = "${finalAttrs.finalPackage.passthru.rev-prefix}${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-4b0H3ZioiXFc4KCeQReobwQZJBl6Ep2/8JlRIwvq/hQ=";
   };
@@ -85,6 +86,13 @@ stdenv.mkDerivation (finalAttrs: {
       "-lXrandr"
     ]
   );
+
+  passthru = {
+    rev-prefix = "release_xt_";
+    updateScript = gitUpdater {
+      inherit (finalAttrs.finalPackage.passthru) rev-prefix;
+    };
+  };
 
   meta = {
     description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -15,14 +15,14 @@
   libXrandr,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "surge-XT";
   version = "1.3.4";
 
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = "surge";
-    tag = "release_xt_${version}";
+    tag = "release_xt_${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-4b0H3ZioiXFc4KCeQReobwQZJBl6Ep2/8JlRIwvq/hQ=";
   };
@@ -82,4 +82,4 @@ stdenv.mkDerivation rec {
       mrtnvgr
     ];
   };
-}
+})

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -27,6 +27,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-4b0H3ZioiXFc4KCeQReobwQZJBl6Ep2/8JlRIwvq/hQ=";
   };
 
+  postPatch = ''
+    # see https://github.com/NixOS/nixpkgs/pull/149487#issuecomment-991747333
+    export XDG_DOCUMENTS_DIR=$(mktemp -d)
+
+    # Required for CMake 4
+    # NOTE: libsamplerate is no longer used in Surge-XT, remove on package update
+    substituteInPlace libs/libsamplerate/CMakeLists.txt --replace-fail \
+      'cmake_minimum_required(VERSION 3.1..3.18)' \
+      'cmake_minimum_required(VERSION 4.0)'
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -50,11 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSURGE_BUILD_LV2=TRUE"
   ];
 
-  CXXFLAGS = [
-    # GCC 13: error: 'uint32_t' has not been declared
-    "-include cstdint"
-  ];
-
   # JUCE dlopen's these at runtime, crashes without them
   NIX_LDFLAGS = (
     toString [
@@ -65,11 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
       "-lXrandr"
     ]
   );
-
-  # see https://github.com/NixOS/nixpkgs/pull/149487#issuecomment-991747333
-  postPatch = ''
-    export XDG_DOCUMENTS_DIR=$(mktemp -d)
-  '';
 
   meta = {
     description = "LV2 & VST3 synthesizer plug-in (previously released as Vember Audio Surge)";


### PR DESCRIPTION
If this PR should be split into smaller parts, let me know :)

Tracking: Build Failures with CMake 4 https://github.com/NixOS/nixpkgs/issues/445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
