### PR TITLE
eartag: 0.6.5 -> 1.0.2

### DIFF
--- a/pkgs/by-name/ea/eartag/package.nix
+++ b/pkgs/by-name/ea/eartag/package.nix
@@ -22,7 +22,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "eartag";
-  version = "0.6.5";
+  version = "1.0.2";
   format = "other";
 
   src = fetchFromGitLab {
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec {
     owner = "World";
     repo = "eartag";
     rev = version;
-    hash = "sha256-sxVivQppX8KdkvHaW6xQ64Wi8Nfv5Rmwf4NADBDpOOo=";
+    hash = "sha256-Iwfk0SqxYF2bzkKZNqGonJh8MQ2c+K1wN0o4GECR/Rw=";
   };
 
   postPatch = ''
@@ -61,6 +61,8 @@ python3Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3Packages; [
+    aiofiles
+    aiohttp
     pygobject3
     eyed3
     pillow
@@ -68,6 +70,7 @@ python3Packages.buildPythonApplication rec {
     pytaglib
     python-magic
     pyacoustid
+    xxhash
   ];
 
   dontWrapGApps = true;
@@ -82,6 +85,7 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/World/eartag";
     description = "Simple music tag editor";
+    changelog = "https://gitlab.gnome.org/World/eartag/-/releases/${version}";
     # This seems to be using ICU license but we're flagging it to MIT license
     # since ICU license is a modified version of MIT and to prevent it from
     # being incorrectly identified as unfree software.


### PR DESCRIPTION
Changelog: https://gitlab.gnome.org/World/eartag/-/releases/1.0.2
Diff: https://gitlab.gnome.org/World/eartag/-/compare/0.6.5..1.0.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
