### PR TITLE
python3Packages.scipy-stubs: 1.16.1.0 -> 1.16.2.4, switch to uv_build

### DIFF
--- a/pkgs/development/python-modules/numpy-typing-compat/default.nix
+++ b/pkgs/development/python-modules/numpy-typing-compat/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  uv-build,
+  numpy,
+}:
+
+buildPythonPackage rec {
+  pname = "numpy-typing-compat";
+  version = "20250818.2.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "numpy_typing_compat";
+    inherit version;
+    hash = "sha256-cug9U1tjXWaLpzFeQ66AvhRppvrqb8ltMSUW85s9j6U=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  pythonImportsCheck = [
+    "numpy_typing_compat"
+  ];
+
+  meta = {
+    description = "Static typing compatibility layer for older versions of NumPy";
+    homepage = "https://pypi.org/project/numpy-typing-compat/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tm-drtina ];
+  };
+}

--- a/pkgs/development/python-modules/optype/default.nix
+++ b/pkgs/development/python-modules/optype/default.nix
@@ -2,9 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  hatchling,
+  uv-build,
   typing-extensions,
   numpy,
+  numpy-typing-compat,
   beartype,
   pytestCheckHook,
   pythonOlder,
@@ -12,20 +13,20 @@
 
 buildPythonPackage rec {
   pname = "optype";
-  version = "0.13.1";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jorenham";
     repo = "optype";
     tag = "v${version}";
-    hash = "sha256-GhG2TR5FJgEXBXLyGTNQKFYtR2iZ0tLgZ9B0YL8SXu8=";
+    hash = "sha256-0CE6dU4Vt3UP8ZfNcmP2Th7ixceCa0ItYUmNcEU7mgw=";
   };
 
   disabled = pythonOlder "3.11";
 
   build-system = [
-    hatchling
+    uv-build
   ];
 
   dependencies = [
@@ -35,6 +36,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     numpy = [
       numpy
+      numpy-typing-compat
     ];
   };
 
@@ -45,6 +47,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     numpy
+    numpy-typing-compat
     beartype
   ];
 

--- a/pkgs/development/python-modules/scipy-stubs/default.nix
+++ b/pkgs/development/python-modules/scipy-stubs/default.nix
@@ -3,27 +3,32 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  hatchling,
+  uv-build,
   optype,
   scipy,
 }:
 
 buildPythonPackage rec {
   pname = "scipy-stubs";
-  version = "1.16.1.0";
+  version = "1.16.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scipy";
     repo = "scipy-stubs";
     tag = "v${version}";
-    hash = "sha256-KRwFQG1Nb+Kh9OpQCGtvUzQA0MHNEZnRlzSkpZCNxuw=";
+    hash = "sha256-cmX9uS055kHvmCmsILEyTxW0p9C8xfD3N7HPBVCmIVI=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.0,<0.10.0" "uv_build"
+  '';
 
   disabled = pythonOlder "3.11";
 
   build-system = [
-    hatchling
+    uv-build
   ];
 
   dependencies = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10746,6 +10746,8 @@ self: super: with self; {
 
   numpy-stl = callPackage ../development/python-modules/numpy-stl { };
 
+  numpy-typing-compat = callPackage ../development/python-modules/numpy-typing-compat { };
+
   numpy_1 = callPackage ../development/python-modules/numpy/1.nix { };
 
   numpy_2 = callPackage ../development/python-modules/numpy/2.nix { };


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
