### PR TITLE
nixos/cosmic: disable libcosmicAppHook includeSettings by default

### DIFF
--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -20,11 +20,7 @@
   nix-update-script,
   nixosTests,
 }:
-let
-  libcosmicAppHook' = (libcosmicAppHook.__spliced.buildHost or libcosmicAppHook).override {
-    includeSettings = false;
-  };
-in
+
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-settings";
   version = "1.0.0-beta.3";
@@ -42,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     cmake
     just
-    libcosmicAppHook'
+    libcosmicAppHook
     pkg-config
     rustPlatform.bindgenHook
     util-linux

--- a/pkgs/by-name/li/libcosmicAppHook/package.nix
+++ b/pkgs/by-name/li/libcosmicAppHook/package.nix
@@ -16,7 +16,7 @@
   wayland,
   vulkan-loader,
 
-  includeSettings ? true,
+  includeSettings ? false,
 }:
 
 makeSetupHook {


### PR DESCRIPTION
Disabled `includeSettings` in `pkgs/by-name/li/libcosmicAppHook/package.nix` by default.

This essentially changes the inclusion of `cosmic-settings` in `XDG_DATA_DIRS` via libcosmicAppHook to an **opt-in** feature instead of **opt-out**. More info about libcosmicAppHook can be found [here](https://github.com/NixOS/nixpkgs/blob/4a830cf221d1d5daaa94f06ce0348b3d9088658f/doc/languages-frameworks/cosmic.section.md)

I noticed no regression in a simple check of most common COSMIC Apps functionality.

This change fixes an issue where the **COSMIC Settings** entry would appear twice in the **COSMIC App Library**.

| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/71a32848-8147-4f8a-896b-fe9b2279db0f) | ![After](https://github.com/user-attachments/assets/c205b32e-4012-41ff-97a1-20e85f0f5247) |


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
