### PR TITLE
cloudsmith-cli: 1.8.3 -> 1.8.7, cloudsmith-api: 2.0.21 -> 2.0.22

### DIFF
--- a/pkgs/by-name/cl/cloudsmith-cli/package.nix
+++ b/pkgs/by-name/cl/cloudsmith-cli/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cloudsmith-cli";
-  version = "1.8.3";
+  version = "1.8.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cloudsmith-io";
     repo = "cloudsmith-cli";
     tag = "v${version}";
-    hash = "sha256-PYqOj6nHjJrG7Ndc5vm//E8mjk4xZFVQopFqiWtH5ZQ=";
+    hash = "sha256-xUaa1B6f6W0Q/9q8sztFoCxEaxqXajImROC1sJb0Zdk=";
   };
 
   postPatch = ''
@@ -59,6 +59,10 @@ python3Packages.buildPythonApplication rec {
     # https://github.com/NixOS/nixpkgs/issues/255262
     cd "$out"
   '';
+
+  disabledTests = [
+    "TestMainCommand"
+  ];
 
   meta = {
     homepage = "https://help.cloudsmith.io/docs/cli/";

--- a/pkgs/development/python-modules/cloudsmith-api/default.nix
+++ b/pkgs/development/python-modules/cloudsmith-api/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "cloudsmith-api";
-  version = "2.0.21";
+  version = "2.0.22";
   format = "wheel";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "cloudsmith_api";
     inherit format version;
-    hash = "sha256-tReoNsSg90wReH/SVa2LAdy5q7DCnWJwnamisPkIuXs=";
+    hash = "sha256-FZcDjrK5+oHC3dVBSXf+txW6hofP6OkmkjO4NJF05YQ=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update cloudsmith stuff to latest. A test broke because nixpkgs' `click` updated to `>8.2`.

Upstream PR (merged, remove `disabledTests` next bump): https://github.com/cloudsmith-io/cloudsmith-cli/pull/224

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
