### PR TITLE
nixos-rebuild-ng: tolerate nixpkgs being read-only

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -372,4 +372,10 @@ def write_version_suffix(build_flags: Args) -> None:
     nixpkgs_path = nix.find_file("nixpkgs", build_flags)
     rev = nix.get_nixpkgs_rev(nixpkgs_path)
     if nixpkgs_path and rev:
-        (nixpkgs_path / ".version-suffix").write_text(rev)
+        try:
+            (nixpkgs_path / ".version-suffix").write_text(rev)
+        except OSError as error:
+            logger.debug(
+                "ignoring error while writing '.version-suffix' to nixpkgs: %s",
+                error,
+            )


### PR DESCRIPTION
Classic nixos-rebuild ignores errors when writing `.version-suffix` since commit 365307ada1b6f3fc85b131cdcaaa9fcf19864a31 .  Without this it is not possible to do `nixos-rebuild -I nixpkgs=/path/to/read-only/nixpkgs ...`.  The pull-request at hand reconstructs the classic behaviour for `nixos-rebuild-ng`.

Notifying sole "nixos-rebuild" maintainer team member @thiagokokada

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `3e329eb058d81bb84ea9170841f4baa905a7879b`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>nixos-rebuild-ng</li>
    <li>nixos-rebuild-ng.dist</li>
    <li>tests.devShellTools.nixos</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
    <li>tests.testers.nixosTest-example</li>
    <li>tests.testers.runNixOSTest-example (tests.testers.runNixOSTest-extendNixOS)</li>
    <li>tests.trivial-builders.references</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Note on tests:

* `nixos-rebuild-ng.tests.linters` fails, also on the parent commit
* `nixos-rebuild-ng.tests.nixos-rebuild-target-host-ng` hangs, also on the parent commit

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
