### PR TITLE
[25.05] jdk8: 8u442-b06 -> 8u472-b08

### DIFF
--- a/pkgs/development/compilers/openjdk/8/source.json
+++ b/pkgs/development/compilers/openjdk/8/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-y+YFPDSkPopIi0++rTwf2fsehzBdW1eR3tEWGGV5Yqk=",
+  "hash": "sha256-CQZKhDojo+a4vZsIzRM/KoUfR17LedQYBWCRJxDFJUM=",
   "owner": "openjdk",
   "repo": "jdk8u",
-  "rev": "refs/tags/jdk8u442-b06"
+  "rev": "refs/tags/jdk8u462-b08"
 }

--- a/pkgs/development/compilers/openjdk/8/source.json
+++ b/pkgs/development/compilers/openjdk/8/source.json
@@ -1,6 +1,6 @@
 {
-  "hash": "sha256-CQZKhDojo+a4vZsIzRM/KoUfR17LedQYBWCRJxDFJUM=",
+  "hash": "sha256-2TN7JG42h9tYJNUzL2OLsbCWdKjWcvRf/4L9jfVfRSQ=",
   "owner": "openjdk",
   "repo": "jdk8u",
-  "rev": "refs/tags/jdk8u462-b08"
+  "rev": "refs/tags/jdk8u472-b08"
 }


### PR DESCRIPTION
Backport of #406572 and #455435

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test