### PR TITLE
courier-unicode: 2.3.2 -> 2.4.0, maildrop: 3.1.8 -> 3.2.1

### DIFF
--- a/pkgs/by-name/co/courier-unicode/package.nix
+++ b/pkgs/by-name/co/courier-unicode/package.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "courier-unicode";
-  version = "2.3.2";
+  version = "2.4.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/courier/courier-unicode/${version}/courier-unicode-${version}.tar.bz2";
-    sha256 = "sha256-tkXS8AqrvGgjIO3mlspQIBJm9xChvOxKxQQmlcmef2k=";
+    hash = "sha256-6Ay88OOmzC56Z+waGDDWxOiqD/aXcy7B0R5UTg5kVw8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ma/maildrop/package.nix
+++ b/pkgs/by-name/ma/maildrop/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "maildrop";
-  version = "3.1.8";
+  version = "3.2.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/courier/maildrop/${version}/maildrop-${version}.tar.bz2";
-    sha256 = "sha256-foJsAxkXRE8berccH82QODWVZEhG4rOyYONSsc4D6VA=";
+    hash = "sha256-PFiQ9NQzItTmPz6Aw6YJzeYF9ylm1iNPyIZBjZSdJLk=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
https://sourceforge.net/p/courier/mailman/message/59250698/

https://www.openwall.com/lists/oss-security/2025/10/26/1

Changes for courier-unicode: 2.3.2 -> 2.4.0:
```
2.4.0

2025-08-24  Sam Varshavchik  <mrsam@courier-mta.com>

	* Updated to the Unicode 16 standard.

2025-08-10  Sam Varshavchik  <mrsam@courier-mta.com>

	* unicode.c: when a conversion error is encountered try to include
	the unconverted input in the output, as <##> sequences.

2025-08-07  Sam Varshavchik  <mrsam@courier-mta.com>

	* unicodecpp.C (unicode::iconvert::convert): Fix null ptr
	dereference.

2025-05-25  Sam Varshavchik  <mrsam@courier-mta.com>

	* Use C++17 features for templates.

2025-05-11  Sam Varshavchik  <mrsam@courier-mta.com>

	* ABI break. Update the C++ API to C++17. Several functions'
	std::u32string parameter replaced with a std::u32string_view,
	where possible. Fill in a small functional gap, implement
	unicode::totitle().
```

Changes for maildrop 3.1.8 -> 3.2.1:
```
3.2.1

2025-10-23  Sam Varshavchik  <mrsam@courier-mta.com>

	* Fix MIME parsing bugs

3.2.0

2025-09-09  Sam Varshavchik  <mrsam@courier-mta.com>

	* mailbot: reimplemented in C++ using the new C++ MIME library.
	
2025-08-31  Sam Varshavchik  <mrsam@courier-mta.com>

	* reformail: reimplemented in C++ using the new C++ MIME library.
	Compare E-mail addresses (for -r, and other options),
	case-insensitively.

2025-08-16  Sam Varshavchik  <mrsam@courier-mta.com>

	* reformime: reimplemented in C++ using the new C++ MIME library.

2025-04-27  Sam Varshavchik  <mrsam@courier-mta.com>

	* all: low level MIME parsing code reimplemented in C++, the
	C code remains in place, with some changes.

	* maildrop: update the low-level message header parsing code, used by
	getaddr() and hasaddr() functions, and the reformail tool.

2024-09-21  Sam Varshavchik  <mrsam@courier-mta.com>

	* packaging: Fix rpm packaging, use a synthesized changelog entry
	with the current date, to set the rpmbuild epoch date.

2024-09-07  Sam Varshavchik  <mrsam@courier-mta.com>

	* packaging: deb packaging fixes.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 455953`
Commit: `e62b630bcfc15e69dd57b4c227cbf93f894de20b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>courier-unicode</li>
    <li>courier-unicode.dev</li>
    <li>maildrop</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
