### PR TITLE
maintainers: drop figsoda 

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -215,10 +215,10 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /pkgs/development/r-modules         @jbedo
 
 # Rust
-/pkgs/development/compilers/rust @alyssais @Mic92 @zowoq @winterqt @figsoda
-/pkgs/build-support/rust @zowoq @winterqt @figsoda
+/pkgs/development/compilers/rust @alyssais @Mic92 @zowoq @winterqt
+/pkgs/build-support/rust @zowoq @winterqt
 /pkgs/build-support/rust/fetch-cargo-vendor* @TomaSajt
-/doc/languages-frameworks/rust.section.md @zowoq @winterqt @figsoda
+/doc/languages-frameworks/rust.section.md @zowoq @winterqt
 
 # Tcl
 /pkgs/development/interpreters/tcl  @fgaz
@@ -447,8 +447,8 @@ pkgs/by-name/fo/forgejo/                @adamcstephens @bendlas @emilylange
 /pkgs/os-specific/linux/zfs              @adamcstephens @amarshall
 
 # Zig
-/pkgs/development/compilers/zig @figsoda @RossComputerGuy
-/doc/hooks/zig.section.md       @figsoda @RossComputerGuy
+/pkgs/development/compilers/zig @RossComputerGuy
+/doc/hooks/zig.section.md       @RossComputerGuy
 
 # Buildbot
 nixos/modules/services/continuous-integration/buildbot @Mic92 @zowoq

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8476,13 +8476,6 @@
     githubId = 52276064;
     name = "figboy9";
   };
-  figsoda = {
-    email = "figsoda@pm.me";
-    matrix = "@figsoda:matrix.org";
-    github = "figsoda";
-    githubId = 40620903;
-    name = "figsoda";
-  };
   fionera = {
     email = "nix@fionera.de";
     github = "fionera";

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -159,5 +159,5 @@ tree-sitter-http,,,,0.0.33-1,,
 tree-sitter-norg,,,,,5.1,mrcjkb
 tree-sitter-orgmode,,,,,,
 vstruct,,,,,,
-vusted,,,,,,figsoda
+vusted,,,,,,
 xml2lua,,,,,,teto

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -982,7 +982,6 @@ with lib.maintainers;
 
   zig = {
     members = [
-      figsoda
       RossComputerGuy
     ];
     scope = "Maintain the Zig compiler toolchain and nixpkgs integration.";

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -13,7 +13,7 @@ in
 
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members ++ (with lib.maintainers; [ figsoda ]);
+    maintainers = lib.teams.freedesktop.members ++ [ ];
   };
 
   options = {

--- a/nixos/modules/programs/git.nix
+++ b/nixos/modules/programs/git.nix
@@ -115,5 +115,5 @@ in
     })
   ];
 
-  meta.maintainers = with lib.maintainers; [ figsoda ];
+  meta.maintainers = [ ];
 }

--- a/nixos/modules/programs/sniffnet.nix
+++ b/nixos/modules/programs/sniffnet.nix
@@ -25,5 +25,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ figsoda ];
+  meta.maintainers = [ ];
 }

--- a/nixos/modules/programs/trippy.nix
+++ b/nixos/modules/programs/trippy.nix
@@ -25,5 +25,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ figsoda ];
+  meta.maintainers = [ ];
 }

--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -51,7 +51,6 @@ in
   };
 
   meta.maintainers = with lib.maintainers; [
-    figsoda
     thiagokokada
   ];
 }

--- a/nixos/tests/sx.nix
+++ b/nixos/tests/sx.nix
@@ -2,7 +2,6 @@
 {
   name = "sx";
   meta.maintainers = with lib.maintainers; [
-    figsoda
     thiagokokada
   ];
 

--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -167,6 +167,6 @@ in
     (super.nvim-treesitter.meta or { })
     // {
       license = licenses.asl20;
-      maintainers = with maintainers; [ figsoda ];
+      maintainers = [ ];
     };
 }

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -32,6 +32,6 @@ buildLua rec {
     changelog = "https://github.com/marzzzello/mpv_thumbnail_script/releases/tag/${version}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ab/abbreviate/package.nix
+++ b/pkgs/by-name/ab/abbreviate/package.nix
@@ -41,6 +41,6 @@ buildGoModule rec {
     homepage = "https://github.com/dnnrly/abbreviate";
     changelog = "https://github.com/dnnrly/abbreviate/releases/tag/${src.rev}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ai/ain/package.nix
+++ b/pkgs/by-name/ai/ain/package.nix
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/jonaslu/ain";
     changelog = "https://github.com/jonaslu/ain/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "ain";
   };
 })

--- a/pkgs/by-name/an/anew/package.nix
+++ b/pkgs/by-name/an/anew/package.nix
@@ -27,6 +27,6 @@ buildGoModule rec {
     mainProgram = "anew";
     homepage = "https://github.com/tomnomnom/anew";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/an/anewer/package.nix
+++ b/pkgs/by-name/an/anewer/package.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "anewer";
     homepage = "https://github.com/ysf/anewer";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/an/anko/package.nix
+++ b/pkgs/by-name/an/anko/package.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     description = "Scriptable interpreter written in golang";
     homepage = "https://github.com/mattn/anko";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -69,6 +69,6 @@ rustPlatform.buildRustPackage rec {
       # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ar/artem/package.nix
+++ b/pkgs/by-name/ar/artem/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/finefindus/artem";
     changelog = "https://github.com/finefindus/artem/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "artem";
   };
 }

--- a/pkgs/by-name/as/asciicam/package.nix
+++ b/pkgs/by-name/as/asciicam/package.nix
@@ -26,7 +26,7 @@ buildGoModule {
     description = "Displays your webcam on the terminal";
     homepage = "https://github.com/muesli/asciicam";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "asciicam";
   };
 }

--- a/pkgs/by-name/as/asciinema-agg/package.nix
+++ b/pkgs/by-name/as/asciinema-agg/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/asciinema/agg";
     changelog = "https://github.com/asciinema/agg/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "agg";
   };
 }

--- a/pkgs/by-name/as/askalono/package.nix
+++ b/pkgs/by-name/as/askalono/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/jpeddicord/askalono";
     changelog = "https://github.com/jpeddicord/askalono/blob/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "askalono";
   };
 }

--- a/pkgs/by-name/as/astronomer/package.nix
+++ b/pkgs/by-name/as/astronomer/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
     homepage = "https://github.com/Ullaakut/astronomer";
     changelog = "https://github.com/Ullaakut/astronomer/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "astronomer";
   };
 }

--- a/pkgs/by-name/au/august/package.nix
+++ b/pkgs/by-name/au/august/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "ag";
   };
 }

--- a/pkgs/by-name/ba/backdown/package.nix
+++ b/pkgs/by-name/ba/backdown/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Canop/backdown";
     changelog = "https://github.com/Canop/backdown/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "backdown";
   };
 }

--- a/pkgs/by-name/ba/bandwhich/package.nix
+++ b/pkgs/by-name/ba/bandwhich/package.nix
@@ -50,7 +50,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Br1ght0ne
-      figsoda
     ];
     platforms = lib.platforms.unix;
     mainProgram = "bandwhich";

--- a/pkgs/by-name/ba/bartib/package.nix
+++ b/pkgs/by-name/ba/bartib/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple timetracker for the command line";
     homepage = "https://github.com/nikolassv/bartib";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "bartib";
   };
 }

--- a/pkgs/by-name/bi/binocle/package.nix
+++ b/pkgs/by-name/bi/binocle/package.nix
@@ -49,6 +49,6 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/bi/biome/package.nix
+++ b/pkgs/by-name/bi/biome/package.nix
@@ -63,7 +63,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/biomejs/biome/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       isabelroses
       wrbbz
     ];

--- a/pkgs/by-name/bo/bombardier/package.nix
+++ b/pkgs/by-name/bo/bombardier/package.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
     homepage = "https://github.com/codesenberg/bombardier";
     changelog = "https://github.com/codesenberg/bombardier/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "bombardier";
   };
 }

--- a/pkgs/by-name/bo/bottom/package.nix
+++ b/pkgs/by-name/bo/bottom/package.nix
@@ -59,7 +59,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "btm";
     maintainers = with lib.maintainers; [
       berbiche
-      figsoda
       gepbird
     ];
   };

--- a/pkgs/by-name/bo/boxxy/package.nix
+++ b/pkgs/by-name/bo/boxxy/package.nix
@@ -38,7 +38,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       dit7ya
-      figsoda
     ];
     platforms = platforms.linux;
     broken = stdenv.hostPlatform.isAarch64;

--- a/pkgs/by-name/br/browsr/package.nix
+++ b/pkgs/by-name/br/browsr/package.nix
@@ -97,6 +97,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://juftin.com/browsr";
     changelog = "https://github.com/juftin/browsr/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-about/package.nix
+++ b/pkgs/by-name/ca/cargo-about/package.nix
@@ -37,7 +37,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       evanjs
-      figsoda
       matthiasbeyer
     ];
     mainProgram = "cargo-about";

--- a/pkgs/by-name/ca/cargo-all-features/package.nix
+++ b/pkgs/by-name/ca/cargo-all-features/package.nix
@@ -23,7 +23,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-audit/package.nix
+++ b/pkgs/by-name/ca/cargo-audit/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       basvandijk
-      figsoda
       jk
     ];
   };

--- a/pkgs/by-name/ca/cargo-benchcmp/package.nix
+++ b/pkgs/by-name/ca/cargo-benchcmp/package.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
       mit
       unlicense
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-binstall/package.nix
+++ b/pkgs/by-name/ca/cargo-binstall/package.nix
@@ -68,6 +68,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/cargo-bins/cargo-binstall";
     changelog = "https://github.com/cargo-bins/cargo-binstall/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-bundle-licenses/package.nix
+++ b/pkgs/by-name/ca/cargo-bundle-licenses/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-bundle/package.nix
+++ b/pkgs/by-name/ca/cargo-bundle/package.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-careful/package.nix
+++ b/pkgs/by-name/ca/cargo-careful/package.nix
@@ -26,7 +26,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-clone/package.nix
+++ b/pkgs/by-name/ca/cargo-clone/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
       janlikar
     ];

--- a/pkgs/by-name/ca/cargo-codspeed/package.nix
+++ b/pkgs/by-name/ca/cargo-codspeed/package.nix
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage rec {
       mit
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "cargo-codspeed";
   };
 }

--- a/pkgs/by-name/ca/cargo-component/package.nix
+++ b/pkgs/by-name/ca/cargo-component/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/bytecodealliance/cargo-component";
     changelog = "https://github.com/bytecodealliance/cargo-component/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "cargo-component";
   };
 }

--- a/pkgs/by-name/ca/cargo-cranky/package.nix
+++ b/pkgs/by-name/ca/cargo-cranky/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-deny/package.nix
+++ b/pkgs/by-name/ca/cargo-deny/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
       jk
     ];

--- a/pkgs/by-name/ca/cargo-depgraph/package.nix
+++ b/pkgs/by-name/ca/cargo-depgraph/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://git.sr.ht/~jplatte/cargo-depgraph/tree/${src.rev}/item/CHANGELOG.md";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-dephell/package.nix
+++ b/pkgs/by-name/ca/cargo-dephell/package.nix
@@ -55,7 +55,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-diet/package.nix
+++ b/pkgs/by-name/ca/cargo-diet/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/the-lean-crate/cargo-diet/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-dist/package.nix
+++ b/pkgs/by-name/ca/cargo-dist/package.nix
@@ -60,7 +60,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
       mistydemeo
     ];

--- a/pkgs/by-name/ca/cargo-duplicates/package.nix
+++ b/pkgs/by-name/ca/cargo-duplicates/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Keruspe/cargo-duplicates";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-edit/package.nix
+++ b/pkgs/by-name/ca/cargo-edit/package.nix
@@ -39,7 +39,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       Br1ght0ne
-      figsoda
       gerschtli
       jb55
       killercup

--- a/pkgs/by-name/ca/cargo-expand/package.nix
+++ b/pkgs/by-name/ca/cargo-expand/package.nix
@@ -26,7 +26,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       xrelkd
     ];
     mainProgram = "cargo-expand";

