### PR TITLE
python3Packages.imagecodecs: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/imagecodecs/default.nix
+++ b/pkgs/development/python-modules/imagecodecs/default.nix
@@ -2,22 +2,30 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   cython,
   numpy,
   setuptools,
+
+  # nativeBuildInputs
   pkgs,
-  jxrlib,
   lcms2,
+  openjpeg,
+
+  # buildInputs
+  jxrlib,
   lerc,
   libdeflate,
+  libjpeg,
   libpng,
   libtiff,
   libwebp,
-  openjpeg,
   xz,
   zlib,
-  zstd,
-  pytest,
+
+  # tests
+  pytestCheckHook,
 }:
 
 let
@@ -48,18 +56,19 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    pkgs.lz4
     jxrlib
     lcms2
     lerc
     libdeflate
+    libjpeg
     libpng
     libtiff
     libwebp
+    pkgs.lz4
     openjpeg
     xz # liblzma
     zlib
-    zstd
+    pkgs.zstd
   ];
 
   dependencies = [
@@ -73,7 +82,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    pytest
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
