### PR TITLE
pymeshlab: fix build issue with cmake4

### DIFF
--- a/pkgs/applications/graphics/pymeshlab/default.nix
+++ b/pkgs/applications/graphics/pymeshlab/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "cnr-isti-vclab";
     repo = "pymeshlab";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-IOlRdXoUPOJt67g3HqsLchV5aL+JUEks2y1Sy+wpwsg=";
     fetchSubmodules = true;
   };
@@ -79,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   preConfigure = ''
+    substituteInPlace src/pymeshlab/pybind11/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 3.4)" "cmake_minimum_required(VERSION 3.10)"
     substituteInPlace src/meshlab/src/external/libigl.cmake \
       --replace-fail '$'{MESHLAB_EXTERNAL_DOWNLOAD_DIR}/libigl-2.4.0 ${libigl}
     substituteInPlace src/meshlab/src/external/nexus.cmake \

--- a/pkgs/by-name/co/corto/package.nix
+++ b/pkgs/by-name/co/corto/package.nix
@@ -5,15 +5,15 @@
   cmake,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "corto";
-  version = "0-unstable-2024-04-05";
+  version = "2025.07";
 
   src = fetchFromGitHub {
     owner = "cnr-isti-vclab";
     repo = "corto";
-    rev = "d880519c490c88a39d12c31a914b6a687a7019c3";
-    hash = "sha256-0OUijrf+0ZNv3oYko2r8Kp9zgtg8b9RPL7DXHf15Ryc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wfIZQdypBTfUZJgPE4DetSt1SUNSyZihmL1Uzapqh1o=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -24,4 +24,4 @@ stdenv.mkDerivation {
     license = licenses.mit;
     maintainers = with maintainers; [ nim65s ];
   };
-}
+})


### PR DESCRIPTION
This fixes two cmake4 issues. 

First `pymeshlab` depends on `corto`, which upstream already had updated cmake. 

Second `pymeshlab` bundles pybind11 which needed a `substituteInPlace` to update to cmake policy 3.10 from 3.4. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