--- a/pkgs/by-name/ca/cargo-generate/package.nix
+++ b/pkgs/by-name/ca/cargo-generate/package.nix
@@ -78,7 +78,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       turbomack
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-guppy/package.nix
+++ b/pkgs/by-name/ca/cargo-guppy/package.nix
@@ -40,6 +40,6 @@ rustPlatform.buildRustPackage {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-hack/package.nix
+++ b/pkgs/by-name/ca/cargo-hack/package.nix
@@ -27,6 +27,6 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-hakari/package.nix
+++ b/pkgs/by-name/ca/cargo-hakari/package.nix
@@ -45,7 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       macalinao
       nartsiss
     ];

--- a/pkgs/by-name/ca/cargo-info/package.nix
+++ b/pkgs/by-name/ca/cargo-info/package.nix
@@ -37,7 +37,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-insta/package.nix
+++ b/pkgs/by-name/ca/cargo-insta/package.nix
@@ -35,7 +35,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/mitsuhiko/insta/blob/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      figsoda
       oxalica
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-license/package.nix
+++ b/pkgs/by-name/ca/cargo-license/package.nix
@@ -22,7 +22,6 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [
       basvandijk
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-llvm-lines/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-lines/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-local-registry/package.nix
+++ b/pkgs/by-name/ca/cargo-local-registry/package.nix
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-lock/package.nix
+++ b/pkgs/by-name/ca/cargo-lock/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-machete/package.nix
+++ b/pkgs/by-name/ca/cargo-machete/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/bnjbvr/cargo-machete/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-make/package.nix
+++ b/pkgs/by-name/ca/cargo-make/package.nix
@@ -47,7 +47,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/sagiegurari/cargo-make/blob/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      figsoda
       xrelkd
     ];
     mainProgram = "cargo-make";

--- a/pkgs/by-name/ca/cargo-modules/package.nix
+++ b/pkgs/by-name/ca/cargo-modules/package.nix
@@ -52,7 +52,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/regexident/cargo-modules/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
-      figsoda
       rvarago
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-mutants/package.nix
+++ b/pkgs/by-name/ca/cargo-mutants/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sourcefrog/cargo-mutants";
     changelog = "https://github.com/sourcefrog/cargo-mutants/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-nextest/package.nix
+++ b/pkgs/by-name/ca/cargo-nextest/package.nix
@@ -46,7 +46,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with maintainers; [
       ekleog
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-play/package.nix
+++ b/pkgs/by-name/ca/cargo-play/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "cargo-play";
     homepage = "https://github.com/fanzeyi/cargo-play";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -52,7 +52,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       gerschtli
     ];
   };

--- a/pkgs/by-name/ca/cargo-semver-checks/package.nix
+++ b/pkgs/by-name/ca/cargo-semver-checks/package.nix
@@ -68,7 +68,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-show-asm/package.nix
+++ b/pkgs/by-name/ca/cargo-show-asm/package.nix
@@ -46,7 +46,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       oxalica
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-shuttle/package.nix
+++ b/pkgs/by-name/ca/cargo-shuttle/package.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://shuttle.rs";
     changelog = "https://github.com/shuttle-hq/shuttle/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/cargo-sort/package.nix
+++ b/pkgs/by-name/ca/cargo-sort/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-supply-chain/package.nix
+++ b/pkgs/by-name/ca/cargo-supply-chain/package.nix
@@ -28,7 +28,6 @@ rustPlatform.buildRustPackage rec {
       zlib
     ]; # any of three
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-tally/package.nix
+++ b/pkgs/by-name/ca/cargo-tally/package.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-tarpaulin/package.nix
+++ b/pkgs/by-name/ca/cargo-tarpaulin/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      figsoda
       hugoreeves
     ];
   };

--- a/pkgs/by-name/ca/cargo-temp/package.nix
+++ b/pkgs/by-name/ca/cargo-temp/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-ui/package.nix
+++ b/pkgs/by-name/ca/cargo-ui/package.nix
@@ -67,7 +67,6 @@ rustPlatform.buildRustPackage rec {
       gpl3Only
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ca/cargo-unused-features/package.nix
+++ b/pkgs/by-name/ca/cargo-unused-features/package.nix
@@ -39,7 +39,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/timonpost/cargo-unused-features";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
     mainProgram = "unused-features";

--- a/pkgs/by-name/ca/cargo-vet/package.nix
+++ b/pkgs/by-name/ca/cargo-vet/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       jk
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-workspaces/package.nix
+++ b/pkgs/by-name/ca/cargo-workspaces/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/pksunkara/cargo-workspaces/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       macalinao
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-zigbuild/package.nix
+++ b/pkgs/by-name/ca/cargo-zigbuild/package.nix
@@ -32,6 +32,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/messense/cargo-zigbuild";
     changelog = "https://github.com/messense/cargo-zigbuild/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ca/catnip-gtk4/package.nix
+++ b/pkgs/by-name/ca/catnip-gtk4/package.nix
@@ -44,7 +44,7 @@ buildGoModule {
     description = "GTK4 frontend for catnip";
     homepage = "https://github.com/diamondburned/catnip-gtk4";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "catnip-gtk4";
   };
 }

--- a/pkgs/by-name/ca/catnip/package.nix
+++ b/pkgs/by-name/ca/catnip/package.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
     homepage = "https://github.com/noriah/catnip";
     changelog = "https://github.com/noriah/catnip/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "catnip";
   };
 }

--- a/pkgs/by-name/ca/cauwugo/package.nix
+++ b/pkgs/by-name/ca/cauwugo/package.nix
@@ -35,6 +35,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cd/cdwe/package.nix
+++ b/pkgs/by-name/cd/cdwe/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Configurable cd wrapper that lets you define your environment per directory";
     homepage = "https://github.com/synoet/cdwe";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "cdwe";
   };
 }

--- a/pkgs/by-name/ce/cel-go/package.nix
+++ b/pkgs/by-name/ce/cel-go/package.nix
@@ -38,6 +38,6 @@ buildGoModule rec {
     homepage = "https://github.com/google/cel-go";
     changelog = "https://github.com/google/cel-go/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ch/changie/package.nix
+++ b/pkgs/by-name/ch/changie/package.nix
@@ -43,7 +43,6 @@ buildGoModule rec {
     changelog = "https://github.com/miniscruff/changie/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ch/checkpwn/package.nix
+++ b/pkgs/by-name/ch/checkpwn/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/brycx/checkpwn";
     changelog = "https://github.com/brycx/checkpwn/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "checkpwn";
   };
 }

--- a/pkgs/by-name/ch/cherrybomb/package.nix
+++ b/pkgs/by-name/ch/cherrybomb/package.nix
@@ -21,6 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/blst-security/cherrybomb";
     changelog = "https://github.com/blst-security/cherrybomb/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ch/chit/package.nix
+++ b/pkgs/by-name/ch/chit/package.nix
@@ -49,6 +49,6 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/peterheesterman/chit";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cl/clima/package.nix
+++ b/pkgs/by-name/cl/clima/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Canop/clima";
     changelog = "https://github.com/Canop/clima/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "clima";
   };
 }

--- a/pkgs/by-name/co/codemov/package.nix
+++ b/pkgs/by-name/co/codemov/package.nix
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage {
     description = "Create a video of how a git repository's code changes over time";
     homepage = "https://github.com/sloganking/codemov";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "codemov";
   };
 }

--- a/pkgs/by-name/co/codevis/package.nix
+++ b/pkgs/by-name/co/codevis/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sloganking/codevis";
     changelog = "https://github.com/sloganking/codevis/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "codevis";
   };
 }

--- a/pkgs/by-name/co/complgen/package.nix
+++ b/pkgs/by-name/co/complgen/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/adaszko/complgen";
     changelog = "https://github.com/adaszko/complgen/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/comrak/package.nix
+++ b/pkgs/by-name/co/comrak/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/kivikakk/comrak/blob/v${version}/changelog.txt";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
-      figsoda
       kivikakk
     ];
   };

--- a/pkgs/by-name/co/confetty/package.nix
+++ b/pkgs/by-name/co/confetty/package.nix
@@ -26,7 +26,7 @@ buildGoModule {
     description = "Confetti in your TTY";
     homepage = "https://github.com/maaslalani/confetty";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "confetty";
   };
 }

--- a/pkgs/by-name/cr/crabz/package.nix
+++ b/pkgs/by-name/cr/crabz/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
       unlicense # or
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "crabz";
   };
 }

--- a/pkgs/by-name/cr/critcmp/package.nix
+++ b/pkgs/by-name/cr/critcmp/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
       mit
       unlicense
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cs/csv2svg/package.nix
+++ b/pkgs/by-name/cs/csv2svg/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     description = "Take a csv as input and outputs svg";
     homepage = "https://github.com/Canop/csv2svg";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "csv2svg";
   };
 }

--- a/pkgs/by-name/cs/csview/package.nix
+++ b/pkgs/by-name/cs/csview/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cs/csvquote/package.nix
+++ b/pkgs/by-name/cs/csvquote/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "Enables common unix utilities like cut, awk, wc, head to work correctly with csv data containing delimiters and newlines";
     homepage = "https://github.com/dbro/csvquote";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/de/delta/package.nix
+++ b/pkgs/by-name/de/delta/package.nix
@@ -65,7 +65,6 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       zowoq
       SuperSandro2000
-      figsoda
     ];
     mainProgram = "delta";
   };

--- a/pkgs/by-name/di/difftastic/package.nix
+++ b/pkgs/by-name/di/difftastic/package.nix
@@ -39,7 +39,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       ethancedwards8
-      figsoda
       matthiasbeyer
       defelo
     ];

--- a/pkgs/by-name/dj/djot-js/package.nix
+++ b/pkgs/by-name/dj/djot-js/package.nix
@@ -31,7 +31,7 @@ buildNpmPackage rec {
     homepage = "https://github.com/jgm/djot.js";
     changelog = "https://github.com/jgm/djot.js/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "djot";
   };
 }

--- a/pkgs/by-name/dn/dnspeep/package.nix
+++ b/pkgs/by-name/dn/dnspeep/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "dnspeep";
     homepage = "https://github.com/jvns/dnspeep";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/do/doctave/package.nix
+++ b/pkgs/by-name/do/doctave/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/doctave/doctave";
     changelog = "https://github.com/doctave/doctave/blob/${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "doctave";
   };
 }

--- a/pkgs/by-name/do/dogdns/package.nix
+++ b/pkgs/by-name/do/dogdns/package.nix
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage {
     description = "Command-line DNS client";
     homepage = "https://dns.lookup.dog";
     license = licenses.eupl12;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "dog";
   };
 }

--- a/pkgs/by-name/do/done/package.nix
+++ b/pkgs/by-name/do/done/package.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/done-devs/done/blob/${src.rev}/CHANGES.md";
     license = licenses.mpl20;
     mainProgram = "done";
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/do/dool/package.nix
+++ b/pkgs/by-name/do/dool/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/scottchiefbaker/dool";
     changelog = "https://github.com/scottchiefbaker/dool/blob/${src.rev}/ChangeLog";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "dool";
   };

--- a/pkgs/by-name/du/dua/package.nix
+++ b/pkgs/by-name/du/dua/package.nix
@@ -46,7 +46,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/Byron/dua-cli/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
-      figsoda
       killercup
       defelo
     ];

--- a/pkgs/by-name/du/duf/package.nix
+++ b/pkgs/by-name/du/duf/package.nix
@@ -35,7 +35,6 @@ buildGoModule (finalAttrs: {
     description = "Disk Usage/Free Utility";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       penguwin
       sigmasquadron
     ];

--- a/pkgs/by-name/du/dufs/package.nix
+++ b/pkgs/by-name/du/dufs/package.nix
@@ -45,7 +45,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      figsoda
       holymonson
     ];
   };

--- a/pkgs/by-name/du/dum/package.nix
+++ b/pkgs/by-name/du/dum/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/egoist/dum";
     changelog = "https://github.com/egoist/dum/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/du/dutree/package.nix
