### PR TITLE
onscripter-en: reinit at 2025-06-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8812,6 +8812,12 @@
     githubId = 13279982;
     name = "freezeboy";
   };
+  Freikugel = {
+    name = "Freikugel";
+    github = "bingbongboink";
+    githubId = 87834830;
+    email = "lmsmallidge@hotmail.com";
+  };
   frenetic00 = {
     github = "frenetic00";
     githubId = 50942055;

--- a/pkgs/by-name/on/onscripter-en/package.nix
+++ b/pkgs/by-name/on/onscripter-en/package.nix
@@ -1,0 +1,61 @@
+{
+  SDL,
+  SDL_image,
+  SDL_mixer,
+  SDL_ttf,
+  fetchFromGitHub,
+  freetype,
+  lib,
+  libjpeg,
+  libogg,
+  libpng,
+  libvorbis,
+  pkg-config,
+  smpeg,
+  stdenv,
+  libx11,
+}:
+
+stdenv.mkDerivation {
+  pname = "onscripter-en";
+  version = "2025-06-08";
+
+  src = fetchFromGitHub {
+    owner = "Galladite27";
+    repo = "ONScripter-EN";
+    tag = "2025-06-08";
+    hash = "sha256-yP4ZzNvh2jUZ5NAWYFhgxxfZ+3SOMj2x/rQjw66yr8s=";
+  };
+
+  nativeBuildInputs = [
+    SDL
+    pkg-config
+    smpeg
+  ];
+
+  buildInputs = [
+    SDL
+    SDL_image
+    SDL_mixer
+    SDL_ttf
+    freetype
+    libjpeg
+    libpng
+    libogg
+    libvorbis
+    libx11
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://github.com/Galladite27/ONScripter-EN";
+    description = "Visual novel scripting engine, with support for English and Japanese.";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "onscripter-en";
+    maintainers = with lib.maintainers; [
+      Freikugel
+    ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1115,7 +1115,6 @@ mapAliases {
   onevpl-intel-gpu = throw "'onevpl-intel-gpu' has been renamed to/replaced by 'vpl-gpu-rt'"; # Converted to throw 2025-10-27
   onlyoffice-bin = throw "'onlyoffice-bin' has been renamed to/replaced by 'onlyoffice-desktopeditors'"; # Converted to throw 2025-10-27
   onlyoffice-bin_latest = throw "'onlyoffice-bin_latest' has been renamed to/replaced by 'onlyoffice-bin'"; # Converted to throw 2025-10-27
-  onscripter-en = throw "onscripter-en has been removed due to lack of maintenance in both upstream and Nixpkgs; onscripter is available instead"; # Added 2025-10-17
   onthespot = throw "onethespot has been removed due to lack of upstream maintenance"; # Added 2025-09-26
   opae = throw "opae has been removed because it has been marked as broken since June 2023."; # Added 2025-10-11
   open-timeline-io = lib.warnOnInstantiate "'open-timeline-io' has been renamed to 'opentimelineio'" opentimelineio; # Added 2025-08-10


### PR DESCRIPTION
## Description of changes
Re-adds [ONScripter-EN](https://github.com/Galladite27/ONScripter-en) which is now being actively maintained by Galladite27.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
