### PR TITLE
freeebsd: Fix cross compilation

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/libthr.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libthr.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   mkDerivation,
   libcMinimal,
   include,
@@ -31,6 +32,19 @@ mkDerivation {
     include
     libgcc
   ];
+
+  patches = [
+    # https://github.com/freebsd/freebsd-src/pull/1882
+    (fetchpatch {
+      name = "freebsd-libthr-use-nonstring-attribute.patch";
+      url = "https://github.com/freebsd/freebsd-src/pull/1882/commits/650800993deb513dc31e99ef5cdecd50ee70bb04.diff";
+      hash = "sha256-WKN7dfGAs1+XADT4aLUkkKmQQ4n7gsyFUTCeo6mcuMY=";
+      includes = [ "lib/libthr/thread/thr_printf.c" ];
+    })
+  ];
+
+  # Presumably newer Clang has gotten more strict.
+  CWARNEXTRA = "-Wno-cast-function-type-mismatch";
 
   preBuild = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -B${csu}/lib"

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rtld-elf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rtld-elf.nix
@@ -1,5 +1,6 @@
 {
   mkDerivation,
+  fetchpatch,
   include,
   rpcgen,
   flex,
@@ -29,6 +30,16 @@ mkDerivation {
     "sys/crypto"
   ]
   ++ extraSrc;
+
+  patches = [
+    # https://github.com/freebsd/freebsd-src/pull/1882
+    (fetchpatch {
+      name = "freebsd-rtld-use-nonstring-attribute.patch";
+      url = "https://github.com/freebsd/freebsd-src/pull/1882/commits/650800993deb513dc31e99ef5cdecd50ee70bb04.diff";
+      hash = "sha256-V9jDE/5Fu6hLIzlG1e6AqLnGwlzW2OjonyUgvSVtm58=";
+      includes = [ "libexec/rtld-elf/rtld.c" ];
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
It looks like upgrading to newer clang has caused some `-Werror` problems. We should probably disable `-Werror` entirely, but for now, I've done the more targetted fix of disabling one specific warning, and sending https://github.com/freebsd/freebsd-src/pull/1882 upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

CC @jonhermansen

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
