### PR TITLE
zoom-us: 6.6.0.4410 -> 6.6.5.5215, add libGLU

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -175,6 +175,7 @@ let
       pkgs.glib.dev
       pkgs.gtk3
       pkgs.libGL
+      pkgs.libGLU
       pkgs.libdrm
       pkgs.libgbm
       pkgs.libkrb5

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -54,25 +54,25 @@ let
   # Zoom versions are released at different times per platform and often with different versions.
   # We write them on three lines like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.6.0.64511";
-  versions.x86_64-darwin = "6.6.0.64511";
+  versions.aarch64-darwin = "6.6.5.67181";
+  versions.x86_64-darwin = "6.6.5.67181";
 
   # This is the fallback version so that evaluation can produce a meaningful result.
-  versions.x86_64-linux = "6.6.0.4410";
+  versions.x86_64-linux = "6.6.5.5215";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-2GdiJ/2K3TDF6nvVaIBVLJHgasx1e22aS4rhP30L2/o=";
+      hash = "sha256-u8jRZNtVM6QdFcrBK5BcO4yPCAMNmKUv1aGRGqdORGw=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-td0EltgpfSGlyo9Pg/4qS8qUdELP+A97iY9z3g19MW8=";
+      hash = "sha256-pKCzrW4Y9YFTS2FyLQR9WA+6oC2hdzzExpEN/VH3PnA=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-KTg6VO1GT/8ppXFevGDx0br9JGl9rdUtuBzHmnjiOuk=";
+      hash = "sha256-sh1PbAxLGd5zsBO6lsIJV7Z22o9A15xAdopdJZ17ZUw=";
     };
   };
 


### PR DESCRIPTION
Extend https://github.com/NixOS/nixpkgs/pull/456016 : new zoom-us version contains a shared library `libdvf.so` that requires `libGLU.so.1` (according to `autoPatchelfHook`).  I don't know what `libdvf.so` is needed for, but it seems to be the right thing to add the dependency to avoid runtime problems.

Notifying co-maintainers @philiptaron @ryan4yin

Notifying reporter of https://github.com/NixOS/nixpkgs/issues/452768 @reilandeubank : I tested only *once*, but it seems your issue got fixed by the new release.  Can you please test the pull request at hand to ensure that wasn't merely luck?


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `cbe1c97d3916b77c4d344c70889f8486a03cdab0`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>zoom-us</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More: Tested with Plasma6/X11/Pulseaudio on a NixOS 25.05 machine (unchecked means "not tested"), after rebasing onto [current `nixos-unstable`](https://github.com/NixOS/nixpkgs/tree/6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce):

- [x] sidebar loads (albeit empty on my installation, cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "collected" by zoom: microphone test shows amplitude and repeats the audio
- [x] audio is produced: "Test speaker" generates audible ting-a-ling
- [x] other participant's audio in video conference is audible
- [x] other participants can hear me
- [x] other participant's camera picture is received/shown
- [x] other participants can see my camera picture
- [x] other participant's screen share is received/shown
- [x] other participants can see my screen sharing
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/issues/116355 )
- [x] receiving an image via in-meeting chat is possible (cf. https://github.com/NixOS/nixpkgs/issues/452768 )
- [x] settings dialog is shown/useable  (cf. https://github.com/NixOS/nixpkgs/pull/410244 )
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual
- [x] reading team chat messages works as expected
- [x] writing team chat messages works
- [ ] sidebar shows content
- [ ] Pipewire
- [ ] Wayland
- [ ] xdg-desktop-portal (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Darwin

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
