### PR TITLE
python3Packages.kaleido: remove sbcl and font dependencies

### DIFF
--- a/pkgs/development/python-modules/kaleido/default.nix
+++ b/pkgs/development/python-modules/kaleido/default.nix
@@ -7,15 +7,12 @@
   fetchurl,
   autoPatchelfHook,
   bash,
-  dejavu_fonts,
   expat,
   fontconfig,
-  lato,
   libGL,
   makeWrapper,
   nspr,
   nss,
-  sbclPackages,
   sqlite,
 }:
 
@@ -52,15 +49,6 @@ buildPythonPackage rec {
   ];
   buildInputs = [
     bash
-    dejavu_fonts
-    expat
-    fontconfig
-    lato
-    libGL
-    nspr
-    nss
-    sbclPackages.cl-dejavu
-    sqlite
   ];
 
   pythonImportsCheck = [ "kaleido" ];
@@ -82,15 +70,7 @@ buildPythonPackage rec {
     rm -rf $out/${python.sitePackages}/kaleido/executable/etc/fonts
     mkdir -p $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d
     ln -s ${fontconfig.out}/etc/fonts/fonts.conf $out/${python.sitePackages}/kaleido/executable/etc/fonts/
-    ls -s ${fontconfig.out}/etc/fonts/conf.d/* $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d/
-    ln -s ${sbclPackages.cl-dejavu}/dejavu-fonts-ttf-2.37/fontconfig/* $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d/
-
-    # Replace bundled fonts with nixpkgs-packaged fonts
-    # Currently this causes an issue where the fonts aren't found. I'm not sure why, so I'm leaving this commented out for now.
-    #rm -rf $out/${python.sitePackages}/kaleido/executable/xdg/fonts
-    #mkdir -p $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/dejavu $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/lato
-    #ln -s ${dejavu_fonts}/share/fonts/truetype/* $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/dejavu/
-    #ln -s ${lato}/share/fonts/lato/* $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/lato/
+    ln -s ${fontconfig.out}/etc/fonts/conf.d/* $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d/
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # Replace bundled swiftshader with libGL

--- a/pkgs/development/python-modules/kaleido/tests.nix
+++ b/pkgs/development/python-modules/kaleido/tests.nix
@@ -11,5 +11,6 @@ runCommand "${kaleido.pname}-tests" {
     python
     plotly
     pandas
+    kaleido
   ];
 } "python3 ${./tests.py}"


### PR DESCRIPTION
I removed unnecessary dependencies based on #454818 but checking that the test `nix-build -A python3Packages.kaleido.passthru.tests.kaleido` passed. I ping @Pandapip1 given that he is the maintainer of the package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
