### PR TITLE
squid: backport a fix for not prohibiting numeric domain names

### DIFF
--- a/pkgs/by-name/sq/squid/package.nix
+++ b/pkgs/by-name/sq/squid/package.nix
@@ -16,6 +16,7 @@
   cppunit,
   ipv6 ? true,
   nixosTests,
+  fetchpatch,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "squid";
@@ -27,6 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
     }/squid-${finalAttrs.version}.tar.xz";
     hash = "sha256-Xgd74dg6nmls6NDZ5yOxJzFSIHoJFAS+aKS5qeGMcAM=";
   };
+
+  patches = lib.optional (lib.versionOlder finalAttrs.version "7.2.0") (fetchpatch {
+    # Merged upstream PR; fixes the issue of rejecting domain names starting with digits
+    # To remove when 7.3 is released (or 7.2.1, but that doesn't seem likely)
+    url = "https://patch-diff.githubusercontent.com/raw/squid-cache/squid/pull/2283.patch";
+    hash = "sha256-HLGmzrAH5y1sFfFnVeeegRihyn+N7csGX9lVqmCDIHc=";
+  });
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
Squid 7.2 contained an implementation of an obsolete RFC defining valid domain names. In fact, components composed exclusively of digits are valid according to a newer RFC.

Will self-merge once CI passes as it is a small and clear bugfix and I am the maintainer. 

FYI @Chaostheorie 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (here the same as) [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
