### PR TITLE
python3Packages.keras: 3.11.3 -> 3.12.0

### DIFF
--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -36,15 +36,25 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.11.3";
+  version = "3.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     tag = "v${version}";
-    hash = "sha256-J/NPLR9ShKhvHDU0/NpUNp95RViS2KygqvnuDHdwiP0=";
+    hash = "sha256-xuCxeQD8NAn7zlqCG+GyFjL6NlnIkGie+4GxzLGsyUg=";
   };
+
+  # Use a raw string to prevent LaTeX codes from being interpreted as escape sequences.
+  # SyntaxError: invalid escape sequence '\h
+  # Fix submitted upstream: https://github.com/keras-team/keras/pull/21790
+  postPatch = ''
+    substituteInPlace keras/src/quantizers/gptq_test.py \
+      --replace-fail \
+        'CALIBRATION_TEXT = """' \
+        'CALIBRATION_TEXT = r"""'
+  '';
 
   build-system = [
     setuptools
@@ -87,6 +97,25 @@ buildPythonPackage rec {
     "test_fit_with_data_adapter_grain_dataloader"
     "test_fit_with_data_adapter_grain_datast"
     "test_fit_with_data_adapter_grain_datast_with_len"
+    "test_image_dataset_from_directory_binary_grain"
+    "test_image_dataset_from_directory_color_modes_grain"
+    "test_image_dataset_from_directory_crop_to_aspect_ratio_grain"
+    "test_image_dataset_from_directory_follow_links_grain"
+    "test_image_dataset_from_directory_manual_labels_grain"
+    "test_image_dataset_from_directory_multiclass_grain"
+    "test_image_dataset_from_directory_no_labels_grain"
+    "test_image_dataset_from_directory_not_batched_grain"
+    "test_image_dataset_from_directory_pad_to_aspect_ratio_grain"
+    "test_image_dataset_from_directory_shuffle_grain"
+    "test_image_dataset_from_directory_validation_split_grain"
+    "test_sample_count_grain"
+    "test_text_dataset_from_directory_binary_grain"
+    "test_text_dataset_from_directory_follow_links_grain"
+    "test_text_dataset_from_directory_manual_labels_grain"
+    "test_text_dataset_from_directory_multiclass_grain"
+    "test_text_dataset_from_directory_not_batched_grain"
+    "test_text_dataset_from_directory_standalone_grain"
+    "test_text_dataset_from_directory_validation_split_grain"
 
     # Tries to install the package in the sandbox
     "test_keras_imports"
@@ -179,6 +208,9 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Require unpackaged `grain`
+    "keras/src/layers/preprocessing/data_layer_test.py"
+    "keras/src/layers/preprocessing/image_preprocessing/resizing_test.py"
+    "keras/src/layers/preprocessing/rescaling_test.py"
     "keras/src/trainers/data_adapters/grain_dataset_adapter_test.py"
 
     # These tests succeed when run individually, but crash within the full test suite:


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/keras-team/keras/compare/v3.11.3...v3.12.0
Changelog: https://github.com/keras-team/keras/releases/tag/v3.12.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc