### PR TITLE
yabause: fix build with cmake4

### DIFF
--- a/pkgs/applications/emulators/yabause/default.nix
+++ b/pkgs/applications/emulators/yabause/default.nix
@@ -18,7 +18,7 @@ mkDerivation rec {
   version = "0.9.15";
 
   src = fetchurl {
-    url = "https://download.tuxfamily.org/yabause/releases/${version}/${pname}-${version}.tar.gz";
+    url = "https://web.archive.org/web/20250129091147/http://free.downloads.tuxfamily.net/yabause/releases/${version}/yabause-${version}.tar.gz";
     sha256 = "1cn2rjjb7d9pkr4g5bqz55vd4pzyb7hg94cfmixjkzzkw0zw8d23";
   };
 
@@ -47,7 +47,15 @@ mkDerivation rec {
     "-DYAB_NETWORK=ON"
     "-DYAB_OPTIMIZED_DMA=ON"
     "-DYAB_PORTS=qt"
+    "-DSH2_DYNAREC=OFF" # https://github.com/Yabause/yabause/issues/270
   ];
+
+  postPatch = ''
+    substituteInPlace {./,src/,src/runner/}CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
+    substituteInPlace src/{c68k,musashi}/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required(VERSION 3.10)"
+  '';
 
   meta = with lib; {
     description = "Open-source Sega Saturn emulator";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

Closes #455930
Updated src url that was outdated, using web archive mirror for reliability.
Fixed cmake4 minimum version and added a flag needed to build due to https://github.com/Yabause/yabause/issues/270

Yabause have some weird graphical issues with Wayland, works fine on X11

<img width="1313" height="1008" alt="Screenshot_20251026_175917" src="https://github.com/user-attachments/assets/920e1d29-1ab0-4366-8362-8871bc5f4375" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
