### PR TITLE
mattermost: update to 10.11 ESR and 11.x latest

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -375,6 +375,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 
+- `services.mattermost` has been updated to use the 10.11 ESR instead of 10.5. While this shouldn't break anyone, we also now package Mattermost 11 as mattermostLatest. Note that Mattermost 11 drops support for MySQL. The Mattermost module will assertion fail if you try to use MySQL with Mattermost 11; support for using MySQL with Mattermost will fully be removed in NixOS 26.
+
 - `simplesamlphp` has been removed since the package was severely outdated, unmaintained in nixpkgs and having known vulnerabilities.
 
 - `networking.wireless.networks.<name>` now has an option to specify SSID, hence allowing duplicated SSID setup. The BSSID option is added along side with this.

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -966,6 +966,13 @@ in
             or hostname, and services.mattermost.port to specify the port separately.
           '';
         }
+        {
+          # Can't use MySQL on version 11.
+          assertion = versionAtLeast cfg.package.version "11" -> cfg.database.driver == "postgres";
+          message = ''
+            Only Postgres is supported as the database driver in Mattermost 11 and later.
+          '';
+        }
       ];
     })
     (mkIf cfg.matterircd.enable {

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -18,11 +18,11 @@
     # the version regex here as well.
     #
     # Ensure you also check ../mattermostLatest/package.nix.
-    regex = "^v(10\\.5\\.[0-9]+)$";
-    version = "10.5.12";
-    srcHash = "sha256-VaW+rA0UeIZhGU9BlYZgyznAOtLN+JI7UPbMRPCwTww=";
-    vendorHash = "sha256-vxUxSkj1EwgMtPpCGJSA9jCDBeLrWhecdwq4KBThhj4=";
-    npmDepsHash = "sha256-tIeuDUZbqgqooDm5TRfViiTT5OIyN0BPwvJdI+wf7p0=";
+    regex = "^v(10\\.11\\.[0-9]+)$";
+    version = "10.11.4";
+    srcHash = "sha256-gSVoO0paAwvxEeZkcCP81oxMcSu/H8n3Tr+2OEXuFyM=";
+    vendorHash = "sha256-DS4OC3eQffD/8yLE01gnTJXwV77G7rWk4kqA/rTCtJw=";
+    npmDepsHash = "sha256-p9dq31qw0EZDQIl2ysKE38JgDyLA6XvSv+VtHuRh+8A=";
     lockfileOverlay = ''
       unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
     '';

--- a/pkgs/by-name/ma/mattermost/tests.nix
+++ b/pkgs/by-name/ma/mattermost/tests.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   mattermost,
   gotestsum,
   which,
@@ -12,16 +11,10 @@
   runtimeShell,
 }:
 
-let
-  inherit (lib.lists) optionals;
-  inherit (lib.strings) versionAtLeast;
-  is10 = version: versionAtLeast version "10.0";
-in
 mattermost.overrideAttrs (
   final: prev: {
     doCheck = true;
     checkTargets = [
-      "test-server"
       "test-mmctl"
     ];
     nativeCheckInputs = [
@@ -52,113 +45,17 @@ mattermost.overrideAttrs (
     # X  TestFoo
     # X  TestFoo/TestBar
     # -> TestFoo/TestBar/baz_test
-    disabledTests = [
+    disabledTests = lib.lists.uniqueStrings [
       # All these plugin tests for mmctl reach out to the marketplace, which is impossible in the sandbox
       "TestMmctlE2ESuite/TestPluginDeleteCmd/Delete_Plugin/SystemAdminClient"
       "TestMmctlE2ESuite/TestPluginDeleteCmd/Delete_Plugin/LocalClient"
       "TestMmctlE2ESuite/TestPluginDeleteCmd/Delete_a_Plugin_without_permissions"
       "TestMmctlE2ESuite/TestPluginDeleteCmd/Delete_Unknown_Plugin/SystemAdminClient"
       "TestMmctlE2ESuite/TestPluginDeleteCmd/Delete_Unknown_Plugin/LocalClient"
-      "TestMmctlE2ESuite/TestPluginInstallURLCmd/install_new_plugins/SystemAdminClient"
-      "TestMmctlE2ESuite/TestPluginInstallURLCmd/install_new_plugins/LocalClient"
-      "TestMmctlE2ESuite/TestPluginInstallURLCmd/install_an_already_installed_plugin_without_force/SystemAdminClient"
-      "TestMmctlE2ESuite/TestPluginInstallURLCmd/install_an_already_installed_plugin_without_force/LocalClient"
-      "TestMmctlE2ESuite/TestPluginInstallURLCmd/install_an_already_installed_plugin_with_force/SystemAdminClient"
-      "TestMmctlE2ESuite/TestPluginInstallURLCmd/install_an_already_installed_plugin_with_force/LocalClient"
-      "TestMmctlE2ESuite/TestPluginMarketplaceInstallCmd/install_a_plugin/SystemAdminClient"
-      "TestMmctlE2ESuite/TestPluginMarketplaceInstallCmd/install_a_plugin/LocalClient"
-      "TestMmctlE2ESuite/TestPluginMarketplaceListCmd/List_Marketplace_Plugins_for_Admin_User/SystemAdminClient"
-      "TestMmctlE2ESuite/TestPluginMarketplaceListCmd/List_Marketplace_Plugins_for_Admin_User/LocalClient"
-
-      # Seems to just be broken.
-      "TestMmctlE2ESuite/TestPreferenceUpdateCmd"
-
-      # Has a hardcoded "google.com" test which also verifies that the address isn't loopback,
-      # so we also can't just substituteInPlace to one that will resolve
-      "TestDialContextFilter"
-
-      # No interfaces but loopback in the sandbox, so returns empty
-      "TestGetServerIPAddress"
-
-      # S3 bucket tests (needs Minio)
-      "TestInsecureMakeBucket"
-      "TestMakeBucket"
-      "TestListDirectory"
-      "TestTimeout"
-      "TestStartServerNoS3Bucket"
-      "TestS3TestConnection"
-      "TestS3FileBackendTestSuite"
-      "TestS3FileBackendTestSuiteWithEncryption"
-      "TestWriteFileVideoMimeTypes"
-
-      # Mail tests (needs a SMTP server)
-      "TestSendMailUsingConfig"
-      "TestSendMailUsingConfigAdvanced"
-      "TestSendMailWithEmbeddedFilesUsingConfig"
-      "TestSendCloudWelcomeEmail"
-      "TestMailConnectionAdvanced"
-      "TestMailConnectionFromConfig"
-      "TestEmailTest"
-      "TestBasicAPIPlugins/test_send_mail_plugin"
-
-      # Seems to be unreliable
-      "TestPluginAPIUpdateUserPreferences"
-      "TestPluginAPIGetUserPreferences"
-
-      # These invite tests try to send a welcome email and we don't have a SMTP server up.
-      "TestInviteUsersToTeam"
-      "TestInviteGuestsToTeam"
-      "TestSendInviteEmails"
-      "TestDeliver"
-
-      # https://github.com/mattermost/mattermost/issues/29184
-      "TestUpAndDownMigrations/Should_be_reversible_for_mysql"
-    ]
-    ++ optionals (is10 final.version) [
-      ## mattermostLatest test ignores
-
-      # These bot related tests appear to be broken.
-      "TestCreateBot"
-      "TestPatchBot"
-      "TestGetBot"
-      "TestEnableBot"
-      "TestDisableBot"
-      "TestAssignBot"
-      "TestConvertBotToUser"
-
-      # Need Elasticsearch or Opensearch
-      "TestBlevePurgeIndexes"
-      "TestOpensearchAggregation"
-      "TestOpensearchInterfaceTestSuite"
-      "TestOpenSearchIndexerJobIsEnabled"
-      "TestOpenSearchIndexerPending"
-      "TestBulkProcessor"
-      "TestElasticsearchAggregation"
-      "TestElasticsearchInterfaceTestSuite"
-      "TestElasticSearchIndexerJobIsEnabled"
-      "TestElasticSearchIndexerPending"
-
-      # Broken in the sandbox.
-      "TestVersion"
-      "TestRunServerNoSystemd"
-
-      # Appear to be broken.
-      "TestSessionStore/MySQL"
-      "TestAccessControlPolicyStore/MySQL"
-      "TestAttributesStore/MySQL"
-      "TestBasicAPIPlugins"
-
-      "TestRunExportJobE2EByType"
-      "TestUpdateTeam"
-      "TestSyncSyncableRoles"
-    ]
-    ++ optionals (!stdenv.hostPlatform.isx86_64) [
-      # aarch64: invalid operating system or processor architecture
-      "TestCanIUpgradeToE0"
-
-      # aarch64: thumbnail previews are nondeterministic
-      "TestUploadFiles/multipart_Happy_image_thumbnail"
-      "TestUploadFiles/simple_Happy_image_thumbnail"
+      "TestMmctlE2ESuite/TestPluginInstallURLCmd"
+      "TestMmctlE2ESuite/TestPluginMarketplaceInstallCmd"
+      "TestMmctlE2ESuite/TestPluginMarketplaceInstallCmd"
+      "TestMmctlE2ESuite/TestPluginMarketplaceListCmd"
     ];
 
     preCheck = ''
@@ -378,7 +275,7 @@ mattermost.overrideAttrs (
 
       # Ensure we parallelize the tests, and skip the correct ones.
       # Spaces are important here due to how the Makefile works.
-      export GOFLAGS=" -parallel=$NIX_BUILD_CORES -skip='$(echo "$disabledTests" | tr ' ' '|')' "
+      export GOFLAGS=" -p=$NIX_BUILD_CORES -parallel=$NIX_BUILD_CORES -skip='$(echo "$disabledTests" | tr ' ' '|')' "
 
       # ce n'est pas un conteneur
       MMCTL_TESTFLAGS="$GOFLAGS" MM_NO_DOCKER=true make $checkTargets

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -10,11 +10,11 @@ mattermost.override {
     # See https://docs.mattermost.com/about/mattermost-server-releases.html
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
-    regex = "^v(10\\.[0-9]+\\.[0-9]+)$";
-    version = "10.12.1";
-    srcHash = "sha256-PL55NKypsLA+H19cS99iIsMI3IBb6vLvAbAVLZyg+sE=";
-    vendorHash = "sha256-DS4OC3eQffD/8yLE01gnTJXwV77G7rWk4kqA/rTCtJw=";
-    npmDepsHash = "sha256-O9iX6hnwkEHK0kkHqWD6RYXqoSEW6zs+utiYHnt54JY=";
+    regex = "^v(11\\.[0-9]+\\.[0-9]+)$";
+    version = "11.0.2";
+    srcHash = "sha256-2w9v/ktmqSwzcylq8ayRDZD5BsHo9tBL+9X3GRNlvd0=";
+    vendorHash = "sha256-JkQvj92q5FZjQWB5gGCsAz7EpHO+IckBSFoFEFi3v0A=";
+    npmDepsHash = "sha256-YU6FDsMX0QIGFatUDRos/AkgwljIBeI5w/TJt/lglw0=";
     lockfileOverlay = ''
       unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
     '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Mattermost 10.5 is scheduled to become EOL while NixOS 25.11 is out, and Mattermost 11 was recently released.

`nix-build -A mattermost mattermostLatest mattermost.tests mattermostLatest.tests`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
