### PR TITLE
vrcx: 2025.10.11 -> 2025.10.27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23877,6 +23877,7 @@
     githubId = 49711232;
     github = "ShyAssassin";
     email = "ShyAssassin@assassin.dev";
+    keys = [ { fingerprint = "370E 8296 12AF D0E1 9A1A  88F6 AA81 2447 4716 E56D"; } ];
   };
   shyim = {
     email = "s.sayakci@gmail.com";

--- a/pkgs/by-name/vr/vrcx/deps.json
+++ b/pkgs/by-name/vr/vrcx/deps.json
@@ -96,8 +96,8 @@
   },
   {
     "pname": "Microsoft.Win32.SystemEvents",
-    "version": "9.0.8",
-    "hash": "sha256-c5gFYcyAO7OgG3K+QPh0HrKJ4GKLIR0R9E69zf0TImk="
+    "version": "9.0.9",
+    "hash": "sha256-5p9c8PwLC5whnkDnk7BvMLIln2RuaKdzdLjpUZDHU98="
   },
   {
     "pname": "Newtonsoft.Json",
@@ -106,13 +106,13 @@
   },
   {
     "pname": "Newtonsoft.Json",
-    "version": "13.0.3",
-    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+    "version": "13.0.4",
+    "hash": "sha256-8JCB1FdAW681qXP6DFDWvycu1oPyVoxaYgpJ2pUvZSk="
   },
   {
     "pname": "NLog",
-    "version": "6.0.3",
-    "hash": "sha256-lrF4+wTsVr7/hD9sJVAMk3+zwH7JMoOEw/pCZm3ki4g="
+    "version": "6.0.5",
+    "hash": "sha256-aP7PsAkzjlZF6m1Tr87dX+5X0YIGov7DrTrIdsqhLUY="
   },
   {
     "pname": "runtime.any.System.Runtime",
@@ -181,8 +181,8 @@
   },
   {
     "pname": "System.CodeDom",
-    "version": "9.0.8",
-    "hash": "sha256-gDsK8Vc4RQvg1erKCpP4GH2OzV6icGD3UHymANiQ1n4="
+    "version": "9.0.9",
+    "hash": "sha256-ajVuEZIA63vQBPPw/SgoTDSA+gGAU7V+QCcBts1LiTE="
   },
   {
     "pname": "System.Collections.Immutable",
@@ -231,13 +231,13 @@
   },
   {
     "pname": "System.Drawing.Common",
-    "version": "9.0.8",
-    "hash": "sha256-D+mrysKnc/zxYLt3tvTBKGO5HXGJTSZU5oOJ5X5EHDs="
+    "version": "9.0.9",
+    "hash": "sha256-gupTW+JBaIaifxULV5m2Q8fccXIboeGd3FI33cn4MFs="
   },
   {
     "pname": "System.Management",
-    "version": "9.0.8",
-    "hash": "sha256-n6lutagH+MqKDTL0fc0yK1YgreGR4IlP/O0y1fjOqIg="
+    "version": "9.0.9",
+    "hash": "sha256-BjnQqiA2z8SkicxP+71lR+WGrBHz9np7MlCUE3oO8IM="
   },
   {
     "pname": "System.Memory",
@@ -316,18 +316,13 @@
   },
   {
     "pname": "System.Text.Json",
-    "version": "9.0.8",
-    "hash": "sha256-CEoLOj0KeuctK2jXd6yZ+/5yx4apsEh7+xsJH95h/1c="
+    "version": "9.0.9",
+    "hash": "sha256-I+GCgXZZUtgAta94BIBqy72HnZJ3egzNBOTxnVy2Ur8="
   },
   {
     "pname": "System.Text.RegularExpressions",
     "version": "4.3.1",
     "hash": "sha256-DxsEZ0nnPozyC1W164yrMUXwnAdHShS9En7ImD/GJMM="
-  },
-  {
-    "pname": "System.Threading.Channels",
-    "version": "8.0.0",
-    "hash": "sha256-c5TYoLNXDLroLIPnlfyMHk7nZ70QAckc/c7V199YChg="
   },
   {
     "pname": "System.Threading.Tasks.Extensions",
@@ -341,7 +336,7 @@
   },
   {
     "pname": "Websocket.Client",
-    "version": "5.2.0",
-    "hash": "sha256-5sVfK1iHclxunfm0ioSFFyo5tG8lPfchClBi4YgeJT4="
+    "version": "5.3.0",
+    "hash": "sha256-FgrtCEVMspgLx5jRwJobE1oiK+dWCl4cXoIfH2/kSGk="
   }
 ]

--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -4,30 +4,30 @@
   buildDotnetModule,
   dotnetCorePackages,
   buildNpmPackage,
-  electron_37,
+  electron_38,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
   stdenv,
 }:
 let
-  electron = electron_37;
+  electron = electron_38;
   dotnet = dotnetCorePackages.dotnet_9;
 in
 buildNpmPackage (finalAttrs: {
   pname = "vrcx";
-  version = "2025.10.11";
+  version = "2025.10.27";
 
   src = fetchFromGitHub {
     repo = "VRCX";
     owner = "vrcx-team";
-    rev = "cb6bc979d9371b89b289b6cb0bb8b6f60b350bc7";
-    hash = "sha256-0LnFXSLyby5b2gSIse7Qld4cQlwNAFHSuGGqk6B9TZY=";
+    rev = "5c3d076e10f7edb09831fba0d5ad44036a43a401";
+    hash = "sha256-XLzUfOXqikJOb8cmnpMI/SLeF6Jnuo4Xvmi8jfgt71Q=";
   };
 
   makeCacheWritable = true;
   npmFlags = [ "--ignore-scripts" ];
-  npmDepsHash = "sha256-giWeXrsiFaZOh5zs7L4L0w3wcnD/F3TyrMM/POfOTvE=";
+  npmDepsHash = "sha256-pghoOI/lotorjCAFGoFjhEx3H7h9J8LhctCMfk6ZTYI=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
https://github.com/vrcx-team/VRCX/releases/tag/v2025.10.27
Along with updating vrcx i have updated my entry in `maintainer-list.nix` to include my pgp key's fingerprint

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
