### PR TITLE
home-assistant-custom-components.elegoo_printer: init at 2.3.5

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/elegoo_printer/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/elegoo_printer/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+
+  # dependencies
+  colorlog,
+  loguru,
+  websocket-client,
+  websockets,
+
+  # tests
+  pytestCheckHook,
+  aiohttp,
+  home-assistant,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "danielcherubini";
+  domain = "elegoo_printer";
+  version = "2.3.5";
+
+  src = fetchFromGitHub {
+    owner = "danielcherubini";
+    repo = "elegoo-homeassistant";
+    tag = "v${version}";
+    hash = "sha256-Ekt19lfn0DdedMFhJDDUkqsv7vjS96+lAhWveag6EeE=";
+  };
+
+  dependencies = [
+    colorlog
+    loguru
+    websocket-client
+    websockets
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    aiohttp
+    home-assistant
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/danielcherubini/elegoo-homeassistant/releases/tag/v${version}";
+    description = "Home Assistant integration for Elegoo 3D printers using the SDCP protocol";
+    homepage = "https://github.com/danielcherubini/elegoo-homeassistant";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      typedrat
+    ];
+  };
+}


### PR DESCRIPTION
[elegoo-homeassistant](https://github.com/danielcherubini/elegoo-homeassistant) is a Home Assistant integration for Elegoo 3D printers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
