### PR TITLE
gst_all_1: convert to scope

### DIFF
--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,52 +1,49 @@
 {
   config,
   lib,
-  callPackage,
-  ipu6ep-camera-hal,
-  ipu6epmtl-camera-hal,
+  newScope,
   apple-sdk,
 }:
 
-let
-  apple-sdk_gstreamer = apple-sdk;
-in
-{
-  inherit apple-sdk_gstreamer;
+lib.makeScope newScope (
+  self:
+  let
+    inherit (self) callPackage;
+  in
+  {
+    apple-sdk_gstreamer = apple-sdk;
 
-  gstreamer = callPackage ./core { };
+    gstreamer = callPackage ./core { };
 
-  gstreamermm = callPackage ./gstreamermm { };
+    gstreamermm = callPackage ./gstreamermm { };
 
-  gst-plugins-base = callPackage ./base { };
+    gst-plugins-base = callPackage ./base { };
 
-  gst-plugins-good = callPackage ./good { };
+    gst-plugins-good = callPackage ./good { };
 
-  gst-plugins-bad = callPackage ./bad { };
+    gst-plugins-bad = callPackage ./bad { };
 
-  gst-plugins-ugly = callPackage ./ugly { };
+    gst-plugins-ugly = callPackage ./ugly { };
 
-  gst-plugins-rs = callPackage ./rs { };
+    gst-plugins-rs = callPackage ./rs { };
 
-  gst-rtsp-server = callPackage ./rtsp-server { };
+    gst-rtsp-server = callPackage ./rtsp-server { };
 
-  gst-libav = callPackage ./libav { };
+    gst-libav = callPackage ./libav { };
 
-  gst-devtools = callPackage ./devtools { };
+    gst-devtools = callPackage ./devtools { };
 
-  gst-editing-services = callPackage ./ges { };
+    gst-editing-services = callPackage ./ges { };
 
-  gst-vaapi = callPackage ./vaapi { };
+    gst-vaapi = callPackage ./vaapi { };
 
-  icamerasrc-ipu6 = callPackage ./icamerasrc { };
-  icamerasrc-ipu6ep = callPackage ./icamerasrc {
-    ipu6-camera-hal = ipu6ep-camera-hal;
-  };
-  icamerasrc-ipu6epmtl = callPackage ./icamerasrc {
-    ipu6-camera-hal = ipu6epmtl-camera-hal;
-  };
+    icamerasrc-ipu6 = callPackage ./icamerasrc { };
+    icamerasrc-ipu6ep = callPackage ./icamerasrc { };
+    icamerasrc-ipu6epmtl = callPackage ./icamerasrc { };
 
-  # note: gst-python is in ../../python-modules/gst-python - called under python3Packages
-}
-// lib.optionalAttrs config.allowAliases {
-  gst-plugins-viperfx = throw "'gst_all_1.gst-plugins-viperfx' was removed as it is broken and not maintained upstream"; # Added 2024-12-16
-}
+    # note: gst-python is in ../../python-modules/gst-python - called under python3Packages
+  }
+  // lib.optionalAttrs config.allowAliases {
+    gst-plugins-viperfx = throw "'gst_all_1.gst-plugins-viperfx' was removed as it is broken and not maintained upstream"; # Added 2024-12-16
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7328,11 +7328,7 @@ with pkgs;
 
   gsettings-qt = libsForQt5.callPackage ../development/libraries/gsettings-qt { };
 
-  gst_all_1 = recurseIntoAttrs (
-    callPackage ../development/libraries/gstreamer {
-      callPackage = newScope gst_all_1;
-    }
-  );
+  gst_all_1 = recurseIntoAttrs (callPackage ../development/libraries/gstreamer { });
 
   gnutls = callPackage ../development/libraries/gnutls {
     util-linux = util-linuxMinimal; # break the cyclic dependency


### PR DESCRIPTION
These packages make sense, at least to me, to live inside of a scope. That way we can also extend the scope with other gst plugins without too much hassel.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
