### PR TITLE
cdxgen: 11.0.3 -> 11.10.0

### DIFF
--- a/pkgs/by-name/cd/cdxgen/package.nix
+++ b/pkgs/by-name/cd/cdxgen/package.nix
@@ -5,7 +5,7 @@
   makeWrapper,
   node-gyp,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   python3,
   stdenv,
   xcbuild,
@@ -13,20 +13,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cdxgen";
-  version = "11.0.3";
+  version = "11.10.0";
 
   src = fetchFromGitHub {
     owner = "CycloneDX";
     repo = "cdxgen";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-H83HEiBdXBIhSR18EtYcQey6aXy8URSjpeNVEs3UBm8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RmgR6OfNrZUYFyn36zTHERIHlzszaFqTX8b4Rf2TF/U=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     nodejs
     node-gyp # required for sqlite3 bindings
-    pnpm_9.configHook
+    pnpm_10.configHook
     python3 # required for sqlite3 bindings
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin [
@@ -34,10 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
     cctools.libtool
   ];
 
-  pnpmDeps = pnpm_9.fetchDeps {
+  pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-7NrDYd4H0cPQs8w4lWlB0BhqcYZVo6/9zf0ujPjBzsE=";
+    fetcherVersion = 2;
+    hash = "sha256-o5pNgn+ZqaEfsWO97jXkRyPH+0pffR6TBZcF6nApWVg=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Changes:
https://github.com/CycloneDX/cdxgen/releases/tag/v11.10.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.9.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.8.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.7.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.6.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.5.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.4.4
https://github.com/CycloneDX/cdxgen/releases/tag/v11.4.3
https://github.com/CycloneDX/cdxgen/releases/tag/v11.4.2
https://github.com/CycloneDX/cdxgen/releases/tag/v11.4.1
https://github.com/CycloneDX/cdxgen/releases/tag/v11.4.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.3.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.2.0
https://github.com/CycloneDX/cdxgen/releases/tag/v11.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 456196`
Commit: `66b13829ca7093ad817cc5ed4a0bf095a7176e1b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>cdxgen</li>
    <li>dep-scan</li>
    <li>dep-scan.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
