### PR TITLE
nixos/boot: fix some accidental expansion

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -83,7 +83,7 @@ let
     fi
   '';
 
-  # 'emergency.serivce' and 'rescue.service' have
+  # 'emergency.service' and 'rescue.service' have
   # 'ExecStartPre=-plymouth quit --wait', but 'plymouth' is not on
   # their 'ExecSearchPath'. We could set 'ExecSearchPath', but it
   # overrides 'DefaultEnvironment=PATH=...', which is trouble for the
@@ -371,7 +371,7 @@ in
 
         # Setup font
         mkdir -p $out/share/fonts
-        cp ${cfg.font} $out/share/fonts
+        cp ${escapeShellArg cfg.font} $out/share/fonts
         mkdir -p $out/etc/fonts
         cat > $out/etc/fonts/fonts.conf <<EOF
         <?xml version="1.0"?>

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -106,13 +106,13 @@ let
         ln -s $out/bin $out/sbin
 
         copy_bin_and_libs () {
-          [ -f "$out/bin/$(basename $1)" ] && rm "$out/bin/$(basename $1)"
-          cp -pdv $1 $out/bin
+          [ -f "$out/bin/$(basename "$1")" ] && rm "$out/bin/$(basename "$1")"
+          cp -pdv "$1" $out/bin
         }
 
         # Copy BusyBox.
         for BIN in ${pkgs.busybox}/{s,}bin/*; do
-          copy_bin_and_libs $BIN
+          copy_bin_and_libs "$BIN"
         done
 
         # Copy some util-linux stuff.
@@ -128,7 +128,7 @@ let
         cp ${lib.getLib udev.kmod}/lib/libkmod.so* $out/lib
         copy_bin_and_libs ${udev}/lib/systemd/systemd-sysctl
         for BIN in ${udev}/lib/udev/*_id; do
-          copy_bin_and_libs $BIN
+          copy_bin_and_libs "$BIN"
         done
         # systemd-udevd is only a symlink to udevadm these days
         ln -sf udevadm $out/bin/systemd-udevd
@@ -156,7 +156,7 @@ let
                 source' = if source == null then dest else source;
               in
               ''
-                mkdir -p $(dirname "$out/secrets/${dest}")
+                mkdir -p "$(dirname "$out/secrets/${dest}")"
                 # Some programs (e.g. ssh) doesn't like secrets to be
                 # symlinks, so we use `cp -L` here to match the
                 # behaviour when secrets are natively supported.


### PR DESCRIPTION
Paths may contain characters that are interpreted specially by bash. In specific, the font Atkinson Hyperlegible Next has [wght] in its ttf font name. Repro config using plymouth:

```nix
boot.plymouth = {
  font = "${pkgs.atkinson-hyperlegible-next}/share/fonts/variable/AtkinsonHyperlegibleNext[wght].ttf";
  enable = true;
};
```

[wght] expanded to nothing (since no replacement of the individual characters would result in the path existing), hence the cp failed since it had nothing to copy.

Fix by adding Just More Shell Escaping And Quoting(tm).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
