### PR TITLE
wallpaper-engine-plugin: Fix Cmake4 and QT 6.10 build issues

### DIFF
--- a/pkgs/kde/third-party/wallpaper-engine-plugin/default.nix
+++ b/pkgs/kde/third-party/wallpaper-engine-plugin/default.nix
@@ -27,7 +27,10 @@ mkKdeDerivation {
     fetchSubmodules = true;
   };
 
-  patches = [ ./nix-plugin.patch ];
+  patches = [
+    ./nix-plugin.patch
+    ./qt-6.10-fix.patch
+  ];
 
   extraNativeBuildInputs = [
     kpackage
@@ -52,6 +55,7 @@ mkKdeDerivation {
       ]
     ))
     (lib.cmakeFeature "Qt6_DIR" "${qtbase}/lib/cmake/Qt6")
+    "-DCMAKE_CXX_FLAGS=-Wno-error=stringop-overflow"
   ];
 
   postInstall = ''

--- a/pkgs/kde/third-party/wallpaper-engine-plugin/qt-6.10-fix.patch
+++ b/pkgs/kde/third-party/wallpaper-engine-plugin/qt-6.10-fix.patch
@@ -1,0 +1,42 @@
+--- a/src/backend_mpv/MpvBackend.cpp
++++ b/src/backend_mpv/MpvBackend.cpp
+@@ -37,7 +37,9 @@
+ #    include <QX11Info> // IWYU pragma: keep
+ #endif
+ //#endif
++#if (QT_VERSION < QT_VERSION_CHECK(6, 10, 0))
+ #    include <qpa/qplatformnativeinterface.h> // IWYU pragma: keep
++#endif
+ #endif
+ 
+ Q_LOGGING_CATEGORY(wekdeMpv, "wekde.mpv")
+@@ -85,8 +87,13 @@ int CreateMpvContex(mpv_handle* mpv, mpv_render_context** mpv_gl) {
+     if (QGuiApplication::platformName().contains("xcb")) {
+         params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
+ #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+-        // TODO: QGuiApplication::nativeInterface<QNativeInterface::QX11Application>()::display();
+-        // same for wayland
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++        if (auto x11App = qApp->nativeInterface<QNativeInterface::QX11Application>()) {
++            params[2].data = x11App->display();
++        }
++#else
++        // Fallback for Qt 6.0-6.9
+         auto* native   = QGuiApplication::platformNativeInterface();
+         params[2].data = native->nativeResourceForWindow("display", nullptr);
++#endif
+ #else
+@@ -95,6 +102,12 @@ int CreateMpvContex(mpv_handle* mpv, mpv_render_context** mpv_gl) {
+     }
+     if (QGuiApplication::platformName().contains("wayland")) {
+         params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
++#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
++        if (auto waylandApp = qApp->nativeInterface<QNativeInterface::QWaylandApplication>()) {
++            params[2].data = waylandApp->display();
++        }
++#else
+         auto* native   = QGuiApplication::platformNativeInterface();
+         params[2].data = native->nativeResourceForWindow("display", nullptr);
++#endif
+     }
+ #endif


### PR DESCRIPTION
Closes #455497 

Fixes build issues with the new implementation of cmake4 and QT6.10

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
