### PR TITLE
python3Packages.kaleido: enable tests on darwin

### DIFF
--- a/pkgs/development/python-modules/kaleido/default.nix
+++ b/pkgs/development/python-modules/kaleido/default.nix
@@ -88,7 +88,7 @@ buildPythonPackage rec {
     ln -s ${libGL}/lib $out/${python.sitePackages}/kaleido/executable/bin/swiftshader
   '';
 
-  passthru.tests = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+  passthru.tests = {
     kaleido = callPackage ./tests.nix { };
   };
 

--- a/pkgs/development/python-modules/kaleido/tests.nix
+++ b/pkgs/development/python-modules/kaleido/tests.nix
@@ -1,15 +1,19 @@
 {
   runCommand,
   python,
-  plotly,
-  pandas,
   kaleido,
 }:
 
+# NOTE: This prints warnings:
+#     /nix/store/...-tests.py:11: DeprecationWarning:
+#     Support for Kaleido versions less than 1.0.0 is deprecated and will be removed after September 2025.
+#     Please upgrade Kaleido to version 1.0.0 or greater (`pip install 'kaleido>=1.0.0'` or `pip install 'plotly[kaleido]'`).
 runCommand "${kaleido.pname}-tests" {
   nativeBuildInputs = [
-    python
-    plotly
-    pandas
+    (python.withPackages (pyPkgs: [
+      pyPkgs.plotly
+      pyPkgs.pandas
+      pyPkgs.kaleido
+    ]))
   ];
 } "python3 ${./tests.py}"

--- a/pkgs/development/python-modules/kaleido/tests.py
+++ b/pkgs/development/python-modules/kaleido/tests.py
@@ -4,8 +4,8 @@ import os.path
 
 out = os.environ["out"]
 if not os.path.exists(out):
-  os.makedirs(out)
+    os.makedirs(out)
 
 outfile = os.path.join(out, "figure.png")
 fig = px.scatter(px.data.iris(), x="sepal_length", y="sepal_width", color="species")
-fig.write_image(outfile, engine="kaleido")
+fig.write_image(outfile)


### PR DESCRIPTION
These seem to pass locally, deprecation warnings notwithstanding.

I removed the `engine=` argument, because that printed a separate deprecation warning saying no engines other than `kaleido` are supported and the argument itself will be removed.

Related:
- #456267
- #455432


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
