### PR TITLE
fetchFromGitHub: converge arguments that determines `useFetchGit`

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -27,7 +27,7 @@ lib.makeOverridable (
     varPrefix ? null,
     passthru ? { },
     meta ? { },
-    ... # For hash agility
+    ... # For hash agility and additional fetchgit arguments
   }@args:
 
   assert (

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -4,8 +4,40 @@
   fetchgit,
   fetchzip,
 }:
+let
+  # Here defines fetchFromGitHub arguments that determines useFetchGit,
+  # The attribute value is their default values.
+  # As fetchFromGitHub prefers fetchzip for hash stability,
+  # `defaultFetchGitArgs` attributes should lead to `useFetchGit = false`.
+  useFetchGitArgsDefault = {
+    deepClone = false;
+    fetchSubmodules = false; # This differs from fetchgit's default
+    fetchLFS = false;
+    forceFetchGit = false;
+    leaveDotGit = null;
+    rootDir = "";
+    sparseCheckout = null;
+  };
+  useFetchGitArgsDefaultNullable = {
+    leaveDotGit = false;
+    sparseCheckout = [ ];
+  };
 
-lib.makeOverridable (
+  useFetchGitargsDefaultNonNull = useFetchGitArgsDefault // useFetchGitArgsDefaultNullable;
+
+  # useFetchGitArgsWD to exclude from automatic passing.
+  # Other useFetchGitArgsWD will pass down to fetchgit.
+  excludeUseFetchGitArgNames = [
+    "forceFetchGit"
+  ];
+
+  faUseFetchGit = lib.mapAttrs (_: _: true) useFetchGitArgsDefault;
+
+  adjustFunctionArgs = f: lib.setFunctionArgs f (faUseFetchGit // lib.functionArgs f);
+
+  decorate = f: lib.makeOverridable (adjustFunctionArgs f);
+in
+decorate (
   {
     owner,
     repo,
@@ -13,16 +45,7 @@ lib.makeOverridable (
     rev ? null,
     # TODO(@ShamrockLee): Add back after reconstruction with lib.extendMkDerivation
     # name ? repoRevToNameMaybe finalAttrs.repo (lib.revOrTag finalAttrs.revCustom finalAttrs.tag) "github",
-    # `fetchFromGitHub` defaults to use `fetchzip` for better hash stability.
-    # We default not to fetch submodules, which is contrary to `fetchgit`'s default.
-    fetchSubmodules ? false,
-    leaveDotGit ? null,
-    deepClone ? false,
     private ? false,
-    forceFetchGit ? false,
-    fetchLFS ? false,
-    rootDir ? "",
-    sparseCheckout ? null,
     githubBase ? "github.com",
     varPrefix ? null,
     passthru ? { },
@@ -37,6 +60,16 @@ lib.makeOverridable (
   );
 
   let
+    useFetchGit = useFetchGitArgsWDNonNull != useFetchGitargsDefaultNonNull;
+
+    useFetchGitArgs = lib.intersectAttrs useFetchGitArgsDefault args;
+    useFetchGitArgsWD = useFetchGitArgsDefault // useFetchGitArgs;
+    useFetchGitArgsWDPassing = removeAttrs useFetchGitArgsWD excludeUseFetchGitArgNames;
+    useFetchGitArgsWDNonNull =
+      useFetchGitArgsWD
+      // lib.mapAttrs (
+        name: nonNullDefault: lib.defaultTo nonNullDefault useFetchGitArgsWD.${name}
+      ) useFetchGitArgsDefaultNullable;
 
     position = (
       if args.meta.description or null != null then
@@ -56,26 +89,19 @@ lib.makeOverridable (
         # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
         position = "${position.file}:${toString position.line}";
       };
-    passthruAttrs = removeAttrs args [
-      "owner"
-      "repo"
-      "tag"
-      "rev"
-      "fetchSubmodules"
-      "forceFetchGit"
-      "private"
-      "githubBase"
-      "varPrefix"
-    ];
+    passthruAttrs = removeAttrs args (
+      [
+        "owner"
+        "repo"
+        "tag"
+        "rev"
+        "private"
+        "githubBase"
+        "varPrefix"
+      ]
+      ++ (if useFetchGit then excludeUseFetchGitArgNames else lib.attrNames faUseFetchGit)
+    );
     varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
-    useFetchGit =
-      fetchSubmodules
-      || lib.defaultTo false leaveDotGit == true
-      || deepClone
-      || forceFetchGit
-      || fetchLFS
-      || (rootDir != "")
-      || lib.defaultTo [ ] sparseCheckout != [ ];
     # We prefer fetchzip in cases we don't need submodules as the hash
     # is more stable in that case.
     fetcher =
@@ -118,16 +144,9 @@ lib.makeOverridable (
       passthruAttrs
       // (
         if useFetchGit then
-          {
-            inherit
-              tag
-              rev
-              deepClone
-              fetchSubmodules
-              leaveDotGit
-              sparseCheckout
-              fetchLFS
-              ;
+          useFetchGitArgsWDPassing
+          // {
+            inherit tag rev;
             url = gitRepoUrl;
             inherit passthru;
             derivationArgs = {

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -60,16 +60,16 @@ decorate (
   );
 
   let
-    useFetchGit = useFetchGitArgsWDNonNull != useFetchGitargsDefaultNonNull;
+    useFetchGit =
+      lib.mapAttrs (
+        name: nonNullDefault:
+        if args ? ${name} && (useFetchGitArgsDefaultNullable ? ${name} -> args.${name} != null) then
+          args.${name}
+        else
+          nonNullDefault
+      ) useFetchGitargsDefaultNonNull != useFetchGitargsDefaultNonNull;
 
-    useFetchGitArgs = lib.intersectAttrs useFetchGitArgsDefault args;
-    useFetchGitArgsWD = useFetchGitArgsDefault // useFetchGitArgs;
-    useFetchGitArgsWDPassing = removeAttrs useFetchGitArgsWD excludeUseFetchGitArgNames;
-    useFetchGitArgsWDNonNull =
-      useFetchGitArgsWD
-      // lib.mapAttrs (
-        name: nonNullDefault: lib.defaultTo nonNullDefault useFetchGitArgsWD.${name}
-      ) useFetchGitArgsDefaultNullable;
+    useFetchGitArgsWDPassing = lib.overrideExisting (removeAttrs useFetchGitArgsDefault excludeUseFetchGitArgNames) args;
 
     position = (
       if args.meta.description or null != null then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Converge `fetchgit`-related `fetchFromGitHub` arguments specification.
Before this change, arguments like `fetchSubmodules` are listed in four places:
- `fetchFromGitHub`'s argument set pattern.
- `useFetchGit` determination.
- `passthruFun`'s exclusion list.
- Arguments to pass down to `fetchgit`.

These lists get out of sync over time. Before this change, specifying any of the following results in `called with unexpected argument` error:
- `leaveDotGit = false`
- `fetchLFS = false`
- `rootDir = ""`
- `sparseCheckout = [ ]`

This PR converges the specification and handling of these argument into the let-in block, and add back the additional `__functionArgs` with a helper function `adjustFunctionArgs`.

This PR depends on PR #462032 for cleaner implementation.
- #462032

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
