### PR TITLE
dockerTools.pullImage: add `ociArchive` parameter

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -864,6 +864,7 @@ See [](#ex-dockerTools-pullImage-nixprefetchdocker) for a tool that can help gat
 
 : Specifies the tag that will be used for the image after it has been downloaded.
   This only applies after the image is downloaded, and is not used to identify the image to be downloaded in the registry.
+  Has no effect if `ociArchive` is `true`.
 
   _Default value:_ `"latest"`.
 
@@ -882,6 +883,13 @@ See [](#ex-dockerTools-pullImage-nixprefetchdocker) for a tool that can help gat
   According to the linked specification, all possible values for `$GOARCH` in [the Go docs](https://go.dev/doc/install/source#environment) should be valid, but will commonly be one of `386`, `amd64`, `arm`, or `arm64`.
 
   _Default value:_ the same value from `pkgs.go.GOARCH`.
+
+`ociArchive` (Boolean; _optional_)
+
+: Used to save the image as an [OCI-compatible archive](https://github.com/containers/image/blob/main/docs/containers-transports.5.md#oci-archivepathreference) rather than a docker-save(1) formatted file.
+  This is useful for preserving the specified `imageDigest`, since docker-save(1) files do not store digest information.
+
+  _Default value:_ `false`.
 
 `tlsVerify` (Boolean; _optional_)
 

--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -24,6 +24,7 @@ Options:
       --image-digest digest     Image digest
       --final-image-name name   Desired name of the image
       --final-image-tag tag     Desired image tag
+      --oci-archive             Save the image as an OCI-compatible archive
       --json                    Output result in json format instead of nix
       --quiet                   Only print the final result
 "
@@ -60,6 +61,7 @@ for arg; do
             --image-digest) argfun=set_imageDigest;;
             --final-image-name) argfun=set_finalImageName;;
             --final-image-tag) argfun=set_finalImageTag;;
+            --oci-archive) ociArchive=true;;
             --quiet) QUIET=true;;
             --json) format=json;;
             --help) usage; exit;;
@@ -128,10 +130,27 @@ trap "rm -rf \"$tmpPath\"" EXIT
 
 tmpFile="$tmpPath/$(get_name $finalImageName $finalImageTag)"
 
-if test -z "$QUIET"; then
-    skopeo --insecure-policy --tmpdir=$TMPDIR --override-os ${os} --override-arch ${arch} copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" >&2
+if test -z "$ociArchive"; then
+    preserveDigests=false
+    destUrl="docker-archive://$tmpFile:$finalImageName:$finalImageTag"
 else
-    skopeo --insecure-policy --tmpdir=$TMPDIR --override-os ${os} --override-arch ${arch} copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" > /dev/null
+    preserveDigests=true
+    destUrl="oci-archive://$tmpFile:$finalImageName@$imageDigest"
+fi
+
+if test -z "$QUIET"; then
+    skopeo --insecure-policy --tmpdir=$TMPDIR --override-os ${os} --override-arch ${arch} copy --preserve-digests=${preserveDigests} "$sourceUrl" "$destUrl" >&2
+else
+    skopeo --insecure-policy --tmpdir=$TMPDIR --override-os ${os} --override-arch ${arch} copy --preserve-digests=${preserveDigests} "$sourceUrl" "$destUrl" > /dev/null
+fi
+
+if test -z "$ociArchive"; then
+    ociArchive=false
+else
+    # Ensure fetched archive is reproducible
+    mkdir "$tmpPath/image"
+    tar -C "$tmpPath/image" -xf $tmpFile
+    tar -C "$tmpPath/image" -cf $tmpFile --sort=name --mtime='1970-01-01 UTC' --numeric-owner --owner=0 --group=0 --format=gnu .
 fi
 
 # Compute the hash.
@@ -157,6 +176,7 @@ cat <<EOF
   hash = "$imageHash";
   finalImageName = "$finalImageName";
   finalImageTag = "$finalImageTag";
+  ociArchive = $ociArchive;
 }
 EOF
 
@@ -168,7 +188,8 @@ cat <<EOF
   "imageDigest": "$imageDigest",
   "hash": "$imageHash",
   "finalImageName": "$finalImageName",
-  "finalImageTag": "$finalImageTag"
+  "finalImageTag": "$finalImageTag",
+  "ociArchive": $ociArchive
 }
 EOF
 


### PR DESCRIPTION
Resolves #451984.

Adds the ability to fetch images as `oci-archive` tarballs, which makes it possible to preserve the digest specified in `imageDigest` (e.g. for importing into containerd, see the linked issue). The option is disabled by default, so it shouldn't cause any breakage.

I've also updated the docs & `nix-prefetch-docker`, let me know if there's anything else I missed.

cc @NixOS/nix-team @offlinehacker (hopefully I pinged the right people, if not - sorry and please feel free to ignore this)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc