### PR TITLE
amazon-q-cli: 1.18.1 -> 1.19.4

### DIFF
--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -8,7 +8,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.19.3";
+  version = "1.19.4";
 
   passthru.updateScript = nix-update-script { };
 
@@ -16,14 +16,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "aws";
     repo = "amazon-q-developer-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mIrRSvneeXjlLQoXNCxg5ApdBvHkf+FUoo5ILPkv5tA=";
+    hash = "sha256-r5aqlhPwrWRyOKY86E7pKV3Gb7Pnwid+RoT9Gt1DS8Q=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-ge+ghdRup0ZH8CV6JEr+rOvXf7yZ9EqW2+Via+FF+Us=";
+  cargoHash = "sha256-s18m3yRJDoDDB8l3HJ0SMLLLmzAs5dZYvopHTG4MbSc=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -8,7 +8,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.19.0";
+  version = "1.19.3";
 
   passthru.updateScript = nix-update-script { };
 
@@ -16,14 +16,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "aws";
     repo = "amazon-q-developer-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2cLbUxyX9MmJU3Q1/b4mfzxEbdLSyEZpljmAancUADU=";
+    hash = "sha256-mIrRSvneeXjlLQoXNCxg5ApdBvHkf+FUoo5ILPkv5tA=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-R6aXuqBBSNwD8qR2mVbxSQWUleWc1oaoiq1dYbcnZPk=";
+  cargoHash = "sha256-ge+ghdRup0ZH8CV6JEr+rOvXf7yZ9EqW2+Via+FF+Us=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -8,22 +8,22 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.18.1";
+  version = "1.19.0";
 
   passthru.updateScript = nix-update-script { };
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-q-developer-cli";
-    tag = finalAttrs.version;
-    hash = "sha256-wAcxXDEadPgyb3OpQXWxOEX3AMtf0ubx0J/H9Iff+rk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2cLbUxyX9MmJU3Q1/b4mfzxEbdLSyEZpljmAancUADU=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-jjx9HBJQ5eTS8+0Wus8hfNPZ+eETKHjjX3BsEq2LRn0=";
+  cargoHash = "sha256-R6aXuqBBSNwD8qR2mVbxSQWUleWc1oaoiq1dYbcnZPk=";
 
   cargoBuildFlags = [
     "-p"


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
