### PR TITLE
qt6Packages.maplibre-native-qt: fix build with Qt 6.10

### DIFF
--- a/pkgs/development/libraries/maplibre-native-qt/default.nix
+++ b/pkgs/development/libraries/maplibre-native-qt/default.nix
@@ -18,8 +18,20 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  postPatch = lib.optionals (lib.versionAtLeast qtlocation.version "6.10") ''
+    # fix build with Qt 6.10
+    # included in https://github.com/maplibre/maplibre-native-qt/pull/216
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'find_package(Qt''${QT_VERSION_MAJOR} COMPONENTS Location REQUIRED)' \
+                     'find_package(Qt''${QT_VERSION_MAJOR} COMPONENTS Location LocationPrivate REQUIRED)'
+  '';
+
   nativeBuildInputs = [
     cmake
+  ];
+
+  env.CXXFLAGS = toString [
+    "-DQT_NO_USE_NODISCARD_FILE_OPEN"
   ];
 
   buildInputs = [


### PR DESCRIPTION
It still fails with
```
/build/source/src/core/style/source_style_change.cpp: In constructor 'QMapLibre::StyleAddSource::StyleAddSource(const QMapLibre::SourceParameter*)':
/build/source/src/core/style/source_style_change.cpp:55:29: error: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Warning-Options.html#index-Wno-unused-result-Werror=unused-result8;;]
   55 |                 geojson.open(QIODevice::ReadOnly);
      |                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/r7wdw4nkkjii690wwnzkgj68cg4shh2v-qtbase-6.10.0/include/QtCore/QFile:1,
                 from /build/source/src/core/style/source_style_change.cpp:11:
/nix/store/r7wdw4nkkjii690wwnzkgj68cg4shh2v-qtbase-6.10.0/include/QtCore/qfile.h:291:32: note: declared here
  291 |     QFILE_MAYBE_NODISCARD bool open(OpenMode flags) override;
      |                                ^~~~
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
