### PR TITLE
nixos/facter: fix conflict with `readOnlyPkgs`

### DIFF
--- a/nixos/modules/hardware/facter/system.nix
+++ b/nixos/modules/hardware/facter/system.nix
@@ -5,11 +5,11 @@
   ...
 }:
 {
-  # Skip setting hostPlatform in test VMs where it's read-only
-  # Tests have virtualisation.test options and import read-only.nix
-  config.nixpkgs = lib.optionalAttrs (!(options ? virtualisation.test)) {
-    hostPlatform = lib.mkIf (
-      config.hardware.facter.report.system or null != null && !options.nixpkgs.pkgs.isDefined
-    ) (lib.mkDefault config.hardware.facter.report.system);
-  };
+  # Skip setting hostPlatform if it's read-only
+  nixpkgs =
+    lib.optionalAttrs
+      (config.hardware.facter.report.system or null != null && !options.nixpkgs.hostPlatform.readOnly)
+      {
+        hostPlatform = lib.mkDefault config.hardware.facter.report.system;
+      };
 }


### PR DESCRIPTION
Fixes #454884 

`nixos/modules/hardware/facter/system.nix` was declaring `nixpkgs.hostPlatform`, even when a `mkIf` check evaluated to false, which obviously conflicts with `readOnlyPkgs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
