### PR TITLE
antlr4, python3Packages.antlr4-python3-runtime: add sarahec as maintainer, fixes

### DIFF
--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -10,13 +10,11 @@ buildPythonPackage rec {
   pname = "antlr4-python3-runtime";
   inherit (antlr4.runtime.cpp) version src;
 
-  format = "pyproject";
-
-  disabled = python.pythonOlder "3.6";
+  pyproject = true;
 
   sourceRoot = "${src.name}/runtime/Python3";
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
   postPatch = ''
     substituteInPlace tests/TestIntervalSet.py \
@@ -36,11 +34,11 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Runtime for ANTLR";
     mainProgram = "pygrun";
     homepage = "https://www.antlr.org/";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ sarahec ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 }

--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -41,5 +41,6 @@ buildPythonPackage rec {
     mainProgram = "pygrun";
     homepage = "https://www.antlr.org/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ sarahec ];
   };
 }

--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -86,6 +86,7 @@ let
           sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
           license = lib.licenses.bsd3;
           platforms = lib.platforms.unix;
+          maintainers = with lib.maintainers; [ sarahec ];
         };
       };
 
@@ -119,6 +120,7 @@ let
             homepage = "https://www.antlr.org/";
             license = lib.licenses.bsd3;
             platforms = lib.platforms.unix;
+            maintainers = with lib.maintainers; [ sarahec ];
           };
         };
       };


### PR DESCRIPTION
1. Added myself as maintainer for the compiler, c++ runtime, and python runtime.
2. Cleaned up the python derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