+++ b/pkgs/by-name/du/dutree/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     description = "Tool to analyze file system usage written in Rust";
     homepage = "https://github.com/nachoparker/dutree";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "dutree";
   };
 }

--- a/pkgs/by-name/dy/dysk/package.nix
+++ b/pkgs/by-name/dy/dysk/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/Canop/dysk/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       koral
     ];
     mainProgram = "dysk";

--- a/pkgs/by-name/eg/egglog/package.nix
+++ b/pkgs/by-name/eg/egglog/package.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/egraphs-good/egglog";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       XBagon
     ];
   };

--- a/pkgs/by-name/em/emblem/package.nix
+++ b/pkgs/by-name/em/emblem/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      figsoda
       foo-dogsquared
     ];
     teams = [ lib.teams.gnome-circle ];

--- a/pkgs/by-name/em/emmet-ls/package.nix
+++ b/pkgs/by-name/em/emmet-ls/package.nix
@@ -32,7 +32,7 @@ buildNpmPackage rec {
     homepage = "https://github.com/aca/emmet-ls";
     changelog = "https://github.com/aca/emmet-ls/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "emmet-ls";
   };
 }

--- a/pkgs/by-name/en/encpipe/package.nix
+++ b/pkgs/by-name/en/encpipe/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Encryption tool";
     homepage = "https://github.com/jedisct1/encpipe";
     license = licenses.isc;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "encpipe";
   };
 }

--- a/pkgs/by-name/ep/epick/package.nix
+++ b/pkgs/by-name/ep/epick/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/vv9k/epick";
     changelog = "https://github.com/vv9k/epick/blob/${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "epick";
   };
 }

--- a/pkgs/by-name/er/erdtree/package.nix
+++ b/pkgs/by-name/er/erdtree/package.nix
@@ -23,7 +23,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/solidiquis/erdtree/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       zendo
     ];
     mainProgram = "erd";

--- a/pkgs/by-name/er/erg/package.nix
+++ b/pkgs/by-name/er/erg/package.nix
@@ -65,6 +65,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/es/esbuild-config/package.nix
+++ b/pkgs/by-name/es/esbuild-config/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Config files for esbuild";
     homepage = "https://github.com/bpierre/esbuild-config";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "esbuild-config";
   };
 }

--- a/pkgs/by-name/eu/eureka-ideas/package.nix
+++ b/pkgs/by-name/eu/eureka-ideas/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/simeg/eureka";
     changelog = "https://github.com/simeg/eureka/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "eureka";
   };
 }

--- a/pkgs/by-name/ev/eva/package.nix
+++ b/pkgs/by-name/ev/eva/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       ma27
-      figsoda
     ];
     mainProgram = "eva";
   };

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -71,7 +71,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       coffeeispower
-      figsoda
       lom
       w-lfchen
     ];

--- a/pkgs/by-name/ex/expr/package.nix
+++ b/pkgs/by-name/ex/expr/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
     homepage = "https://github.com/expr-lang/expr";
     changelog = "https://github.com/expr-lang/expr/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "expr";
   };
 }

--- a/pkgs/by-name/ez/ezno/package.nix
+++ b/pkgs/by-name/ez/ezno/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kaleidawave/ezno";
     changelog = "https://github.com/kaleidawave/ezno/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fa/faketty/package.nix
+++ b/pkgs/by-name/fa/faketty/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "faketty";
   };
 }

--- a/pkgs/by-name/fb/fblog/package.nix
+++ b/pkgs/by-name/fb/fblog/package.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "fblog";
     homepage = "https://github.com/brocode/fblog";
     license = licenses.wtfpl;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fc/fclones-gui/package.nix
+++ b/pkgs/by-name/fc/fclones-gui/package.nix
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/pkolaczk/fclones-gui";
     changelog = "https://github.com/pkolaczk/fclones-gui/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = builtins.attrValues { inherit (lib.maintainers) figsoda; };
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/fc/fclones/package.nix
+++ b/pkgs/by-name/fc/fclones/package.nix
@@ -45,7 +45,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       cyounkins
-      figsoda
     ];
     mainProgram = "fclones";
   };

--- a/pkgs/by-name/fc/fcp/package.nix
+++ b/pkgs/by-name/fc/fcp/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/svetlitski/fcp/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "fcp";
   };
 }

--- a/pkgs/by-name/fd/fd/package.nix
+++ b/pkgs/by-name/fd/fd/package.nix
@@ -64,7 +64,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       dywedir
-      figsoda
       globin
       ma27
       zowoq

--- a/pkgs/by-name/fe/felix-fm/package.nix
+++ b/pkgs/by-name/fe/felix-fm/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kyoheiu/felix";
     changelog = "https://github.com/kyoheiu/felix/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "fx";
   };
 }

--- a/pkgs/by-name/fh/fh/package.nix
+++ b/pkgs/by-name/fh/fh/package.nix
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/DeterminateSystems/fh";
     changelog = "https://github.com/DeterminateSystems/fh/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "fh";
   };
 }

--- a/pkgs/by-name/fi/findomain/package.nix
+++ b/pkgs/by-name/fi/findomain/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       Br1ght0ne
-      figsoda
     ];
     mainProgram = "findomain";
   };

--- a/pkgs/by-name/fo/fontfinder/package.nix
+++ b/pkgs/by-name/fo/fontfinder/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mmstick/fontfinder";
     changelog = "https://github.com/mmstick/fontfinder/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "fontfinder-gtk";
   };
 }

--- a/pkgs/by-name/fr/frawk/package.nix
+++ b/pkgs/by-name/fr/frawk/package.nix
@@ -51,6 +51,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fr/freshfetch/package.nix
+++ b/pkgs/by-name/fr/freshfetch/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     description = "Fresh take on neofetch";
     homepage = "https://github.com/k4rakara/freshfetch";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "freshfetch";
   };
 }

--- a/pkgs/by-name/fr/frogmouth/package.nix
+++ b/pkgs/by-name/fr/frogmouth/package.nix
@@ -40,6 +40,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/Textualize/frogmouth";
     changelog = "https://github.com/Textualize/frogmouth/blob/${src.rev}/ChangeLog.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fu/fundoc/package.nix
+++ b/pkgs/by-name/fu/fundoc/package.nix
@@ -32,6 +32,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "fundoc";
     homepage = "https://github.com/daynin/fundoc";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fu/funzzy/package.nix
+++ b/pkgs/by-name/fu/funzzy/package.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/cristianoliveira/funzzy";
     changelog = "https://github.com/cristianoliveira/funzzy/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fw/fw/package.nix
+++ b/pkgs/by-name/fw/fw/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
     description = "Workspace productivity booster";
     homepage = "https://github.com/brocode/fw";
     license = licenses.wtfpl;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "fw";
   };
 }

--- a/pkgs/by-name/fx/fx/package.nix
+++ b/pkgs/by-name/fx/fx/package.nix
@@ -36,6 +36,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/antonmedv/fx";
     license = lib.licenses.mit;
     mainProgram = "fx";
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/fz/fzf-make/package.nix
+++ b/pkgs/by-name/fz/fzf-make/package.nix
@@ -42,7 +42,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/kyu08/fzf-make/releases/tag/${src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       sigmanificient
     ];
     mainProgram = "fzf-make";

--- a/pkgs/by-name/ga/gambit-chess/package.nix
+++ b/pkgs/by-name/ga/gambit-chess/package.nix
@@ -52,6 +52,6 @@ buildGoModule rec {
     homepage = "https://github.com/maaslalani/gambit";
     changelog = "https://github.com/maaslalani/gambit/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gd/gdrive3/package.nix
+++ b/pkgs/by-name/gd/gdrive3/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/glotlabs/gdrive";
     changelog = "https://github.com/glotlabs/gdrive/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "gdrive";
   };
 }

--- a/pkgs/by-name/ge/genact/package.nix
+++ b/pkgs/by-name/ge/genact/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/svenstaro/genact";
     changelog = "https://github.com/svenstaro/genact/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "genact";
   };
 }

--- a/pkgs/by-name/gi/gifski/package.nix
+++ b/pkgs/by-name/gi/gifski/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://gif.ski/";
     changelog = "https://github.com/ImageOptim/gifski/releases/tag/${src.rev}";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "gifski";
   };
 }

--- a/pkgs/by-name/gi/git-dive/package.nix
+++ b/pkgs/by-name/gi/git-dive/package.nix
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "git-dive";
   };
 }

--- a/pkgs/by-name/gi/git-ignore/package.nix
+++ b/pkgs/by-name/gi/git-ignore/package.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sondr3/git-ignore";
     changelog = "https://github.com/sondr3/git-ignore/blob/${src.rev}/CHANGELOG.md";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "git-ignore";
   };
 }

--- a/pkgs/by-name/gi/git-mit/package.nix
+++ b/pkgs/by-name/gi/git-mit/package.nix
@@ -47,6 +47,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/PurpleBooth/git-mit";
     changelog = "https://github.com/PurpleBooth/git-mit/releases/tag/v${version}";
     license = lib.licenses.cc0;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gi/gitnr/package.nix
+++ b/pkgs/by-name/gi/gitnr/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/reemus-dev/gitnr/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
     mainProgram = "gitnr";

--- a/pkgs/by-name/gl/glicol-cli/package.nix
+++ b/pkgs/by-name/gl/glicol-cli/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/glicol/glicol-cli";
     changelog = "https://github.com/glicol/glicol-cli/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "glicol-cli";
   };
 }

--- a/pkgs/by-name/gl/glitter/package.nix
+++ b/pkgs/by-name/gl/glitter/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/milo123459/glitter";
     changelog = "https://github.com/Milo123459/glitter/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "glitter";
   };
 }

--- a/pkgs/by-name/go/gobang/package.nix
+++ b/pkgs/by-name/go/gobang/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage {
     description = "Cross-platform TUI database management tool written in Rust";
     homepage = "https://github.com/tako8ki/gobang";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/go/gopatch/package.nix
+++ b/pkgs/by-name/go/gopatch/package.nix
@@ -41,6 +41,6 @@ buildGoModule rec {
     homepage = "https://github.com/uber-go/gopatch";
     changelog = "https://github.com/uber-go/gopatch/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gp/gpython/package.nix
+++ b/pkgs/by-name/gp/gpython/package.nix
@@ -44,6 +44,6 @@ buildGoModule rec {
     homepage = "https://github.com/go-python/gpython";
     changelog = "https://github.com/go-python/gpython/releases/tag/${src.rev}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gq/gql/package.nix
+++ b/pkgs/by-name/gq/gql/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/AmrDeveloper/GQL";
     changelog = "https://github.com/AmrDeveloper/GQL/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "gitql";
   };
 }

--- a/pkgs/by-name/gr/gradescope-submit/package.nix
+++ b/pkgs/by-name/gr/gradescope-submit/package.nix
@@ -30,7 +30,7 @@ ocamlPackages.buildDunePackage rec {
     description = "Small script to submit to Gradescope via GitHub";
     homepage = "https://github.com/nmittu/gradescope-submit";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "submit";
   };
 }

--- a/pkgs/by-name/gr/grass-sass/package.nix
+++ b/pkgs/by-name/gr/grass-sass/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
       replaceStrings [ "." ] [ "" ] version
     }";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "grass";
   };
 }

--- a/pkgs/by-name/gr/gridlock/package.nix
+++ b/pkgs/by-name/gr/gridlock/package.nix
@@ -40,6 +40,6 @@ rustPlatform.buildRustPackage {
     description = "Nix compatible lockfile manager, without Nix";
     homepage = "https://github.com/lf-/gridlock";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gt/gtree/package.nix
+++ b/pkgs/by-name/gt/gtree/package.nix
@@ -42,6 +42,6 @@ buildGoModule rec {
     homepage = "https://github.com/ddddddO/gtree";
     changelog = "https://github.com/ddddddO/gtree/releases/tag/${src.rev}";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ha/halp/package.nix
+++ b/pkgs/by-name/ha/halp/package.nix
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "halp";
   };
 })

--- a/pkgs/by-name/ha/hayagriva/package.nix
+++ b/pkgs/by-name/ha/hayagriva/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "hayagriva";
   };
 }

