### PR TITLE
fetchFromGitHub: take `passthru` and avoid arbitrary arguments overwriting

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -60,6 +60,7 @@ lib.makeOverridable (
       # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
       # needed for netrcPhase
       netrcImpureEnvVars ? [ ],
+      passthru ? { },
       meta ? { },
       allowedRequisites ? null,
       # fetch all tags after tree (useful for git describe)
@@ -195,7 +196,8 @@ lib.makeOverridable (
         passthru = {
           gitRepoUrl = url;
           inherit tag;
-        };
+        }
+        // passthru;
       }
   )
 )

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -112,7 +112,8 @@ lib.makeOverridable (
     revWithTag = if tag != null then "refs/tags/${tag}" else rev;
 
     fetcherArgs =
-      (
+      passthruAttrs
+      // (
         if useFetchGit then
           {
             inherit
@@ -152,7 +153,6 @@ lib.makeOverridable (
           }
       )
       // privateAttrs
-      // passthruAttrs
       // {
         inherit name;
       };

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -22,6 +22,7 @@ lib.makeOverridable (
     sparseCheckout ? lib.optional (rootDir != "") rootDir,
     githubBase ? "github.com",
     varPrefix ? null,
+    passthru ? { },
     meta ? { },
     ... # For hash agility
   }@args:
@@ -125,6 +126,7 @@ lib.makeOverridable (
               fetchLFS
               ;
             url = gitRepoUrl;
+            inherit passthru;
           }
           // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
         else
@@ -149,7 +151,8 @@ lib.makeOverridable (
 
             passthru = {
               inherit gitRepoUrl;
-            };
+            }
+            // passthru;
           }
       )
       // privateAttrs


### PR DESCRIPTION
1. Lower the precedence of `passthruAttrs` (miscellaneous user-specified arguments passing to the base fetcher) to avoid overwriting `url` and netrc-related arguments. We don't mean to support `fetchFromGitHub {  url = "https://random-site.com"; }`.
2. Take and handle `passthru` so that user-defined `passthru` won't get shadowed after the above change.
3. Make `fetchgit` take and handle `passthru` so that `fetchFromGitHub` can utilize it.

This PR also help de-duplicate existing works trying to fix the `fetchFromGitHub`'s exposing `owner` and `repo`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no rebuilds)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
