### PR TITLE
tracy: 0.11.1 -> 0.12.2

### DIFF
--- a/pkgs/by-name/tr/tracy/package.nix
+++ b/pkgs/by-name/tr/tracy/package.nix
@@ -28,13 +28,13 @@ assert withGtkFileSelector -> stdenv.hostPlatform.isLinux;
 
 stdenv.mkDerivation rec {
   pname = if withWayland then "tracy-wayland" else "tracy-glfw";
-  version = "0.11.1";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "wolfpld";
     repo = "tracy";
     rev = "v${version}";
-    hash = "sha256-HofqYJT1srDJ6Y1f18h7xtAbI/Gvvz0t9f0wBNnOZK8=";
+    hash = "sha256-CWF3Zbpf8aptoSjZujxggWbF7wWsKOK7d/eRJp1ESVI=";
   };
 
   patches = lib.optional (


### PR DESCRIPTION
##### Description of changes

Update tracy profiler from 0.11.1 to 0.12.2.

##### Upstream changes

- Release notes: https://github.com/wolfpld/tracy/releases/tag/v0.12.2
- v0.12.0 adds flame graphs, Metal/CUDA GPU profiling, thread wakeup visualization
- v0.12.1 fixes macOS window sizing, CMake include paths
- v0.12.2 fixes git checkout builds, Wayland include paths

##### Things done

- [ ] Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux  
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested basic functionality
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

---

##### Notes

- No dependency changes required
- Existing patches still apply
- Same build configuration as 0.11.1
- Homebrew update blocked by zstd FetchContent issue; Nix unaffected

---

##### Maintainer ping

cc @mpickering @nagisa