### PR TITLE
ghc: provide JavaScript CPP command for ghcjs build

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -859,7 +859,7 @@ stdenv.mkDerivation (
       ghc-settings-edit "$settingsFile" \
       "windres command" "${toolPath "windres" installCC}"
     ''
-    + lib.optionalString stdenv.targetPlatform.isGhcjs ''
+    + lib.optionalString (stdenv.targetPlatform.isGhcjs && lib.versionOlder version "9.12") ''
       ghc-settings-edit "$settingsFile" \
         "JavaScript CPP command" "${toolPath "cc" installCC}"
       ghc-settings-edit "$settingsFile" \

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -859,6 +859,12 @@ stdenv.mkDerivation (
       ghc-settings-edit "$settingsFile" \
       "windres command" "${toolPath "windres" installCC}"
     ''
+    + lib.optionalString stdenv.targetPlatform.isGhcjs ''
+      ghc-settings-edit "$settingsFile" \
+        "JavaScript CPP command" "${toolPath "cc" installCC}"
+      ghc-settings-edit "$settingsFile" \
+        "JavaScript CPP flags" "-E"
+    ''
     + ''
 
       # Install the bash completion file.

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -863,7 +863,7 @@ stdenv.mkDerivation (
       ghc-settings-edit "$settingsFile" \
         "JavaScript CPP command" "${toolPath "cc" installCC}"
       ghc-settings-edit "$settingsFile" \
-        "JavaScript CPP flags" "-E"
+        "JavaScript CPP flags" "-E -CC -Wno-unicode -nostdinc"
     ''
     + ''
 


### PR DESCRIPTION
Configure ghc javascript cpp command for ghcjs build. By default it is empty, which breaks building of some packages (for example, ghcjs-base)

For example, `nix build nixpkgs#pkgsCross.ghcjs.haskellPackages.ghcjs-base` fails in nixpkgs master and succeeds after aplying this PR.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
