### PR TITLE
authentik: 2025.8.4 -> 2025.10.1

### DIFF
--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -15,13 +15,13 @@
 let
   nodejs = nodejs_24;
 
-  version = "2025.8.4";
+  version = "2025.10.1";
 
   src = fetchFromGitHub {
     owner = "goauthentik";
     repo = "authentik";
     rev = "version/${version}";
-    hash = "sha256-pIzDaoDWc58cY/XhsyweCwc4dfRvkaT/zqsV1gDSnCI=";
+    hash = "sha256-HowB6DTGCqz770fKYbnE+rQ11XRV0WSNkLD+HSWZwz8=";
   };
 
   meta = {
@@ -48,8 +48,8 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-fa/WGRb4lWSXMqBmGhCd+N2fZr1YZKsskr3Oowp8gRE=";
-        "x86_64-linux" = "sha256-jVi+pgcz96Dj25T4e/s+SHqsZfonzXs1WZYe0lCI48Q=";
+        "aarch64-linux" = "sha256-aXXlzTsZp5mOrsxy9oHNzcc+1cFSnbC9RmtawBohmLI=";
+        "x86_64-linux" = "sha256-Hi0HXzwTLuer0v4IKF3aim0tVe7AVLi67DiMimrIq5s=";
       }
       .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
 
@@ -119,8 +119,8 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-4JkNwQACS3tiiLuj41cGRWNspljVQxlsJvCM9KE2JrQ=";
-        "x86_64-linux" = "sha256-LD+zXc8neRbEwq1mx9y7b+08p8hxvo/RW6QzsFQgaUs=";
+        "aarch64-linux" = "sha256-t/jyzG3ibTW3fu8Gl1tWkSjMG6Lek/7JDccDrZX6sD0=";
+        "x86_64-linux" = "sha256-8I1YAKvgWjM3p9O1mCetZvhZelrfB31w0ZwkZBUEoh4=";
       }
       .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported host platform");
     outputHashMode = "recursive";
