### PR TITLE
typora: 1.11.5 -> 1.12.2; modernize

### DIFF
--- a/pkgs/by-name/ty/typora/package.nix
+++ b/pkgs/by-name/ty/typora/package.nix
@@ -22,14 +22,27 @@
 
 let
   pname = "typora";
-  version = "1.11.5";
-  src = fetchurl {
-    urls = [
-      "https://download.typora.io/linux/typora_${version}_amd64.deb"
-      "https://downloads.typoraio.cn/linux/typora_${version}_amd64.deb"
-    ];
-    hash = "sha256-CpUF8pRLzR3RzFD85Cobbmo3BInaeCee0NWKsmelPGs=";
-  };
+  version = "1.12.2";
+
+  src =
+    fetchurl
+      {
+        x86_64-linux = {
+          urls = [
+            "https://download.typora.io/linux/typora_${version}_amd64.deb"
+            "https://downloads.typoraio.cn/linux/typora_${version}_amd64.deb"
+          ];
+          hash = "sha256-g5GB4hc1cphnOXcVV+YR+YULJOzWAslio3yXjW9MGOk=";
+        };
+        aarch64-linux = {
+          urls = [
+            "https://download.typora.io/linux/typora_${version}_arm64.deb"
+            "https://downloads.typoraio.cn/linux/typora_${version}_arm64.deb"
+          ];
+          hash = "sha256-br9kn3P4Pzbef6u581YcX8c0uiB/c1pKqGogLX3sruw=";
+        };
+      }
+      .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
 
   typoraBase = stdenv.mkDerivation {
     inherit pname version src;
@@ -116,7 +129,7 @@ let
 
 in
 stdenv.mkDerivation {
-  inherit pname version;
+  inherit pname version src;
 
   dontUnpack = true;
   dontConfigure = true;
@@ -132,11 +145,17 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "A minimal Markdown editor and reader.";
     homepage = "https://typora.io/";
+    changelog = "https://typora.io/releases/all";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ npulidomateo ];
+    maintainers = with lib.maintainers; [
+      npulidomateo
+      chillcicada
+    ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "typora";
   };

--- a/pkgs/by-name/ty/typora/update.sh
+++ b/pkgs/by-name/ty/typora/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -euo pipefail
+
+version=$(curl -s "https://typora.io/#linux" | sed -E -n 's/.*typora_([0-9.]+)_amd64.*/\1/p')
+
+amd64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/linux/typora_${version}_amd64.deb))
+update-source-version typora $version $amd64_hash --system=x86_64-linux --ignore-same-version
+
+arm64_hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url https://download.typora.io/linux/typora_${version}_arm64.deb))
+update-source-version typora $version $arm64_hash --system=aarch64-linux --ignore-same-version


### PR DESCRIPTION
update [typora](https://typora.io) from 1.11.5 to 1.12.2, add update script.

can anyone test on aarch64-linux

close #441310

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