--- a/pkgs/by-name/hc/hck/package.nix
+++ b/pkgs/by-name/hc/hck/package.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
       unlicense
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       gepbird
     ];
     mainProgram = "hck";

--- a/pkgs/by-name/he/hexyl/package.nix
+++ b/pkgs/by-name/he/hexyl/package.nix
@@ -41,7 +41,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       dywedir
-      figsoda
       SuperSandro2000
     ];
     mainProgram = "hexyl";

--- a/pkgs/by-name/hi/highlight-assertions/package.nix
+++ b/pkgs/by-name/hi/highlight-assertions/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "highlight-assertions";
     homepage = "https://github.com/thehamsta/highlight-assertions";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/hm/hmm/package.nix
+++ b/pkgs/by-name/hm/hmm/package.nix
@@ -31,6 +31,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/samwho/hmm";
     changelog = "https://github.com/samwho/hmm/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ho/hoard/package.nix
+++ b/pkgs/by-name/ho/hoard/package.nix
@@ -32,7 +32,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       builditluc
-      figsoda
     ];
     mainProgram = "hoard";
   };

--- a/pkgs/by-name/ho/hors/package.nix
+++ b/pkgs/by-name/ho/hors/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/windsoilder/hors";
     changelog = "https://github.com/WindSoilder/hors/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ht/httplz/package.nix
+++ b/pkgs/by-name/ht/httplz/package.nix
@@ -49,6 +49,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/thecoshman/http";
     changelog = "https://github.com/thecoshman/http/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ht/httpref/package.nix
+++ b/pkgs/by-name/ht/httpref/package.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/dnnrly/httpref";
     changelog = "https://github.com/dnnrly/httpref/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ht/httprobe/package.nix
+++ b/pkgs/by-name/ht/httprobe/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
     description = "Take a list of domains and probe for working HTTP and HTTPS servers";
     homepage = "https://github.com/tomnomnom/httprobe";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "httprobe";
   };
 }

--- a/pkgs/by-name/hu/huniq/package.nix
+++ b/pkgs/by-name/hu/huniq/package.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "huniq";
     homepage = "https://github.com/koraa/huniq";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/hu/hurl/package.nix
+++ b/pkgs/by-name/hu/hurl/package.nix
@@ -58,7 +58,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/Orange-OpenSource/hurl/blob/${version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       eonpatapon
-      figsoda
     ];
     license = lib.licenses.asl20;
     mainProgram = "hurl";

--- a/pkgs/by-name/hv/hvm/package.nix
+++ b/pkgs/by-name/hv/hvm/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "hvm";
     homepage = "https://github.com/higherorderco/hvm";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/hy/hyperfine/package.nix
+++ b/pkgs/by-name/hy/hyperfine/package.nix
@@ -37,7 +37,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       thoughtpolice
     ];
     mainProgram = "hyperfine";

--- a/pkgs/by-name/ic/icebreaker/package.nix
+++ b/pkgs/by-name/ic/icebreaker/package.nix
@@ -41,7 +41,7 @@ buildGoModule {
     description = "Web app that allows students to ask real-time, anonymous questions during class";
     homepage = "https://github.com/jonhoo/icebreaker";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "icebreaker";
   };
 }

--- a/pkgs/by-name/im/image-roll/package.nix
+++ b/pkgs/by-name/im/image-roll/package.nix
@@ -48,6 +48,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "image-roll";
     homepage = "https://github.com/weclaw1/image-roll";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/in/inferno/package.nix
+++ b/pkgs/by-name/in/inferno/package.nix
@@ -33,6 +33,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/jonhoo/inferno";
     changelog = "https://github.com/jonhoo/inferno/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.cddl;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/in/inlyne/package.nix
+++ b/pkgs/by-name/in/inlyne/package.nix
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Inlyne-Project/inlyne";
     changelog = "https://github.com/Inlyne-Project/inlyne/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "inlyne";
   };
 }

--- a/pkgs/by-name/iw/iwgtk/package.nix
+++ b/pkgs/by-name/iw/iwgtk/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/j-lentz/iwgtk";
     changelog = "https://github.com/j-lentz/iwgtk/blob/v${version}/CHANGELOG";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "iwgtk";
   };

--- a/pkgs/by-name/ja/jacoco/package.nix
+++ b/pkgs/by-name/ja/jacoco/package.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     changelog = "https://www.jacoco.org/jacoco/trunk/doc/changes.html";
     license = licenses.epl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ja/jaq/package.nix
+++ b/pkgs/by-name/ja/jaq/package.nix
@@ -72,7 +72,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     teams = [ lib.teams.ngi ];
     maintainers = with lib.maintainers; [
-      figsoda
       siraben
     ];
     mainProgram = "jaq";

--- a/pkgs/by-name/je/jen/package.nix
+++ b/pkgs/by-name/je/jen/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "jen";
     homepage = "https://github.com/whitfin/jen";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ji/jinja2-cli/package.nix
+++ b/pkgs/by-name/ji/jinja2-cli/package.nix
@@ -53,7 +53,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "CLI for Jinja2";
     homepage = "https://github.com/mattrobenolt/jinja2-cli";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "jinja2";
   };
 }

--- a/pkgs/by-name/jl/jless/package.nix
+++ b/pkgs/by-name/jl/jless/package.nix
@@ -31,7 +31,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/PaulJuliusMartinez/jless/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       jfchevrette
     ];
   };

--- a/pkgs/by-name/jo/joshuto/package.nix
+++ b/pkgs/by-name/jo/joshuto/package.nix
@@ -34,7 +34,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/kamiyaa/joshuto/releases/tag/${src.rev}";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [
-      figsoda
       totoroot
       xrelkd
     ];

--- a/pkgs/by-name/jo/jotdown/package.nix
+++ b/pkgs/by-name/jo/jotdown/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hellux/jotdown";
     changelog = "https://github.com/hellux/jotdown/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/jq/jql/package.nix
+++ b/pkgs/by-name/jq/jql/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with maintainers; [
       akshgpt7
-      figsoda
     ];
     mainProgram = "jql";
   };

--- a/pkgs/by-name/jr/jrsonnet/package.nix
+++ b/pkgs/by-name/jr/jrsonnet/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/CertainLach/jrsonnet";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       lach
     ];
   };

--- a/pkgs/by-name/js/jsonfmt/package.nix
+++ b/pkgs/by-name/js/jsonfmt/package.nix
@@ -36,7 +36,7 @@ buildGoModule rec {
     homepage = "https://github.com/caarlos0/jsonfmt";
     changelog = "https://github.com/caarlos0/jsonfmt/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "jsonfmt";
   };
 }

--- a/pkgs/by-name/ju/jumpy/package.nix
+++ b/pkgs/by-name/ju/jumpy/package.nix
@@ -92,6 +92,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       # Assets
       cc-by-nc-40
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ka/kalker/package.nix
+++ b/pkgs/by-name/ka/kalker/package.nix
@@ -58,7 +58,6 @@ rustPlatform.buildRustPackage rec {
     '';
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       lovesegfault
     ];
     mainProgram = "kalker";

--- a/pkgs/by-name/kb/kbt/package.nix
+++ b/pkgs/by-name/kb/kbt/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     description = "Keyboard tester in terminal";
     homepage = "https://github.com/bloznelis/kbt";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "kbt";
   };
 }

--- a/pkgs/by-name/ke/keyscope/package.nix
+++ b/pkgs/by-name/ke/keyscope/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/spectralops/keyscope";
     changelog = "https://github.com/spectralops/keyscope/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "keyscope";
   };
 }

--- a/pkgs/by-name/ki/kind2/package.nix
+++ b/pkgs/by-name/ki/kind2/package.nix
@@ -30,6 +30,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "kind2";
     homepage = "https://github.com/higherorderco/kind";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/km/kmon/package.nix
+++ b/pkgs/by-name/km/kmon/package.nix
@@ -36,7 +36,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      figsoda
       matthiasbeyer
     ];
     mainProgram = "kmon";

--- a/pkgs/by-name/ko/kool/package.nix
+++ b/pkgs/by-name/ko/kool/package.nix
@@ -37,6 +37,6 @@ buildGoModule rec {
     homepage = "https://kool.dev";
     changelog = "https://github.com/kool-dev/kool/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/la/lact/package.nix
+++ b/pkgs/by-name/la/lact/package.nix
@@ -128,7 +128,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/ilya-zlobintsev/LACT";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       atemu
       cything
       johnrtitor

--- a/pkgs/by-name/la/lazycli/package.nix
+++ b/pkgs/by-name/la/lazycli/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     description = "Tool to static turn CLI commands into TUIs";
     homepage = "https://github.com/jesseduffield/lazycli";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lazycli";
   };
 }

--- a/pkgs/by-name/le/lemmeknow/package.nix
+++ b/pkgs/by-name/le/lemmeknow/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/swanandx/lemmeknow/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       Br1ght0ne
     ];
     mainProgram = "lemmeknow";

--- a/pkgs/by-name/le/lemmy-help/package.nix
+++ b/pkgs/by-name/le/lemmy-help/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/numToStr/lemmy-help";
     changelog = "https://github.com/numToStr/lemmy-help/releases/tag/v${version}";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lemmy-help";
   };
 }

--- a/pkgs/by-name/le/leptosfmt/package.nix
+++ b/pkgs/by-name/le/leptosfmt/package.nix
@@ -27,6 +27,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/li/lineselect/package.nix
+++ b/pkgs/by-name/li/lineselect/package.nix
@@ -33,7 +33,7 @@ buildNpmPackage rec {
     description = "Shell utility to interactively select lines from stdin";
     homepage = "https://github.com/chfritz/lineselect";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lineselect";
   };
 }

--- a/pkgs/by-name/li/linuxwave/package.nix
+++ b/pkgs/by-name/li/linuxwave/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Generate music from the entropy of Linux";
     changelog = "https://github.com/orhun/linuxwave/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     inherit (zig.meta) platforms;
     mainProgram = "linuxwave";
   };

--- a/pkgs/by-name/li/lipl/package.nix
+++ b/pkgs/by-name/li/lipl/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage {
     description = "Command line tool to analyse the output over time of custom shell commands";
     homepage = "https://github.com/yxdunc/lipl";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lipl";
   };
 }

--- a/pkgs/by-name/lu/lua-language-server/package.nix
+++ b/pkgs/by-name/lu/lua-language-server/package.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/LuaLS/lua-language-server/blob/${finalAttrs.version}/changelog.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       gepbird
       sei40kr
     ];

--- a/pkgs/by-name/lu/luaformatter/package.nix
+++ b/pkgs/by-name/lu/luaformatter/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Koihik/LuaFormatter";
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lua-format";
   };
 }

--- a/pkgs/by-name/lu/lucky-commit/package.nix
+++ b/pkgs/by-name/lu/lucky-commit/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
     description = "Change the start of your git commit hashes to whatever you want";
     homepage = "https://github.com/not-an-aardvark/lucky-commit";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lucky_commit";
   };
 }

--- a/pkgs/by-name/lu/lunatic/package.nix
+++ b/pkgs/by-name/lu/lunatic/package.nix
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/lu/lurk/package.nix
+++ b/pkgs/by-name/lu/lurk/package.nix
@@ -28,8 +28,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/jakwai01/lurk";
     license = lib.licenses.agpl3Only;
     mainProgram = "lurk";
-    maintainers = with lib.maintainers; [
-      figsoda
+    maintainers = [
     ];
     platforms = [
       "i686-linux"

--- a/pkgs/by-name/lw/lwc/package.nix
+++ b/pkgs/by-name/lw/lwc/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
     description = "Live-updating version of the UNIX wc command";
     homepage = "https://github.com/timdp/lwc";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "lwc";
   };
 }

--- a/pkgs/by-name/ma/macchina/package.nix
+++ b/pkgs/by-name/ma/macchina/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       _414owen
-      figsoda
     ];
     mainProgram = "macchina";
   };

--- a/pkgs/by-name/ma/markscribe/package.nix
+++ b/pkgs/by-name/ma/markscribe/package.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/muesli/markscribe";
     changelog = "https://github.com/muesli/markscribe/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ma/mask/package.nix
+++ b/pkgs/by-name/ma/mask/package.nix
@@ -50,7 +50,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/jacobdeichert/mask/blob/mask/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       defelo
     ];
   };

--- a/pkgs/by-name/ma/mastotool/package.nix
+++ b/pkgs/by-name/ma/mastotool/package.nix
@@ -27,7 +27,7 @@ buildGoModule rec {
     homepage = "https://github.com/muesli/mastotool";
     changelog = "https://github.com/muesli/mastotool/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "mastotool";
   };
 }

--- a/pkgs/by-name/md/mdr/package.nix
+++ b/pkgs/by-name/md/mdr/package.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
     description = "MarkDown Renderer for the terminal";
     homepage = "https://github.com/MichaelMure/mdr";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "mdr";
   };
 }

--- a/pkgs/by-name/me/menyoki/package.nix
+++ b/pkgs/by-name/me/menyoki/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://menyoki.cli.rs/";
     changelog = "https://github.com/orhun/menyoki/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "menyoki";
   };
 }

--- a/pkgs/by-name/mi/microbin/package.nix
+++ b/pkgs/by-name/mi/microbin/package.nix
@@ -80,7 +80,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       dit7ya
-      figsoda
     ];
     mainProgram = "microbin";
   };

--- a/pkgs/by-name/mi/miniserve/package.nix
+++ b/pkgs/by-name/mi/miniserve/package.nix
@@ -69,7 +69,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/svenstaro/miniserve/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
-      figsoda
       defelo
     ];
     mainProgram = "miniserve";

--- a/pkgs/by-name/mi/minizign/package.nix
+++ b/pkgs/by-name/mi/minizign/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Minisign reimplemented in Zig";
     homepage = "https://github.com/jedisct1/zig-minisign";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "minizign";
     inherit (zig.meta) platforms;
   };

--- a/pkgs/by-name/mm/mmtc/package.nix
+++ b/pkgs/by-name/mm/mmtc/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/figsoda/mmtc";
     changelog = "https://github.com/figsoda/mmtc/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "mmtc";
   };
 }

--- a/pkgs/by-name/mu/muffet/package.nix
+++ b/pkgs/by-name/mu/muffet/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/raviqqe/muffet";
     changelog = "https://github.com/raviqqe/muffet/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "muffet";
   };
 })

--- a/pkgs/by-name/na/namaka/package.nix
+++ b/pkgs/by-name/na/namaka/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/namaka";
     changelog = "https://github.com/nix-community/namaka/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ne/nerdfix/package.nix
+++ b/pkgs/by-name/ne/nerdfix/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ni/nil/package.nix
+++ b/pkgs/by-name/ni/nil/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       oxalica
     ];
     mainProgram = "nil";

--- a/pkgs/by-name/ni/nix-index-unwrapped/package.nix
+++ b/pkgs/by-name/ni/nix-index-unwrapped/package.nix
@@ -44,7 +44,6 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [
       bennofs
-      figsoda
       ncfavier
     ];
   };

--- a/pkgs/by-name/ni/nix-init/package.nix
+++ b/pkgs/by-name/ni/nix-init/package.nix
@@ -96,6 +96,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/nix-community/nix-init";
     changelog = "https://github.com/nix-community/nix-init/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ni/nix-melt/package.nix
+++ b/pkgs/by-name/ni/nix-melt/package.nix
@@ -37,6 +37,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/nix-melt";
     changelog = "https://github.com/nix-community/nix-melt/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mpl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ni/nix-update/package.nix
+++ b/pkgs/by-name/ni/nix-update/package.nix
@@ -52,7 +52,6 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://github.com/Mic92/nix-update/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       mic92
     ];
     mainProgram = "nix-update";

--- a/pkgs/by-name/ni/nixpkgs-hammering/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-hammering/package.nix
@@ -41,6 +41,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/jtojnar/nixpkgs-hammering";
     license = lib.licenses.mit;
     mainProgram = "nixpkgs-hammer";
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ni/nixpkgs-lint-community/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-lint-community/package.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       artturin
-      figsoda
     ];
   };
 }

--- a/pkgs/by-name/ni/nixpkgs-review/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-review/package.nix
@@ -86,7 +86,6 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.mit;
     mainProgram = "nixpkgs-review";
     maintainers = with lib.maintainers; [
-      figsoda
       mic92
     ];
   };

--- a/pkgs/by-name/no/nomino/package.nix
+++ b/pkgs/by-name/no/nomino/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "nomino";
   };
 }

--- a/pkgs/by-name/nu/nurl/package.nix
+++ b/pkgs/by-name/nu/nurl/package.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/nurl";
     changelog = "https://github.com/nix-community/nurl/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "nurl";
   };
 }

--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -91,7 +91,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "oculante";
     maintainers = with lib.maintainers; [
       dit7ya
-      figsoda
     ];
   };
 }

--- a/pkgs/by-name/oh/oha/package.nix
+++ b/pkgs/by-name/oh/oha/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/hatoo/oha";
     changelog = "https://github.com/hatoo/oha/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "oha";
   };
 }

--- a/pkgs/by-name/on/onefetch/package.nix
+++ b/pkgs/by-name/on/onefetch/package.nix
@@ -71,7 +71,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Br1ght0ne
-      figsoda
       kloenk
     ];
     mainProgram = "onefetch";

--- a/pkgs/by-name/or/oranda/package.nix
+++ b/pkgs/by-name/or/oranda/package.nix
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "oranda";
   };
 }

--- a/pkgs/by-name/or/org-stats/package.nix
+++ b/pkgs/by-name/or/org-stats/package.nix
@@ -60,7 +60,7 @@ buildGoModule rec {
     homepage = "https://github.com/caarlos0/org-stats";
     changelog = "https://github.com/caarlos0/org-stats/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "org-stats";
   };
 }

--- a/pkgs/by-name/or/orz/package.nix
+++ b/pkgs/by-name/or/orz/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage {
     description = "High performance, general purpose data compressor written in rust";
     homepage = "https://github.com/richox/orz";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "orz";
   };
 }

--- a/pkgs/by-name/ou/ouch/package.nix
+++ b/pkgs/by-name/ou/ouch/package.nix
@@ -71,7 +71,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/ouch-org/ouch/blob/${version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ] ++ lib.optionals enableUnfree [ unfreeRedistributable ];
     maintainers = with lib.maintainers; [
-      figsoda
       psibi
       krovuxdev
     ];

--- a/pkgs/by-name/ov/ov/package.nix
+++ b/pkgs/by-name/ov/ov/package.nix
@@ -75,7 +75,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       farcaller
-      figsoda
     ];
     mainProgram = "ov";
   };

--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/oxc-project/oxc";
     changelog = "https://github.com/oxc-project/oxc/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "oxlint";
   };
 })

--- a/pkgs/by-name/pa/pactorio/package.nix
+++ b/pkgs/by-name/pa/pactorio/package.nix
@@ -40,6 +40,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/figsoda/pactorio";
     changelog = "https://github.com/figsoda/pactorio/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/pa/panamax/package.nix
+++ b/pkgs/by-name/pa/panamax/package.nix
@@ -35,6 +35,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/pa/patsh/package.nix
+++ b/pkgs/by-name/pa/patsh/package.nix
@@ -48,6 +48,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/patsh";
     changelog = "https://github.com/nix-community/patsh/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/pe/peep/package.nix
+++ b/pkgs/by-name/pe/peep/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/ryochack/peep";
     changelog = "https://github.com/ryochack/peep/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "peep";
   };
 }

--- a/pkgs/by-name/pi/piknik/package.nix
+++ b/pkgs/by-name/pi/piknik/package.nix
@@ -36,7 +36,7 @@ buildGoModule rec {
     homepage = "https://github.com/jedisct1/piknik";
     changelog = "https://github.com/jedisct1/piknik/blob/${src.rev}/ChangeLog";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "piknik";
   };
 }

--- a/pkgs/by-name/pi/pipe-rename/package.nix
+++ b/pkgs/by-name/pi/pipe-rename/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     description = "Rename your files using your favorite text editor";
     homepage = "https://github.com/marcusbuffett/pipe-rename";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "renamer";
   };
 }

--- a/pkgs/by-name/pi/piping-server-rust/package.nix
+++ b/pkgs/by-name/pi/piping-server-rust/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nwtgck/piping-server-rust";
     changelog = "https://github.com/nwtgck/piping-server-rust/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "piping-server";
   };
 }

--- a/pkgs/by-name/pk/pkgtop/package.nix
+++ b/pkgs/by-name/pk/pkgtop/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
     homepage = "https://github.com/orhun/pkgtop";
     changelog = "https://github.com/orhun/pkgtop/releases/tag/${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "pkgtop";
   };
 }

--- a/pkgs/by-name/pl/planus/package.nix
+++ b/pkgs/by-name/pl/planus/package.nix
@@ -38,6 +38,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/po/pods/package.nix
+++ b/pkgs/by-name/po/pods/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/marhkb/pods";
     changelog = "https://github.com/marhkb/pods/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "pods";
   };

--- a/pkgs/by-name/po/poethepoet/package.nix
+++ b/pkgs/by-name/po/poethepoet/package.nix
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/nat-n/poethepoet";
     changelog = "https://github.com/nat-n/poethepoet/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "poe";
   };
 }

--- a/pkgs/by-name/po/pomsky/package.nix
+++ b/pkgs/by-name/po/pomsky/package.nix
@@ -44,6 +44,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/po/poop/package.nix
+++ b/pkgs/by-name/po/poop/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/andrewrk/poop";
     changelog = "https://github.com/andrewrk/poop/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "poop";
   };

--- a/pkgs/by-name/po/popsicle/package.nix
+++ b/pkgs/by-name/po/popsicle/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/pop-os/popsicle/releases/tag/${finalAttrs.version}";
     maintainers = with lib.maintainers; [
       _13r0ck
-      figsoda
     ];
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/po/postgres-language-server/package.nix
+++ b/pkgs/by-name/po/postgres-language-server/package.nix
@@ -54,7 +54,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://pg-language-server.com";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       myypo
     ];
     mainProgram = "postgres-language-server";

--- a/pkgs/by-name/pr/process-viewer/package.nix
+++ b/pkgs/by-name/pr/process-viewer/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
     description = "Process viewer GUI in rust";
     homepage = "https://github.com/guillaumegomez/process-viewer";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "process_viewer";
   };
 }

--- a/pkgs/by-name/pr/projectable/package.nix
+++ b/pkgs/by-name/pr/projectable/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dzfrias/projectable";
     changelog = "https://github.com/dzfrias/projectable/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "prj";
   };
 }

--- a/pkgs/by-name/pr/protox/package.nix
+++ b/pkgs/by-name/pr/protox/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/pr/proximity-sort/package.nix
+++ b/pkgs/by-name/pr/proximity-sort/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "proximity-sort";
   };
 }

--- a/pkgs/by-name/ps/psitop/package.nix
+++ b/pkgs/by-name/ps/psitop/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
     description = "Top for /proc/pressure";
     homepage = "https://github.com/jamespwilliams/psitop";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "psitop";
   };
 }

--- a/pkgs/by-name/pw/pw-viz/package.nix
+++ b/pkgs/by-name/pw/pw-viz/package.nix
@@ -62,7 +62,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple and elegant pipewire graph editor";
     homepage = "https://github.com/ax9d/pw-viz";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/pw/pw-volume/package.nix
+++ b/pkgs/by-name/pw/pw-volume/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       astro
-      figsoda
     ];
     platforms = lib.platforms.linux;
     mainProgram = "pw-volume";

--- a/pkgs/by-name/pw/pwvucontrol/package.nix
+++ b/pkgs/by-name/pw/pwvucontrol/package.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/saivert/pwvucontrol";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      figsoda
       Guanran928
       johnrtitor
     ];

--- a/pkgs/by-name/py/pysentation/package.nix
+++ b/pkgs/by-name/py/pysentation/package.nix
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/mimseyedi/pysentation";
     changelog = "https://github.com/mimseyedi/pysentation/releases/tag/${src.rev}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "pysentation";
   };
 }

