### PR TITLE
python3Packages.grimp: init at 3.12; import-linter: init at 2.5.2; maintainers: add sloschert

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24197,6 +24197,12 @@
     githubId = 1505617;
     name = "Sean Lee";
   };
+  sloschert = {
+    email = "sebastian.loschert@gmx.de";
+    github = "sloschert";
+    githubId = 61537351;
+    name = "Sebastian Loschert";
+  };
   SlothOfAnarchy = {
     email = "slothofanarchy1@gmail.com";
     matrix = "@michel.weitbrecht:helsinki-systems.de";

--- a/pkgs/by-name/im/import-linter/package.nix
+++ b/pkgs/by-name/im/import-linter/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "import-linter";
+  version = "2.5.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "import_linter";
+    hash = "sha256-2PLcZDKXXMNe3EzAv88bgR8FUAs3fODD9icp1o9Gxpg=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    hatchling
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    click
+    grimp
+    typing-extensions
+  ];
+
+  meta = {
+    description = "Enforces rules for the imports within and between Python packages";
+    homepage = "https://github.com/seddonym/import-linter/";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ sloschert ];
+    mainProgram = "lint-imports";
+  };
+
+}

--- a/pkgs/development/python-modules/grimp/default.nix
+++ b/pkgs/development/python-modules/grimp/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  rustPlatform,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "grimp";
+  version = "3.12";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-GnM7HXGcQr0vraWCQJdfp9CZNrVxIMNLZM+zHkJwEBA=";
+  };
+
+  cargoRoot = "rust";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    sourceRoot = "grimp-${version}/${cargoRoot}";
+    hash = "sha256-85MKqQ77mjUdjDZP6pvAN7HQvzaEIukDl7Pl+YS1HSM=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  meta = {
+    description = "Builds a queryable graph of the imports within one or more Python packages";
+    homepage = "https://github.com/python-grimp/grimp";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ sloschert ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6356,6 +6356,8 @@ self: super: with self; {
 
   griffe = callPackage ../development/python-modules/griffe { };
 
+  grimp = callPackage ../development/python-modules/grimp { };
+
   grip = callPackage ../development/python-modules/grip { };
 
   groestlcoin-hash = callPackage ../development/python-modules/groestlcoin-hash { };


### PR DESCRIPTION
Added grimp: https://github.com/python-grimp/grimp
Added import-linter (depends on grimp) https://github.com/seddonym/import-linter

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
