### PR TITLE
jj-fzf: 0.33.0 -> 0.34.0

### DIFF
--- a/pkgs/by-name/jj/jj-fzf/nix-preflight.patch
+++ b/pkgs/by-name/jj/jj-fzf/nix-preflight.patch
@@ -1,0 +1,24 @@
+diff --git a/preflight.sh b/preflight.sh
+index f1ed02fe60..43b9c365c5 100755
+--- a/preflight.sh
++++ b/preflight.sh
+@@ -78,19 +78,6 @@
+   test $(awk 'BEGIN{print(123)}') == 123 ||
+     __preflightish_die "Failed to find usable 'awk' executable in \$PATH"
+
+-# == Jujutsu ==
+-__preflightish_require "0.34" jj --version --ignore-working-copy
+-
+-# == fzf ==
+-__preflightish_require "0.65.2" fzf --version
+-
+-# == python3 ==
+-__preflightish_require "3.9" python3 --version
+-
+-# == column ==
+-command -v "column" > /dev/null 2>&1 ||
+-  __preflightish_die "Failed to find the 'column' executable in \$PATH"
+-
+ # == Success ==
+ [[ "${BASH_SOURCE[0]}" == "$0" ]] &&
+   echo "  OK         All preflight.sh checks passed"

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -8,42 +8,55 @@
   gnused,
   jujutsu,
   makeWrapper,
+  pandoc,
+  python3,
+  unixtools,
   stdenv,
 }:
 
 stdenv.mkDerivation rec {
   pname = "jj-fzf";
-  version = "0.33.0";
+  version = "0.34.0";
 
   src = fetchFromGitHub {
     owner = "tim-janik";
     repo = "jj-fzf";
     tag = "v${version}";
-    hash = "sha256-iVgX2Lu06t1pCQl5ZGgl3+lTv4HAPKbD/83STDtYhdU=";
+    hash = "sha256-aJyKVMg/yI2CmAx5TxN0w670Rq26ESdLzESgh8Jr4nE=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  strictDeps = true;
+  buildInputs = [ bashInteractive ];
+  nativeBuildInputs = [
+    bashInteractive
+    makeWrapper
+    pandoc
+    jujutsu
+  ];
 
   dontConfigure = true;
   dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-    install -D jj-fzf $out/bin/jj-fzf
-    substituteInPlace $out/bin/jj-fzf \
-      --replace-fail "/usr/bin/env bash" "${lib.getExe bashInteractive}"
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  patches = [ ./nix-preflight.patch ];
+  postPatch = ''
+    substituteInPlace lib/gen-message.py \
+      --replace-fail '/usr/bin/env -S python3 -B' '${python3}/bin/python -B'
+    patchShebangs --build lib/*.sh
+    patchShebangs --host jj-fzf *.sh contrib/*.sh
+  '';
+  postInstall = ''
     wrapProgram $out/bin/jj-fzf \
       --prefix PATH : ${
         lib.makeBinPath [
-          bashInteractive
           coreutils
           fzf
           gawk
           gnused
           jujutsu
+          python3
+          unixtools.column
         ]
       }
-    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
This is an amendment to https://github.com/NixOS/nixpkgs/pull/448133, as changes in the upstream [jj-fzf](https://github.com/tim-janik/jj-fzf/tree/v0.34.0) project necessitate additional files added to the output derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
