### PR TITLE
i3a: 2.1.1 -> 2.4.0

### DIFF
--- a/pkgs/by-name/i3/i3a/package.nix
+++ b/pkgs/by-name/i3/i3a/package.nix
@@ -6,17 +6,18 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "i3a";
-  version = "2.1.1";
+  version = "2.4.0";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-b1bB7Gto4aL1rbQXIelBVhutjIvZY+K+Y66BGN7OcCs=";
+    hash = "sha256-BcGAFFq3UEj4o7nNQ9aStueKmeDNIqSIqkYWhs2Tnqg=";
   };
 
   build-system = [
     python3Packages.setuptools
     python3Packages.setuptools-scm
+    python3Packages.hatchling
   ];
 
   dependencies = [ python3Packages.i3ipc ];
@@ -25,11 +26,15 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "i3a" ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://git.goral.net.pl/i3a.git/log/";
     description = "Set of scripts used for automation of i3 and sway window manager layouts";
     homepage = "https://git.goral.net.pl/i3a.git/about";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ moni ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      moni
+      teohz
+    ];
+    broken = python3Packages.python.version < "3.11";
   };
 }


### PR DESCRIPTION
Updating the package from 2.1.1 to 2.4.0.

Key changes:
* The package now requires **Python 3.11 or newer**.
* The build system was switched to **Hatchling** (from Poetry/Setuptools).
* New commands added:
    * `i3a-cycle-focus`
    * `i3a-scale-cycle`
    * `i3a-trail`

Developer's Logs (since 2.1.1):
* 	[i3a-trail: include socket stem in default db path](https://git.goral.net.pl/i3a.git/commit/?id=ff0575090e090049090727484e09b9e1167e0256)[HEAD](https://git.goral.net.pl/i3a.git/commit/?id=ff0575090e090049090727484e09b9e1167e0256)[2.4.0](https://git.goral.net.pl/i3a.git/tag/?h=2.4.0)[master](https://git.goral.net.pl/i3a.git/log/)	Michal Goral	2025-09-26	-4/+8
* 	[Added i3a-trail, switched from poetry to uv, minimum python 3.11](https://git.goral.net.pl/i3a.git/commit/?id=f8ee373572dad37d4740d1053ff412941d745db2)	Michal Goral	2025-09-25	-17/+407
* 	[Make comments clearer](https://git.goral.net.pl/i3a.git/commit/?id=b4c60049e085cfcfc07dece664de60d832aaba8e)	Michal Goral	2025-05-19	-8/+11
* 	[master-stack: get rid of intermediate "split" containers created for the stack](https://git.goral.net.pl/i3a.git/commit/?id=7c7a8d569022c6e5f22a5a8874aba6264011404a)[2.3.1](https://git.goral.net.pl/i3a.git/tag/?h=2.3.1)	Michal Goral	2025-05-19	-3/+14
* 	[Add justfile](https://git.goral.net.pl/i3a.git/commit/?id=ce50050736f9aedfe2e64bcfd182dd53398f336e)	Michal Goral	2024-12-08	-0/+9
* 	[Bump version](https://git.goral.net.pl/i3a.git/commit/?id=7c9f92479771e84af076a88a6e3cfc7d99894df3)[2.3.0](https://git.goral.net.pl/i3a.git/tag/?h=2.3.0)	Michal Goral	2024-12-08	-2/+2
* 	[Fix detecting tiled windows and rename move_stack to cycle_focus](https://git.goral.net.pl/i3a.git/commit/?id=fc2c351dcbb6530d67ecd061c2e995427b7a37a9)	Michal Goral	2024-12-08	-5/+7
* 	[Reformat](https://git.goral.net.pl/i3a.git/commit/?id=d00e30bb8ca4846b49c43de199edf2e7cfe5e080)	Michal Goral	2024-12-08	-9/+22
* 	[Feat: added stack-move functionality like in dwm](https://git.goral.net.pl/i3a.git/commit/?id=a6c658fde7667a093fe4f3a875ec898aec428334)	DjejDjej	2024-12-08	-1/+61
* 	[Comment fix](https://git.goral.net.pl/i3a.git/commit/?id=f7b294dcf686b99d8407fe7ffce4edb97032689b)	Michal Goral	2024-11-21	-2/+2
* 	[Improve a performance of moving windows](https://git.goral.net.pl/i3a.git/commit/?id=39c05f034aedd2f81e160024ceb48a2c212d5c54)[2.2.3](https://git.goral.net.pl/i3a.git/tag/?h=2.2.3)	Michal Goral	2024-11-20	-5/+13
* 	[i3a-scale-cycle: fix crash when there are disabled outputs](https://git.goral.net.pl/i3a.git/commit/?id=aacde164271421e8ddb1d4a804b08a9880679443)[2.2.2](https://git.goral.net.pl/i3a.git/tag/?h=2.2.2)	Michal Goral	2024-09-18	-2/+6
* 	[fix readme](https://git.goral.net.pl/i3a.git/commit/?id=6dbdfced89b1fbbcbeb64f48d3190d25d1fc9c15)	Michal Goral	2024-09-15	-1/+1
* 	[fix help message](https://git.goral.net.pl/i3a.git/commit/?id=88950b28e5e303a3287eee67577ee58adeb98655)[2.2.1](https://git.goral.net.pl/i3a.git/tag/?h=2.2.1)	Michal Goral	2024-09-15	-2/+2
* 	[New command: i3a-scale-cycle](https://git.goral.net.pl/i3a.git/commit/?id=0880718f935da2ebadf9c500ea481cbcd4816d36)[2.2.0](https://git.goral.net.pl/i3a.git/tag/?h=2.2.0)	Michal Goral	2024-09-15	-1/+146
* 	[Move to poetry](https://git.goral.net.pl/i3a.git/commit/?id=6ef1279a9ab95dcbc2d36b95bf853e84b6b5447b)	Michal Goral	2024-09-15	-65/+50

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
