### PR TITLE
nixos/oidentd: overhaul, nixos/tests/oidentd: init

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -133,7 +133,7 @@ in
       rabbitmq = 85;
       activemq = 86;
       gnunet = 87;
-      oidentd = 88;
+      # oidentd = 88; # dynamically allocated as of 2026-07-23
       quassel = 89;
       amule = 90;
       minidlna = 91;
@@ -475,7 +475,7 @@ in
       rabbitmq = 85;
       activemq = 86;
       gnunet = 87;
-      oidentd = 88;
+      # oidentd = 88; # dynamically allocated as of 2026-07-23
       quassel = 89;
       amule = 90;
       minidlna = 91;

--- a/nixos/modules/services/networking/oidentd.nix
+++ b/nixos/modules/services/networking/oidentd.nix
@@ -4,45 +4,476 @@
   pkgs,
   ...
 }:
-
-with lib;
-
+let
+  cfg = config.services.oidentd;
+in
 {
+  meta.maintainers = [ lib.maintainers.h7x4 ];
 
-  ###### interface
-
-  options = {
-
-    services.oidentd.enable = mkOption {
+  options.services.oidentd = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
-      type = types.bool;
+      example = true;
       description = ''
-        Whether to enable ‘oidentd’, an implementation of the Ident
-        protocol (RFC 1413).  It allows remote systems to identify the
+        Whether to enable `oidentd`, an implementation of the Ident
+        protocol (RFC 1413). It allows remote systems to identify the
         name of the user associated with a TCP connection.
       '';
     };
 
+    package = lib.mkPackageOption pkgs "oidentd" { };
+
+    grantHomeDirectoryAccess = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to allow the daemon to read user's home directories.
+        This is useful if you want to support user config specified in
+        {file}`~/config/oidentd.conf`
+      '';
+    };
+
+    listenStreams = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ "113" ];
+      description = ''
+        Which addresses to listen on.
+
+        See {manpage}`systemd.socket(5)` for more information about the format.
+
+        :::{.warning}
+          If you change this to a different port, the {option}`openFirewall` option will not follow along.
+
+          Please set {option}`networking.firewall.allowedTCPPorts` accordingly.
+        :::
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to open port `113` in the firewall.
+      '';
+    };
+
+    settings =
+      let
+        capabilityDirectivesType =
+          let
+            mkCapabilityToggle =
+              name:
+              lib.mkOption {
+                type = lib.types.nullOr lib.types.bool;
+                description = "Whether to allow the user to use the `${name}` capability.";
+                default = null;
+                example = true;
+              };
+          in
+          lib.types.submodule {
+            options = {
+              forward = mkCapabilityToggle "forward";
+              hide = mkCapabilityToggle "hide";
+              numeric = mkCapabilityToggle "numeric";
+              random = mkCapabilityToggle "random";
+              random_numeric = mkCapabilityToggle "random_numeric";
+              spoof = mkCapabilityToggle "spoof";
+              spoof_all = mkCapabilityToggle "spoof_all";
+              spoof_privport = mkCapabilityToggle "spoof_privport";
+
+              force = lib.mkOption {
+                type = capabilityStatementsType;
+                default = { };
+                description = "Directives specified here forces the user to use the specified capability.";
+              };
+            };
+          };
+
+        capabilityStatementsType = lib.types.submodule {
+          options = {
+            forward = lib.mkOption {
+              type = lib.types.nullOr (
+                lib.types.submodule {
+                  options = {
+                    host = lib.mkOption {
+                      type = lib.types.str;
+                      description = "The FQDN of the target Ident server.";
+                    };
+                    port = lib.mkOption {
+                      type = lib.types.port;
+                      description = "The port of the target Ident server.";
+                    };
+                  };
+                }
+              );
+              default = null;
+              description = ''
+                Forward received queries to another Ident server.
+
+                The target server must support forwarding.
+              '';
+            };
+            hide = lib.mkEnableOption "" // {
+              description = ''
+                If forwarding fails, oidentd responds with a "HIDDEN-USER" error.
+
+                If set in {option}`settings.users`, the service might answer with
+                the real username depending on whether the user has been granted
+                the hide capability from the global configuration.
+              '';
+            };
+            numeric = lib.mkEnableOption "" // {
+              description = "Respond with the user ID (UID).";
+            };
+            random = lib.mkEnableOption "" // {
+              description = ''
+                Send randomly generated, alphanumeric Ident replies.
+
+                A new reply is generated for each Ident lookup.
+              '';
+            };
+            random_numeric = lib.mkEnableOption "" // {
+              description = ''
+                Send randomly generated, numeric Ident replies between 0 (inclusive) and 100,000 (exclusive), prefixed with "user"
+
+                A new reply is generated for each Ident lookup.
+              '';
+            };
+            reply = lib.mkOption {
+              type = with lib.types; nullOr (nonEmptyListOf str);
+              default = null;
+              description = ''
+                Send an Ident reply chosen at random from the given list of quoted replies.
+
+                When used in a user configuration file, at most 20 replies may be specified. In the system-wide configuration file, up to 255 replies may be specified.
+              '';
+            };
+          };
+        };
+
+        rangeDirectivesType = lib.types.submodule {
+          freeformType = lib.types.attrsOf capabilityDirectivesType;
+          options = {
+            default = lib.mkOption {
+              type = capabilityDirectivesType;
+              description = "Default configuration without any range specified";
+            };
+          };
+        };
+      in
+      {
+        default = lib.mkOption {
+          type = rangeDirectivesType;
+          default = { };
+          example = {
+            default = {
+              spoof = true;
+            };
+            "fport 6667" = {
+              spoof = false;
+              hide = true;
+            };
+            "lport 1024:" = {
+              force.hide = true;
+            };
+          };
+          description = ''
+            Systemwide configuration for oidentd.
+
+            See {manpage}`oidentd.conf(5)` for more details.
+          '';
+        };
+        users = lib.mkOption {
+          type = lib.types.attrsOf rangeDirectivesType;
+          default = { };
+          example = {
+            "root" = {
+              default = {
+                hide = true;
+              };
+            };
+            "alice" = {
+              default = {
+                hide = false;
+              };
+              "to irc.example.net fport 6667" = {
+                force.reply = [ "me" ];
+              };
+            };
+          };
+          description = ''
+            User-specific configuration for oidentd.
+
+            See {manpage}`oidentd.conf(5)` for more details.
+          '';
+        };
+      };
+
+    masqSettings = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            host = lib.mkOption {
+              type = lib.types.str;
+              description = "Hostname, IP address or network mask for this rule.";
+            };
+            response = lib.mkOption {
+              type = lib.types.str;
+              description = "The response to be send when receiveing a query for the host.";
+            };
+            system-type = lib.mkOption {
+              type = lib.types.str;
+              description = "The OS type send send along the Ident response.";
+            };
+          };
+        }
+      );
+      default = [ ];
+      example = [
+        {
+          host = "10.0.0.1";
+          response = "user1";
+          system-type = "UNIX";
+        }
+        {
+          host = "server.internal";
+          response = "user2";
+          system-type = "UNIX-BSD";
+        }
+        {
+          host = "10.0.0.0/24";
+          response = "user3";
+          system-type = "UNIX";
+        }
+        {
+          host = "10.0.0.0/255.255.0.0";
+          response = "user4";
+          system-type = "UNKNOWN";
+        }
+      ];
+      description = ''
+        NAT rules for oidentd.
+
+        See {manpage}`oidentd_masq.conf(5)` for more information.
+      '';
+    };
+
+    extraFlags = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          bool
+          str
+          int
+        ]);
+      default = { };
+      example = {
+        debug = true;
+        error = true;
+        timeout = 10;
+      };
+      description = ''
+        Commandline flags to append when invoking `oidentd`.
+
+        See {manpage}`oidentd(8)` for a list of available flags.
+      '';
+    };
   };
 
