### PR TITLE
opencloud-desktop v2: generate plugin metadata

### DIFF
--- a/pkgs/by-name/op/opencloud-desktop/fix-qml-plugin.patch
+++ b/pkgs/by-name/op/opencloud-desktop/fix-qml-plugin.patch
@@ -1,0 +1,36 @@
+diff --git i/src/gui/CMakeLists.txt w/src/gui/CMakeLists.txt
+index 5d85fe4..6d75834 100644
+--- i/src/gui/CMakeLists.txt
++++ w/src/gui/CMakeLists.txt
+@@ -107,6 +107,7 @@ ecm_add_qml_module(OpenCloudGui
+         URI eu.OpenCloud.gui
+         VERSION 1.0
+         NAMESPACE OCC
++        GENERATE_PLUGIN_SOURCE
+         QML_FILES
+             qml/OpenCloud.js
+ 
+diff --git i/src/libsync/CMakeLists.txt w/src/libsync/CMakeLists.txt
+index c6f50fa..9bd2a47 100644
+--- i/src/libsync/CMakeLists.txt
++++ w/src/libsync/CMakeLists.txt
+@@ -101,6 +101,7 @@ ecm_add_qml_module(libsync
+         URI eu.OpenCloud.libsync
+         VERSION 1.0
+         NAMESPACE OCC
++        GENERATE_PLUGIN_SOURCE
+ )
+ 
+ ecm_finalize_qml_module(libsync DESTINATION ${KDE_INSTALL_QMLDIR})
+diff --git i/src/resources/CMakeLists.txt w/src/resources/CMakeLists.txt
+index c127cf1..8c63c99 100644
+--- i/src/resources/CMakeLists.txt
++++ w/src/resources/CMakeLists.txt
+@@ -46,6 +46,7 @@ ecm_add_qml_module(OpenCloudResources
+         URI eu.OpenCloud.resources
+         VERSION 1.0
+         NAMESPACE OCC
++        GENERATE_PLUGIN_SOURCE
+ )
+ 
+ ecm_finalize_qml_module(OpenCloudResources DESTINATION ${KDE_INSTALL_QMLDIR})

--- a/pkgs/by-name/op/opencloud-desktop/package.nix
+++ b/pkgs/by-name/op/opencloud-desktop/package.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-NM9SspeMXu1q3tfpcFk4OuLapu/clbotJLu2u4nmAlY=";
   };
 
+  patches = [
+    # Fix QML plugin metadata generation for Qt 6.
+    # Fixed upstream for 3.0.0
+    ./fix-qml-plugin.patch
+  ];
+
   buildInputs = [
     kdePackages.extra-cmake-modules
     qt6.qtbase


### PR DESCRIPTION
Fixes the following error for me when starting `opencloud-desktop`:
```
QList(qrc:/qt/qml/eu/OpenCloud/gui/qml/AccountBar.qml:18:1: Failed to extract plugin meta data from '/nix/store/1281zvpdy77rxsdcva0dwvlwdw8jpm5h-opencloud-desktop-2.0.0/lib/qt-6/qml/eu/OpenCloud/gui/libOpenCloudGuiplugin.so': '/nix/store/1281zvpdy77rxsdcva0dwvlwdw8jpm5h-opencloud-desktop-2.0.0/lib/qt-6/qml/eu/OpenCloud/gui/libOpenCloudGuiplugin.so' is not a Qt plugin (metadata not found)
    import eu.OpenCloud.gui 1.0
    ^)
```

It instructs CMake to generate Qt plugin metadata required for Qt 6, as far as I understand.

Apparently, this is a non-issue for 3.0.0(beta), so this is merely a workaround until 3.0.0 is released.

@FKouhai 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
