### PR TITLE
cargo-nextest: Avoid usdt on macos entirely

### DIFF
--- a/pkgs/by-name/ca/cargo-nextest/no-dtrace-macos.patch
+++ b/pkgs/by-name/ca/cargo-nextest/no-dtrace-macos.patch
@@ -1,0 +1,62 @@
+diff --git a/nextest-runner/Cargo.toml b/nextest-runner/Cargo.toml
+index 776c9341..06196bd2 100644
+--- a/nextest-runner/Cargo.toml
++++ b/nextest-runner/Cargo.toml
+@@ -118,7 +118,7 @@ nix.workspace = true
+ #
+ # Also, usdt 0.6.0 fails to compile on x86_64-apple-darwin, so restrict it to
+ # aarch64-apple-darwin.
+-[target.'cfg(any(all(target_arch = "x86_64", any(target_os = "linux", target_os = "freebsd", target_os = "illumos")), all(target_arch = "aarch64", any(target_os = "macos", target_os = "freebsd", target_os = "illumos"))))'.dependencies]
++[target.'cfg(any(all(target_arch = "x86_64", any(target_os = "linux", target_os = "freebsd", target_os = "illumos")), all(target_arch = "aarch64", any(target_os = "freebsd", target_os = "illumos"))))'.dependencies]
+ usdt = "0.6.0"
+ 
+ [target.'cfg(windows)'.dependencies]
+diff --git a/nextest-runner/src/usdt.rs b/nextest-runner/src/usdt.rs
+index 7732eeb4..af69015b 100644
+--- a/nextest-runner/src/usdt.rs
++++ b/nextest-runner/src/usdt.rs
+@@ -28,7 +28,7 @@ use serde::Serialize;
+     ),
+     all(
+         target_arch = "aarch64",
+-        any(target_os = "macos", target_os = "freebsd", target_os = "illumos")
++        any(target_os = "freebsd", target_os = "illumos")
+     )
+ ))]
+ pub fn register_probes() -> Result<(), usdt::Error> {
+@@ -43,7 +43,7 @@ pub fn register_probes() -> Result<(), usdt::Error> {
+     ),
+     all(
+         target_arch = "aarch64",
+-        any(target_os = "macos", target_os = "freebsd", target_os = "illumos")
++        any(target_os = "freebsd", target_os = "illumos")
+     )
+ )))]
+ pub fn register_probes() -> Result<(), std::convert::Infallible> {
+@@ -57,7 +57,7 @@ pub fn register_probes() -> Result<(), std::convert::Infallible> {
+     ),
+     all(
+         target_arch = "aarch64",
+-        any(target_os = "macos", target_os = "freebsd", target_os = "illumos")
++        any(target_os = "freebsd", target_os = "illumos")
+     )
+ ))]
+ #[usdt::provider(provider = "nextest")]
+@@ -135,7 +135,7 @@ pub mod usdt_probes {
+     ),
+     all(
+         target_arch = "aarch64",
+-        any(target_os = "macos", target_os = "freebsd", target_os = "illumos")
++        any(target_os = "freebsd", target_os = "illumos")
+     )
+ ))]
+ #[macro_export]
+@@ -246,7 +246,7 @@ macro_rules! fire_usdt {
+     ),
+     all(
+         target_arch = "aarch64",
+-        any(target_os = "macos", target_os = "freebsd", target_os = "illumos")
++        any(target_os = "freebsd", target_os = "illumos")
+     )
+ )))]
+ #[macro_export]

--- a/pkgs/by-name/ca/cargo-nextest/package.nix
+++ b/pkgs/by-name/ca/cargo-nextest/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
@@ -15,6 +16,11 @@ rustPlatform.buildRustPackage rec {
     rev = "cargo-nextest-${version}";
     hash = "sha256-DY/FNtlNQg9Ym6PKo6UqSuWzGC3cDhbNU6MKTDxIaU4=";
   };
+
+  # FIXME: we don't support dtrace probe generation on macOS until we have a dtrace build: https://github.com/NixOS/nixpkgs/pull/392918
+  patches = lib.optionals stdenv.isDarwin [
+    ./no-dtrace-macos.patch
+  ];
 
   cargoHash = "sha256-uQH9d+9VByXe/lL4Ybz07p+iYWUhbATMBCu7mYKxOSE=";
 


### PR DESCRIPTION
usdt depends on dtrace for macos which is unsupported in nixpkgs, so need to avoid. Disable by patching so future updates will likely fail to apply the patch if anything changes here. This was introduced in https://github.com/NixOS/nixpkgs/pull/455250.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
