### PR TITLE
mmseqs2: avoid pkgsStatic

### DIFF
--- a/pkgs/by-name/mm/mmseqs2/package.nix
+++ b/pkgs/by-name/mm/mmseqs2/package.nix
@@ -16,12 +16,12 @@
   llvmPackages,
   zlib,
   bzip2,
-  pkgsStatic,
+  zstd,
   runCommand,
-}:
+}@args:
 let
   # require static library, libzstd.a
-  inherit (pkgsStatic) zstd;
+  zstd = args.zstd.override { enableStatic = true; };
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     xxd
     perl
     installShellFiles
-    zstd
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_nvcc
@@ -58,17 +57,19 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
   ];
 
-  buildInputs =
-    lib.optionals stdenv.cc.isClang [
-      llvmPackages.openmp
-      zlib
-      bzip2
-    ]
-    ++ lib.optional enableMpi mpi
-    ++ lib.optionals cudaSupport [
-      cudaPackages.cuda_cudart
-      cudaPackages.cuda_cccl
-    ];
+  buildInputs = [
+    zstd
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+    zlib
+    bzip2
+  ]
+  ++ lib.optional enableMpi mpi
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_cccl
+  ];
 
   postInstall = ''
     installShellCompletion --bash --cmd mmseqs $out/util/bash-completion.sh


### PR DESCRIPTION
Pulling in a zstd built with possibly a different libc, from an entirely different package set and putting it in nativeBuildInputs is.. brave!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
