### PR TITLE
hmcl: 3.6.18 -> 3.7.6

### DIFF
--- a/pkgs/by-name/hm/hmcl/package.nix
+++ b/pkgs/by-name/hm/hmcl/package.nix
@@ -31,13 +31,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hmcl";
-  version = "3.6.18";
+  version = "3.7.6";
 
   src = fetchurl {
     # HMCL has built-in keys, such as the Microsoft OAuth secret and the CurseForge API key.
     # See https://github.com/HMCL-dev/HMCL/blob/refs/tags/release-3.6.12/.github/workflows/gradle.yml#L26-L28
-    url = "https://github.com/HMCL-dev/HMCL/releases/download/release-${finalAttrs.version}/HMCL-${finalAttrs.version}.jar";
-    hash = "sha256-x8UcHdBYXdnTabJh2hxsknYipYNBJW2vKxJKHhryMLQ=";
+    url = "https://github.com/HMCL-dev/HMCL/releases/download/v${finalAttrs.version}/HMCL-${finalAttrs.version}.jar";
+    hash = "sha256-bgZsQ/5CUeOkbahIV0hQSPHrYfK+EaAIV6uMZzpLOVM=";
   };
 
   icon = fetchurl {
@@ -106,11 +106,14 @@ stdenv.mkDerivation (finalAttrs: {
           alsa-lib
         ]
       );
+      hmclJdk' = hmclJdk.override {
+        enableJavaFX = true; # Necessary for hardware acceleration.
+      };
     in
     ''
       runHook preFixup
 
-      makeBinaryWrapper ${hmclJdk}/bin/java $out/bin/hmcl \
+      makeBinaryWrapper ${hmclJdk'}/bin/java $out/bin/hmcl \
         --add-flags "-jar $out/lib/hmcl/hmcl.jar" \
         --set LD_LIBRARY_PATH ${libpath} \
         --prefix PATH : "${lib.makeBinPath minecraftJdks}"\
@@ -128,6 +131,14 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "hmcl";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.gpl3Only;
+    longDescription = ''
+      Hello Minecraft! Launcher (HMCL) is a free, open-source, and cross-platform Minecraft launcher.
+      It provides comprehensive support for managing multiple game versions and mod loaders,
+      including Forge, NeoForge, Fabric, Quilt, LiteLoader, and OptiFine.
+
+      Note: HMCL manages the Terracotta binary internally. On NixOS, Terracotta-related features
+      require `programs.nix-ld` to be enabled, as the runtime-downloaded binary is not patched.
+    '';
     maintainers = with lib.maintainers; [
       daru-san
       moraxyc

--- a/pkgs/by-name/hm/hmcl/update.nix
+++ b/pkgs/by-name/hm/hmcl/update.nix
@@ -27,7 +27,7 @@ writeShellApplication {
     }
 
     version=$(get_latest_release)
-    version="''${version#release-}"
+    version="''${version#v-}"
 
     if [[ "$oldVersion" == "$version" ]]; then
         echo "Already up to date!"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update [hmcl](https://github.com/HMCL-dev/HMCL) to latest stable version 3.6.20 (https://github.com/HMCL-dev/HMCL/releases/tag/v3.6.20).
Also override jdk to enable hardware acceleration.

On a side note, I have 170% scaling on KDE (wayland). 
I wasn't able to make it scale up and it's all very tiny (also is on nixpkgs-unstable) . Suggestions welcome!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
