### PR TITLE
grandperspective: 3.5.1 -> 3.6

### DIFF
--- a/pkgs/by-name/gr/grandperspective/package.nix
+++ b/pkgs/by-name/gr/grandperspective/package.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.5.1";
+  version = "3.6";
   pname = "grandperspective";
 
   src = fetchurl {
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/grandperspectiv/GrandPerspective-${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }.dmg";
-    hash = "sha256-ZD6XUtsbwxHe3MYdCH9I/pYBCGgilPhhbYQChr0wCj4=";
+    hash = "sha256-DSdtaf5GN1PSIt8GTGrMUuaVI2C+ANKi78E1cxVrYTE=";
   };
 
   sourceRoot = "GrandPerspective.app";


### PR DESCRIPTION
## Things done

https://sourceforge.net/projects/grandperspectiv/files/grandperspective/3.6/#:~:text=Version%203.6%2C%2027%2D08%2D2025

<img width="781" height="368" alt="image" src="https://github.com/user-attachments/assets/73750495-b5a7-4b86-9149-15890291480f" />


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
