### PR TITLE
sbcl: fix build on darwin

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -154,6 +154,10 @@ stdenv.mkDerivation (self: {
       # Fail intermittently
       "gc.impure.lisp"
       "threads.pure.lisp"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Fails in sandbox
+      "sb-posix.impure.lisp"
     ];
 
   patches =
@@ -287,6 +291,8 @@ stdenv.mkDerivation (self: {
       }
     ''
   );
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Common Lisp compiler";

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   callPackage,
+  darwin,
   ecl,
   coreutils,
   fetchurl,
@@ -69,6 +70,7 @@ let
       "${sbclBootstrap}/bin/sbcl --disable-debugger --no-userinit --no-sysinit"
     else
       "${lib.getExe ecl} --norc";
+  posixUtils = if stdenv.hostPlatform.isDarwin then darwin.shell_cmds else coreutils;
 
 in
 
@@ -188,8 +190,8 @@ stdenv.mkDerivation (self: {
         # definitely NOT be patched this way, hence just a single * (and no
         # globstar).
         substituteInPlace ${if self.purgeNixReferences then "tests" else "{tests,src/code}"}/*.{lisp,sh} \
-          --replace-quiet /usr/bin/env "${coreutils}/bin/env" \
-          --replace-quiet /bin/uname "${coreutils}/bin/uname" \
+          --replace-quiet /usr/bin/env "${posixUtils}/bin/env" \
+          --replace-quiet /bin/uname "${posixUtils}/bin/uname" \
           --replace-quiet /bin/sh "${stdenv.shell}"
       )
       # Official source release tarballs will have a version.lispexpr, but if you


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See individual commits and their messages for details.

Upstream bug report in coreutils: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79714

## Things done

(confirmed drv is unchanged on x86_64-linux)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
