### PR TITLE
sagelib: remove unused deps

### DIFF
--- a/pkgs/by-name/sa/sage/sagelib.nix
+++ b/pkgs/by-name/sa/sage/sagelib.nix
@@ -13,7 +13,6 @@
   gd,
   iml,
   libpng,
-  readline,
   blas,
   boost,
   brial,
@@ -23,7 +22,6 @@
   fflas-ffpack,
   flint,
   gap,
-  giac,
   givaro,
   glpk,
   gsl,
@@ -44,7 +42,6 @@
   planarity,
   ppl,
   rankwidth,
-  ratpoints,
   singular,
   sqlite,
   symmetrica,
@@ -60,7 +57,6 @@
   ipykernel,
   ipython,
   ipywidgets,
-  jinja2,
   jupyter-client,
   jupyter-core,
   lrcalc-python,
@@ -117,7 +113,6 @@ buildPythonPackage rec {
     gd
     iml
     libpng
-    readline
   ];
 
   env = lib.optionalAttrs stdenv.cc.isClang {
@@ -138,7 +133,6 @@ buildPythonPackage rec {
     fflas-ffpack
     flint
     gap
-    giac
     givaro
     glpk
     gsl
@@ -159,7 +153,6 @@ buildPythonPackage rec {
     planarity
     ppl
     rankwidth
-    ratpoints
     singular
     sqlite
     symmetrica
@@ -177,7 +170,6 @@ buildPythonPackage rec {
     ipykernel
     ipython
     ipywidgets
-    jinja2
     jupyter-client
     jupyter-core
     lrcalc-python


### PR DESCRIPTION
ratpoints 2.2.2 fails to build with Clang; it would be relatively easy to fix (by either updating
https://github.com/sagemath/sage/blob/1615f58890e8f9881c4228c78a6b39b9aab1303a/build/pkgs/ratpoints/patches/sturm_and_rp_private.patch or using gccStdenv on Darwin too), but Sage dropped the dependency 3 years ago, so drop the dependency here too.

While I was at it, I also dropped all the other dependencies which seem to be unused (by looking at
https://github.com/sagemath/sage/commits/10.7/build/pkgs/sagelib/dependencies).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
