### PR TITLE
letterpress: 2.1 -> 2.2

### DIFF
--- a/pkgs/by-name/le/letterpress/package.nix
+++ b/pkgs/by-name/le/letterpress/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitLab,
-  fetchpatch,
   wrapGAppsHook4,
   appstream,
   blueprint-compiler,
@@ -18,24 +17,15 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "letterpress";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "letterpress";
     rev = version;
-    hash = "sha256-9U8iH3V4WMljdtWLmb0RlexLeAN5StJ0c9RlEB2E7Xs=";
+    hash = "sha256-cqLodI6UjdLCKLGGcSIbXu1+LOcq2DE00V+lVS7OBMg=";
   };
-
-  patches = [
-    # Fix application segmentation fault on file chooser dialog opening
-    # https://gitlab.gnome.org/World/Letterpress/-/merge_requests/16
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/World/Letterpress/-/commit/15059eacca14204d1092a6e32ef30c6ce4df6d36.patch";
-      hash = "sha256-pjg/O9advtkZ0l73GQtL/GYcTWeOs5l3VGOdnsZCWI0=";
-    })
-  ];
 
   runtimeDeps = [
     jp2a
@@ -81,6 +71,7 @@ python3Packages.buildPythonApplication rec {
       High-res output can still be viewed comfortably by lowering the zoom factor.
     '';
     homepage = "https://apps.gnome.org/Letterpress/";
+    changelog = "https://gitlab.gnome.org/World/Letterpress/-/releases/${version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.dawidd6 ];
     teams = [ teams.gnome-circle ];


### PR DESCRIPTION
Changelog: https://gitlab.gnome.org/World/Letterpress/-/releases/2.2
Diff: https://gitlab.gnome.org/World/Letterpress/-/compare/2.1..2.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
