### PR TITLE
bencher-cli: init at 0.5.6; Fixes #390884

### DIFF
--- a/pkgs/by-name/be/bencher-cli/package.nix
+++ b/pkgs/by-name/be/bencher-cli/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bencher-cli";
+  version = "v0.5.6";
+
+  src = fetchFromGitHub {
+    owner = "bencherdev";
+    repo = "bencher";
+    tag = finalAttrs.version;
+    hash = "sha256-iv0BScnDYVtkMnvGv3JysamuOANRNpvY8+ZC32aa2iA=";
+  };
+
+  cargoHash = "sha256-9Uf2XvBjZUudrfrLQCu4lCsGLx1zUz95nkNrMHTekm8=";
+
+  cargoBuildFlags = [
+    "--package"
+    "bencher_cli"
+  ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  # The default features include `plus` which has a custom license
+  buildNoDefaultFeatures = true;
+
+  postPatch = ''
+    # Remove mold linker configuration which is not available in the Nix build environment
+    rm -f .cargo/config.toml
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bencher CLI";
+    longDescription = ''
+      Bencher is a suite of continuous benchmarking tools.
+    '';
+    homepage = "https://bencher.dev/";
+    changelog = "https://github.com/bencherdev/bencher/blob/${finalAttrs.version}/services/console/src/chunks/docs-reference/changelog/en/changelog.mdx";
+    license = [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    maintainers = with lib.maintainers; [ michaelvanstraten ];
+    mainProgram = "bencher";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Bencher is a suite of continuous benchmarking tools.

The release notes can be found here:

https://github.com/bencherdev/bencher/releases/tag/v0.5.6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin (built on aarch64 darwin with rosetta 2)
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
