### PR TITLE
botan3: fix `pkgsStatic` eval

### DIFF
--- a/pkgs/by-name/bo/botan3/package.nix
+++ b/pkgs/by-name/bo/botan3/package.nix
@@ -34,7 +34,7 @@ assert lib.assertOneOf "policy" policy [
 ];
 
 let
-  stdenv' = if static then buildPackages.libxccStdenv else stdenv;
+  stdenv' = if static then buildPackages.libcxxStdenv else stdenv;
 in
 stdenv'.mkDerivation (finalAttrs: {
   version = "3.9.0";


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix build --no-link -f. pkgsStatic.botan3
    error:
       … while calling a functor (an attribute set with a '__functor' attribute)
         at lib/customisation.nix:317:7:
          316|     if missingArgs == { } then
          317|       makeOverridable f allArgs
             |       ^
          318|     # This needs to be an abort so it can't be caught with `builtins.tryEval`,

       … while evaluating a branch condition
         at lib/customisation.nix:182:7:
          181|       in
          182|       if isAttrs result then
             |       ^
          183|         result

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'libxccStdenv' missing
       at pkgs/by-name/bo/botan3/package.nix:37:28:
           36| let
           37|   stdenv' = if static then buildPackages.libxccStdenv else stdenv;
             |                            ^
           38| in


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
