### PR TITLE
tahoe-lafs: 1.20.0 -> 1.20.0-unstable-2025-10-12

### DIFF
--- a/pkgs/by-name/ta/tahoe-lafs/package.nix
+++ b/pkgs/by-name/ta/tahoe-lafs/package.nix
@@ -1,47 +1,25 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   texinfo,
   versionCheckHook,
 }:
 
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      # tahoe-lafs is incompatible with magic-wormhole >= 0.19.0
-      # TODO: unpin, when https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4180 is fixed
-      magic-wormhole = super.magic-wormhole.overridePythonAttrs (oldAttrs: rec {
-        version = "0.18.0";
-
-        src = fetchFromGitHub {
-          owner = "magic-wormhole";
-          repo = "magic-wormhole";
-          tag = version;
-          hash = "sha256-FQ7m6hkJcFZaE+ptDALq/gijn/RcAM1Zvzi2+xpoXBU=";
-        };
-
-        nativeCheckInputs = lib.filter (
-          input: (input.pname or null) != "pytest-twisted"
-        ) oldAttrs.nativeCheckInputs;
-
-        doCheck = false;
-      });
-    };
-  };
-  python3Packages = python.pkgs;
-in
 python3Packages.buildPythonApplication rec {
   pname = "tahoe-lafs";
-  version = "1.20.0";
+  version = "1.20.0-unstable-2025-10-12";
   pyproject = true;
+
+  # workaround required to build an unstable version
+  # TODO: when moving to a tagged version, remove this and the workaround for versionCheckHook
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = builtins.elemAt (builtins.split "-" version) 0;
 
   src = fetchFromGitHub {
     owner = "tahoe-lafs";
     repo = "tahoe-lafs";
-    tag = "tahoe-lafs-${version}";
-    hash = "sha256-9qaL4GmdjClviKTnwAxaTywvJChQ5cVVgWs1IkFxhIY=";
+    rev = "7b96d16aba511fd34dcc0c14c9db754229e19531";
+    hash = "sha256-7qMeyL0j0D6Yos7qDhhplinKPV87Vu72dbE4eWql/g4=";
   };
 
   outputs = [
@@ -89,8 +67,8 @@ python3Packages.buildPythonApplication rec {
       eliot
       filelock
       foolscap
-      future
       klein
+      legacy-cgi
       magic-wormhole
       netifaces
       psutil
@@ -139,13 +117,13 @@ python3Packages.buildPythonApplication rec {
     ++ [
       versionCheckHook
     ];
-  versionCheckProgram = "${placeholder "out"}/bin/tahoe";
+
   versionCheckProgramArg = "--version";
 
   checkPhase = ''
     runHook preCheck
 
-    runHook versionCheckHook
+    version=$SETUPTOOLS_SCM_PRETEND_VERSION runHook versionCheckHook
     trial --rterrors allmydata
 
     runHook postCheck

--- a/pkgs/by-name/ta/tahoe-lafs/package.nix
+++ b/pkgs/by-name/ta/tahoe-lafs/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  installShellFiles,
   texinfo,
   versionCheckHook,
 }:
@@ -26,6 +27,7 @@ python3Packages.buildPythonApplication rec {
     "out"
     "doc"
     "info"
+    "man"
   ];
 
   # Remove broken and expensive tests.
@@ -46,13 +48,16 @@ python3Packages.buildPythonApplication rec {
     hatchling
   ];
 
-  nativeBuildInputs = with python3Packages; [
-    # docs
+  nativeBuildInputs = # docs
+  [
+    installShellFiles
+    texinfo
+  ]
+  ++ (with python3Packages; [
     recommonmark
     sphinx
     sphinx-rtd-theme
-    texinfo
-  ];
+  ]);
 
   dependencies =
     with python3Packages;
@@ -99,6 +104,8 @@ python3Packages.buildPythonApplication rec {
       make info
       mkdir -p "$info/share/info"
       cp -rv _build/texinfo/*.info "$info/share/info"
+
+      installManPage man/man*/*
     )
   '';
 


### PR DESCRIPTION
https://github.com/tahoe-lafs/tahoe-lafs/compare/refs/tags/tahoe-lafs-1.20.0...7b96d16aba511fd34dcc0c14c9db754229e19531

+ fixes build against latest versions of dependencies (Python 3.13, Twisted)
+ adds man pages

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `5ef030a22cd4651b45f6d71c7fe3bb157a252967`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
    <li>tahoe-lafs.man</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc