### PR TITLE
Reapply "splice.nix: make pkgs splicedPackages"

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -303,15 +303,6 @@ rec {
   };
 
   #
-  # Redox
-  #
-
-  x86_64-unknown-redox = {
-    config = "x86_64-unknown-redox";
-    libc = "relibc";
-  };
-
-  #
   # Darwin
   #
 

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -202,7 +202,7 @@ in
     _module.args = {
       hostPkgs =
         # Comment is in nixos/modules/misc/nixpkgs.nix
-        lib.mkOverride lib.modules.defaultOverridePriority config.hostPkgs.__splicedPackages;
+        lib.mkOverride lib.modules.defaultOverridePriority config.hostPkgs;
     };
 
     driver = withChecks driver;

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -355,7 +355,7 @@ in
         # which is somewhat costly for Nixpkgs. With an explicit priority, we only
         # evaluate the wrapper to find out that the priority is lower, and then we
         # don't need to evaluate `finalPkgs`.
-        lib.mkOverride lib.modules.defaultOverridePriority finalPkgs.__splicedPackages;
+        lib.mkOverride lib.modules.defaultOverridePriority finalPkgs;
     };
 
     assertions =

--- a/nixos/modules/misc/nixpkgs/read-only.nix
+++ b/nixos/modules/misc/nixpkgs/read-only.nix
@@ -63,7 +63,7 @@ in
       # find mistaken definitions
       builtins.seq cfg.config builtins.seq cfg.overlays builtins.seq cfg.hostPlatform builtins.seq
         cfg.buildPlatform
-        cfg.pkgs.__splicedPackages;
+        cfg.pkgs;
     nixpkgs.config = cfg.pkgs.config;
     nixpkgs.overlays = cfg.pkgs.overlays;
     nixpkgs.hostPlatform = cfg.pkgs.stdenv.hostPlatform;

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  __splicedPackages,
+  pkgs,
   erlang,
 }:
 
 let
-  pkgs = __splicedPackages;
   inherit (lib) makeExtensible;
 
   # FIXME: add support for overrideScope

--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   pkgs,
+  overrideCC,
+  buildPackages,
   targetPackages,
   callPackage,
   isl_0_20,
@@ -62,7 +64,7 @@ let
                 )
                 && stdenv.cc.isGNU
               then
-                pkgs."gcc${majorVersion}Stdenv"
+                overrideCC stdenv buildPackages."gcc${majorVersion}"
               else
                 stdenv;
           }

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -30,11 +30,7 @@ let
             }:
             let
               perlPackagesFun = callPackage ../../../top-level/perl-packages.nix {
-                # allow 'perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig; }; }' like in python3Packages
-                # most perl packages aren't called with callPackage so it's not possible to override their arguments individually
-                # the conditional is because the // above won't be applied to __splicedPackages and hopefully no one is doing that when cross-compiling
-                pkgs = if stdenv.buildPlatform != stdenv.hostPlatform then pkgs.__splicedPackages else pkgs;
-                inherit stdenv;
+                inherit stdenv pkgs;
                 perl = self;
               };
 

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -27,11 +27,11 @@ lib.makeScope newScope (
       else
         buildPackages.gccWithoutTargetLibc.override (old: {
           bintools = old.bintools.override {
-            libc = pkgs.libc;
+            libc = pkgs.pkgsHostTarget.libc;
             noLibc = pkgs.libc == null;
             nativeLibc = false;
           };
-          libc = pkgs.libc;
+          libc = pkgs.pkgsHostTarget.libc;
           noLibc = pkgs.libc == null;
           nativeLibc = false;
         })

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -162,5 +162,9 @@ let
         buildPackages.stdenv.cc;
   };
 
+  pkgs = dfold folder postStage (_: { }) withAllowCustomOverrides;
+
 in
