### PR TITLE
canaille: 0.0.74 -> 0.2.1

### DIFF
--- a/nixos/modules/services/security/canaille.nix
+++ b/nixos/modules/services/security/canaille.nix
@@ -40,7 +40,7 @@ let
       ++ old.optional-dependencies.otp
       ++ old.optional-dependencies.sms;
     makeWrapperArgs = (old.makeWrapperArgs or [ ]) ++ [
-      "--set CONFIG /etc/canaille/config.toml"
+      "--set CANAILLE_CONFIG /etc/canaille/config.toml"
       "--set SECRETS_DIR \"${secretsDir}\""
     ];
   });
@@ -303,7 +303,7 @@ in
       ];
       environment = {
         PYTHONPATH = "${pythonEnv}/${python.sitePackages}/";
-        CONFIG = "/etc/canaille/config.toml";
+        CANAILLE_CONFIG = "/etc/canaille/config.toml";
         SECRETS_DIR = secretsDir;
       };
       serviceConfig = commonServiceConfig // {

--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -2,9 +2,9 @@
   lib,
   python3,
   fetchFromGitLab,
-  fetchpatch,
   openldap,
   nixosTests,
+  postgresql,
 }:
 
 let
@@ -12,23 +12,15 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "canaille";
-  version = "0.0.74";
+  version = "0.2.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "yaal";
     repo = "canaille";
     tag = version;
-    hash = "sha256-FL02ADM7rUU43XR71UWr4FLr/NeUau7zRwTMOSFm1T4=";
+    hash = "sha256-6Ksvl03HgpVQRhHtKWQwTrPBkaXcVWoejGaMFBAykHM=";
   };
