### PR TITLE
quodlibet: don't use Xine unnecessarily

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -34,7 +34,7 @@
   withGstPlugins ? withGstreamerBackend,
   withGstreamerBackend ? true,
   gst_all_1,
-  withXineBackend ? true,
+  withXineBackend ? !withGstreamerBackend,
   xine-lib,
 
   # tests


### PR DESCRIPTION
In 50dc0203707d (quodlibet: makeover, 2022-08-05) / #185236, the quodlibet library was refactored.  That commit appears to have accidentally changed the default arguments for building quodlibet to mean the Xine backend would always be included, rather than only as an alternative to the Gstreamer backend.  This adds unnecessary dependencies for the non-Xine quodlibet packages, so default to only including Xine if Gstreamer is absent.

I strongly expect this will make no visible difference to anyone, so I'm not going to add any release notes, but I'm also not going to suggest backporting to a stable release branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
