### PR TITLE
massif-visualizer: fix build with CMake 4

### DIFF
--- a/pkgs/development/tools/analysis/massif-visualizer/cmake-minimum-required.patch
+++ b/pkgs/development/tools/analysis/massif-visualizer/cmake-minimum-required.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d7067dc..337c4ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.10)
+ project(massif-visualizer)
+ 
+ set(QT_MIN_VERSION "5.2.0")

--- a/pkgs/development/tools/analysis/massif-visualizer/default.nix
+++ b/pkgs/development/tools/analysis/massif-visualizer/default.nix
@@ -25,6 +25,8 @@ mkDerivation rec {
     sha256 = "0v8z6r9gngzckvqyxjm9kp7hilwfqibyk2f9vag9l98ar0iwr97q";
   };
 
+  patches = [ ./cmake-minimum-required.patch ];
+
   nativeBuildInputs = [
     extra-cmake-modules
     shared-mime-info


### PR DESCRIPTION
This PR is strongly based on https://github.com/NixOS/nixpkgs/pull/455240 and https://github.com/NixOS/nixpkgs/pull/456230:

- https://github.com/NixOS/nixpkgs/issues/445447

To fix the `nix build .#massif-visualizer` evaluation, this PR needs to be stacked on top of https://github.com/NixOS/nixpkgs/pull/455240 and https://github.com/NixOS/nixpkgs/pull/456230.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
    - Ensure `nix run .#massif-visualizer` is not complete nonsense.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
