### PR TITLE
uhhyou-plugins-juce: init at 0.1.0

### DIFF
--- a/pkgs/by-name/uh/uhhyou-plugins-juce/package.nix
+++ b/pkgs/by-name/uh/uhhyou-plugins-juce/package.nix
@@ -1,0 +1,63 @@
+{
+  alsa-lib,
+  cmake,
+  curl,
+  fetchFromGitHub,
+  freetype,
+  lib,
+  libGL,
+  libXcursor,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libjack2,
+  pkg-config,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "uhhyou-plugins-juce";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    owner = "ryukau";
+    repo = "UhhyouPluginsJuce";
+    tag = "UhhyouPluginsJuce${finalAttrs.version}";
+    hash = "sha256-oHxyOTiqEwdNUKGQNjjfdRkzMa+4TYX6Vf6ZS9BTcC0=";
+    fetchSubmodules = true;
+  };
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+  buildInputs = [
+    alsa-lib
+    curl
+    freetype
+    libGL
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    libjack2
+  ];
+
+  # Disable LTO to avoid optimization mismatch issues
+  NIX_CFLAGS_COMPILE = [
+    "-fno-lto"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3
+    cp -r *_artefacts/Release/VST3/*.vst3 $out/lib/vst3/
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/ryukau/UhhyouPluginsJuce";
+    description = "A collection of VST3 effect plugins";
+    license = [ lib.licenses.agpl3Only ];
+    maintainers = with lib.maintainers; [ magnetophon ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A collection of Juce based VST3 audio plugins:
https://github.com/ryukau/UhhyouPluginsJuce

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