-dfold folder postStage (_: { }) withAllowCustomOverrides
+# Return the spliced package set, so that consumers of the nixpkgs top-level
+# attributes, like NixOS, don't break when cross-compiling.
+pkgs.__splicedPackages

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -254,6 +254,7 @@ mapAliases {
   elasticsearch7Plugins = elasticsearchPlugins; # preserve, reason: until v8
   fetchFromGithub = throw "You meant fetchFromGitHub, with a capital H"; # preserve, reason: common typo
   fuse2fs = if stdenv.hostPlatform.isLinux then e2fsprogs.fuse2fs else null; # Added 2022-03-27 preserve, reason: convenience, arch has a package named fuse2fs too.
+  uclibc = uclibc-ng; # preserve, because uclibc-ng can't be used in config string
   wlroots = wlroots_0_19; # preserve, reason: wlroots is unstable, we must keep depending on 'wlroots_0_*', convert to package after a stable(1.x) release
   wormhole-rs = magic-wormhole-rs; # Added 2022-05-30. preserve, reason: Arch package name, main binary name
 
@@ -1507,7 +1508,6 @@ mapAliases {
   uade123 = throw "'uade123' has been renamed to/replaced by 'uade'"; # Converted to throw 2025-10-27
   uae = throw "'uae' has been removed due to lack of upstream maintenance. Consider using 'fsuae' instead."; # Added 2025-06-11
   ubuntu_font_family = throw "'ubuntu_font_family' has been renamed to/replaced by 'ubuntu-classic'"; # Converted to throw 2025-10-27
-  uclibc = throw "'uclibc' has been renamed to/replaced by 'uclibc-ng'"; # Converted to throw 2025-10-27
   unicap = throw "'unicap' has been removed because it is unmaintained"; # Added 2025-05-17
   unifi-poller = throw "'unifi-poller' has been renamed to/replaced by 'unpoller'"; # Converted to throw 2025-10-27
   unzoo = throw "'unzoo' has been removed since it is unmaintained upstream and doesn't compile with newer versions of GCC anymore"; # Removed 2025-05-24

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8865,8 +8865,6 @@ with pkgs;
   );
   agda = agdaPackages.agda;
 
-  ### DEVELOPMENT / LIBRARIES / BASH
-
   ### DEVELOPMENT / LIBRARIES / JAVA
 
   saxonb = saxonb_8_8;
@@ -9866,8 +9864,6 @@ with pkgs;
   zabbix60 = recurseIntoAttrs (zabbixFor "v60");
 
   zabbix = zabbix60;
-
-  ### SERVERS / GEOSPATIAL
 
   ### OS-SPECIFIC
 
@@ -13614,10 +13610,6 @@ with pkgs;
     libxc = pkgs.libxc_7;
   };
 
-  ### SCIENCE/GEOMETRY
-
-  ### SCIENCE/BENCHMARK
-
   ### SCIENCE/BIOLOGY
 
   cd-hit = callPackage ../applications/science/biology/cd-hit {
@@ -13764,8 +13756,6 @@ with pkgs;
     }
   );
 
-  ### SCIENCE/MEDICINE
-
   ### SCIENCE/PHYSICS
 
   mcfm = callPackage ../applications/science/physics/MCFM {
@@ -13777,8 +13767,6 @@ with pkgs;
   };
 
   xflr5 = libsForQt5.callPackage ../applications/science/physics/xflr5 { };
-
-  ### SCIENCE/PROGRAMMING
 
   ### SCIENCE/LOGIC
 
@@ -13917,8 +13905,6 @@ with pkgs;
   tlaps = callPackage ../applications/science/logic/tlaplus/tlaps.nix {
     inherit (ocaml-ng.ocamlPackages_4_14_unsafe_string) ocaml;
   };
-
-  ### SCIENCE / ENGINEERING
 
   ### SCIENCE / ELECTRONICS
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6320,7 +6320,7 @@ with pkgs;
       null;
   bintoolsNoLibc = wrapBintoolsWith {
     bintools = bintools-unwrapped;
-    libc = targetPackages.preLibcHeaders;
+    libc = targetPackages.preLibcHeaders or preLibcHeaders;
   };
   bintools = wrapBintoolsWith {
     bintools = bintools-unwrapped;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4089,11 +4089,7 @@ with pkgs;
 
   tldr-hs = haskellPackages.tldr;
 
-  tmuxPlugins = recurseIntoAttrs (
-    callPackage ../misc/tmux-plugins {
-      pkgs = pkgs.__splicedPackages;
-    }
-  );
+  tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins { });
 
   tpm2-totp-with-plymouth = tpm2-totp.override {
     withPlymouth = true;
@@ -4311,9 +4307,7 @@ with pkgs;
   yarn-berry_4 = yarn-berry.override { berryVersion = 4; };
   yarn-berry_3 = yarn-berry.override { berryVersion = 3; };
 
-  yarn2nix-moretea = callPackage ../development/tools/yarn2nix-moretea {
-    pkgs = pkgs.__splicedPackages;
-  };
+  yarn2nix-moretea = callPackage ../development/tools/yarn2nix-moretea { };
 
   inherit (yarn2nix-moretea)
     yarn2nix
@@ -5015,7 +5009,6 @@ with pkgs;
   idrisPackages = recurseIntoAttrs (
     callPackage ../development/idris-modules {
       idris-no-deps = haskellPackages.idris;
-      pkgs = pkgs.__splicedPackages;
     }
   );
 

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -173,6 +173,8 @@ in
 
   newScope = extra: lib.callPackageWith (pkgsForCall // extra);
 
+  pkgs = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;
+
   # prefill 2 fields of the function for convenience
   makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
   makeScopeWithSplicing' = lib.makeScopeWithSplicing' {


### PR DESCRIPTION
This reapplies #349316, which was tried in #362499, but then abandoned.

Does https://github.com/NixOS/nixpkgs/pull/349316#issuecomment-2478607271, too, but not https://github.com/NixOS/nixpkgs/pull/349316#discussion_r1826155762. The latter still causes me some infrec headache for darwin cross.

Dropping `stdenv/native` along the way, which was broken right now anyway - and causes infinite recursions through these `nativeTools` & co. arguments.

## Things done

- [x] Basic tests work.
- [ ] Do more sophisticated testing.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
