### PR TITLE
julefmt: init at 0.0.0-unstable-2025-09-08

### DIFF
--- a/pkgs/by-name/ju/julefmt/package.nix
+++ b/pkgs/by-name/ju/julefmt/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  julec,
+  clangStdenv,
+  fetchFromGitHub,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "julefmt";
+  version = "0.0.0-unstable-2025-09-08";
+
+  src = fetchFromGitHub {
+    owner = "julelang";
+    repo = "julefmt";
+    rev = "cc30781206d3d7b88599cc51b3f9d7d7936de527";
+    hash = "sha256-g3vN2Hz4BA5c0KqIbNKHg0W77xKGZQFHUIKWjg5/UTM=";
+  };
+
+  nativeBuildInputs = [ julec.hook ];
+
+  JULE_OUT_NAME = "julefmt";
+
+  meta = {
+    description = "Official formatter tool for the Jule programming language";
+    homepage = "https://manual.jule.dev/tools/julefmt";
+    license = lib.licenses.bsd3;
+    mainProgram = "julefmt";
+    inherit (julec.meta) platforms maintainers;
+  };
+})


### PR DESCRIPTION
JuleFmt is the official code formatter for the Jule programming language.
https://github.com/julelang/julefmt
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
