### PR TITLE
irods: 5.0.1 -> 5.0.2

### DIFF
--- a/pkgs/by-name/ir/irods-icommands/package.nix
+++ b/pkgs/by-name/ir/irods-icommands/package.nix
@@ -16,7 +16,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     owner = "irods";
     repo = "irods_client_icommands";
     tag = finalAttrs.version;
-    hash = "sha256-lo1eCI/CSzl7BJWdPo7KKVHfznkPN6GwsiQThUGuQdw=";
+    hash = "sha256-jR7AhWeXYuJKzZRmYQUjiKSwK6PaB4dLQO8GVZwJQXk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ir/irods/package.nix
+++ b/pkgs/by-name/ir/irods/package.nix
@@ -16,19 +16,19 @@
   boost183,
   nlohmann_json,
   nanodbc,
-  fmt_9,
+  fmt,
   spdlog,
 }:
 
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "irods";
-  version = "5.0.1";
+  version = "5.0.2";
 
   src = fetchFromGitHub {
     owner = "irods";
     repo = "irods";
     tag = finalAttrs.version;
-    hash = "sha256-/mcuqukgDoMc89FL/TfOhHWglsfdLmQbAnQYT8vTFsY=";
+    hash = "sha256-gYwuXWRf5MZv3CTUq/RDlU9Ekbw4jZJmSgWRBKqdKJo=";
   };
 
   nativeBuildInputs = [
@@ -54,12 +54,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     boost183
     nlohmann_json
     nanodbc
-    # Tracking issue for `fmt_11`:
-    # <https://github.com/irods/irods/issues/8454>
-    fmt_9
-    (spdlog.override {
-      fmt = fmt_9;
-    })
+    fmt
+    spdlog
   ];
 
   cmakeFlags = finalAttrs.passthru.commonCmakeFlags ++ [


### PR DESCRIPTION
Upgrading iRods. 

https://docs.irods.org/5.0.2/release_notes/

FMT v9 dependency no more needed

Should build once #455607 merged

Closes #456133 
Closes #456136

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