--- a/pkgs/by-name/py/python-launcher/package.nix
+++ b/pkgs/by-name/py/python-launcher/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/brettcannon/python-launcher";
     changelog = "https://github.com/brettcannon/python-launcher/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "py";
   };
 }

--- a/pkgs/by-name/pz/pzip/package.nix
+++ b/pkgs/by-name/pz/pzip/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     homepage = "https://github.com/ybirader/pzip";
     changelog = "https://github.com/ybirader/pzip/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "pzip";
   };
 }

--- a/pkgs/by-name/ra/rare-regex/package.nix
+++ b/pkgs/by-name/ra/rare-regex/package.nix
@@ -48,6 +48,6 @@ buildGoModule rec {
     homepage = "https://rare.zdyn.net";
     changelog = "https://github.com/zix99/rare/releases/tag/${src.rev}";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/re/reason-shell/package.nix
+++ b/pkgs/by-name/re/reason-shell/package.nix
@@ -33,6 +33,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/jaywonchung/reason";
     changelog = "https://github.com/jaywonchung/reason/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/re/regex-cli/package.nix
+++ b/pkgs/by-name/re/regex-cli/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/re/repgrep/package.nix
+++ b/pkgs/by-name/re/repgrep/package.nix
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       unlicense
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rgr";
   };
 }

--- a/pkgs/by-name/re/rewrk/package.nix
+++ b/pkgs/by-name/re/rewrk/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/lnx-search/rewrk";
     changelog = "https://github.com/lnx-search/rewrk/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rewrk";
   };
 }

--- a/pkgs/by-name/rh/rhack/package.nix
+++ b/pkgs/by-name/rh/rhack/package.nix
@@ -22,6 +22,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "rhack";
     homepage = "https://github.com/nakabonne/rhack";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rh/rhai-doc/package.nix
+++ b/pkgs/by-name/rh/rhai-doc/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rhai-doc";
   };
 }

--- a/pkgs/by-name/ri/riff/package.nix
+++ b/pkgs/by-name/ri/riff/package.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://riff.sh";
     changelog = "https://github.com/DeterminateSystems/riff/releases/tag/v${version}";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ri/ripdrag/package.nix
+++ b/pkgs/by-name/ri/ripdrag/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nik012003/ripdrag";
     changelog = "https://github.com/nik012003/ripdrag/releases/tag/${src.rev}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "ripdrag";
   };
 }

--- a/pkgs/by-name/ri/ripsecrets/package.nix
+++ b/pkgs/by-name/ri/ripsecrets/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sirwart/ripsecrets";
     changelog = "https://github.com/sirwart/ripsecrets/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "ripsecrets";
   };
 }

--- a/pkgs/by-name/ri/risor/package.nix
+++ b/pkgs/by-name/ri/risor/package.nix
@@ -43,6 +43,6 @@ buildGoModule rec {
     homepage = "https://github.com/risor-io/risor";
     changelog = "https://github.com/risor-io/risor/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rl/rlci/package.nix
+++ b/pkgs/by-name/rl/rlci/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/orsinium-labs/rlci";
     changelog = "https://github.com/orsinium-labs/rlci/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rn/rnr/package.nix
+++ b/pkgs/by-name/rn/rnr/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/ismaelgv/rnr";
     changelog = "https://github.com/ismaelgv/rnr/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ro/roogle/package.nix
+++ b/pkgs/by-name/ro/roogle/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rq/rq/package.nix
+++ b/pkgs/by-name/rq/rq/package.nix
@@ -50,7 +50,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       aristid
       Br1ght0ne
-      figsoda
     ];
   };
 })

--- a/pkgs/by-name/rs/rsass/package.nix
+++ b/pkgs/by-name/rs/rsass/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rs/rsign2/package.nix
+++ b/pkgs/by-name/rs/rsign2/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     description = "Command-line tool to sign files and verify signatures";
     homepage = "https://github.com/jedisct1/rsign2";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rsign";
   };
 }

--- a/pkgs/by-name/rs/rslint/package.nix
+++ b/pkgs/by-name/rs/rslint/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     description = "Fast, customizable, and easy to use JavaScript and TypeScript linter";
     homepage = "https://rslint.org";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rs/rsonpath/package.nix
+++ b/pkgs/by-name/rs/rsonpath/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/v0ldek/rsonpath";
     changelog = "https://github.com/v0ldek/rsonpath/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rq";
   };
 }

--- a/pkgs/by-name/rt/rtz/package.nix
+++ b/pkgs/by-name/rt/rtz/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/twitchax/rtz";
     changelog = "https://github.com/twitchax/rtz/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rtz";
   };
 }

--- a/pkgs/by-name/ru/ruff/package.nix
+++ b/pkgs/by-name/ru/ruff/package.nix
@@ -95,7 +95,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "ruff";
     maintainers = with lib.maintainers; [
       bengsparks
-      figsoda
       GaetanLepage
     ];
   };

--- a/pkgs/by-name/ru/rune-languageserver/package.nix
+++ b/pkgs/by-name/ru/rune-languageserver/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rune-languageserver";
   };
 }

--- a/pkgs/by-name/ru/rune/package.nix
+++ b/pkgs/by-name/ru/rune/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rune";
   };
 }

--- a/pkgs/by-name/ru/runiq/package.nix
+++ b/pkgs/by-name/ru/runiq/package.nix
@@ -26,6 +26,6 @@ rustPlatform.buildRustPackage {
     mainProgram = "runiq";
     homepage = "https://github.com/whitfin/runiq";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ru/runme/package.nix
+++ b/pkgs/by-name/ru/runme/package.nix
@@ -76,6 +76,6 @@ buildGoModule rec {
     homepage = "https://runme.dev";
     changelog = "https://github.com/runmedev/runme/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ru/rust-audit-info/package.nix
+++ b/pkgs/by-name/ru/rust-audit-info/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ru/rust-code-analysis/package.nix
+++ b/pkgs/by-name/ru/rust-code-analysis/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
       mit # grammars
       mpl20 # code
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rust-code-analysis-cli";
   };
 }

--- a/pkgs/by-name/ru/rust-motd/package.nix
+++ b/pkgs/by-name/ru/rust-motd/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rust-motd/rust-motd";
     changelog = "https://github.com/rust-motd/rust-motd/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rust-motd";
   };
 }

--- a/pkgs/by-name/ru/rust-petname/package.nix
+++ b/pkgs/by-name/ru/rust-petname/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
     description = "Generate human readable random names";
     homepage = "https://github.com/allenap/rust-petname";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "petname";
   };
 }

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ru/rust-traverse/package.nix
+++ b/pkgs/by-name/ru/rust-traverse/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dmcg310/Rust-Traverse";
     changelog = "https://github.com/dmcg310/Rust-Traverse/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rt";
   };
 }

--- a/pkgs/by-name/ru/rustscan/package.nix
+++ b/pkgs/by-name/ru/rustscan/package.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/RustScan/RustScan";
     changelog = "https://github.com/RustScan/RustScan/releases/tag/${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rustscan";
   };
 }

--- a/pkgs/by-name/ru/rusty-man/package.nix
+++ b/pkgs/by-name/ru/rusty-man/package.nix
@@ -32,7 +32,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://git.sr.ht/~ireas/rusty-man/tree/v${finalAttrs.version}/item/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       defelo
     ];
   };

--- a/pkgs/by-name/ru/rustycli/package.nix
+++ b/pkgs/by-name/ru/rustycli/package.nix
@@ -24,6 +24,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/pwnwriter/rustycli";
     changelog = "https://github.com/pwnwriter/rustycli/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ru/rustypaste-cli/package.nix
+++ b/pkgs/by-name/ru/rustypaste-cli/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/orhun/rustypaste-cli";
     changelog = "https://github.com/orhun/rustypaste-cli/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "rpaste";
   };
 }

--- a/pkgs/by-name/ru/rustypaste/package.nix
+++ b/pkgs/by-name/ru/rustypaste/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/orhun/rustypaste/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       seqizz
     ];
     mainProgram = "rustypaste";

--- a/pkgs/by-name/ru/rustywind/package.nix
+++ b/pkgs/by-name/ru/rustywind/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/avencera/rustywind";
     changelog = "https://github.com/avencera/rustywind/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sa/safecloset/package.nix
+++ b/pkgs/by-name/sa/safecloset/package.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Canop/safecloset";
     changelog = "https://github.com/Canop/safecloset/blob/${src.rev}/CHANGELOG.md";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "safecloset";
   };
 }

--- a/pkgs/by-name/sa/sagoin/package.nix
+++ b/pkgs/by-name/sa/sagoin/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/figsoda/sagoin";
     changelog = "https://github.com/figsoda/sagoin/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "sagoin";
   };
 }

--- a/pkgs/by-name/sa/samply/package.nix
+++ b/pkgs/by-name/sa/samply/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "samply";
   };
 }

--- a/pkgs/by-name/sc/sccache/package.nix
+++ b/pkgs/by-name/sc/sccache/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/mozilla/sccache/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [
       doronbehar
-      figsoda
     ];
     license = lib.licenses.asl20;
   };

--- a/pkgs/by-name/sc/scip/package.nix
+++ b/pkgs/by-name/sc/scip/package.nix
@@ -44,6 +44,6 @@ buildGoModule rec {
     homepage = "https://github.com/sourcegraph/scip";
     changelog = "https://github.com/sourcegraph/scip/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sc/scraper/package.nix
+++ b/pkgs/by-name/sc/scraper/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/causal-agent/scraper";
     changelog = "https://github.com/causal-agent/scraper/releases/tag/v${version}";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sc/scriptisto/package.nix
+++ b/pkgs/by-name/sc/scriptisto/package.nix
@@ -32,6 +32,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/igor-petruk/scriptisto";
     changelog = "https://github.com/igor-petruk/scriptisto/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/se/selene/package.nix
+++ b/pkgs/by-name/se/selene/package.nix
@@ -36,6 +36,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/kampfkarren/selene";
     changelog = "https://github.com/kampfkarren/selene/blob/${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sh/shaq/package.nix
+++ b/pkgs/by-name/sh/shaq/package.nix
@@ -60,7 +60,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/woodruffw/shaq/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       mig4ng
     ];
     mainProgram = "shaq";

--- a/pkgs/by-name/sh/shell2http/package.nix
+++ b/pkgs/by-name/sh/shell2http/package.nix
@@ -48,6 +48,6 @@ buildGoModule rec {
     homepage = "https://github.com/msoap/shell2http";
     changelog = "https://github.com/msoap/shell2http/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sh/shotgun/package.nix
+++ b/pkgs/by-name/sh/shotgun/package.nix
@@ -22,7 +22,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/neXromancers/shotgun";
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [
-      figsoda
       lumi
     ];
     platforms = platforms.linux;

--- a/pkgs/by-name/si/sic-image-cli/package.nix
+++ b/pkgs/by-name/si/sic-image-cli/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "sic";
   };
 }

--- a/pkgs/by-name/si/simple-http-server/package.nix
+++ b/pkgs/by-name/si/simple-http-server/package.nix
@@ -32,7 +32,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/TheWaWaR/simple-http-server/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       mephistophiles
     ];
     mainProgram = "simple-http-server";

--- a/pkgs/by-name/sk/skate/package.nix
+++ b/pkgs/by-name/sk/skate/package.nix
@@ -30,7 +30,6 @@ buildGoModule rec {
     changelog = "https://github.com/charmbracelet/skate/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       penguwin
     ];
     mainProgram = "skate";

--- a/pkgs/by-name/sl/slingshot/package.nix
+++ b/pkgs/by-name/sl/slingshot/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/caio-ishikawa/slingshot";
     changelog = "https://github.com/caio-ishikawa/slingshot/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "slingshot";
   };
 }

--- a/pkgs/by-name/sl/slippy/package.nix
+++ b/pkgs/by-name/sl/slippy/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "slippy";
   };
 }

--- a/pkgs/by-name/sm/smartcrop/package.nix
+++ b/pkgs/by-name/sm/smartcrop/package.nix
@@ -26,7 +26,7 @@ buildGoModule {
     description = "Find good image crops for arbitrary crop sizes";
     homepage = "https://github.com/muesli/smartcrop";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "smartcrop";
   };
 }