-  ###### implementation
+  config = lib.mkIf cfg.enable {
+    services.oidentd.settings = {
+      default.default = {
+        spoof = lib.mkDefault false;
+        spoof_all = lib.mkDefault false;
+        spoof_privport = lib.mkDefault false;
+        random = lib.mkDefault false;
+        random_numeric = lib.mkDefault false;
+        numeric = lib.mkDefault false;
+        hide = lib.mkDefault false;
+        forward = lib.mkDefault false;
+      };
+      users.root.default.force.hide = lib.mkDefault true;
+    };
 
-  config = mkIf config.services.oidentd.enable {
-    systemd.services.oidentd = {
+    environment.etc = {
+      "oidentd/oidentd_masq.conf".text = lib.concatMapStringsSep "\n" (
+        {
+          host,
+          response,
+          system-type,
+        }:
+        "${host}\t${response}\t${system-type}"
+      ) cfg.masqSettings;
+
+      "oidentd/oidentd.conf".text =
+        let
+          quoteString = s: ''"${builtins.replaceStrings [ "\"" ] [ "\\\"" ] s}"'';
+
+          indent = str: lib.concatStringsSep "\n" (map (l: "  ${l}") (lib.splitString "\n" str));
+
+          capabilityStatementsToStrList =
+            cs:
+            (lib.optional (cs.forward != null) "forward ${cs.forward.host} ${toString cs.forward.port}")
+            ++ (lib.optional cs.hide "hide")
+            ++ (lib.optional cs.numeric "numeric")
+            ++ (lib.optional cs.random "random")
+            ++ (lib.optional cs.random_numeric "random_numeric")
+            ++ (lib.optional (cs.reply != null) "reply ${lib.concatMapStringsSep " " quoteString cs.reply}");
+
+          capabilityStatementsToStr = cs: lib.concatStringsSep "\n" (capabilityStatementsToStrList cs);
+
+          capabilityDirectivesToStr =
+            cds:
+            let
+              allowDeny =
+                opt: lib.optional (cds.${opt} != null) "${if cds.${opt} then "allow" else "deny"} ${opt}";
+            in
+            lib.concatStringsSep "\n" (
+              (allowDeny "forward")
+              ++ (allowDeny "hide")
+              ++ (allowDeny "numeric")
+              ++ (allowDeny "random_numeric")
+              ++ (allowDeny "spoof")
+              ++ (allowDeny "spoof_all")
+              ++ (allowDeny "spoof_privport")
+              ++ map (x: "force ${x}") (capabilityStatementsToStrList cds.force)
+            );
+
+          rangeDirectivesToStr =
+            rds:
+            (lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (name: value: ''
+                ${if name == "default" then "default" else quoteString name} {
+                ${indent (capabilityDirectivesToStr value)}
+                }'') rds
+            ));
+
+          userConfigToStr =
+            users:
+            lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (name: value: ''
+                user ${quoteString name} {
+                ${indent (rangeDirectivesToStr value)}
+                }'') users
+            );
+        in
+        ''
+          default {
+          ${indent (rangeDirectivesToStr cfg.settings.default)}
+          }
+          ${userConfigToStr cfg.settings.users}
+        '';
+    };
+
+    systemd.sockets.oidentd = {
+      documentation = [
+        "man:oidentd(8)"
+        "man:oidentd.conf(5)"
+        "man:oidentd_masq.conf(5)"
+      ];
+
+      wantedBy = [ "sockets.target" ];
+
+      inherit (cfg) listenStreams;
+
+      socketConfig = {
+        Accept = true;
+        PrivateDevices = true;
+      };
+    };
+
+    services.oidentd.extraFlags = {
+      stdio = true;
+      foreground = true;
+    };
+
+    systemd.services."oidentd@" = {
       after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig.Type = "forking";
-      script = "${pkgs.oidentd}/sbin/oidentd -u oidentd -g nogroup";
+
+      reloadTriggers = [
+        config.environment.etc."oidentd/oidentd.conf".source
+        config.environment.etc."oidentd/oidentd_masq.conf".source
+      ];
+
+      serviceConfig =
+        let
+          masqueradingEnabled = lib.any (b: b) [
+            (cfg.extraFlags.m or cfg.extraFlags.masq or false)
+            (cfg.extraFlags.f or false != false)
+            (cfg.extraFlags.forward or false != false)
+          ];
+        in
+        {
+          Type = "simple";
+          DynamicUser = true;
+          StandardInput = "socket";
+          StandardOutput = "socket";
+          StandardError = "journal";
+          Restart = "on-failure";
+          ConfigurationDirectory = "oidentd";
+
+          ExecStart =
+            let
+              flags = lib.cli.toCommandLineShellGNU { } cfg.extraFlags;
+            in
+            "${lib.getExe cfg.package} ${flags}";
+          ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -HUP $MAINPID";
+
+          # Needs to see users to respond with identities.
+          PrivateUsers = "full";
+
+          # Allow the daemon to read configfiles in ~/.config/odidentd.conf and ~/.odidentd.conf
+          ProtectHome = if cfg.grantHomeDirectoryAccess then "read-only" else "yes";
+          # Even if we need access to /home and /root, we don't need /run/user
+          InaccessiblePaths = lib.mkIf cfg.grantHomeDirectoryAccess [ "/run/user" ];
+
+          # Needs to read /proc/net/nf_conntrack and possibly homedirs
+          AmbientCapabilities = [ "CAP_DAC_READ_SEARCH" ];
+          CapabilityBoundingSet = [ "CAP_DAC_READ_SEARCH" ];
+
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = "disconnected";
+          ProtectClock = true;
+          ProtectControlGroups = "strict";
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "noaccess";
+          ProtectSystem = "strict";
+          RemoveIPC = true;
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SocketBindDeny = "any";
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@resources"
+          ];
+          UMask = "0777";
+
+          RestrictAddressFamilies =
+            if masqueradingEnabled then
+              [
+                "AF_INET"
+                "AF_INET6"
+                "AF_NETLINK"
+              ]
+            else
+              [ "none" ];
+        };
     };
 
