### PR TITLE
python3Packages.construct-typing: 0.6.2 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/construct-typing/default.nix
+++ b/pkgs/development/python-modules/construct-typing/default.nix
@@ -8,6 +8,7 @@
   typing-extensions,
   arrow,
   cloudpickle,
+  cryptography,
   numpy,
   pytestCheckHook,
   ruamel-yaml,
@@ -15,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "construct-typing";
-  version = "0.6.2";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "timrid";
     repo = "construct-typing";
     tag = "v${version}";
-    hash = "sha256-zXpxu+VUcepEoAPLQnSlMCZkt8fDsMCLS0HBKhaYD20=";
+    hash = "sha256-iiMnt/f1ppciL6AVq3q0wOtoARcNYJycQA5Ev+dIow8=";
   };
 
   build-system = [ setuptools ];
@@ -42,20 +43,10 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     arrow
     cloudpickle
+    cryptography
     numpy
     pytestCheckHook
     ruamel-yaml
-  ];
-
-  disabledTests = [
-    # tests fail with construct>=2.10.70
-    "test_bitsinteger"
-    "test_bytesinteger"
-  ]
-  ++ lib.optionals (pythonAtLeast "3.13") [
-    # https://github.com/timrid/construct-typing/issues/31
-    "test_tenum_docstring"
-    "test_tenum_flags_docstring"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/timrid/construct-typing/compare/v0.6.2...v0.7.0

Changelog: https://github.com/timrid/construct-typing/releases/tag/v0.7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
