### PR TITLE
various: drop darwin workarounds for infrec

### DIFF
--- a/pkgs/development/libraries/libxml2/common.nix
+++ b/pkgs/development/libraries/libxml2/common.nix
@@ -1,6 +1,5 @@
 {
   stdenv,
-  darwin,
   lib,
   pkg-config,
   autoreconfHook,
@@ -27,12 +26,7 @@
   freezeUpdateScript ? false,
 }:
 
-let
-  # libxml2 is a dependency of xcbuild. Avoid an infinite recursion by using a bootstrap stdenv
-  # that does not propagate xcrun.
-  stdenv' = if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-in
-stdenv'.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   inherit
     version
     src

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6913,12 +6913,6 @@ with pkgs;
 
   watson-ruby = callPackage ../development/tools/misc/watson-ruby { };
 
-  xcbuild = callPackage ../by-name/xc/xcbuild/package.nix {
-    stdenv =
-      # xcbuild is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
-      if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-  };
-
   xcbuildHook = makeSetupHook {
     name = "xcbuild-hook";
     propagatedBuildInputs = [ xcbuild ];
@@ -7898,12 +7892,7 @@ with pkgs;
   libpeas = callPackage ../development/libraries/libpeas { };
   libpeas2 = callPackage ../development/libraries/libpeas/2.x.nix { };
 
-  libpng = callPackage ../development/libraries/libpng {
-    stdenv =
-      # libpng is a dependency of xcbuild. Avoid an infinite recursion by using a bootstrap stdenv
-      # that does not propagate xcrun.
-      if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-  };
+  libpng = callPackage ../development/libraries/libpng { };
 
   libpng12 = callPackage ../development/libraries/libpng/12.nix { };
 
@@ -8147,7 +8136,7 @@ with pkgs;
       null
     else
       callPackage ../development/libraries/ncurses {
-        # ncurses is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
+        # ncurses is included in the SDK. Avoid an infinite recursion with `pkgsStatic` by using a bootstrap stdenv.
         stdenv = if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
       };
 
@@ -8776,12 +8765,7 @@ with pkgs;
 
   xgboostWithCuda = xgboost.override { cudaSupport = true; };
 
-  zlib = callPackage ../development/libraries/zlib {
-    stdenv =
-      # zlib is a dependency of xcbuild. Avoid an infinite recursion by using a bootstrap stdenv
-      # that does not propagate xcrun.
-      if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-  };
+  zlib = callPackage ../development/libraries/zlib { };
 
   inherit
     (rec {


### PR DESCRIPTION
I can't cause infinite recursion by dropping these workarounds, so I conclude they're not necessary anymore.

Of course - it could very well be that I just hold it wrong, if that's the case please tell me how to reproduce that infrec :)

These were introduced in #346043, but I can't find reproducers in the commit messages.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