-    users.users.oidentd = {
-      description = "Ident Protocol daemon user";
-      group = "oidentd";
-      uid = config.ids.uids.oidentd;
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 113 ];
     };
-
-    users.groups.oidentd.gid = config.ids.gids.oidentd;
-
   };
-
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1257,6 +1257,7 @@ in
     _module.args.package = pkgs.odoo19;
   };
   oh-my-zsh = runTest ./oh-my-zsh.nix;
+  oidentd = runTest ./oidentd.nix;
   oku = runTest ./oku.nix;
   olivetin = runTest ./olivetin.nix;
   ollama = runTest ./ollama.nix;

--- a/nixos/tests/oidentd.nix
+++ b/nixos/tests/oidentd.nix
@@ -1,0 +1,144 @@
+{ pkgs, lib, ... }:
+{
+  name = "oidentd";
+  meta.maintainers = with lib.maintainers; [ h7x4 ];
+
+  nodes = {
+    loginbox =
+      { pkgs, ... }:
+      {
+        imports = [ ./common/user-account.nix ];
+
+        users.users.bob.homeMode = "0755";
+
+        virtualisation.vlans = [ 1 ];
+
+        networking = {
+          useNetworkd = true;
+          useDHCP = false;
+        };
+
+        systemd.network.networks."01-eth1" = {
+          name = "eth1";
+          networkConfig.Address = "10.0.0.1/24";
+        };
+
+        services.oidentd = {
+          enable = true;
+          openFirewall = true;
+          extraFlags.debug = true;
+
+          settings = {
+            default.default.spoof = false;
+            users.bob.default.spoof = true;
+          };
+        };
+
+        specialisation = {
+          withHomeAccess.configuration = {
+            services.oidentd.grantHomeDirectoryAccess = true;
+          };
+        };
+      };
+
+    server =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = with pkgs; [ netcat ];
+
+        virtualisation.vlans = [ 1 ];
+
+        networking = {
+          useNetworkd = true;
+          useDHCP = false;
+        };
+
+        systemd.network.networks."01-eth1" = {
+          name = "eth1";
+          networkConfig.Address = "10.0.0.2/24";
+        };
+
+        systemd.sockets.sleep-hello = {
+          wantedBy = [ "sockets.target" ];
+          socketConfig = {
+            ListenStream = 8080;
+            Accept = true;
+          };
+        };
+        systemd.services."sleep-hello@" = {
+          serviceConfig = {
+            Type = "simple";
+            StandardInput = "socket";
+            StandardOutput = "socket";
+            StandardError = "journal";
+
+            KillSignal = "USR1";
+            SendSIGHUP = false;
+          };
+          script = ''
+            read -r key
+
+            echo "Got connection with key $key, holding line" >&2
+
+            exitprog() {
+              echo "Exiting" >&2
+              exit 0
+            }
+
+            trap exitprog USR1
+
+            while true; do
+                sleep 1
+            done
+          '';
+        };
+
+        networking.firewall.allowedTCPPorts = [ 8080 ];
+      };
+  };
+
+  testScript =
+    { nodes }:
+    let
+      bobConfig = pkgs.writeText "nixos-test-oidentd-bob-config" ''
+        global {
+          reply "thingamabob"
+        }
+      '';
+    in
+    ''
+      start_all()
+
+      loginbox.wait_for_unit("oidentd.socket")
+      server.wait_for_unit("sleep-hello.socket")
+
+      with subtest("Basic connection"):
+        loginbox.execute("sudo -u alice -- nc 10.0.0.2 -p 63000 8080 <<<ALICE1 >&2 &")
+        server.wait_for_console_text("Got connection with key ALICE1, holding line")
+        server.succeed("nc 10.0.0.1 113 <<<'63000, 8080' | grep alice")
+        server.systemctl("stop sleep-hello@*")
+
+      with subtest("Root connection hidden"):
+        loginbox.execute("nc 10.0.0.2 -p 63000 8080 <<<ROOT1 >&2 &")
+        server.wait_for_console_text("Got connection with key ROOT1, holding line")
+        server.succeed("nc 10.0.0.1 113 <<<'63000, 8080' | grep HIDDEN-USER")
+        server.systemctl("stop sleep-hello@*")
+
+      loginbox.succeed("sudo -u bob -- install -Dm644 ${bobConfig} /home/bob/.config/oidentd.conf")
+
+      with subtest("Installed user config without home access"):
+        loginbox.execute("sudo -u bob -- nc 10.0.0.2 -p 63000 8080 <<<BOB1 >&2 &")
+        server.wait_for_console_text("Got connection with key BOB1, holding line")
+        server.succeed("nc 10.0.0.1 113 <<<'63000, 8080' | grep -v thingamabob")
+        server.systemctl("stop sleep-hello@*")
+
+      loginbox.succeed("/run/current-system/specialisation/withHomeAccess/bin/switch-to-configuration switch")
+      loginbox.wait_for_unit("oidentd.socket")
+
+      with subtest("Installed user config with home access"):
+        loginbox.execute("sudo -u bob -- nc 10.0.0.2 -p 63000 8080 <<<BOB2 >&2 &")
+        server.wait_for_console_text("Got connection with key BOB2, holding line")
+        server.succeed("nc 10.0.0.1 113 <<<'63000, 8080' | grep thingamabob")
+        server.systemctl("stop sleep-hello@*")
+    '';
+}

