### PR TITLE
[25.05] Hardened Linux kernel updates 2025-10-28

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -2,12 +2,12 @@
     "5.10": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v5.10.238-hardened1.patch",
-            "sha256": "1y4srk40v0gzfnlqsbh6g9h5vcs8rp5g2b8jjch6xx7dji189myq",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.10.238-hardened1/linux-hardened-v5.10.238-hardened1.patch"
+            "name": "linux-hardened-v5.10.245-hardened1.patch",
+            "sha256": "1yc5bq01nm7h2i8ygv0nnqsy7j31fhl5339al39nd28sffn073hf",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.10.245-hardened1/linux-hardened-v5.10.245-hardened1.patch"
         },
-        "sha256": "1dkblixa0as9h11m081dqq8vlz4dcjbzdz7phkz07p621na55j07",
-        "version": "5.10.238"
+        "sha256": "17wxs8i8vd5ivv99ra0sri3wmkw5c22wsaw8nf1xcvys2kmpa7hk",
+        "version": "5.10.245"
     },
     "5.15": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -42,12 +42,12 @@
     "6.12": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.43-hardened1.patch",
-            "sha256": "10hp4718agz7bj4wnis7g1c8ahnwn5917a5v88y9iwawrjm9148v",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.43-hardened1/linux-hardened-v6.12.43-hardened1.patch"
+            "name": "linux-hardened-v6.12.50-hardened1.patch",
+            "sha256": "0bzq364d6i7wis9sdljjkzmbvjnv45hmyqikmxagps2rdh57916p",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.50-hardened1/linux-hardened-v6.12.50-hardened1.patch"
         },
-        "sha256": "1vmxywg11z946i806sg7rk7jr9px87spmwwbzjxpps2nsjybpjqg",
-        "version": "6.12.43"
+        "sha256": "19bjzhxasj4r6m1lhsa486a96axfigbm06kqa2lwa7y2s5sbsdf4",
+        "version": "6.12.50"
     },
     "6.6": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -32,12 +32,12 @@
     "6.1": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.1.141-hardened1.patch",
-            "sha256": "10wbx6sjzjh3krx15pb65xxl55xcpia54ws825s9619wx059dskl",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.1.141-hardened1/linux-hardened-v6.1.141-hardened1.patch"
+            "name": "linux-hardened-v6.1.155-hardened1.patch",
+            "sha256": "0bihz31mic1j6wjfgzkm829d8k1y50p18v024px5yvg1gdkx86ww",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.1.155-hardened1/linux-hardened-v6.1.155-hardened1.patch"
         },
-        "sha256": "05n1561cbzaw9vcxp86bqzvhqz5wv7dajpy7cq34bw7myvx4ag5w",
-        "version": "6.1.141"
+        "sha256": "0wsw99h2jsrcx9fff59nqjx66l40vywj8qi3j6yvqpq8xsp8g4y2",
+        "version": "6.1.155"
     },
     "6.12": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -22,12 +22,12 @@
     "5.4": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v5.4.294-hardened1.patch",
-            "sha256": "1q6ffxnpk8j2fwi3g8rpf1lc247m8xiqix2kichxvggkadmjyzg0",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.4.294-hardened1/linux-hardened-v5.4.294-hardened1.patch"
+            "name": "linux-hardened-v5.4.300-hardened1.patch",
+            "sha256": "1k6ca8ifcqva6r4qrg403l5d0q9n9ph96vihyz75mzkq08w8kbvb",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.4.300-hardened1/linux-hardened-v5.4.300-hardened1.patch"
         },
-        "sha256": "16bv0x4c9ssr66vrd6jnv2dw5na1y7hxfn4d67g0zaksh6xd0yf8",
-        "version": "5.4.294"
+        "sha256": "0nl1l689d4jq2l39v816yy7z5lzc5dvv8aqn85xlv4najc022jcr",
+        "version": "5.4.300"
     },
     "6.1": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -52,11 +52,11 @@
     "6.6": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.6.94-hardened1.patch",
-            "sha256": "0i1dshmsr8v230qmbawda916420m6njwwmillcbr42hsagdjhd0i",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.6.94-hardened1/linux-hardened-v6.6.94-hardened1.patch"
+            "name": "linux-hardened-v6.6.109-hardened1.patch",
+            "sha256": "1hjjacf2gm02wkilimn58ny2y0slazjy1vfm5rx6agjj2pg7nd9f",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.6.109-hardened1/linux-hardened-v6.6.109-hardened1.patch"
         },
-        "sha256": "0mncdsqbqrxii0hirnymi1kmg50jn9v0p26flimlf2xj4vm82fbi",
-        "version": "6.6.94"
+        "sha256": "1x1h2x04xvds8k59x36zqxzbj4cm6yl5l6xacgfyxzccfycwscbp",
+        "version": "6.6.109"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -12,12 +12,12 @@
     "5.15": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v5.15.185-hardened1.patch",
-            "sha256": "00m1p8cm1d76drdlafv4bdrq81xkh40jgg33kvkk3wqcbiikq3h7",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.15.185-hardened1/linux-hardened-v5.15.185-hardened1.patch"
+            "name": "linux-hardened-v5.15.194-hardened1.patch",
+            "sha256": "1r2iflsnvg9l9isn5n2d401jvm2pni75vc1g3vbirg55nqp7ykgs",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.15.194-hardened1/linux-hardened-v5.15.194-hardened1.patch"
         },
-        "sha256": "1p0kjc09qqv361phscny1gqj38di9dpab9gxywljkwqhi5wyn0rx",
-        "version": "5.15.185"
+        "sha256": "0zi6ihvjmaf940arnc7jjvdqrjf3cvkc9mqc8n24dz85vam6z39l",
+        "version": "5.15.194"
     },
     "5.4": {
         "patch": {


### PR DESCRIPTION
Most of these have been removed on master, which means updates are not getting backported to stable, so the update script needs to be run on 25.05 regularly for the remainder of its lifetime.

The final commit is a backport of https://github.com/NixOS/nixpkgs/pull/455563, which had to be done manually due to a conflict caused by the removal of the 6.6 hardened kernel.  The other commits are all new.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
