### PR TITLE
graphite-cli: 1.7.2 -> 1.7.5

### DIFF
--- a/pkgs/by-name/gr/graphite-cli/package-lock.json
+++ b/pkgs/by-name/gr/graphite-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withgraphite/graphite-cli",
-  "version": "1.7.2",
+  "version": "1.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withgraphite/graphite-cli",
-      "version": "1.7.2",
+      "version": "1.7.5",
       "hasInstallScript": true,
       "license": "None",
       "dependencies": {

--- a/pkgs/by-name/gr/graphite-cli/package.nix
+++ b/pkgs/by-name/gr/graphite-cli/package.nix
@@ -4,19 +4,20 @@
   buildNpmPackage,
   fetchurl,
   git,
+  makeBinaryWrapper,
   installShellFiles,
 }:
 
 buildNpmPackage rec {
   pname = "graphite-cli";
-  version = "1.7.2";
+  version = "1.7.5";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/@withgraphite/graphite-cli/-/graphite-cli-${version}.tgz";
-    hash = "sha256-FoQvtywam4AXAavRtwfoTMaaMijW67hp317VLupCaCI=";
+    hash = "sha256-P9hqSriOe+UHF9tjJMiX2X0M7WGG5A+ZLYo3emvdP9Q=";
   };
 
-  npmDepsHash = "sha256-POWRxgrny27+7ymrhP5iFPBYzCmjCDWB8jGmOSieq0k=";
+  npmDepsHash = "sha256-HXdJAKfIMq4iclIxQHLHVOyHkab7j+7R+NayWKDw6S0=";
 
   postPatch = ''
     ln -s ${./package-lock.json} package-lock.json
@@ -24,12 +25,17 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [
     git
+    makeBinaryWrapper
     installShellFiles
   ];
 
   dontNpmBuild = true;
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = ''
+    wrapProgram $out/bin/gt \
+      --set GRAPHITE_DISABLE_UPGRADE_PROMPT 1
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gt \
       --bash <($out/bin/gt completion) \
       --fish <(GT_PAGER= $out/bin/gt fish) \


### PR DESCRIPTION
Automatic updates were added in 1.7.4[1]. Since this feature isn't conducive with nix, I've disabled it via an environment variable.

[1] https://graphite.dev/docs/cli-changelog#1-7-4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
