### PR TITLE
openssh_10_2: drop

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -37,31 +37,6 @@ in
     };
   };
 
-  openssh_10_2 = common rec {
-    pname = "openssh";
-    version = "10.2p1";
-
-    src = fetchurl {
-      url = urlFor version;
-      hash = "sha256-zMQsBBmTeVkmP6Hb0W2vwYxWuYTANWLSk3zlamD3mLI=";
-    };
-
-    extraPatches = [
-      # Use ssh-keysign from PATH
-      # ssh-keysign is used for host-based authentication, and is designed to be used
-      # as SUID-root program. OpenSSH defaults to referencing it from libexec, which
-      # cannot be made SUID in Nix.
-      ./ssh-keysign-8.5.patch
-    ];
-    extraMeta = {
-      maintainers = with lib.maintainers; [
-        philiptaron
-        numinit
-      ];
-      teams = [ lib.teams.helsinki-systems ];
-    };
-  };
-
   openssh_hpn = common rec {
     pname = "openssh-with-hpn";
     version = "10.2p1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3629,10 +3629,6 @@ with pkgs;
     etcDir = "/etc/ssh";
   };
 
-  openssh_10_2 = opensshPackages.openssh_10_2.override {
-    etcDir = "/etc/ssh";
-  };
-
   opensshTest = openssh.tests.openssh;
 
   opensshWithKerberos = openssh.override {


### PR DESCRIPTION
The main openssh package has already been updated in [1].

[1] https://github.com/NixOS/nixpkgs/pull/450658

This reverts commit 249e1f973023eb9deb6e0be00e09ad74301d22c7 from https://github.com/NixOS/nixpkgs/pull/456392.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
