### PR TITLE
enpass-mac: 6.11.8.1861 -> 6.11.20.2229

### DIFF
--- a/pkgs/by-name/en/enpass-mac/package.nix
+++ b/pkgs/by-name/en/enpass-mac/package.nix
@@ -17,11 +17,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "enpass-mac";
-  version = "6.11.8.1861";
+  version = "6.11.20.2229";
 
   src = fetchurl {
     url = "https://dl.enpass.io/stable/mac/package/${finalAttrs.version}/Enpass.pkg";
-    hash = "sha256-n0ClsyGTS52ms161CJihIzBI5GjiMIF6HEJ59+jciq8=";
+    hash = "sha256-o4IHDeuoOtZ6gvvfxrPFXCou0nkLOpcMnip/+f6eVkU=";
   };
 
   dontPatch = true;
@@ -39,7 +39,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preUnpack
 
     xar -xf $src
-    gunzip -dc Enpass_temp.pkg/Payload | cpio -i
+    gunzip -dc Enpass_temp.pkg/Payload > decompressed.out
+    cat decompressed.out | cpio -it | grep -v '/._' > file-list-no-resource-forks.txt
+    cat decompressed.out | cpio -i -E file-list-no-resource-forks.txt
 
     runHook postUnpack
   '';


### PR DESCRIPTION
## Things done

https://www.enpass.io/release-notes/macos-website-ver/#:~:text=Version%206.11.20%20(2229)

<img width="1087" height="724" alt="image" src="https://github.com/user-attachments/assets/488f0050-b0c0-4c4f-9788-ef010f503ec8" />

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
