### PR TITLE
genemichaels: add updateScript, switch to `fetchCrate`, 0.5.13 -> 0.8.5

### DIFF
--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "genemichaels";
-  version = "0.5.13";
+  version = "0.8.5";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-ZJr5cN+Bam71fPDwhcYUVop5JW8145tzY7Sk75fjhvQ=";
+    hash = "sha256-5cM5VyS5w92CjP3nVumuUNkCFlhipukRhM8ERhE36n4=";
   };
 
-  cargoHash = "sha256-SVJ3vXa2yNhdayUsYNpXSqLrMzi4JzjKuh0VTteIOLs=";
+  cargoHash = "sha256-aJDtXsGVUxUrh3yLWEcobvFUqy/7PGFQHWIWU54zYdE=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -1,28 +1,19 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitHub,
+  fetchCrate,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "genemichaels";
   version = "0.5.13";
 
-  src = fetchFromGitHub {
-    owner = "andrewbaxter";
-    repo = "genemichaels";
-    rev = "genemichaels-v${version}";
-    hash = "sha256-pzGTKswETm7RR0up1eSWC+X633rsVmEAJ3DYM8z6paQ=";
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-ZJr5cN+Bam71fPDwhcYUVop5JW8145tzY7Sk75fjhvQ=";
   };
 
-  cargoHash = "sha256-J7uibeoIKLC3jo5TstzC8udK+miAA52321eapOHVzbM=";
-
-  cargoBuildFlags = [ "--package ${pname}" ];
-  # cargoTestFlags is not used because genemichaels is tightly coupled to the
-  # other crates in the workspace and by not setting it, we run all the tests.
-  # If a dependency crate is failing its tests, we want to know about it. For
-  # example, between versions 0.5.8 and 0.5.12, there was a failing test in one
-  # of the other workspace members that genemichaels depends on.
+  cargoHash = "sha256-SVJ3vXa2yNhdayUsYNpXSqLrMzi4JzjKuh0VTteIOLs=";
 
   meta = {
     description = "Even formats macros";

--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchCrate,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -14,6 +15,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoHash = "sha256-SVJ3vXa2yNhdayUsYNpXSqLrMzi4JzjKuh0VTteIOLs=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Even formats macros";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
