### PR TITLE
libsForQt5.kdb: 3.2.0 -> 3.2.0-unstable-2025-10-17

### DIFF
--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -1,8 +1,7 @@
 {
   mkDerivation,
   lib,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitLab,
   extra-cmake-modules,
   qtbase,
   kcoreaddons,
@@ -13,27 +12,17 @@
   qttools,
 }:
 
-mkDerivation rec {
+mkDerivation {
   pname = "kdb";
-  version = "3.2.0";
+  version = "3.2.0-unstable-2025-10-17";
 
-  src = fetchurl {
-    url = "mirror://kde/stable/kdb/src/kdb-${version}.tar.xz";
-    sha256 = "0s909x34a56n3xwhqz27irl2gbzidax0685w2kf34f0liny872cg";
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "libraries";
+    repo = "kdb";
+    rev = "819f9f61d629ffd80990ae17ae6c8078721a142b";
+    hash = "sha256-XkpFFzTgLEjPxEzwinbGhHRTULQrhl5TdakJlQuI27A=";
   };
-
-  patches = [
-    # fix build with newer QT versions
-    (fetchpatch {
-      url = "https://github.com/KDE/kdb/commit/b36d74f13a1421437a725fb74502c993c359392a.patch";
-      sha256 = "sha256-ENMZTUZ3yCKUhHPMUcDe1cMY2GLBz0G3ZvMRyj8Hfrw=";
-    })
-    # fix build with newer posgresql versions
-    (fetchpatch {
-      url = "https://github.com/KDE/kdb/commit/40cdaea4d7824cc1b0d26e6ad2dcb61fa2077911.patch";
-      sha256 = "sha256-cZpX6L/NZX3vztnh0s2+v4J7kBcKgUdecY53LRp8CwM=";
-    })
-  ];
 
   nativeBuildInputs = [
     extra-cmake-modules
@@ -50,11 +39,11 @@ mkDerivation rec {
 
   propagatedBuildInputs = [ qtbase ];
 
-  meta = with lib; {
+  meta = {
     description = "Database connectivity and creation framework for various database vendors";
     mainProgram = "kdb3_sqlite3_dump";
-    license = licenses.lgpl2;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ zraexy ];
+    license = lib.licenses.lgpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ zraexy ];
   };
 }


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/445447

Updating using latest changes from master branch, which fixes build issues.

I tested functionality with a sample sqlite db, dumping it without any problems.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
