### PR TITLE
{libreoffice-{fresh,still},calligra}: Fix build

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -313,7 +313,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Revert part of https://github.com/LibreOffice/core/commit/6f60670877208612b5ea320b3677480ef6508abb that broke zlib linking
     ./readd-explicit-zlib-link.patch
-
+  ]
+  ++ lib.optionals (lib.versionOlder version "25.8.2.1") [
     # Backport patch to fix build with Poppler 25.09
     (fetchpatch2 {
       url = "https://github.com/LibreOffice/core/commit/7848e02819c007026952a3fdc9da0961333dc079.patch";
@@ -321,10 +322,10 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-Nw6GFmkFy13w/ktCxw5s7SHL34auP1BQ9JvQnQ65aVU=";
     })
   ]
-  ++ lib.optionals (lib.versionAtLeast version "25.8") [
+  ++ lib.optionals (lib.versionAtLeast version "25.8.2.2") [
     # Fix build with Poppler 25.10
     (fetchpatch2 {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libreoffice-fresh/-/raw/41e58e117c356af2be83993595caf61f9f30cc89/poppler-25.10.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libreoffice-fresh/-/raw/f7b0e4385108b95c134599502a7bccf0a41925c8/poppler-25.10.patch";
       hash = "sha256-KMsjDtRRH8Vy/FXaVwxUo0Ww10PCE0sK8+ZL0Ja2kJQ=";
     })
   ]

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -321,6 +321,11 @@ stdenv.mkDerivation (finalAttrs: {
       includes = [ "sdext/*" ];
       hash = "sha256-Nw6GFmkFy13w/ktCxw5s7SHL34auP1BQ9JvQnQ65aVU=";
     })
+    # Fix build with Poppler 25.10
+    (fetchpatch2 {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libreoffice-still/-/raw/f5241554e4a0f6fd95ac4e5cc398a30243407e6a/fix_build_with_poppler_25.10.patch";
+      hash = "sha256-lbPOkc1HeT5Qsp6XfVyVJtmvSL68qTrmbd3q9lvKSu8=";
+    })
   ]
   ++ lib.optionals (lib.versionAtLeast version "25.8.2.2") [
     # Fix build with Poppler 25.10

--- a/pkgs/kde/gear/calligra/default.nix
+++ b/pkgs/kde/gear/calligra/default.nix
@@ -1,6 +1,7 @@
 {
   mkKdeDerivation,
   lib,
+  fetchpatch,
   boost,
   eigen,
   gsl,
@@ -25,6 +26,14 @@
 
 mkKdeDerivation {
   pname = "calligra";
+
+  patches = [
+    # Fix build with Poppler 25.10
+    (fetchpatch {
+      url = "https://invent.kde.org/office/calligra/-/commit/45e8b302bce1d318f310ea13599d7ce84acc477e.patch";
+      hash = "sha256-TECB3eo24+gI8TXL8gw9BIdFWqw0JBKCWpoNVqBSan8=";
+    })
+  ];
 
   extraBuildInputs = [
     boost


### PR DESCRIPTION
The patch is part of libreoffice 25.8.2.1.

Fixes race between https://github.com/NixOS/nixpkgs/pull/453015 and https://github.com/NixOS/nixpkgs/pull/452081

Closes #455999
Closes #455995

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