--- a/pkgs/by-name/oi/oidentd/package.nix
+++ b/pkgs/by-name/oi/oidentd/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   bison,
   flex,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
         '#define CONFFILE${"\t\t"}SYSCONFDIR "/oidentd.conf"' \
         '#define CONFFILE${"\t\t"}"/etc/oidentd/oidentd.conf"'
   '';
+
+  passthru.tests.nixos = nixosTests.oidentd;
 
   meta = {
     description = "Configurable Ident protocol server";

--- a/pkgs/by-name/oi/oidentd/package.nix
+++ b/pkgs/by-name/oi/oidentd/package.nix
@@ -19,6 +19,16 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-yyvcnabxNkcIMOiZBjvoOm/pEjrGXFt4W4SG5lprkbc=";
   };
 
+  postPatch = ''
+    substituteInPlace src/oidentd.h \
+      --replace-fail \
+        '#define MASQ_MAP${"\t\t"}SYSCONFDIR "/oidentd_masq.conf"' \
+        '#define MASQ_MAP${"\t\t"}"/etc/oidentd/oidentd_masq.conf"' \
+      --replace-fail \
+        '#define CONFFILE${"\t\t"}SYSCONFDIR "/oidentd.conf"' \
+        '#define CONFFILE${"\t\t"}"/etc/oidentd/oidentd.conf"'
+  '';
+
   meta = {
     description = "Configurable Ident protocol server";
     mainProgram = "oidentd";

--- a/pkgs/by-name/oi/oidentd/package.nix
+++ b/pkgs/by-name/oi/oidentd/package.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://oidentd.janikrabe.com/";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ h7x4 ];
   };
 })

--- a/pkgs/by-name/oi/oidentd/package.nix
+++ b/pkgs/by-name/oi/oidentd/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Configurable Ident protocol server";
     mainProgram = "oidentd";
     homepage = "https://oidentd.janikrabe.com/";
+    changelog = "https://github.com/janikrabe/oidentd/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ h7x4 ];

--- a/pkgs/by-name/oi/oidentd/package.nix
+++ b/pkgs/by-name/oi/oidentd/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://oidentd.janikrabe.com/";
     changelog = "https://github.com/janikrabe/oidentd/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ freebsd ++ openbsd ++ netbsd;
     maintainers = with lib.maintainers; [ h7x4 ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR is effectively a rewrite of the entire oidentd nixos module.

Some highlighted changes are:

- Socket activated units.
- Settings options for multiple config files.
- Options for setting extra flags.
- Systemd hardening.
- Reloadable units.
- Firewall options.
- Allow listening on different addresses.
- Removal of the fixed uid/gid oidentd user/group
- Added NixOS test
- Add h7x4 to maintainer lists for both package, module and test.

Ref https://github.com/NixOS/nixpkgs/issues/377827

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
