### PR TITLE
[RFC] python: add home path to virtualenv

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.13/virtualenv-add-home-path.patch
+++ b/pkgs/development/interpreters/python/cpython/3.13/virtualenv-add-home-path.patch
@@ -1,0 +1,51 @@
+diff --git a/Lib/venv/__init__.py b/Lib/venv/__init__.py
+index dc9c5991df7..a1e8cb07a91 100644
+--- a/Lib/venv/__init__.py
++++ b/Lib/venv/__init__.py
+@@ -497,6 +497,7 @@ def replace_variables(self, text, context):
+             '__VENV_PROMPT__': context.prompt,
+             '__VENV_BIN_NAME__': context.bin_name,
+             '__VENV_PYTHON__': context.env_exe,
++            '__HOME_DIR__': context.python_dir,
+         }
+ 
+         def quote_ps1(s):
+diff --git a/Lib/venv/scripts/common/activate b/Lib/venv/scripts/common/activate
+index 70673a265d4..398848f6f89 100644
+--- a/Lib/venv/scripts/common/activate
++++ b/Lib/venv/scripts/common/activate
+@@ -51,7 +51,7 @@ case "$(uname)" in
+ esac
+ 
+ _OLD_VIRTUAL_PATH="$PATH"
+-PATH="$VIRTUAL_ENV/"__VENV_BIN_NAME__":$PATH"
++PATH="$VIRTUAL_ENV/"__VENV_BIN_NAME__:"__HOME_DIR__":"$PATH"
+ export PATH
+ 
+ VIRTUAL_ENV_PROMPT=__VENV_PROMPT__
+diff --git a/Lib/venv/scripts/common/activate.fish b/Lib/venv/scripts/common/activate.fish
+index 284a7469c99..9d821d83554 100644
+--- a/Lib/venv/scripts/common/activate.fish
++++ b/Lib/venv/scripts/common/activate.fish
+@@ -36,7 +36,7 @@ deactivate nondestructive
+ set -gx VIRTUAL_ENV __VENV_DIR__
+ 
+ set -gx _OLD_VIRTUAL_PATH $PATH
+-set -gx PATH "$VIRTUAL_ENV/"__VENV_BIN_NAME__ $PATH
++set -gx PATH "$VIRTUAL_ENV/"__VENV_BIN_NAME__ "__HOME_DIR__" $PATH
+ set -gx VIRTUAL_ENV_PROMPT __VENV_PROMPT__
+ 
+ # Unset PYTHONHOME if set.
+diff --git a/Lib/venv/scripts/posix/activate.csh b/Lib/venv/scripts/posix/activate.csh
+index 2a3fa835476..717c1eeb6b3 100644
+--- a/Lib/venv/scripts/posix/activate.csh
++++ b/Lib/venv/scripts/posix/activate.csh
+@@ -12,7 +12,7 @@ deactivate nondestructive
+ setenv VIRTUAL_ENV __VENV_DIR__
+ 
+ set _OLD_VIRTUAL_PATH="$PATH"
+-setenv PATH "$VIRTUAL_ENV/"__VENV_BIN_NAME__":$PATH"
++setenv PATH "$VIRTUAL_ENV/"__VENV_BIN_NAME__:"__HOME_DIR__":"$PATH"
+ setenv VIRTUAL_ENV_PROMPT __VENV_PROMPT__
+ 
+ 

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -357,6 +357,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optionals (pythonAtLeast "3.13") [
     ./3.13/virtualenv-permissions.patch
+    ./3.13/virtualenv-add-home-path.patch
   ]
   ++ optionals mimetypesSupport [
     # Make the mimetypes module refer to the right file


### PR DESCRIPTION
follow https://github.com/NixOS/nixpkgs/pull/442540

now we can create python virtual env with system packages in nixos.
the common way we create a mixed python venv looks like
```
nix-shell  -p "python3.withPackages (ps: [ps.pytest])"
python -m venv --system-site-packages venv
source venv/bin/activate
```
Then we can make use of the system python3Packages.pytest package

However, there exsits problem when we exit the temporay nix-shell: we lost the path to pytest exectuable.
In design, venv should work as a persistent python-venv with access to both system python-env's packages and bin exectuables. Hence, we modify the python venv activate script to add additonal the original python home directory to system path.

I am not a cpython/pypy developer, not sure patching cpython/pypy is the best solution for this problem. not sure upstream can adopt this patch.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
