### PR TITLE
nixos/authentik: init module, nixosTests/authentik: init tests

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -38,6 +38,8 @@
 
 - [Watt](https://github.com/NotAShelf/watt), a CPU frequency and power management daemon for Linux. Available as [services.watt](#opt-services.watt.enable).
 
+- [authentik](https://goauthentik.io), an open-source Identity Provider (IdP) for modern SSO. Available as [services.authentik](#opt-services.authentik.enable).
+
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
 - [feishin](https://github.com/jeffvli/feishin), a modern self-hosted music player. Available as [services.feishin](#opt-services.feishin.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1526,6 +1526,7 @@
   ./services/search/typesense.nix
   ./services/security/aesmd.nix
   ./services/security/authelia.nix
+  ./services/security/authentik.nix
   ./services/security/bitwarden-directory-connector-cli.nix
   ./services/security/canaille.nix
   ./services/security/certmgr.nix

--- a/nixos/modules/services/security/authentik.nix
+++ b/nixos/modules/services/security/authentik.nix
@@ -1,0 +1,351 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.services.authentik;
+
+  after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    mkIf
+    ;
+
+  secretsFor =
+    path: secretFiles:
+    secretFiles // (lib.attrsets.attrByPath path { secretFiles = { }; } cfg).secretFiles;
+
+  credentialsEnv =
+    path: secretFiles: lib.mapAttrs (name: file: "file:%d/${name}") (secretsFor path secretFiles);
+
+  credentials =
+    path: secretFiles: lib.mapAttrsToList (name: file: "${name}:${file}") (secretsFor path secretFiles);
+
+  commonServiceConfig = {
+    Type = "simple";
+    Restart = "always";
+    RestartSec = 3;
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    ProtectHome = true;
+    ProtectSystem = "full";
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    SystemCallFilter = "~@cpu-emulation @keyring @module @obsolete @raw-io @reboot @swap @sync";
+    ConfigurationDirectory = "authentik";
+  };
+
+  secret = types.nullOr (
+    types.str
+    // {
+      # We don't want users to be able to pass a path literal here but
+      # it should look like a path.
+      check = it: lib.isString it && lib.types.path.check it;
+    }
+  );
+
+  mkEnvOptions = name: global: {
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        AUTHENTIK_LISTEN__METRICS = "localhost:9300";
+      };
+      description = ''
+        Extra configuration environment variables for the authentik ${name}.${lib.optionalString global " These overwrite the global environment variables."}
+        Refer to the [documentation](https://docs.goauthentik.io/install-config/configuration) for options.
+      '';
+    };
+
+    secretFiles = mkOption {
+      type = types.attrsOf secret;
+      example = {
+        AUTHENTIK_POSTGRESQL__PASSWORD = "/run/secrets/authentik_postgress_passwd";
+      };
+      default = { };
+      description = ''
+        Attribute set containing paths to files to add to the environment of the authentik ${name}.${lib.optionalString global " These overwrite the global secret files."}
+        The files are not added to the nix store, so they can be used to pass secrets.
+        Refer to the [documentation](https://docs.goauthentik.io/install-config/configuration/) for options.
+      '';
+    };
+  };
+
+  mkOutpost =
+    name:
+    {
+      enable = mkEnableOption "the authentik ${name} outpost";
+      package = mkPackageOption pkgs "authentik.outposts.${name}" {
+        default = [
+          "authentik"
+          "outposts"
+          name
+        ];
+      };
+      environmentFile = mkOption {
+        type = secret;
+        example = "/run/secrets/authentik_${name}";
+        default = null;
+        description = ''
+          Path of a file with extra environment variables to be loaded from disk.
+          This file is not added to the nix store, so it can be used to pass secrets to authentik ${name} outpost.
+          Refer to the [documentation](https://docs.goauthentik.io/install-config/configuration/) for options.
+        '';
+      };
+    }
+    // mkEnvOptions "${name} outpost" false;
+
+  mkOutpostConfig =
+    name:
+    mkIf cfg.outposts.${name}.enable {
+      description = "authentik ${name} outpost";
+      after = [ "network-online.target" ];
+      requires = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.outposts.${name}.environment // (credentialsEnv [ "outposts" name ] { });
+      serviceConfig = commonServiceConfig // {
+        ExecStart = lib.getExe cfg.outposts.${name}.package;
+        EnvironmentFile = cfg.outposts.${name}.environmentFile;
+        LoadCredential = credentials [ "outposts" name ] { };
+        DynamicUser = true;
+      };
+    };
+in
+{
+  options.services.authentik = {
+    enable = mkEnableOption "authentik, the open-source Identity Provider that emphasizes flexibility and versatility";
+    package = mkPackageOption pkgs "authentik" {
+      default = [ "authentik" ];
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "authentik";
+      description = "The user authentik should run as";
+    };
+    group = mkOption {
+      type = types.str;
+      default = "authentik";
+      description = "The group authentik should run as.";
+    };
+
+    database = {
+      createLocally = mkEnableOption "a local PostgreSQL instance for authentik." // {
+        default = true;
+      };
+      host = mkOption {
+        type = types.str;
+        default = "/run/postgresql";
+        example = "localhost";
+        description = "Hostname or IP address of your PostgreSQL server";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 5432;
+        description = "Port on which PostgreSQL is listening";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "authentik";
+        description = "Username that authentik will use to authenticate with PostgreSQL";
+      };
+      name = mkOption {
+        type = types.str;
+        default = "authentik";
+        description = "The name of the database for authentik to use";
+      };
+    };
+
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        AUTHENTIK_LOG_LEVEL = "warning";
+      };
+      description = ''
+        Extra configuration environment variables. Refer to the [documentation](https://docs.goauthentik.io/install-config/configuration) for options. These variables are shared between the authentik worker and server.
+      '';
+    };
+
+    server = {
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1"; # Authentik errors on `localhost`
+        description = "Host on which the authentik server will listen";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 9000;
+        description = "Port on which the authentik server will listen";
+      };
+      metricsPort = mkOption {
+        type = types.port;
+        default = 9300;
+        description = "The port on which the authentik server exposes prometheus metrics";
+      };
+    }
+    // mkEnvOptions "server" true;
+
+    worker = {
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1"; # Authentik errors on `localhost`
+        description = "Host on which the authentik worker will listen";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 9001;
+        description = "Port on which the authentik worker will listen";
+      };
+      metricsPort = mkOption {
+        type = types.port;
+        default = 9301;
+        description = "The port on which the authentik worker exposes prometheus metrics";
+      };
+    }
+    // mkEnvOptions "worker" true;
+
+    environmentFile = mkOption {
+      type = secret;
+      example = "/run/secrets/authentik";
+      default = null;
+      description = ''
+        Path of a file with extra environment variables to be loaded from disk. They are shared between the authentik server and worker.
+        This file is not added to the nix store, so it can be used to pass secrets to authentik.
+        Refer to the [documentation](https://docs.goauthentik.io/install-config/configuration/) for options.
+        Authentik needs at least a secret key. To set a database password use AUTHENTIK_POSTGRESQL__PASSWORD:
+        ```
+        AUTHENTIK_SECRET_KEY=<secret>
+        AUTHENTIK_POSTGRESQL__PASSWORD=<pass>
+        ```
+      '';
+    };
+
+    secretFiles = mkOption {
+      type = types.attrsOf secret;
+      example = {
+        AUTHENTIK_SECRET_KEY = "/run/secrets/authentik_secret_key";
+        AUTHENTIK_POSTGRESQL__PASSWORD = "/run/secrets/authentik_postgress_passwd";
+      };
+      default = { };
+      description = ''
+        Attribute set containing paths to files to add to the environment of authentik. They are shared between the authentik server and worker.
+        The files are not added to the nix store, so they can be used to pass secrets to authentik.
+        Refer to the [documentation](https://docs.goauthentik.io/install-config/configuration/) for options.
+        Authentik needs at least a secret key. To set a database password use AUTHENTIK_POSTGRESQL__PASSWORD.
+      '';
+    };
+
+    outposts = {
+      ldap = mkOutpost "ldap";
+      radius = mkOutpost "radius";
+      proxy = mkOutpost "proxy";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+
+        assertion = cfg.database.createLocally -> cfg.database.name == cfg.database.user;
+        message = "The postgres module requires the database name and the database user name to be the same.";
+      }
+      {
+        assertion = cfg.environmentFile == null -> cfg.secretFiles ? "AUTHENTIK_SECRET_KEY";
+        message = ''
+          Authentik needs at least a secret key to run.
+          Use either the environmentFile or secretFiles.AUTHENTIK_SECRET_KEY to provide one.
+        '';
+      }
+    ];
+
+    services.authentik.environment = {
+      AUTHENTIK_POSTGRESQL__HOST = cfg.database.host;
+      AUTHENTIK_POSTGRESQL__PORT = toString cfg.database.port;
+      AUTHENTIK_POSTGRESQL__USER = cfg.database.user;
+      AUTHENTIK_POSTGRESQL__NAME = cfg.database.name;
+      AUTHENTIK_OUTPOSTS__DISCOVER = "false";
+    };
+
+    services.authentik.server.environment = {
+      AUTHENTIK_LISTEN__HTTP = "${cfg.server.host}:${toString cfg.server.port}";
+      AUTHENTIK_LISTEN__METRICS = "${cfg.server.host}:${toString cfg.server.metricsPort}";
+    };
+
+    services.authentik.worker.environment = {
+      AUTHENTIK_LISTEN__HTTP = "${cfg.worker.host}:${toString cfg.worker.port}";
+      AUTHENTIK_LISTEN__METRICS = "${cfg.worker.host}:${toString cfg.worker.metricsPort}";
+    };
+
+    systemd.services.authentik-server = {
+      description = "authentik server";
+      requires = after;
+      inherit after;
+      wantedBy = [ "multi-user.target" ];
+      environment =
+        cfg.environment // cfg.server.environment // (credentialsEnv [ "server" ] cfg.secretFiles);
+      serviceConfig = commonServiceConfig // {
+        ExecStart = "${lib.getExe cfg.package} server";
+        EnvironmentFile = cfg.environmentFile;
+        LoadCredential = credentials [ "server" ] cfg.secretFiles;
+        User = cfg.user;
+        Group = cfg.group;
+        RuntimeDirectory = "authentik";
+      };
+    };
+
+    systemd.services.authentik-worker = {
+      description = "authentik worker";
+      requires = after;
+      inherit after;
+      wantedBy = [ "multi-user.target" ];
+      environment =
+        cfg.environment // cfg.worker.environment // (credentialsEnv [ "worker" ] cfg.secretFiles);
+      serviceConfig = commonServiceConfig // {
+        ExecStart = "${lib.getExe cfg.package} worker";
+        EnvironmentFile = cfg.environmentFile;
+        LoadCredential = credentials [ "server" ] cfg.secretFiles;
+        User = cfg.user;
+        Group = cfg.group;
+        RuntimeDirectory = "authentik";
+      };
+    };
+
+    systemd.services.authentik-ldap-outpost = mkOutpostConfig "ldap";
+    systemd.services.authentik-proxy-outpost = mkOutpostConfig "proxy";
+    systemd.services.authentik-radius-outpost = mkOutpostConfig "radius";
+
+    services.postgresql = mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+          ensureClauses.login = true;
+        }
+      ];
+    };
+
+    users.users = mkIf (cfg.user == "authentik") {
+      authentik = {
+        name = "authentik";
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+    users.groups = mkIf (cfg.group == "authentik") { authentik = { }; };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    jvanbruegge
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -249,6 +249,7 @@ in
   audit-testsuite = runTest ./audit-testsuite.nix;
   auth-mysql = runTest ./auth-mysql.nix;
   authelia = runTest ./authelia.nix;
+  authentik = runTest ./authentik.nix;
   auto-cpufreq = runTest ./auto-cpufreq.nix;
   autobrr = runTest ./autobrr.nix;
   autopush-rs = runTest ./autopush-rs.nix;

--- a/nixos/tests/authentik.nix
+++ b/nixos/tests/authentik.nix
@@ -1,0 +1,99 @@
+{ ... }:
+{
+  name = "authentik-nixos";
+
+  nodes.machine =
+    { lib, pkgs, ... }:
+    let
+      secretsFile = pkgs.writeText "authentik-secret-env" ''
+        VERY_SENSITIVE_SECRET
+      '';
+    in
+    {
+      # These tests need a little more juice
+      virtualisation = {
+        cores = 2;
+        memorySize = 2048;
+      };
+
+      environment.systemPackages = [
+        pkgs.jq
+        pkgs.openldap
+      ];
+
+      services.authentik = {
+        enable = true;
+        secretFiles = {
+          AUTHENTIK_SECRET_KEY = toString secretsFile;
+        };
+        outposts.ldap = {
+          enable = true;
+          environment = {
+            AUTHENTIK_HOST = "http://localhost:9000";
+            AUTHENTIK_INSECURE = "true";
+          };
+          secretFiles.AUTHENTIK_TOKEN = "/var/lib/authentik/token";
+        };
+        environment = {
+          AUTHENTIK_BOOTSTRAP_PASSWORD = "admin";
+          AUTHENTIK_BOOTSTRAP_TOKEN = "mysecrettoken";
+          AUTHENTIK_BOOTSTRAP_EMAIL = "admin@example.com";
+        };
+      };
+
+      systemd.services.authentik-ldap-outpost = {
+        wantedBy = lib.mkForce [ ];
+        serviceConfig.RuntimeDirectory = "authentik";
+      };
+    };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("authentik-server.service")
+    machine.wait_for_unit("authentik-worker.service")
+
+    machine.wait_for_open_port(9000)
+
+    getcmd = "curl -s -H 'Authorization: Bearer mysecrettoken' -H 'Accept: application/json' "
+    postcmd = getcmd + "-H 'Content-Type: application/json' -X POST "
+
+    def get_flow(slug):
+      return json.loads(machine.wait_until_succeeds(getcmd + "http://localhost:9000/api/v3/flows/instances/ | jq -e '.results.[] | select(.slug == \"" + slug + "\")'", timeout=30*60))
+
+    auth_flow = get_flow("default-authentication-flow")
+    invalid_flow = get_flow("default-invalidation-flow")
+
+    data = {
+      'name': 'ldap',
+      'authorization_flow': auth_flow['pk'],
+      'invalidation_flow': invalid_flow['pk']
+    }
+    ldap_provider = json.loads(machine.succeed(postcmd + "--data '" + json.dumps(data) + "' http://localhost:9000/api/v3/providers/ldap/"))
+
+    data = {
+      'name': 'ldap',
+      'slug': 'ldap',
+      'provider': ldap_provider['pk']
+    }
+    machine.succeed(postcmd + "--data '" + json.dumps(data) + "' http://localhost:9000/api/v3/core/applications/")
+
+    data = {
+      'name': 'ldap',
+      'type': 'ldap',
+      'providers': [ldap_provider['pk']],
+      'config': {}
+    }
+    ldap_outpost = json.loads(machine.succeed(postcmd + "--data '" + json.dumps(data) + "' http://localhost:9000/api/v3/outposts/instances/"))
+
+    ldap_token = json.loads(machine.succeed(getcmd + " http://localhost:9000/api/v3/core/tokens/" + ldap_outpost['token_identifier'] + "/view_key/"))['key']
+
+    machine.succeed("mkdir -p /var/lib/authentik")
+    machine.succeed("echo '" + ldap_token + "' > /var/lib/authentik/token")
+
+    machine.systemctl("start authentik-ldap-outpost")
+    machine.wait_for_open_port(3389)
+
+    machine.succeed("ldapsearch -x -H ldap://localhost:3389 -D 'cn=akadmin,ou=users,dc=ldap,dc=goauthentik,dc=io' -w admin -b 'dc=ldap,dc=goauthentik,dc=io' '(objectClass=user)'")
+  '';
+}

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   callPackages,
+  nixosTests,
   cacert,
   clangStdenv,
   cmake,
@@ -602,6 +603,7 @@ stdenvNoCC.mkDerivation {
 
   passthru = {
     inherit proxy worker apiGoVendorHook;
+    tests = nixosTests.authentik;
     outposts = callPackages ./outposts.nix {
       inherit (proxy) vendorHash;
       inherit apiGoVendorHook;


### PR DESCRIPTION
Adds a module and substantial test for authentik, Currently in draft until #456433 is merged

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
