### PR TITLE
opencode: 0.15.14 -> 0.15.18

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -22,12 +22,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.15.14";
+  version = "0.15.18";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K7TmsJm11uDNjN3fUaapM1A01FmHUSfXMiqOzhLzRI8=";
+    hash = "sha256-yQfOgLJkSeBDTMS7MHuEQVzd8oG8EzQZRFYFHRO/08o=";
   };
 
   tui = buildGoModule {


### PR DESCRIPTION
Automatic update generated by [nixpkgs-update-gha](https://github.com/delafthi/nixpkgs-update-gha). This update was made based on information from `passthru.updateScript`.

meta.description for opencode is: AI coding agent built for the terminal

meta.homepage for opencode is: https://github.com/sst/opencode

meta.changelog for opencode is: 

###### Updates performed

- Ran `passthru.updateScript`

###### To inspect upstream changes

https://github.com/sst/opencode

###### Impact

<b>Checks done</b>

---

- built on NixOS
- passthru.tests: 0 passed, 1 failed
  - ❌ failed: version
- nixpkgs-review-gha triggered for multi-platform testing ([view workflow runs](https://github.com/delafthi/nixpkgs-review-gha/actions))

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
Build logs: https://github.com/delafthi/nixpkgs-update-gha/actions/runs/18862979241
```

</details>

### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review wip`

---
### `x86_64-linux`
:information_source: No packages were built
---

###### Maintainer pings

cc @zestsystem @delafthi for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.com/blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
