### PR TITLE
kmymoney: fix build for Qt 6.10

### DIFF
--- a/pkgs/by-name/km/kmymoney/kmymoney-fix-build-against-qt-6-10.patch
+++ b/pkgs/by-name/km/kmymoney/kmymoney-fix-build-against-qt-6-10.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 32e2840..f21e7ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,7 +183,7 @@ if (PkgConfig_FOUND)
+ endif()
+ 
+ find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} REQUIRED COMPONENTS Core DBus Widgets Svg Xml Test PrintSupport)
+-find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} OPTIONAL_COMPONENTS Sql Concurrent QuickWidgets)
++find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} OPTIONAL_COMPONENTS Sql SqlPrivate Concurrent QuickWidgets)
+ 
+ find_package(KF${QT_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS Archive CoreAddons Config ConfigWidgets Crash I18n Completion KCMUtils ItemModels ItemViews Service XmlGui TextWidgets Notifications KIO)
+ 
+diff --git a/kmymoney/plugins/sqlcipher/CMakeLists.txt b/kmymoney/plugins/sqlcipher/CMakeLists.txt
+index ee6f2e7..aa3fc19 100644
+--- a/kmymoney/plugins/sqlcipher/CMakeLists.txt
++++ b/kmymoney/plugins/sqlcipher/CMakeLists.txt
+@@ -32,10 +32,8 @@ target_link_libraries(qsqlcipher
+   PRIVATE
+     PkgConfig::SQLCIPHER
+ )
+-if (TARGET Qt::SqlPrivate)
+-  target_link_libraries(qsqlcipher PRIVATE Qt::SqlPrivate)
+-endif()
+-target_link_libraries(qsqlcipher PRIVATE Qt::Sql)
++
++target_link_libraries(qsqlcipher PRIVATE Qt::Sql Qt::SqlPrivate)
+ 
+ if(BUILD_TESTING)
+  add_subdirectory(tests)

--- a/pkgs/by-name/km/kmymoney/package.nix
+++ b/pkgs/by-name/km/kmymoney/package.nix
@@ -77,6 +77,11 @@ stdenv.mkDerivation (finalAttrs: {
     python3.pkgs.woob
   ];
 
+  patches = [
+    # from https://src.fedoraproject.org/rpms/kmymoney/c/8f7f40d7fec6db96610e60a6a99717479594c8bd
+    ./kmymoney-fix-build-against-qt-6-10.patch
+  ];
+
   postPatch = ''
     buildPythonPath "${python3.pkgs.woob}"
     patchPythonScript "kmymoney/plugins/woob/interface/kmymoneywoob.py"


### PR DESCRIPTION
Fix KMyMoney build for (I presume from the patch name) Qt 6.10 by adding patch `kmymoney-fix-build-against-qt-6-10.patch` from <https://src.fedoraproject.org/rpms/kmymoney/blob/rawhide/f/kmymoney-fix-build-against-qt-6-10.patch>. (See https://github.com/NixOS/nixpkgs/issues/455948#issuecomment-3448763451.)

Resolves #455948


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
