### PR TITLE
python3Packages.pyopen-wakeword: 1.0.1 -> 1.1.0; wyoming-openwakeword: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/by-name/wy/wyoming-openwakeword/package.nix
+++ b/pkgs/by-name/wy/wyoming-openwakeword/package.nix
@@ -2,28 +2,19 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "wyoming-openwakeword";
-  version = "2.0.0";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming-openwakeword";
     rev = "refs/tags/v${version}";
-    hash = "sha256-edSZ5W6oSPYLKuxjQerWRkAO/C+WeTiCosNnbS2sbh0=";
+    hash = "sha256-yYDZ1wOhCTdYGeRmtbOgx5/zkF0Baxmha7eO/i0p49g=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Expose entrypoint as wyoming-openwakeword script
-      url = "https://github.com/rhasspy/wyoming-openwakeword/commit/a8c8419bc65fab07a554aa0925f898a7f3b65d79.patch";
-      hash = "sha256-GSViQA01RwkFYEH7CPdU1P0EQ2ml6Vp1OukQ/0VOm+Y=";
-    })
-  ];
 
   build-system = with python3Packages; [
     setuptools

--- a/pkgs/development/python-modules/pyopen-wakeword/default.nix
+++ b/pkgs/development/python-modules/pyopen-wakeword/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyopen-wakeword";
-  version = "1.0.1";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "pyopen-wakeword";
     tag = "v${version}";
-    hash = "sha256-LJ0pHP4nsTx3GPuWUwOwNuXR9tUKABqSHnLSvMlfm1Y=";
+    hash = "sha256-czFDuIZ10aetr6frkKSozPjS7zMeNJ5/WVLA7Ib1CaI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
https://github.com/rhasspy/pyopen-wakeword/blob/v1.1.0/CHANGELOG.md

Unfortunately the tests segfault for me on aarch64-linux. Already on 1.0.1.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