-
-  patches = [
-    # https://gitlab.com/yaal/canaille/-/merge_requests/275
-    (fetchpatch {
-      url = "https://gitlab.com/yaal/canaille/-/commit/1c7fc8b1034a4423f7f46ad8adeced854910b702.patch";
-      hash = "sha256-fu7D010NG7yUChOve7HY3e7mm2c/UGpfcTAiTU8BnGg=";
-    })
-  ];
 
   build-system = with python.pkgs; [
     hatchling
@@ -36,31 +28,36 @@ python.pkgs.buildPythonApplication rec {
     setuptools
   ];
 
-  dependencies =
-    with python.pkgs;
-    [
-      blinker
-      flask
-      flask-caching
-      flask-wtf
-      pydantic-settings
-      httpx
-      wtforms
-    ]
-    ++ sentry-sdk.optional-dependencies.flask;
+  dependencies = with python.pkgs; [
+    blinker
+    click
+    dramatiq
+    dramatiq-eager-broker
+    flask
+    flask-caching
+    flask-dramatiq
+    flask-session
+    flask-wtf
+    httpx
+    pydantic-settings
+    wtforms
+  ];
 
   nativeCheckInputs =
     with python.pkgs;
     [
       pytestCheckHook
+      postgresql
       coverage
       flask-webtest
       pyquery
       pytest-cov-stub
       pytest-httpserver
       pytest-lazy-fixtures
+      pytest-postgresql
       pytest-smtpd
       pytest-xdist
+      python-avatars
       scim2-tester
       slapd
       toml
@@ -68,13 +65,7 @@ python.pkgs.buildPythonApplication rec {
       time-machine
       pytest-scim2-server
     ]
-    ++ optional-dependencies.front
-    ++ optional-dependencies.oidc
-    ++ optional-dependencies.scim
-    ++ optional-dependencies.ldap
-    ++ optional-dependencies.postgresql
-    ++ optional-dependencies.otp
-    ++ optional-dependencies.sms;
+    ++ (lib.concatLists (builtins.attrValues optional-dependencies));
 
   postInstall = ''
     mkdir -p $out/etc/schema
@@ -87,10 +78,13 @@ python.pkgs.buildPythonApplication rec {
     export SBIN="${openldap}/bin"
     export SLAPD="${openldap}/libexec/slapd"
     export SCHEMA="${openldap}/etc/schema"
-
-    # Just use their example config for testing
-    export CONFIG=tests/app/fixtures/default-config.toml
   '';
+
+  disabledTests = [
+    # Tries to use DNS resolution
+    "test_send_new_email_error"
+    "test_send_test_email_ssl"
+  ];
 
   optional-dependencies = with python.pkgs; {
     front = [
@@ -98,6 +92,7 @@ python.pkgs.buildPythonApplication rec {
       flask-babel
       flask-talisman
       flask-themer
+      isodate
       pycountry
       pytz
       tomlkit
@@ -108,10 +103,10 @@ python.pkgs.buildPythonApplication rec {
       joserfc
     ];
     scim = [
-      httpx
-      scim2-models
       authlib
+      httpx
       scim2-client
+      scim2-models
     ];
     ldap = [ python-ldap ];
     sentry = [ sentry-sdk ];
@@ -128,8 +123,18 @@ python.pkgs.buildPythonApplication rec {
       pillow
       qrcode
     ];
+    fido = [ webauthn ];
     sms = [ smpplib ];
-    server = [ hypercorn ];
+    captcha = [ captcha ];
+    server = [
+      asgiref
+      hypercorn
+      isodate
+      pydanclick
+      tomlkit
+    ];
+    redis = [ dramatiq ] ++ dramatiq.optional-dependencies.redis;
+    rabbitmq = [ dramatiq ] ++ dramatiq.optional-dependencies.rabbitmq;
   };
 
   passthru = {

--- a/pkgs/development/python-modules/dramatiq-eager-broker/default.nix
+++ b/pkgs/development/python-modules/dramatiq-eager-broker/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  uv-build,
+  dramatiq,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "dramatiq-eager-broker";
+  version = "0.3.0";
+
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "yaal";
+    repo = "dramatiq-eager-broker";
+    tag = version;
+    hash = "sha256-tz4Gy31y5oaTHFAzb5L7bg0AhG1U/JKDySGloA7/A/8=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [ dramatiq ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "An eager broker for Dramatiq that executes tasks synchronously and immediately, without queuing";
+    homepage = "https://codeberg.org/yaal/dramatiq-eager-broker";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/flask-dramatiq/default.nix
+++ b/pkgs/development/python-modules/flask-dramatiq/default.nix
@@ -38,6 +38,8 @@ buildPythonPackage {
 
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [ "dramatiq" ];
+
   dependencies = [ dramatiq ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/periodiq/default.nix
+++ b/pkgs/development/python-modules/periodiq/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage rec {
       --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api'
   '';
 
+  pythonRelaxDeps = [ "dramatiq" ];
+
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pydanclick/default.nix
+++ b/pkgs/development/python-modules/pydanclick/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pydantic,
+  pydantic-core,
+  click,
+  pytest7CheckHook,
+  pydantic-settings,
+}:
+
+buildPythonPackage rec {
+  pname = "pydanclick";
+  version = "0.5.1";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "felix-martel";
+    repo = "pydanclick";
+    tag = "v${version}";
+    hash = "sha256-Cgjq+9j6v7KILjfhK+4Y5joZPU2/ufJiIsdAfnSG9x4=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pydantic
+    pydantic-core
+    click
+  ];
+
+  nativeCheckInputs = [
+    # Still uses RaisesContext from pytest 7
+    # https://github.com/felix-martel/pydanclick/issues/53
+    pytest7CheckHook
+    pydantic-settings
+  ];
+
+  disabledTests = [
+    # No idea about these two failures
+    "test_complex_types_example_help"
+    "test_simple_example_with_invalid_args"
+  ];
+
+  pythonImportsCheck = [ "pydanclick" ];
+
+  meta = {
+    description = "Add click options from a Pydantic model";
+    homepage = "https://github.com/felix-martel/pydanclick";
+    changelog = "https://github.com/felix-martel/pydanclick/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/python-avatars/default.nix
+++ b/pkgs/development/python-modules/python-avatars/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "python-avatars";
+  version = "1.4.1";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ibonn";
+    repo = "python_avatars";
+    tag = "v${version}";
+    hash = "sha256-8/uhzOr0AukH0VgUhnsPNSEGJ2D5z1tqdIKzNHyHCgY=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "python_avatars" ];
+
+  meta = {
+    description = "Avatar generation package for Python";
+    homepage = "https://github.com/ibonn/python_avatars";
+    changelog = "https://github.com/ibonn/python_avatars/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/scim2-client/default.nix
+++ b/pkgs/development/python-modules/scim2-client/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  hatchling,
+  fetchFromGitHub,
+  uv-build,
   scim2-models,
   pytestCheckHook,
   portpicker,
@@ -16,17 +16,23 @@
 
 buildPythonPackage rec {
   pname = "scim2-client";
-  version = "0.6.1";
+  version = "0.7.3";
 
   pyproject = true;
 
-  src = fetchPypi {
-    inherit version;
-    pname = "scim2_client";
-    hash = "sha256-5XOUOKf0vYHkewY22x5NQdhICXCd+EftKhsxtQurgHQ=";
+  src = fetchFromGitHub {
+    owner = "python-scim";
+    repo = "scim2-client";
+    tag = version;
+    hash = "sha256-jw8Dp/PekM0JrgxRkN+A896O2twkSDxQpsGsljJFdB0=";
   };
 
-  build-system = [ hatchling ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.9,<0.9.0' 'uv_build'
+  '';
+
+  build-system = [ uv-build ];
 
   dependencies = [ scim2-models ];
 
@@ -40,12 +46,6 @@ buildPythonPackage rec {
     cacert
   ]
   ++ optional-dependencies.httpx;
-
-  # Werkzeug returns 500, didn't deem it worth it to investigate
-  disabledTests = [
-    "test_search_request"
-    "test_query_dont_check_request_payload"
-  ];
 
   pythonImportsCheck = [ "scim2_client" ];
 

--- a/pkgs/development/python-modules/scim2-models/default.nix
+++ b/pkgs/development/python-modules/scim2-models/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "scim2-models";
-  version = "0.5.1";
+  version = "0.6.4";
 
   pyproject = true;
 
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     owner = "python-scim";
     repo = "scim2-models";
     tag = finalAttrs.version;
-    hash = "sha256-ahwHmWsM9IoK+yq0Qd0c2+kagMlXGi80/rAB4UQsf6U=";
+    hash = "sha256-MyKe1OeaYwqHCma/HEunNCJ49ssHM+pTtnM4XnDZBCE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/scim2-server/default.nix
+++ b/pkgs/development/python-modules/scim2-server/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  hatchling,
+  fetchFromGitHub,
+  uv-build,
   scim2-filter-parser,
   scim2-models,
   werkzeug,
@@ -13,17 +13,23 @@
 
 buildPythonPackage rec {
   pname = "scim2-server";
-  version = "0.1.7";
+  version = "0.1.8";
 
   pyproject = true;
 
-  src = fetchPypi {
-    inherit version;
-    pname = "scim2_server";
-    hash = "sha256-nMS6vjMZ/Lyu0kiVH+IlmxZsuu7McY7AZS/xamfZSlk=";
+  src = fetchFromGitHub {
+    owner = "python-scim";
+    repo = "scim2-server";
+    tag = version;
+    hash = "sha256-7st/8KI8xWDkeUiID6TUKFdc2U8uFWe+xDUFbe9w22M=";
   };
 
-  build-system = [ hatchling ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.9,<0.9.0' 'uv_build'
+  '';
+
+  build-system = [ uv-build ];
 
   dependencies = [
     scim2-filter-parser

--- a/pkgs/development/python-modules/scim2-tester/default.nix
+++ b/pkgs/development/python-modules/scim2-tester/default.nix
@@ -1,38 +1,45 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  hatchling,
+  pythonOlder,
+  fetchFromGitHub,
+  uv-build,
   scim2-client,
+  scim2-models,
   pytestCheckHook,
-  werkzeug,
-  scim2-server,
+  pytest-scim2-server,
   pytest-httpserver,
-  cacert,
 }:
 
 buildPythonPackage rec {
   pname = "scim2-tester";
-  version = "0.2.4";
+  version = "0.2.6";
 
   pyproject = true;
 
-  src = fetchPypi {
-    inherit version;
-    pname = "scim2_tester";
-    hash = "sha256-r67e3AnqhLWVmtOFDj3P2Baa2Ch3TjyHm3Ol8ZwXH/g=";
+  src = fetchFromGitHub {
+    owner = "python-scim";
+    repo = "scim2-tester";
+    tag = version;
+    hash = "sha256-PoaY3gPSm+J/C1ad81Dmn7zrbf00pies8CLmLdV+gus=";
   };
 
-  build-system = [ hatchling ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.9,<0.9.0' 'uv_build'
+  '';
 
-  dependencies = [ scim2-client ];
+  build-system = [ uv-build ];
+
+  dependencies = [
+    scim2-client
+    scim2-models
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    werkzeug
-    scim2-server
+    pytest-scim2-server
     pytest-httpserver
-    cacert
   ]
   ++ optional-dependencies.httpx;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13419,6 +13419,8 @@ self: super: with self; {
 
   pydal = callPackage ../development/python-modules/pydal { };
 
+  pydanclick = callPackage ../development/python-modules/pydanclick { };
+
   pydanfossair = callPackage ../development/python-modules/pydanfossair { };
 
   pydantic = callPackage ../development/python-modules/pydantic { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4651,6 +4651,8 @@ self: super: with self; {
 
   dramatiq-abort = callPackage ../development/python-modules/dramatiq-abort { };
 
+  dramatiq-eager-broker = callPackage ../development/python-modules/dramatiq-eager-broker { };
+
   drawille = callPackage ../development/python-modules/drawille { };
 
   drawilleplot = callPackage ../development/python-modules/drawilleplot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15395,6 +15395,8 @@ self: super: with self; {
 
   python-arango = callPackage ../development/python-modules/python-arango { };
 
+  python-avatars = callPackage ../development/python-modules/python-avatars { };
+
   python-awair = callPackage ../development/python-modules/python-awair { };
 
   python-axolotl = callPackage ../development/python-modules/python-axolotl { };


### PR DESCRIPTION


## Things done

New packages:

- pydanclick

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
