### PR TITLE
forge-mtg: fix audio support in forge-adventure mode

### DIFF
--- a/pkgs/by-name/fo/forge-mtg/package.nix
+++ b/pkgs/by-name/fo/forge-mtg/package.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   openjdk,
   libGL,
+  alsa-lib,
   makeDesktopItem,
   copyDesktopItems,
   imagemagick,
@@ -106,7 +107,12 @@ maven.buildMavenPackage {
       chmod 555 $out/share/forge/$commandToInstall.sh
       PREFIX_CMD=""
       if [ "$commandToInstall" = "forge-adventure" ]; then
-        PREFIX_CMD="--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGL ]}"
+        PREFIX_CMD="--prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            libGL
+            alsa-lib
+          ]
+        }"
       fi
 
       makeWrapper $out/share/forge/$commandToInstall.sh $out/bin/$commandToInstall \


### PR DESCRIPTION
The forge-adventure executable uses LWJGL3 backend which requires native audio libraries for sound playback.

This change adds `alsa-lib` to the library path for forge-adventure, enabling proper audio functionality.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
