### PR TITLE
octotype: init at 0.8.0

### DIFF
--- a/pkgs/by-name/oc/octotype/package.nix
+++ b/pkgs/by-name/oc/octotype/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "octotype";
+  version = "0.8.0";
+  src = fetchFromGitHub {
+    owner = "mahlquistj";
+    repo = "octotype";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hP21kU6KuilV4T/eiBgSPu4bBccXbesFDTczuMZymDs=";
+  };
+  cargoHash = "sha256-V6IYjFRL2Ca9UDq3En9Y2cIVxjKsjlJQ5L5vHHshK7M=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  postInstall = ''
+    install -Dm644 modes/default.toml $out/share/octotype/modes/default.toml
+    install -Dm644 modes/perfectionism.toml $out/share/octotype/modes/perfectionism.toml
+    install -Dm644 modes/wordcount.toml $out/share/octotype/modes/wordcount.toml
+
+    mkdir -p $out/share/octotype/sources
+    substitute sources/random.toml $out/share/octotype/sources/random.toml \
+      --replace-fail './gibberish.sh' './random.sh'
+    install -Dm755 sources/random.sh $out/share/octotype/sources/random.sh
+
+    wrapProgram $out/bin/octotype \
+      --run 'CONFIG_DIR=''${XDG_CONFIG_HOME:-$HOME/.config}/octotype; mkdir -p "$CONFIG_DIR"/{modes,sources}; [ ! -f "$CONFIG_DIR/modes/default.toml" ] && cp '"$out"'/share/octotype/modes/*.toml "$CONFIG_DIR/modes/" 2>/dev/null || true; [ ! -f "$CONFIG_DIR/sources/random.toml" ] && cp '"$out"'/share/octotype/sources/* "$CONFIG_DIR/sources/" 2>/dev/null || true'
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/mahlquistj/octotype/releases/tag/v${finalAttrs.version}";
+    description = "TUI typing trainer inspired by monkeytype with a focus on customization";
+    homepage = "https://github.com/mahlquistj/octotype";
+    license = lib.licenses.mit;
+    mainProgram = "octotype";
+    maintainers = with lib.maintainers; [ linuxmobile ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
OctoType is a TUI typing trainer made with Ratatui, and powered by Gladius - Heavily inspired by [Monkeytype](https://monkeytype.com/), with a focus on customizability

[OctoType](https://github.com/mahlquistj/octotype)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
