### PR TITLE
[25.05] librenms: apply patches for CVE-2025-62411 and CVE-2025-62412

### DIFF
--- a/pkgs/by-name/li/librenms/package.nix
+++ b/pkgs/by-name/li/librenms/package.nix
@@ -46,6 +46,18 @@ phpPackage.buildComposerProject2 rec {
       url = "https://github.com/librenms/librenms/commit/ec89714d929ef0cf2321957ed9198b0f18396c81.patch";
       hash = "sha256-UJy0AZXpvowvjSnJy7m4Z5JPoYWjydUg1R+jz/Pl1s0=";
     })
+    (fetchpatch {
+      # https://github.com/advisories/GHSA-frc6-pwgr-c28w
+      name = "CVE-2025-62411.patch";
+      url = "https://github.com/librenms/librenms/commit/706a77085f4d5964f7de9444208ef707e1f79450.patch";
+      hash = "sha256-egltEZEg8yn+JCe/rlpxMuVMBbRgruIwR5y9aNwjrGg=";
+    })
+    (fetchpatch {
+      # https://github.com/advisories/GHSA-6g2v-66ch-6xmh
+      name = "CVE-2025-62412.patch";
+      url = "https://github.com/librenms/librenms/commit/d9ec1d500b71b5ad268c71c0d1fde323da70c694.patch";
+      hash = "sha256-DIE92KEegRoZNGSEr5VcbG0NQXNZbaKi0DeIBAyn608=";
+    })
   ];
 
   php = phpPackage;


### PR DESCRIPTION
https://github.com/librenms/librenms/security/advisories/GHSA-frc6-pwgr-c28w
https://github.com/librenms/librenms/security/advisories/GHSA-6g2v-66ch-6xmh

Not-cherry-picked-because: changelogs of recent versions mention breaking changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
