### PR TITLE
uptime-kuma: 1.23.16 -> 2.0.2

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -17,7 +17,9 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- `uptime-kuma` has been updated to v2, which requires an automated migration that can take a few hours. **A backup is highly recommended.**
+  If your SQLite database is corrupted, the migration might fail and require [manual intervention](https://github.com/louislam/uptime-kuma/issues/5281).
+  See the [migration guide](https://github.com/louislam/uptime-kuma/wiki/Migration-From-v1-To-v2) for more information.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-26.05-lib}
 

--- a/nixos/modules/services/monitoring/uptime-kuma.nix
+++ b/nixos/modules/services/monitoring/uptime-kuma.nix
@@ -25,6 +25,11 @@ in
         example = {
           PORT = "4000";
           NODE_EXTRA_CA_CERTS = lib.literalExpression "config.security.pki.caBundle";
+          UPTIME_KUMA_DB_TYPE = "mariadb";
+          UPTIME_KUMA_DB_HOSTNAME = "localhost";
+          UPTIME_KUMA_DB_NAME = "uptime-kuma";
+          UPTIME_KUMA_DB_USERNAME = "uptime-kuma";
+          UPTIME_KUMA_DB_PASSWORD = "uptime-kuma";
         };
         description = ''
           Additional configuration for Uptime Kuma, see
@@ -42,6 +47,7 @@ in
       NODE_ENV = lib.mkDefault "production";
       HOST = lib.mkDefault "127.0.0.1";
       PORT = lib.mkDefault "3001";
+      UPTIME_KUMA_DB_TYPE = lib.mkDefault "sqlite";
     };
 
     systemd.services.uptime-kuma = {

--- a/pkgs/by-name/up/uptime-kuma/fix-database-permissions.patch
+++ b/pkgs/by-name/up/uptime-kuma/fix-database-permissions.patch
@@ -1,12 +1,12 @@
-diff --git a/server/server.js b/server/server.js
-index 0c9a45e6..cec31c7c 100644
---- a/server/server.js
-+++ b/server/server.js
-@@ -1583,6 +1583,7 @@ async function initDatabase(testMode = false) {
-     if (! fs.existsSync(Database.path)) {
-         log.info("server", "Copying Database");
-         fs.copyFileSync(Database.templatePath, Database.path);
-+        fs.chmodSync(Database.path, 0o640);
-     }
+diff --git a/server/database.js b/server/database.js
+index d22ceb29..7490be8a 100644
+--- a/server/database.js
++++ b/server/database.js
+@@ -236,6 +236,7 @@ class Database {
+             if (! fs.existsSync(Database.sqlitePath)) {
+                 log.info("server", "Copying Database");
+                 fs.copyFileSync(Database.templatePath, Database.sqlitePath);
++                fs.chmodSync(Database.sqlitePath, 0o640);
+             }
 
-     log.info("server", "Connecting to the Database");
+             const Dialect = require("knex/lib/dialects/sqlite3/index.js");

--- a/pkgs/by-name/up/uptime-kuma/package.nix
+++ b/pkgs/by-name/up/uptime-kuma/package.nix
@@ -3,33 +3,28 @@
   stdenv,
   fetchFromGitHub,
   buildNpmPackage,
-  python3,
   nodejs,
   nixosTests,
 }:
 
 buildNpmPackage rec {
   pname = "uptime-kuma";
-  version = "1.23.16";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "louislam";
     repo = "uptime-kuma";
     rev = version;
-    hash = "sha256-+bhKnyZnGd+tNlsxvP96I9LXOca8FmOPhIFHp7ijmyA=";
+    hash = "sha256-zW5sl1g96PvDK3S6XhJ6F369/NSnvU9uSQORCQugfvs=";
   };
 
-  npmDepsHash = "sha256-5i1NxwHqOahkioyM4wSu2X5KeMu7CdC4BqoUooAshn4=";
+  npmDepsHash = "sha256-EmSZJUbtD4FW7Rzdpue6/bV8oZt7RUL11tFBXGJQthg=";
 
   patches = [
     # Fixes the permissions of the database being not set correctly
     # See https://github.com/louislam/uptime-kuma/pull/2119
     ./fix-database-permissions.patch
   ];
-
-  nativeBuildInputs = [ python3 ];
-
-  CYPRESS_INSTALL_BINARY = 0; # Stops Cypress from trying to download binaries
 
   postInstall = ''
     cp -r dist $out/lib/node_modules/uptime-kuma/

--- a/pkgs/by-name/up/uptime-kuma/package.nix
+++ b/pkgs/by-name/up/uptime-kuma/package.nix
@@ -7,14 +7,14 @@
   nixosTests,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "uptime-kuma";
   version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "louislam";
     repo = "uptime-kuma";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-zW5sl1g96PvDK3S6XhJ6F369/NSnvU9uSQORCQugfvs=";
   };
 
@@ -45,10 +45,10 @@ buildNpmPackage rec {
     description = "Fancy self-hosted monitoring tool";
     mainProgram = "uptime-kuma-server";
     homepage = "https://github.com/louislam/uptime-kuma";
-    changelog = "https://github.com/louislam/uptime-kuma/releases/tag/${version}";
+    changelog = "https://github.com/louislam/uptime-kuma/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ julienmalka ];
     # FileNotFoundError: [Errno 2] No such file or directory: 'xcrun'
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})


### PR DESCRIPTION
Breaking changes: https://github.com/louislam/uptime-kuma/wiki/Migration-From-v1-To-v2#breaking-changes
https://github.com/louislam/uptime-kuma/releases/tag/2.0.0
https://github.com/louislam/uptime-kuma/releases/tag/2.0.1
https://github.com/louislam/uptime-kuma/releases/tag/2.0.2

I know the breaking changes window has already closed for 25.11, but I think it would be important to get this in since v1 is now deprecated and might not get security updates: https://github.com/louislam/uptime-kuma/blob/master/SECURITY.md

This doesn't add support for passing a secret to the MySQL password as to not stall it further. It can be added later in a future PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
