### PR TITLE
python3Packages.kaleido: remove sbcl dependency (!!!) (minimal)

### DIFF
--- a/pkgs/development/python-modules/kaleido/default.nix
+++ b/pkgs/development/python-modules/kaleido/default.nix
@@ -15,7 +15,6 @@
   makeWrapper,
   nspr,
   nss,
-  sbclPackages,
   sqlite,
 }:
 
@@ -59,7 +58,6 @@ buildPythonPackage rec {
     libGL
     nspr
     nss
-    sbclPackages.cl-dejavu
     sqlite
   ];
 
@@ -82,15 +80,7 @@ buildPythonPackage rec {
     rm -rf $out/${python.sitePackages}/kaleido/executable/etc/fonts
     mkdir -p $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d
     ln -s ${fontconfig.out}/etc/fonts/fonts.conf $out/${python.sitePackages}/kaleido/executable/etc/fonts/
-    ls -s ${fontconfig.out}/etc/fonts/conf.d/* $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d/
-    ln -s ${sbclPackages.cl-dejavu}/dejavu-fonts-ttf-2.37/fontconfig/* $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d/
-
-    # Replace bundled fonts with nixpkgs-packaged fonts
-    # Currently this causes an issue where the fonts aren't found. I'm not sure why, so I'm leaving this commented out for now.
-    #rm -rf $out/${python.sitePackages}/kaleido/executable/xdg/fonts
-    #mkdir -p $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/dejavu $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/lato
-    #ln -s ${dejavu_fonts}/share/fonts/truetype/* $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/dejavu/
-    #ln -s ${lato}/share/fonts/lato/* $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/lato/
+    ln -s ${fontconfig.out}/etc/fonts/conf.d/* $out/${python.sitePackages}/kaleido/executable/etc/fonts/conf.d/
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # Replace bundled swiftshader with libGL


### PR DESCRIPTION
This package was introduced in #339136, which attracted quite a bit of conversation. I don't have the energy to go through the conversations but it looks like some low-hanging fruit got overlooked. This package depends on `sbcl` (!!) in order to get `fontconfig` files for `dejavu` (!!!), which is ... already in the default `pkgs.fontconfig` config files.

This is a stripped-down version of #454818 to (hopefully) expedite its merge.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
