### PR TITLE
hyperscan: cleanup, fix CMake 4 compatibility

### DIFF
--- a/pkgs/by-name/hy/hyperscan/package.nix
+++ b/pkgs/by-name/hy/hyperscan/package.nix
@@ -80,14 +80,23 @@ stdenv.mkDerivation (finalAttrs: {
       mkdir -p pcre
       tar xvf ${pcre.src} --strip-components 1 -C pcre
     ''
-    # CMake 4 dropped support of versions lower than 3.5,
-    # versions lower than 3.10 are deprecated.
-    # https://github.com/NixOS/nixpkgs/issues/445447
+    # - CMake 4 dropped support of versions lower than 3.5, versions lower than 3.10 are deprecated.
+    #   https://github.com/NixOS/nixpkgs/issues/445447
+    # - CMake Error at pcre/CMakeLists.txt:843 (GET_TARGET_PROPERTY):
+    #   The LOCATION property may not be read from target "pcretest".  Use the
+    #   target name directly with add_custom_command, or use the generator
+    #   expression $<TARGET_FILE>, as appropriate.
     + ''
       substituteInPlace pcre/CMakeLists.txt \
         --replace-fail \
           "CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)" \
           "CMAKE_MINIMUM_REQUIRED(VERSION 3.10)" \
+        --replace-fail \
+          "CMAKE_POLICY(SET CMP0026 OLD)" \
+          "CMAKE_POLICY(SET CMP0026 NEW)" \
+        --replace-fail \
+          "GET_TARGET_PROPERTY(PCRETEST_EXE pcretest DEBUG_LOCATION)" \
+          "set(PCRETEST_EXE $<TARGET_FILE:pcretest>)"
     ''
   );
 

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  nativeBuildInputs = [
+  build-system = [
     cmake
     pathspec
     ninja
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  meta = with lib; {
+  meta = {
     description = "CPython extension for the Hyperscan regular expression matching library";
     homepage = "https://github.com/darvid/python-hyperscan";
     changelog = "https://github.com/darvid/python-hyperscan/blob/${src.tag}/CHANGELOG.md";
@@ -61,7 +61,7 @@ buildPythonPackage rec {
       "x86_64-linux"
       "x86_64-darwin"
     ];
-    license = licenses.mit;
-    maintainers = with maintainers; [ mbalatsko ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mbalatsko ];
   };
 }


### PR DESCRIPTION
## Things done

- **hyperscan: cleanup**
- **hyperscan: fix CMake 4 compatibility**
- **python3Packages.hyperscan: cleanup**
- **hyperscan: fix build with withStatic enabled**

cc @avnik

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