--- a/pkgs/by-name/sn/snazy/package.nix
+++ b/pkgs/by-name/sn/snazy/package.nix
@@ -47,7 +47,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/chmouel/snazy/releases/tag/${src.rev}";
     license = licenses.asl20;
     maintainers = with maintainers; [
-      figsoda
       jk
     ];
   };

--- a/pkgs/by-name/sn/sniffnet/package.nix
+++ b/pkgs/by-name/sn/sniffnet/package.nix
@@ -99,7 +99,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     teams = [ lib.teams.ngi ];
     mainProgram = "sniffnet";
   };

--- a/pkgs/by-name/sn/snixembed/package.nix
+++ b/pkgs/by-name/sn/snixembed/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     changelog = "https://git.sr.ht/~steef/snixembed/refs/${version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "snixembed";
   };
 }

--- a/pkgs/by-name/sp/spacer/package.nix
+++ b/pkgs/by-name/sp/spacer/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/samwho/spacer";
     changelog = "https://github.com/samwho/spacer/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "spacer";
   };
 }

--- a/pkgs/by-name/sp/specr-transpile/package.nix
+++ b/pkgs/by-name/sp/specr-transpile/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sr/src-cli/package.nix
+++ b/pkgs/by-name/sr/src-cli/package.nix
@@ -44,7 +44,6 @@ buildGoModule rec {
     changelog = "https://github.com/sourcegraph/src-cli/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [
-      figsoda
       keegancsmith
     ];
     mainProgram = "src";

--- a/pkgs/by-name/st/star-history/package.nix
+++ b/pkgs/by-name/st/star-history/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "star-history";
   };
 }

--- a/pkgs/by-name/st/starcharts/package.nix
+++ b/pkgs/by-name/st/starcharts/package.nix
@@ -31,6 +31,6 @@ buildGoModule rec {
     homepage = "https://github.com/caarlos0/starcharts";
     changelog = "https://github.com/caarlos0/starcharts/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/st/starlark-rust/package.nix
+++ b/pkgs/by-name/st/starlark-rust/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/facebook/starlark-rust";
     changelog = "https://github.com/facebook/starlark-rust/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "starlark";
   };
 }

--- a/pkgs/by-name/st/starry/package.nix
+++ b/pkgs/by-name/st/starry/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     description = "Current stars history tells only half the story";
     homepage = "https://github.com/Canop/starry";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "starry";
   };
 }

--- a/pkgs/by-name/st/static-server/package.nix
+++ b/pkgs/by-name/st/static-server/package.nix
@@ -53,7 +53,7 @@ buildGoModule rec {
     description = "Simple, zero-configuration HTTP server CLI for serving static files";
     homepage = "https://github.com/eliben/static-server";
     license = licenses.unlicense;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "static-server";
   };
 }

--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -41,7 +41,6 @@ rustPlatform.buildRustPackage rec {
       asl20
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       misilelab
     ];
     mainProgram = "static-web-server";

--- a/pkgs/by-name/st/statix/package.nix
+++ b/pkgs/by-name/st/statix/package.nix
@@ -33,7 +33,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     mainProgram = "statix";
     maintainers = with maintainers; [
-      figsoda
       nerdypepper
     ];
   };

--- a/pkgs/by-name/st/strace-analyzer/package.nix
+++ b/pkgs/by-name/st/strace-analyzer/package.nix
@@ -31,6 +31,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "strace-analyzer";
     homepage = "https://github.com/wookietreiber/strace-analyzer";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/st/stylua/package.nix
+++ b/pkgs/by-name/st/stylua/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/johnnymorganz/stylua";
     changelog = "https://github.com/johnnymorganz/stylua/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "stylua";
   };
 }

--- a/pkgs/by-name/su/suckit/package.nix
+++ b/pkgs/by-name/su/suckit/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "suckit";
   };
 }

--- a/pkgs/by-name/sv/svg2pdf/package.nix
+++ b/pkgs/by-name/sv/svg2pdf/package.nix
@@ -31,7 +31,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with maintainers; [
       doronbehar
-      figsoda
     ];
     mainProgram = "svg2pdf";
   };

--- a/pkgs/by-name/sx/sx/package.nix
+++ b/pkgs/by-name/sx/sx/package.nix
@@ -56,7 +56,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "sx";
     maintainers = with lib.maintainers; [
-      figsoda
       thiagokokada
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sy/symbolicator/package.nix
+++ b/pkgs/by-name/sy/symbolicator/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://getsentry.github.io/symbolicator/";
     changelog = "https://github.com/getsentry/symbolicator/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "symbolicator";
   };
 }

--- a/pkgs/by-name/sy/synth/package.nix
+++ b/pkgs/by-name/sy/synth/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage rec {
     description = "Tool for generating realistic data using a declarative data model";
     homepage = "https://github.com/getsynth/synth";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sy/systeroid/package.nix
+++ b/pkgs/by-name/sy/systeroid/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with maintainers; [
-      figsoda
       matthiasbeyer
     ];
   };

--- a/pkgs/by-name/ta/tailer/package.nix
+++ b/pkgs/by-name/ta/tailer/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
     description = "CLI tool to insert lines when command output stops";
     homepage = "https://github.com/hionay/tailer";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "tailer";
   };
 }

--- a/pkgs/by-name/ta/taizen/package.nix
+++ b/pkgs/by-name/ta/taizen/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage {
     description = "Curses-based mediawiki browser";
     homepage = "https://github.com/oppiliappan/taizen";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "taizen";
   };
 }

--- a/pkgs/by-name/ta/taplo/package.nix
+++ b/pkgs/by-name/ta/taplo/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
     description = "TOML toolkit written in Rust";
     homepage = "https://taplo.tamasfe.dev";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "taplo";
   };
 }

--- a/pkgs/by-name/te/teehee/package.nix
+++ b/pkgs/by-name/te/teehee/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Gskartwii/teehee";
     changelog = "https://github.com/Gskartwii/teehee/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "teehee";
   };
 }

--- a/pkgs/by-name/te/teip/package.nix
+++ b/pkgs/by-name/te/teip/package.nix
@@ -43,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/greymd/teip";
     changelog = "https://github.com/greymd/teip/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/te/tela-icon-theme/package.nix
+++ b/pkgs/by-name/te/tela-icon-theme/package.nix
@@ -56,6 +56,6 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.gpl3Only;
     # darwin systems use case-insensitive filesystems that cause hash mismatches
     platforms = subtractLists platforms.darwin platforms.unix;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/te/termimage/package.nix
+++ b/pkgs/by-name/te/termimage/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nabijaczleweli/termimage";
     changelog = "https://github.com/nabijaczleweli/termimage/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "termimage";
   };
 }

--- a/pkgs/by-name/te/textplots/package.nix
+++ b/pkgs/by-name/te/textplots/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Terminal plotting written in Rust";
     homepage = "https://github.com/loony-bean/textplots-rs";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "textplots";
   };
 }

--- a/pkgs/by-name/te/texture-synthesis/package.nix
+++ b/pkgs/by-name/te/texture-synthesis/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "texture-synthesis";
   };
 }

--- a/pkgs/by-name/th/the-way/package.nix
+++ b/pkgs/by-name/th/the-way/package.nix
@@ -40,7 +40,6 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      figsoda
       numkem
     ];
   };

--- a/pkgs/by-name/th/theme-sh/package.nix
+++ b/pkgs/by-name/th/theme-sh/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/lemnos/theme.sh";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "theme.sh";
   };
 }

--- a/pkgs/by-name/th/thokr/package.nix
+++ b/pkgs/by-name/th/thokr/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Typing tui with visualized results and historical logging";
     homepage = "https://github.com/thatvegandev/thokr";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "thokr";
   };
 }

--- a/pkgs/by-name/ti/tidy-viewer/package.nix
+++ b/pkgs/by-name/ti/tidy-viewer/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/alexhallam/tv";
     changelog = "https://github.com/alexhallam/tv/blob/${version}/CHANGELOG.md";
     license = lib.licenses.unlicense;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ti/timelimit/package.nix
+++ b/pkgs/by-name/ti/timelimit/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = "https://devel.ringlet.net/sysutils/timelimit/";
     license = licenses.bsd2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "timelimit";
   };
 }

--- a/pkgs/by-name/tm/tml/package.nix
+++ b/pkgs/by-name/tm/tml/package.nix
@@ -28,6 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/liamg/tml";
     changelog = "https://github.com/liamg/tml/releases/tag/v${version}";
     license = lib.licenses.unlicense;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/to/toml2nix/package.nix
+++ b/pkgs/by-name/to/toml2nix/package.nix
@@ -27,6 +27,6 @@ rustPlatform.buildRustPackage rec {
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/to/topfew-rs/package.nix
+++ b/pkgs/by-name/to/topfew-rs/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Rust implementation of Tim Bray's topfew tool";
     homepage = "https://github.com/djc/topfew-rs";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "tf";
   };
 }

--- a/pkgs/by-name/to/topfew/package.nix
+++ b/pkgs/by-name/to/topfew/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
     description = "Finds the fields (or combinations of fields) which appear most often in a stream of records";
     homepage = "https://github.com/timbray/topfew";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "tf";
   };
 }

--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -101,7 +101,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/tweag/topiary/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       nartsiss
     ];
   };

--- a/pkgs/by-name/tr/trippy/package.nix
+++ b/pkgs/by-name/tr/trippy/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://trippy.cli.rs";
     changelog = "https://github.com/fujiapple852/trippy/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "trip";
   };
 }

--- a/pkgs/by-name/tt/ttop/package.nix
+++ b/pkgs/by-name/tt/ttop/package.nix
@@ -35,7 +35,6 @@ buildNimPackage (finalAttrs: {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      figsoda
       sikmir
     ];
     mainProgram = "ttop";

--- a/pkgs/by-name/tt/ttyper/package.nix
+++ b/pkgs/by-name/tt/ttyper/package.nix
@@ -23,7 +23,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/max-niederman/ttyper/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       max-niederman
     ];
     mainProgram = "ttyper";

--- a/pkgs/by-name/tu/tui-journal/package.nix
+++ b/pkgs/by-name/tu/tui-journal/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/AmmarAbouZor/tui-journal";
     changelog = "https://github.com/AmmarAbouZor/tui-journal/blob/${src.rev}/CHANGELOG.ron";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "tjournal";
   };
 }

--- a/pkgs/by-name/tu/turtle-build/package.nix
+++ b/pkgs/by-name/tu/turtle-build/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "turtle";
   };
 }

--- a/pkgs/by-name/tv/tv/package.nix
+++ b/pkgs/by-name/tv/tv/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/uzimaru0000/tv";
     changelog = "https://github.com/uzimaru0000/tv/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ty/typer/package.nix
+++ b/pkgs/by-name/ty/typer/package.nix
@@ -26,7 +26,7 @@ buildGoModule {
     description = "Typing test in your terminal";
     homepage = "https://github.com/maaslalani/typer";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "typer";
   };
 }

--- a/pkgs/by-name/ty/typeshare/package.nix
+++ b/pkgs/by-name/ty/typeshare/package.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ty/typical/package.nix
+++ b/pkgs/by-name/ty/typical/package.nix
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/stepchowfun/typical";
     changelog = "https://github.com/stepchowfun/typical/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ty/typioca/package.nix
+++ b/pkgs/by-name/ty/typioca/package.nix
@@ -36,7 +36,7 @@ buildGoModule rec {
     homepage = "https://github.com/bloznelis/typioca";
     changelog = "https://github.com/bloznelis/typioca/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "typioca";
   };
 }

--- a/pkgs/by-name/ty/typos/package.nix
+++ b/pkgs/by-name/ty/typos/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [
-      figsoda
       mgttlinger
     ];
   };

--- a/pkgs/by-name/ty/typst-live/package.nix
+++ b/pkgs/by-name/ty/typst-live/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
     description = "Hot reloading for your typst files";
     homepage = "https://github.com/ItsEthra/typst-live";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "typst-live";
   };
 }

--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -82,7 +82,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "typst";
     maintainers = with lib.maintainers; [
-      figsoda
       kanashimia
       RossSmyth
     ];

