### PR TITLE
home-assistant-custom-components.local_luftdaten: drop async-timeout dependency

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/local_luftdaten/async-timeout.patch
+++ b/pkgs/servers/home-assistant/custom-components/local_luftdaten/async-timeout.patch
@@ -1,0 +1,31 @@
+From 06a6b3ff1ae181f9972b47838569d658ba4b3d9c Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Sat, 4 Oct 2025 14:45:02 +0200
+Subject: [PATCH] Use the python native asyncio timeout function
+
+instead of depending on the undeclared async-timeout package.
+---
+ custom_components/local_luftdaten/sensor.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/custom_components/local_luftdaten/sensor.py b/custom_components/local_luftdaten/sensor.py
+index 4f4f5b4..82ea041 100644
+--- a/custom_components/local_luftdaten/sensor.py
++++ b/custom_components/local_luftdaten/sensor.py
+@@ -12,7 +12,6 @@
+ import asyncio
+ from typing import Optional
+ import aiohttp
+-import async_timeout
+ import datetime
+ 
+ import json
+@@ -170,7 +169,7 @@ async def async_update(self):
+             responseData = None
+             try:
+                 _LOGGER.debug("Get data from %s", str(self._resource))
+-                with async_timeout.timeout(30):
++                async with asyncio.timeout(30):
+                     response = await self._session.get(self._resource)
+                 responseData = await response.text()
+                 _LOGGER.debug("Received data: %s", str(self.data))

--- a/pkgs/servers/home-assistant/custom-components/local_luftdaten/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/local_luftdaten/package.nix
@@ -16,6 +16,10 @@ buildHomeAssistantComponent rec {
     hash = "sha256-68clZgS7Qo62srcZWD3Un9BnNSwQUBr4Z5oBMTC9m8o=";
   };
 
+  # https://github.com/lichtteil/local_luftdaten/pull/70
+  # Replace undeclared async-timeout dependency with native asyncio.timeout
+  patches = [ ./async-timeout.patch ];
+
   meta = with lib; {
     changelog = "https://github.com/lichtteil/local_luftdaten/releases/tag/${version}";
     description = "Custom component for Home Assistant that integrates your (own) local Luftdaten sensor (air quality/particle sensor) without using the cloud";


### PR DESCRIPTION
The dependency was undeclared and can simply be replaced with stdlib functionality.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