@@ -205,10 +205,32 @@ let
   python = python312.override {
     self = python;
     packageOverrides = final: prev: {
-      # https://github.com/goauthentik/authentik/pull/14709
-      django = final.django_5_1;
+      # https://github.com/goauthentik/authentik/pull/16324
+      django = final.django_5_2;
 
-      django-dramatiq-postgres = prev.buildPythonPackage {
+      django-channels-postgres = final.buildPythonPackage {
+        pname = "django-channels-postgres";
+        inherit version src meta;
+        pyproject = true;
+
+        sourceRoot = "${src.name}/packages/django-channels-postgres";
+
+        build-system = with final; [ hatchling ];
+
+        propagatedBuildInputs =
+          with final;
+          [
+            channels
+            django
+            django-pgtrigger
+            msgpack
+            psycopg
+            structlog
+          ]
+          ++ psycopg.optional-dependencies.pool;
+      };
+
+      django-dramatiq-postgres = final.buildPythonPackage {
         pname = "django-dramatiq-postgres";
         inherit version src meta;
         pyproject = true;
@@ -222,6 +244,7 @@ let
           [
             cron-converter
             django
+            django-pglock
             django-pgtrigger
             dramatiq
             structlog
@@ -230,10 +253,25 @@ let
           ++ dramatiq.optional-dependencies.watch;
       };
 
+      django-postgres-cache = final.buildPythonPackage {
+        pname = "django-postgres-cache";
+        inherit version src meta;
+        pyproject = true;
+
+        sourceRoot = "${src.name}/packages/django-postgres-cache";
+
+        build-system = with final; [ hatchling ];
+
+        propagatedBuildInputs = with final; [
+          django
+          django-postgres-extra
+        ];
+      };
+
       # Running authentik currently requires a custom version.
       # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
       # See https://github.com/goauthentik/authentik/pull/14057 for latest version bump.
-      djangorestframework = prev.buildPythonPackage {
+      djangorestframework = final.buildPythonPackage {
         pname = "djangorestframework";
         version = "3.16.0";
         format = "setuptools";
@@ -286,18 +324,7 @@ let
         };
       });
 
-      tenant-schemas-celery = prev.tenant-schemas-celery.overrideAttrs (_: rec {
-        version = "3.0.0";
-
-        src = fetchFromGitHub {
-          owner = "maciej-gol";
-          repo = "tenant-schemas-celery";
-          tag = version;
-          hash = "sha256-3ZUXSAOBMtj72sk/VwPV24ysQK+E4l1HdwKa78xrDtg=";
-        };
-      });
-
-      authentik-django = prev.buildPythonPackage {
+      authentik-django = final.buildPythonPackage {
         pname = "authentik-django";
         inherit version src meta;
         pyproject = true;
@@ -326,14 +353,13 @@ let
           with final;
           [
             argon2-cffi
-            celery
             channels
-            channels-redis
             cryptography
             dacite
             deepmerge
             defusedxml
             django
+            django-channels-postgres
             django-countries
             django-cte
             django-dramatiq-postgres
@@ -342,8 +368,9 @@ let
             django-model-utils
             django-pglock
             django-pgtrigger
+            django-postgres-cache
+            django-postgres-extra
             django-prometheus
-            django-redis
             django-storages
             django-tenants
             djangoql
@@ -354,7 +381,6 @@ let
             drf-spectacular
             duo-client
             fido2
-            flower
             geoip2
             geopy
             google-api-python-client
@@ -383,7 +409,6 @@ let
             setproctitle
             structlog
             swagger-spec-validator
-            tenant-schemas-celery
             twilio
             ua-parser
             unidecode
@@ -396,7 +421,6 @@ let
             zxcvbn
           ]
           ++ django-storages.optional-dependencies.s3
-          ++ opencontainers.optional-dependencies.reggie
           ++ psycopg.optional-dependencies.c
           ++ psycopg.optional-dependencies.pool
           ++ uvicorn.optional-dependencies.standard;
@@ -431,7 +455,7 @@ let
 
     env.CGO_ENABLED = 0;
 
-    vendorHash = "sha256-wTTEDBRYCW1UFaeX49ufLT0c17sacJzcCaW/8cPNYR4=";
+    vendorHash = "sha256-m2shrCwoVdbtr8B83ZcAyG+J6dEys2xdjtlfFFF4CDo=";
 
     postInstall = ''
       mv $out/bin/server $out/bin/authentik

--- a/pkgs/development/python-modules/django-postgres-extra/default.nix
+++ b/pkgs/development/python-modules/django-postgres-extra/default.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  django,
+  python-dateutil,
+  # test dependencies
+  coverage,
+  dj-database-url,
+  freezegun,
+  postgresql,
+  psycopg2,
+  pytest,
+  pytest-benchmark,
+  pytest-cov,
+  pytest-django,
+  pytest-freezegun,
+  pytest-lazy-fixture,
+  pytestCheckHook,
+  syrupy,
+  tox,
+  types-psycopg2,
+}:
+buildPythonPackage rec {
+  pname = "django-postgres-extra";
+  version = "2.0.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SectorLabs";
+    repo = "django-postgres-extra";
+    rev = "v${version}";
+    hash = "sha256-/2qoXZ2f3un2cgJFAGMnQWBraJ7urkb0kHtcKKJsh6w=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    python-dateutil
+  ];
+
+  nativeCheckInputs = [
+    coverage
+    dj-database-url
+    freezegun
+    postgresql
+    psycopg2
+    pytest
+    pytest-benchmark
+    pytest-cov
+    pytest-django
+    pytest-freezegun
+    pytest-lazy-fixture
+    pytestCheckHook
+    syrupy
+    tox
+    types-psycopg2
+  ];
+
+  preCheck = ''
+    # Start Postgres.
+    export PGDATA="$NIX_BUILD_TOP/.postgres"
+    export PGHOST="$PGDATA/run"
+    export DATABASE_URL=postgresql://''${PGHOST//\//%2F}/psqlextra
+    initdb -E UTF8
+    mkdir -p "$PGDATA/run"
+    cat <<EOF >> "$PGDATA/postgresql.conf"
+    unix_socket_directories = '$PGDATA/run'
+    EOF
+    echo "CREATE DATABASE psqlextra" | postgres --single -E postgres
+    echo "Starting Postgres at $PGDATA" >&2
+    pg_ctl start -w
+  '';
+
+  postCheck = ''
+    echo "Stopping Postgres at $PGDATA" >&2
+    pg_ctl stop -w
+  '';
+
+  disabledTests = [
+    "test_management_command_partition_auto_confirm"
+    "test_management_command_partition_confirm_no"
+    "test_management_command_partition_confirm_yes"
+    "test_management_command_partition_dry_run"
+  ]
+  # tests incompatible with django>=5
+  ++ lib.optionals (lib.versionAtLeast django.version "5") [
+    "test_schema_editor_clone_model_to_schema"
+    "test_schema_editor_clone_model_to_schema_custom_constraint_names"
+  ]
+  # tests incompatible with django>=5.2
+  ++ lib.optionals (lib.versionAtLeast django.version "5.2") [
+    "test_query_annotate_rename_chain"
+  ];
+
+  pythonImportsCheck = [ "psqlextra" ];
+
+  meta = with lib; {
+    description = "Bringing all of PostgreSQL's awesomeness to Django";
+    homepage = "https://github.com/SectorLabs/django-postgres-extra";
+    changelog = "https://github.com/SectorLabs/django-postgres-extra/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ b4dm4n ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4096,6 +4096,8 @@ self: super: with self; {
 
   django-polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-postgres-extra = callPackage ../development/python-modules/django-postgres-extra { };
+
   django-postgres-partition = callPackage ../development/python-modules/django-postgres-partition { };
 
   django-postgresql-netfields =


### PR DESCRIPTION
Update authentik and the outposts to `2025.10.0`.

This removes all redis dependencies (see release notes) and also all old celery and flower dependencies (replaced by dramatiq).

[Release Notes](https://docs.goauthentik.io/releases/2025.10)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
