### PR TITLE
srb2kart: fixed build for cmake 4 + refactor

### DIFF
--- a/pkgs/by-name/sr/srb2kart/package.nix
+++ b/pkgs/by-name/sr/srb2kart/package.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5sIHdeenWZjczyYM2q+F8Y1SyLqL+y77yxYDUM3dVA0=";
   };
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 3.0)" "cmake_minimum_required(VERSION 3.10)"
+  '';
+
   assets = stdenv.mkDerivation {
     pname = "srb2kart-data";
     version = finalAttrs.version;

--- a/pkgs/by-name/sr/srb2kart/package.nix
+++ b/pkgs/by-name/sr/srb2kart/package.nix
@@ -32,24 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "cmake_minimum_required(VERSION 3.0)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
-  assets = stdenv.mkDerivation {
-    pname = "srb2kart-data";
-    version = finalAttrs.version;
-
-    src = fetchzip {
-      url = "https://github.com/STJr/Kart-Public/releases/download/v${finalAttrs.version}/AssetsLinuxOnly.zip";
-      hash = "sha256-yaVdsQUnyobjSbmemeBEyu35GeZCX1ylTRcjcbDuIu4=";
-      stripRoot = false;
-    };
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/share/srb2kart
-      cp -r * $out/share/srb2kart
-
-      runHook postInstall
-    '';
+  assets = fetchzip {
+    name = "srb2kart-data";
+    url = "https://github.com/STJr/Kart-Public/releases/download/v${finalAttrs.version}/AssetsLinuxOnly.zip";
+    hash = "sha256-yaVdsQUnyobjSbmemeBEyu35GeZCX1ylTRcjcbDuIu4=";
+    stripRoot = false;
   };
 
   nativeBuildInputs = [
@@ -69,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DSRB2_ASSET_DIRECTORY=${finalAttrs.assets}/share/srb2kart"
+    "-DSRB2_ASSET_DIRECTORY=${finalAttrs.assets}"
     "-DGME_INCLUDE_DIR=${game-music-emu}/include"
     "-DSDL2_MIXER_INCLUDE_DIR=${lib.getDev SDL2_mixer}/include/SDL2"
     "-DSDL2_INCLUDE_DIR=${lib.getDev SDL2}/include/SDL2"
@@ -96,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 bin/srb2kart $out/bin/srb2kart
 
     wrapProgram $out/bin/srb2kart \
-      --set SRB2WADDIR "${finalAttrs.assets}/share/srb2kart"
+      --set-default SRB2WADDIR ${finalAttrs.assets}
 
     runHook postInstall
   '';


### PR DESCRIPTION
part of #445447

- fixed build for cmake 4
- refactored redundancy in assets derivation
- used `--set-default` in wrapper over `--set`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