--- a/pkgs/by-name/ty/typstfmt/package.nix
+++ b/pkgs/by-name/ty/typstfmt/package.nix
@@ -24,7 +24,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     mainProgram = "typstfmt";
     maintainers = with lib.maintainers; [
-      figsoda
       geri1701
     ];
   };

--- a/pkgs/by-name/ty/tyson/package.nix
+++ b/pkgs/by-name/ty/tyson/package.nix
@@ -41,6 +41,6 @@ buildGoModule rec {
     homepage = "https://github.com/jetify-com/tyson";
     changelog = "https://github.com/jetify-com/tyson/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ul/ulid/package.nix
+++ b/pkgs/by-name/ul/ulid/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     homepage = "https://github.com/oklog/ulid";
     changelog = "https://github.com/oklog/ulid/blob/${src.rev}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "ulid";
   };
 }

--- a/pkgs/by-name/un/unfurl/package.nix
+++ b/pkgs/by-name/un/unfurl/package.nix
@@ -32,6 +32,6 @@ buildGoModule rec {
     mainProgram = "unfurl";
     homepage = "https://github.com/tomnomnom/unfurl";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/un/unimap/package.nix
+++ b/pkgs/by-name/un/unimap/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Edu4rdSHL/unimap";
     changelog = "https://github.com/Edu4rdSHL/unimap/releases/tag/${src.rev}";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "unimap";
   };
 }

--- a/pkgs/by-name/un/unzrip/package.nix
+++ b/pkgs/by-name/un/unzrip/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage {
     description = "Unzip implementation, support for parallel decompression, automatic detection encoding";
     homepage = "https://github.com/quininer/unzrip";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "unzrip";
   };
 }

--- a/pkgs/by-name/up/upiano/package.nix
+++ b/pkgs/by-name/up/upiano/package.nix
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Piano in your terminal";
     homepage = "https://github.com/eliasdorneles/upiano";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "upiano";
   };
 }

--- a/pkgs/by-name/ve/verco/package.nix
+++ b/pkgs/by-name/ve/verco/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple Git/Mercurial/PlasticSCM tui client based on keyboard shortcuts";
     homepage = "https://vamolessa.github.io/verco";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "verco";
   };
 }

--- a/pkgs/by-name/wa/wasmer-pack/package.nix
+++ b/pkgs/by-name/wa/wasmer-pack/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/wasmerio/wasmer-pack";
     changelog = "https://github.com/wasmerio/wasmer-pack/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/wa/wazero/package.nix
+++ b/pkgs/by-name/wa/wazero/package.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
     homepage = "https://github.com/tetratelabs/wazero";
     changelog = "https://github.com/tetratelabs/wazero/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "wazero";
   };
 }

--- a/pkgs/by-name/wt/wthrr/package.nix
+++ b/pkgs/by-name/wt/wthrr/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/ttytm/wthrr-the-weathercrab";
     changelog = "https://github.com/ttytm/wthrr-the-weathercrab/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "wthrr";
   };
 }

--- a/pkgs/by-name/xc/xc/package.nix
+++ b/pkgs/by-name/xc/xc/package.nix
@@ -50,7 +50,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/joerdav/xc/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       joerdav
     ];
   };

--- a/pkgs/by-name/xh/xh/package.nix
+++ b/pkgs/by-name/xh/xh/package.nix
@@ -71,7 +71,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/ducaale/xh/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      figsoda
       defelo
     ];
     mainProgram = "xh";

--- a/pkgs/by-name/xp/xplr/package.nix
+++ b/pkgs/by-name/xp/xplr/package.nix
@@ -52,7 +52,6 @@ rustPlatform.buildRustPackage rec {
       suryasr007
       pyrox0
       mimame
-      figsoda
     ];
   };
 }

--- a/pkgs/by-name/xq/xq-xml/package.nix
+++ b/pkgs/by-name/xq/xq-xml/package.nix
@@ -38,6 +38,6 @@ buildGoModule rec {
     homepage = "https://github.com/sibprogrammer/xq";
     changelog = "https://github.com/sibprogrammer/xq/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ya/yaegi/package.nix
+++ b/pkgs/by-name/ya/yaegi/package.nix
@@ -42,6 +42,6 @@ buildGoModule rec {
     homepage = "https://github.com/traefik/yaegi";
     changelog = "https://github.com/traefik/yaegi/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ze/zet/package.nix
+++ b/pkgs/by-name/ze/zet/package.nix
@@ -30,6 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/zf/zf/package.nix
+++ b/pkgs/by-name/zf/zf/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       dit7ya
-      figsoda
       mmlb
     ];
     mainProgram = "zf";

--- a/pkgs/by-name/zi/zine/package.nix
+++ b/pkgs/by-name/zi/zine/package.nix
@@ -37,7 +37,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       dit7ya
-      figsoda
     ];
     mainProgram = "zine";
   };

--- a/pkgs/by-name/zo/zon2nix/package.nix
+++ b/pkgs/by-name/zo/zon2nix/package.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/nix-community/zon2nix/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
-      figsoda
       RossComputerGuy
     ];
     inherit (zig_0_14.meta) platforms;

--- a/pkgs/by-name/zp/zps/package.nix
+++ b/pkgs/by-name/zp/zps/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/orhun/zps";
     changelog = "https://github.com/orhun/zps/releases/tag/${version}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "zps";
   };

--- a/pkgs/by-name/zt/ztags/package.nix
+++ b/pkgs/by-name/zt/ztags/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Generate tags files for Zig projects";
     homepage = "https://github.com/gpanders/ztags";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "ztags";
     inherit (zig.meta) platforms;
   };

--- a/pkgs/by-name/zx/zxpy/package.nix
+++ b/pkgs/by-name/zx/zxpy/package.nix
@@ -39,7 +39,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/tusharsadhwani/zxpy";
     changelog = "https://github.com/tusharsadhwani/zxpy/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
     mainProgram = "zxpy";
   };
 }

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -38,7 +38,7 @@ let
         mit # or
         asl20
       ];
-      maintainers = with maintainers; [ figsoda ];
+      maintainers = [ ];
       broken = stdenv.hostPlatform != stdenv.buildPlatform;
     };
   };

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -5281,7 +5281,7 @@ final: prev: {
       meta = {
         homepage = "https://github.com/notomo/vusted";
         description = "`busted` wrapper for testing neovim plugin";
-        maintainers = with lib.maintainers; [ figsoda ];
+        maintainers = [ ];
         license.fullName = "MIT <http://opensource.org/licenses/MIT>";
       };
     }

--- a/pkgs/development/python-modules/art/default.nix
+++ b/pkgs/development/python-modules/art/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/sepandhaghighi/art";
     changelog = "https://github.com/sepandhaghighi/art/blob/${src.tag}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/dataclass-factory/default.nix
+++ b/pkgs/development/python-modules/dataclass-factory/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/reagento/dataclass-factory";
     changelog = "https://github.com/reagento/dataclass-factory/releases/tag/${src.rev}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/jello/default.nix
+++ b/pkgs/development/python-modules/jello/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/kellyjonbrazil/jello";
     changelog = "https://github.com/kellyjonbrazil/jello/blob/${src.tag}/CHANGELOG";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ochre/default.nix
+++ b/pkgs/development/python-modules/ochre/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/getcuia/ochre";
     changelog = "https://github.com/getcuia/ochre/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyfluidsynth/default.nix
+++ b/pkgs/development/python-modules/pyfluidsynth/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Python bindings for FluidSynth, a MIDI synthesizer that uses SoundFont instruments";
     homepage = "https://github.com/nwhitehead/pyfluidsynth";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pynvim/default.nix
+++ b/pkgs/development/python-modules/pynvim/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/neovim/pynvim";
     changelog = "https://github.com/neovim/pynvim/releases/tag/${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rich-pixels/default.nix
+++ b/pkgs/development/python-modules/rich-pixels/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/darrenburns/rich-pixels";
     changelog = "https://github.com/darrenburns/rich-pixels/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/shazamio/default.nix
+++ b/pkgs/development/python-modules/shazamio/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/dotX12/ShazamIO";
     changelog = "https://github.com/dotX12/ShazamIO/releases/tag/${src.tag}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
     # https://github.com/shazamio/ShazamIO/issues/80
     broken = versionAtLeast pydantic.version "2";
   };

--- a/pkgs/development/python-modules/stransi/default.nix
+++ b/pkgs/development/python-modules/stransi/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/getcuia/stransi";
     changelog = "https://github.com/getcuia/stransi/releases/tag/${src.rev}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/textual-universal-directorytree/default.nix
+++ b/pkgs/development/python-modules/textual-universal-directorytree/default.nix
@@ -53,6 +53,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/juftin/textual-universal-directorytree";
     changelog = "https://github.com/juftin/textual-universal-directorytree/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/universal-pathlib/default.nix
+++ b/pkgs/development/python-modules/universal-pathlib/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/fsspec/universal_pathlib";
     changelog = "https://github.com/fsspec/universal_pathlib/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/xdg-base-dirs/default.nix
+++ b/pkgs/development/python-modules/xdg-base-dirs/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/srstevenson/xdg-base-dirs";
     changelog = "https://github.com/srstevenson/xdg-base-dirs/releases/tag/${version}";
     license = licenses.isc;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/zls/default.nix
+++ b/pkgs/development/tools/zls/default.nix
@@ -18,7 +18,6 @@ let
       homepage = "https://github.com/zigtools/zls";
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [
-        figsoda
         moni
         _0x5a4
         jmbaur

--- a/pkgs/shells/fish/plugins/async-prompt.nix
+++ b/pkgs/shells/fish/plugins/async-prompt.nix
@@ -19,6 +19,6 @@ buildFishPlugin rec {
     description = "Make your prompt asynchronous to improve the reactivity";
     homepage = "https://github.com/acomagu/fish-async-prompt";
     license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/shells/fish/plugins/autopair.nix
+++ b/pkgs/shells/fish/plugins/autopair.nix
@@ -20,7 +20,6 @@ buildFishPlugin rec {
     homepage = "https://github.com/jorgebucaran/autopair.fish";
     license = licenses.mit;
     maintainers = with maintainers; [
-      figsoda
       kidonng
       pyrox0
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12322,11 +12322,11 @@ with self;
       hash = "sha256-VaUsIz4troYRP58Zs09hftz8hBb5vs5nEme9GBGxIRE=";
     };
     outputs = [ "out" ];
-    meta = with lib; {
+    meta = {
       description = "Simplified safe evaluation of Perl code";
       homepage = "https://github.com/mkende/perl-eval-safe";
-      license = licenses.mit;
-      maintainers = with maintainers; [ figsoda ];
+      license = lib.licenses.mit;
+      maintainers = [ ];
     };
   };
 
@@ -24770,14 +24770,14 @@ with self;
       TestPod
       TestPodCoverage
     ];
-    meta = with lib; {
+    meta = {
       description = "Perl bindings to the msgpack C library";
       homepage = "https://github.com/jacquesg/p5-MsgPack-Raw";
-      license = with licenses; [
+      license = with lib.licenses; [
         gpl1Plus # or
         artistic1
       ];
-      maintainers = with maintainers; [ figsoda ];
+      maintainers = [ ];
     };
   };
 
@@ -24927,14 +24927,14 @@ with self;
     ];
     # TODO: fix tests
     doCheck = false;
-    meta = with lib; {
+    meta = {
       description = "Perl bindings for Neovim";
       homepage = "https://github.com/jacquesg/p5-Neovim-Ext";
-      license = with licenses; [
+      license = with lib.licenses; [
         gpl1Plus # or
         artistic1
       ];
-      maintainers = with maintainers; [ figsoda ];
+      maintainers = [ ];
     };
   };
 


### PR DESCRIPTION
figsoda does not seem to have had any nixpkgs activity since 2024. Their last review was in Feburary 2024, per https://github.com/NixOS/nixpkgs/pull/455328#pullrequestreview-3381138510.

Because figsoda maintained so many packages, I split up my commits by the regex I used.

@figsoda: if you'd like to stay involved as maintainer, please respond within a week.

Finally, I see that figsoda is a committer as well. That is not changed by this PR.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Verified 0 rebuilds.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
