### PR TITLE
python3Packages.vegehub: 0.1.24 -> 0.1.25

### DIFF
--- a/pkgs/development/python-modules/vegehub/default.nix
+++ b/pkgs/development/python-modules/vegehub/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "vegehub";
-  version = "0.1.24";
+  version = "0.1.25";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Thulrus";
     repo = "VegeHubPyPiLib";
     tag = "V${version}";
-    hash = "sha256-W/5kvertNC7w2IS/N5k06cDyNFgel2s4/znR+Lz5RJU=";
+    hash = "sha256-jdD+vYcnrwPVJhVBVvB7ULcD1KrOudUC2K/agxHLnwY=";
   };
 
   postPatch = ''
@@ -40,6 +40,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/Thulrus/VegeHubPyPiLib/releases/tag/${src.tag}";
     description = "Basic package for simplifying interactions with the Vegetronix VegeHub";
     homepage = "https://github.com/Thulrus/VegeHubPyPiLib";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
Diff: https://github.com/Thulrus/VegeHubPyPiLib/compare/V0.1.24...V0.1.25

Changelog: https://github.com/Thulrus/VegeHubPyPiLib/releases/tag/V0.1.25


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
