### PR TITLE
blueboy: init at 0.1.0, maintainers: add chetanjangir0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4545,6 +4545,12 @@
     githubId = 18648043;
     name = "Daniel Cartwright";
   };
+  chetanjangir0 = {
+    email = "chetanrjj2002@gmail.com";
+    github = "chetanjangir0";
+    githubId = 69336404;
+    name = "Chetan Jangir";
+  };
   chewblacka = {
     github = "chewblacka";
     githubId = 18430320;

--- a/pkgs/by-name/bl/blueboy/package.nix
+++ b/pkgs/by-name/bl/blueboy/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  networkmanager,
+}:
+
+buildGoModule rec {
+  pname = "blueboy";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "chetanjangir0";
+    repo = "blueboy";
+    rev = "v${version}";
+    sha256 = "sha256-f9aj0MRdsQPEMhvTwtDyxBEqB1yKJNuP0Yug51ybDhU=";
+  };
+
+  vendorHash = "sha256-4rK69s1uTFBV20endymLw6JEUfrh51bznZEgbujUQls=";
+
+  buildInputs = [ networkmanager ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${version}"
+  ];
+
+  meta = with lib; {
+    description = "A simple TUI network manager";
+    homepage = "https://github.com/chetanjangir0/blueboy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chetanjangir0 ];
+    mainProgram = "blueboy";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
### Summary

This PR adds **Blueboy**, a simple TUI network manager written in Go.  
It provides an interactive interface for managing NetworkManager connections directly from the terminal.

**Repository:** https://github.com/chetanjangir0/blueboy
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
