### PR TITLE
mpv: append yt-dlp to PATH instead of prepending it

### DIFF
--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -33,13 +33,16 @@ let
         [
           mpv.luaEnv
         ]
-        ++ lib.optionals youtubeSupport [
-          yt-dlp
-        ]
         ++ lib.optionals mpv.vapoursynthSupport [
           mpv.vapoursynth.python3
         ]
       );
+
+      # With some tools, we want to prioritize tools that are in PATH. For example, users may want
+      # to quickly expose a newer version of yt-dlp through the nix shell because it needs to be
+      # kept up-to-date for it to work.
+      fallbackBinPath = lib.makeBinPath (lib.optionals youtubeSupport [ yt-dlp ]);
+
       # All arguments besides the input and output binaries (${mpv}/bin/mpv and
       # $out/bin/mpv). These are used by the darwin specific makeWrapper call
       # used to wrap $out/Applications/mpv.app/Contents/MacOS/mpv as well.
@@ -67,6 +70,12 @@ let
           "PATH"
           ":"
           binPath
+        ]
+        ++ lib.optionals (fallbackBinPath != "") [
+          "--suffix"
+          "PATH"
+          ":"
+          fallbackBinPath
         ]
         ++ (lib.lists.flatten (
           map


### PR DESCRIPTION
Make the mpv wrapper script append yt-dlp to PATH instead of prepending. This will enable users to quickly expose a newer version of yt-dlp through the PATH using the Nix shell. It's useful because yt-dlp breaks constantly for some sites unless it's kept updated.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
