### PR TITLE
systemd-credsubst: init at 0.1.0

### DIFF
--- a/pkgs/by-name/sy/systemd-credsubst/package.nix
+++ b/pkgs/by-name/sy/systemd-credsubst/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "systemd-credsubst";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    owner = "yaxitech";
+    repo = "systemd-credsubst";
+    tag = "v${version}";
+    hash = "sha256-3KbO93OWJuiV8oYLSlqaj0i2x/2GwGxfQ7QwwSrfb1Y=";
+  };
+  cargoHash = "sha256-B2TxFgq/8z0KyL2soFwz/OqFVOVMNP7bamOXg0MuSK8=";
+  meta = {
+    description = "envsubst for systemd credentials";
+    longDescription = "Substitute systemd credential references from ExecStart=/ExecStartPre= calls";
+    homepage = "https://github.com/yaxitech/systemd-credsubst";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    mainProgram = "systemd-credsubst";
+    maintainers = [ lib.maintainers.veehaitch ];
+  };
+}


### PR DESCRIPTION
Adds `systemd-credsubst`, a tool which works similar to envsubst but instead of replacing a placeholder name in a file with the corresponding environment variable value, it uses the content of the corresponding systemd credential. For details, please refer to [the README](https://github.com/yaxitech/systemd-credsubst) of the project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
