### PR TITLE
batticonplus: init at 2.0.1

### DIFF
--- a/pkgs/by-name/ba/batticonplus/package.nix
+++ b/pkgs/by-name/ba/batticonplus/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  gettext,
+  glib,
+  gtk3,
+  libnotify,
+  wrapGAppsHook3,
+  libayatana-appindicator,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "batticonplus";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "artist4xlibre";
+    repo = "batticonplus";
+    tag = "v${version}";
+    hash = "sha256-H9ZoiQ5zWMIoWWol2a6f9Z8g4o9DIHYdF+/nEsBfuzc=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libnotify
+    libayatana-appindicator
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "WITH_APPINDICATOR=1"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lightweight battery status icon for the system tray and notifier (based on cbatticon)";
+    mainProgram = "batticonplus";
+    homepage = "https://github.com/artist4xlibre/batticonplus";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ yechielw ];
+  };
+}


### PR DESCRIPTION
This is a drop-in replacement for cbatticon with wayland support
link: https://github.com/artist4xlibre/batticonplus


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
