### PR TITLE
wpsoffice-cn: fix md5hash and dbus

### DIFF
--- a/pkgs/by-name/wp/wpsoffice-cn/package.nix
+++ b/pkgs/by-name/wp/wpsoffice-cn/package.nix
@@ -23,6 +23,7 @@
   xorg,
   # wpsoffice runtime dependencies
   cups,
+  dbus,
   pango,
 }:
 
@@ -51,10 +52,9 @@ let
       }
       ''
         readonly SECURITY_KEY="7f8faaaa468174dc1c9cd62e5f218a5b"
-        prefix="https://wps-linux-personal.wpscdn.cn"
 
         timestamp10=$(date '+%s')
-        md5hash=($(printf '%s' "$SECURITY_KEY''${${url}#$prefix}$timestamp10" | md5sum))
+        md5hash=($(printf '%s' "$SECURITY_KEY${lib.removePrefix "https://wps-linux-personal.wpscdn.cn" url}$timestamp10" | md5sum))
 
         curl --retry 3 --retry-delay 3 "${url}?t=$timestamp10&k=$md5hash" > $out
       '';
@@ -96,6 +96,7 @@ stdenv.mkDerivation {
 
   runtimeDependencies = map lib.getLib [
     cups
+    dbus
     pango
   ];
 


### PR DESCRIPTION
Sorry for bothering the other maintainers again, i find that the hash mismatch for wpsoffice-cn when updating my system, and there is an issue with the md5hash calculation in the last [commit](https://github.com/chillcicada/nixpkgs/blob/97d95da2cd150d475b355e540e6ddd45fc25c7c9/pkgs/by-name/wp/wpsoffice-cn/package.nix#L57). Due to the cache of nix-prefetch-url, i overlooked it.

To avoid toxic conflicts between parameter expansion and string interpolation and escape syntax, i use a more concise and intuitive approach. Then i clear the cache for testing, and now it builds correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
