### PR TITLE
workflows/team: Prefix PR branch with create-pull-request

### DIFF
--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -75,7 +75,7 @@ jobs:
           author: ${{ steps.user.outputs.git-string }}
           committer: ${{ steps.user.outputs.git-string }}
           commit-message: "maintainers/github-teams.json: Automated sync"
-          branch: github-team-sync
+          branch: pr/github-team-sync
           title: "maintainers/github-teams.json: Automated sync"
           body: |
             This is an automated PR to sync the GitHub teams with access to this repository to the `lib.teams` list.


### PR DESCRIPTION
Allows better scoping of branch creation restrictions. See https://github.com/NixOS/nixpkgs/pull/450864#discussion_r2467509174

Weakly depends on https://github.com/NixOS/org/pull/186

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
