### PR TITLE
python3Packages.bleak: enable darwin build

### DIFF
--- a/pkgs/development/python-modules/bleak/default.nix
+++ b/pkgs/development/python-modules/bleak/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   async-timeout,
   bluez,
   buildPythonPackage,
@@ -10,6 +11,9 @@
   pytestCheckHook,
   pythonOlder,
   typing-extensions,
+  pyobjc-core,
+  pyobjc-framework-CoreBluetooth,
+  pyobjc-framework-libdispatch,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +30,7 @@ buildPythonPackage rec {
     hash = "sha256-z0Mxr1pUQWNEK01PKMV/CzpW+GeCRcv/+9BADts1FuU=";
   };
 
-  postPatch = ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     # bleak checks BlueZ's version with a call to `bluetoothctl --version`
     substituteInPlace bleak/backends/bluezdbus/version.py \
       --replace-fail \"bluetoothctl\" \"${bluez}/bin/bluetoothctl\"
@@ -35,7 +39,16 @@ buildPythonPackage rec {
   build-system = [ poetry-core ];
 
   dependencies = [
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     dbus-fast
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    pyobjc-core
+    pyobjc-framework-CoreBluetooth
+    pyobjc-framework-libdispatch
+  ]
+  ++ lib.optionals (pythonOlder "3.12") [
     typing-extensions
   ]
   ++ lib.optionals (pythonOlder "3.11") [
@@ -54,7 +67,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/hbldh/bleak";
     changelog = "https://github.com/hbldh/bleak/blob/${src.tag}/CHANGELOG.rst";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ oxzi ];
   };
 }

--- a/pkgs/development/python-modules/pyobjc-core/default.nix
+++ b/pkgs/development/python-modules/pyobjc-core/default.nix
@@ -23,7 +23,6 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   buildInputs = [
-    darwin.DarwinTools
     darwin.libffi
   ];
 
@@ -39,11 +38,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "objc" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python <-> Objective-C bridge";
-    homepage = "https://github.com/ronaldoussoren/pyobjc";
-    license = licenses.mit;
-    platforms = platforms.darwin;
-    maintainers = with maintainers; [ samuela ];
+    homepage = "https://github.com/ronaldoussoren/pyobjc/tree/main/pyobjc-core";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ samuela ];
   };
 }

--- a/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
@@ -9,15 +9,11 @@
 
 buildPythonPackage rec {
   pname = "pyobjc-framework-Cocoa";
-  version = "11.1";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "ronaldoussoren";
-    repo = "pyobjc";
-    tag = "v${version}";
-    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
-  };
+  inherit (pyobjc-core) version src;
+
+  patches = pyobjc-core.patches or [ ];
 
   sourceRoot = "${src.name}/pyobjc-framework-Cocoa";
 
@@ -56,11 +52,11 @@ buildPythonPackage rec {
     "PyObjCTools"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "PyObjC wrappers for the Cocoa frameworks on macOS";
-    homepage = "https://github.com/ronaldoussoren/pyobjc";
-    license = licenses.mit;
-    platforms = platforms.darwin;
-    maintainers = with maintainers; [ samuela ];
+    homepage = "https://github.com/ronaldoussoren/pyobjc/tree/main/pyobjc-framework-Cocoa";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ samuela ];
   };
 }

--- a/pkgs/development/python-modules/pyobjc-framework-CoreBluetooth/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-CoreBluetooth/default.nix
@@ -1,0 +1,66 @@
+{
+  buildPythonPackage,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  setuptools,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-CoreBluetooth";
+  pyproject = true;
+
+  inherit (pyobjc-core) version src;
+
+  patches = pyobjc-core.patches or [ ];
+
+  sourceRoot = "${src.name}/pyobjc-framework-CoreBluetooth";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    darwin.libffi
+  ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/" ""
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${lib.getDev darwin.libffi}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "CoreBluetooth"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the CoreBluetooth framework on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc/tree/main/pyobjc-framework-CoreBluetooth";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjc-framework-libdispatch/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-libdispatch/default.nix
@@ -1,0 +1,67 @@
+{
+  buildPythonPackage,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  setuptools,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-libdispatch";
+  pyproject = true;
+
+  inherit (pyobjc-core) version src;
+
+  patches = pyobjc-core.patches or [ ];
+
+  sourceRoot = "${src.name}/pyobjc-framework-libdispatch";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    darwin.libffi
+  ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/" ""
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "dispatch"
+    "libdispatch"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the libdispatch framework on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc/tree/main/pyobjc-framework-libdispatch";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13954,6 +13954,10 @@ self: super: with self; {
 
   pyobjc-framework-WebKit = callPackage ../development/python-modules/pyobjc-framework-WebKit { };
 
+  pyobjc-framework-libdispatch =
+    callPackage ../development/python-modules/pyobjc-framework-libdispatch
+      { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13944,6 +13944,10 @@ self: super: with self; {
 
   pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
 
+  pyobjc-framework-CoreBluetooth =
+    callPackage ../development/python-modules/pyobjc-framework-CoreBluetooth
+      { };
+
   pyobjc-framework-Quartz = callPackage ../development/python-modules/pyobjc-framework-Quartz { };
 
   pyobjc-framework-Security = callPackage ../development/python-modules/pyobjc-framework-Security { };


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/456469

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
