### PR TITLE
cfn-changeset-viewer: 0.2.1 -> 0.3.6

### DIFF
--- a/pkgs/by-name/cf/cfn-changeset-viewer/package.nix
+++ b/pkgs/by-name/cf/cfn-changeset-viewer/package.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage rec {
   pname = "cfn-changeset-viewer";
-  version = "0.2.1";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "trek10inc";
     repo = "cfn-changeset-viewer";
     tag = version;
-    hash = "sha256-PPMmU5GMxxzBiTNAv/Rbtvkl5QK1BZjW4TJLT7xlpw4=";
+    hash = "sha256-hz1woGmJYOVGuu52DPPwkfbA49F/0hsxoAU6tiTvJx0=";
   };
 
-  npmDepsHash = "sha256-ICaGtofENMaAjk/KGRn8RgpMAICSttx4AIcbi1HsW8Q=";
+  npmDepsHash = "sha256-NyWZ+8ArlUCsuBN5wZA9vnuX/3HFtuI42/V1+RIKom0=";
 
   dontNpmBuild = true;
 

--- a/pkgs/by-name/cf/cfn-changeset-viewer/package.nix
+++ b/pkgs/by-name/cf/cfn-changeset-viewer/package.nix
@@ -1,8 +1,8 @@
 {
   buildNpmPackage,
   fetchFromGitHub,
-  gitUpdater,
   lib,
+  nix-update-script,
   versionCheckHook,
 }:
 
@@ -27,7 +27,7 @@ buildNpmPackage rec {
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "CLI to view the changes calculated in a CloudFormation ChangeSet in a more human-friendly way";


### PR DESCRIPTION
Also changed updateScript to nix-update-script. For some reason back then I thought that it would update npmDepsHash.

Tested on actual changesets and it works fine

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
