### PR TITLE
kanban: init at 0.1.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9133,6 +9133,13 @@
     githubId = 23723926;
     name = "Dash R";
   };
+  fulsomenko = {
+    email = "max.blomstervall@gmail.com";
+    github = "fulsomenko";
+    githubId = 14945057;
+    name = "Max Emil Yoon Blomstervall";
+    keys = [ { fingerprint = "D14A 78F2 AAC5 9A1B 3E1F  0547 044B 046E 5745 CC2B"; } ];
+  };
   funkeleinhorn = {
     email = "git@funkeleinhorn.com";
     github = "funkeleinhorn";

--- a/pkgs/by-name/ka/kanban/package.nix
+++ b/pkgs/by-name/ka/kanban/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kanban";
+  version = "0.1.16";
+
+  src = fetchFromGitHub {
+    owner = "fulsomenko";
+    repo = "kanban";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WksL0AhooBTV+W1knU+tns/qvHDd0z6mE2HkC57BAcU=";
+  };
+
+  GIT_COMMIT_HASH = finalAttrs.src.rev;
+
+  cargoHash = "sha256-Q/o5MHjVRrJpfhkzNNJ6j4oASV5wDg/0Zi43zPlp5p8=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-based project management solution";
+    longDescription = ''
+      A terminal-based kanban/project management tool inspired by lazygit,
+      built with Rust. Features include file persistence, keyboard-driven
+      navigation, multi-select capabilities, and sprint management.
+    '';
+    homepage = "https://github.com/fulsomenko/kanban";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fulsomenko ];
+    mainProgram = "kanban";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Terminal-based kanban/project management tool with vim-like navigation, built in Rust.

**Features:**
- Keyboard-driven TUI inspired by lazygit
- JSON-based persistence with auto-save
- Sprint management and task tracking
- Multi-select operations and filtering

**Links:**
- Repository: https://github.com/fulsomenko/kanban
- Homepage: https://github.com/fulsomenko/kanban

**Testing:**
- Built successfully on x86_64-darwin
- Tested basic functionality (board creation, task management, import/export)

**Maintainer:**
Added myself (fulsomenko) as maintainer.