### PR TITLE
Grayjay: 10 -> 12

### DIFF
--- a/pkgs/by-name/gr/grayjay/package.nix
+++ b/pkgs/by-name/gr/grayjay/package.nix
@@ -35,13 +35,13 @@
   _experimental-update-script-combinators,
 }:
 let
-  version = "10";
+  version = "12";
   src = fetchFromGitLab {
     domain = "gitlab.futo.org";
     owner = "videostreaming";
     repo = "Grayjay.Desktop";
     tag = version;
-    hash = "sha256-ap0NnjyBjvyFjHPu9vACQMoOXqwz90/8QqSfPFqfh5U=";
+    hash = "sha256-+Rm7dHXsna0espYe3hti2X3YO6E4aWcMY3VXljNqoXU=";
     fetchSubmodules = true;
     fetchLFS = true;
   };
@@ -52,7 +52,7 @@ let
     sourceRoot = "source/Grayjay.Desktop.Web";
 
     npmBuildScript = "build";
-    npmDepsHash = "sha256-3RMUV6o6422PEuqYg7B+y6JjlaiHDhnwsgsaKEbu5BM=";
+    npmDepsHash = "sha256-3nPzQcDWhPCdLrPvwGY+K0t1OSxWrVwQ3hH7i0eynRU=";
 
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumped Grayjay to version tag 12.

Changelogs (as taken from upstream):
- [11](https://gitlab.futo.org/videostreaming/Grayjay.Desktop/-/tags/11)
- [12](https://gitlab.futo.org/videostreaming/Grayjay.Desktop/-/tags/12)
```
Features:
 - Added native wayland support.
 - Conditional mobile emulation for auth/captcha.
 - Added new experimental casting backend.
 - New key bindings:
   o Added CTRL+Left/Right Arrow for navigating chapters. 
   o Added Shift + n/p for navigating queue.
   o Added j/l for jumping 10s instead of 5s with arrows. 
   o Added c for toggling subtitles. 
   o Added / for opening search. 
   o Added </> for changing playback speed. 
   o Added ,/. for skipping single frames when paused.
   o Space/k for pausing video (already existed).
   o f for full screen toggle (already existed).
   o Arrows up/down for controlling volume (already existed).
   o ...
 
Improvements:
 - Updated CEF to latest version.
 - Added LoginButton support for auth.
 - Improved size/speed estimation for UMP downloads.
 - Added copy settings to clipboard option on plugin.
 - Sync pairing will now always happen in parallel for direct and relayed.
 
Fixes:
 - Cancel button on sync confirm dialog now also selectable with controller.
 - Made sync confirm dialog useable with controller and changed initial and repeat delay behavior.
 - Fix for wayland fullscreen.
 - Fixed issue with plugin dialog staying open after install succeeded.
 - DevPortal fix for when there are no settings.
 - Added separate desktop auth config.
 - Fix download completion, and overflow for big files.
 - Fixed sources page toggle states.
 - Search history toggle now works.
 - Fixed issue where headless would not have key events work on login screen.
 - Gamepad polling loop now only active during focus and connected gamepad.
 - Fixed overflow for chapter overlay.
 - Fixed icons double clicking cause fullscreen on player.
 - Search bar now hides whenever scrolling down on ChannelPage and no longer wrongly overlays.
 - Added stop propagation to all dialogs that did not have it yet.
 - Fixed bug where i when comments are open would cause minimized view to be incorrect. 
 - Removed arrow keys from being able to navigate elements, instead WASD is used for this. Arrow keys now function globally to control the video player like they used to. Remapped space to uniquely work for globally controlling playback state (play/pause).
 - Fixed dialog background not closing dialog. 
 - Fixed checkbox list not changing properly when interacted with mouse. 
 - Fixed issue where arrow left/right would skip/not skip depending on editable state.
 - File picker now works with windows network paths and additional improvements.
 - Fixed issue where file dialog would not work when you have a bad hard drive connected on windows.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
