### PR TITLE
rxvt-unicode: fix evaluation

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-bidi/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-bidi/default.nix
@@ -32,5 +32,8 @@ perlPackages.buildPerlPackage rec {
     homepage = "https://github.com/mkamensky/Text-Bidi";
     maintainers = with maintainers; [ doronbehar ];
     platforms = with platforms; unix;
+    # Quote from the README:
+    # same terms as the Perl 5 programming language system itself
+    license = perlPackages.perl.meta.license;
   };
 }

--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-tabbedex/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-tabbedex/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mina86/urxvt-tabbedex";
     maintainers = [ ];
     platforms = with platforms; unix;
+    license = lib.licenses.gpl3Plus;
   };
 }

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/wrapper.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/wrapper.nix
@@ -16,7 +16,9 @@
 }:
 
 let
-  availablePlugins = lib.filterAttrs (_: v: lib.isDerivation v) rxvt-unicode-plugins;
+  availablePlugins = lib.filterAttrs (
+    _: v: (lib.isDerivation v && (v.meta.license.free or false))
+  ) rxvt-unicode-plugins;
 
   # Transform the string "self" to the plugin itself.
   # It's needed for plugins like bidi who depends on the perl


### PR DESCRIPTION
After a license cleanup it became visible that one of the plugins, theme-switch, has a non-commercial (thus unfree) license.

Added missing licenses, and added a filter for skipping unfree plugins by default.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
