### PR TITLE
superlu_dist: 9.1.0 -> 9.2.0

### DIFF
--- a/pkgs/by-name/pa/parmetis/package.nix
+++ b/pkgs/by-name/pa/parmetis/package.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation {
     hash = "sha256-L9SLyr7XuBUniMH3JtaBrUHIGzVTF5pr014xovQf2cI=";
   };
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
+  '';
+
   nativeBuildInputs = [ cmake ];
   enableParallelBuilding = true;
   buildInputs = [

--- a/pkgs/by-name/su/superlu_dist/mc64ad_dist-stub.patch
+++ b/pkgs/by-name/su/superlu_dist/mc64ad_dist-stub.patch
@@ -13,19 +13,30 @@ mc64ad_dist.c was removed (DFSG nonfree), create stubs
 +
 +/* only mc64id_dist and mc64ad_dist are referenced by SuperLU-Dist code */
 +
-+/* Subroutine */ int_t mc64id_dist(int_t *icntl)
++/* Subroutine */ int mc64id_dist(int *icntl)
 +{
 +    fprintf(stderr, "SuperLU-Dist: MC64 functionality not available.\n(It uses code under a non-free HSL licence which does not permit redistribution).\nAborting mc64id_dist.\n");
 +    abort();
 +    return 0;
 +}
 +
-+int_t mc64ad_dist(int_t *job, int_t *n, int_t *ne, int_t *
-+	ip, int_t *irn, double *a, int_t *num, int_t *cperm,
-+	int_t *liw, int_t *iw, int_t *ldw, double *dw, int_t *
-+	icntl, int_t *info)
++int mc64ad_dist(int *job, int *n, int_t *ne, int_t *
++	ip, int_t *irn, double *a, int *num, int_t *cperm,
++	int_t *liw, int_t *iw, int_t *ldw, double *dw, int *
++	icntl, int *info)
 +{
 +    fprintf(stderr, "SuperLU-Dist: MC64 functionality not available.\n(It uses code under a non-free HSL licence which does not permit redistribution).\nAborting mc64ad_dist.\n");
 +    abort();
 +    return 0;
 +}
+--- a/SRC/prec-independent/util.c
++++ b/SRC/prec-independent/util.c
+@@ -217,7 +217,7 @@ void set_default_options_dist(superlu_dist_options_t *options)
+ #else
+     options->ColPerm = MMD_AT_PLUS_A;
+ #endif
+-    options->RowPerm = LargeDiag_MC64;
++    options->RowPerm = NOROWPERM;
+     options->ReplaceTinyPivot = NO;
+     options->IterRefine = SLU_DOUBLE;
+     options->Trans = NOTRANS;

--- a/pkgs/by-name/su/superlu_dist/package.nix
+++ b/pkgs/by-name/su/superlu_dist/package.nix
@@ -13,9 +13,6 @@
   mpiCheckPhaseHook,
   metis,
   parmetis,
-  withExamples ? false,
-  fortranSupport ? true,
-  enableOpenMP ? true,
   # Todo: ask for permission of unfree parmetis
   withParmetis ? false,
 }:
@@ -49,8 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ]
-  ++ lib.optionals fortranSupport [
     gfortran
   ];
 
@@ -65,17 +60,15 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.cc.isClang [
     gfortran.cc.lib
-  ]
-  ++ lib.optionals (enableOpenMP && stdenv.cc.isClang) [
     llvmPackages.openmp
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "enable_examples" withExamples)
-    (lib.cmakeBool "enable_openmp" enableOpenMP)
+    (lib.cmakeBool "enable_examples" false)
+    (lib.cmakeBool "enable_openmp" true)
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "BUILD_STATIC_LIBS" stdenv.hostPlatform.isStatic)
-    (lib.cmakeBool "XSDK_ENABLE_Fortran" fortranSupport)
+    (lib.cmakeBool "XSDK_ENABLE_Fortran" true)
     (lib.cmakeBool "BLA_PREFER_PKGCONFIG" true)
     (lib.cmakeBool "TPL_ENABLE_INTERNAL_BLASLIB" false)
     (lib.cmakeBool "TPL_ENABLE_LAPACKLIB" true)

--- a/pkgs/by-name/su/superlu_dist/package.nix
+++ b/pkgs/by-name/su/superlu_dist/package.nix
@@ -24,7 +24,7 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "superlu_dist";
-  version = "9.1.0";
+  version = "9.2.0";
 
   __structuredAttrs = true;
 
@@ -34,15 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     # Remove non‐free files.
     postFetch = "rm $out/SRC/prec-independent/mc64ad_dist.c";
-    hash = "sha256-NMAEtTmTY189p8BlmsTugwMuxKZh+Bs1GyuwUHkLA1U=";
+    hash = "sha256-i/Gg+9oMNNRlviwXUSRkWNaLRZLPWZRtA1fGYqh2X0k=";
   };
 
   patches = [
     ./mc64ad_dist-stub.patch
-    (fetchurl {
-      url = "https://github.com/xiaoyeli/superlu_dist/commit/8ef3f7fda091529d7e7f16087864fee66c4834c9.patch";
-      hash = "sha256-kCSqojYKpk75m+FwhS0hXHSybm+GZzOYikePcf2U3Fw=";
-    })
   ];
 
   postPatch = ''
@@ -58,24 +54,21 @@ stdenv.mkDerivation (finalAttrs: {
     gfortran
   ];
 
-  buildInputs =
-    lib.optionals (enableOpenMP && stdenv.cc.isClang) [
-      # cmake can not find mpi if openmp is placed after mpi
-      llvmPackages.openmp
-    ]
-    ++ [
-      mpi
-      lapack
-    ]
-    ++ lib.optionals withParmetis [
-      metis
-      parmetis
-    ]
-    ++ lib.optionals stdenv.cc.isClang [
-      gfortran.cc.lib
-    ];
-
-  propagatedBuildInputs = [ blas ];
+  buildInputs = [
+    mpi
+    blas
+    lapack
+  ]
+  ++ lib.optionals withParmetis [
+    metis
+    parmetis
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    gfortran.cc.lib
+  ]
+  ++ lib.optionals (enableOpenMP && stdenv.cc.isClang) [
+    llvmPackages.openmp
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "enable_examples" withExamples)
@@ -94,6 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+
+  __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [ mpiCheckPhaseHook ];
 


### PR DESCRIPTION
changelog: https://github.com/xiaoyeli/superlu_dist/releases/tag/v9.2.0

other changes:
1. fix building parmetis with cmake4
2. move blas from propagatedBuildInputs to buildInputs
3. remove optional flags that rarely used
4. fix build on aarch64-darwin with sandbox=true
5. support ilp64

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
