### PR TITLE
python3Packages.gst-python: disable tests on darwin

### DIFF
--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -6,6 +6,9 @@
   fetchpatch,
   meson,
   ninja,
+  # TODO: We can get rid of this once `buildPythonPackage` accepts `finalAttrs`.
+  # See: https://github.com/NixOS/nixpkgs/pull/271387
+  gst-python,
 
   pkg-config,
   python,
@@ -42,13 +45,6 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # The analytics tests often timeout under load on Darwin (e.g. on Hydra), so remove them
-    substituteInPlace testsuite/meson.build --replace-fail \
-      "['Test analytics', 'test_analytics.py', ['gst-plugins-bad/gst-libs/gst/analytics', 'gst-plugins-base/gst-libs/gst/video']]," \
-      ""
-  '';
-
   # Python 2.x is not supported.
   disabled = !isPy3k;
 
@@ -80,7 +76,19 @@ buildPythonPackage rec {
     "-Dpygi-overrides-dir=${placeholder "out"}/${python.sitePackages}/gi/overrides"
     # Exec format error during configure
     "-Dpython-exe=${python.pythonOnBuildForHost.interpreter}"
+    # This is needed to prevent the project from looking for `gst-rtsp-server`
+    # from `checkInputs`.
+    #
+    # TODO: This should probably be moved at least partially into the Meson hook.
+    #
+    # NB: We need to use `doInstallCheck` here because `buildPythonPackage`
+    # renames `doCheck` to `doInstallCheck`.
+    (lib.mesonEnable "tests" gst-python.doInstallCheck)
   ];
+
+  # Tests are very flaky on Darwin.
+  # See: https://github.com/NixOS/nixpkgs/issues/454955
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
   # empty. It renames `doCheck` from its arguments, but not `checkPhase`.

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -82,9 +82,10 @@ buildPythonPackage rec {
     "-Dpython-exe=${python.pythonOnBuildForHost.interpreter}"
   ];
 
-  # TODO: Meson setup hook does not like buildPythonPackage
-  # https://github.com/NixOS/nixpkgs/issues/47390
-  installCheckPhase = "meson test --print-errorlogs";
+  # `buildPythonPackage` uses `installCheckPhase` and leaves `checkPhase`
+  # empty. It renames `doCheck` from its arguments, but not `checkPhase`.
+  # See: https://github.com/NixOS/nixpkgs/issues/47390
+  installCheckPhase = "mesonCheckPhase";
 
   preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export DYLD_LIBRARY_PATH="${gst_all_1.gst-plugins-base}/lib"


### PR DESCRIPTION
Closes #454955

These tests are very flaky on Darwin for whatever reason. Sometimes they just mysteriously time out.

When setting `doCheck = !stdenv.hostPlatform.isDarwin`, I discovered that the `checkInputs` entry `gst-rtsp-server` is in fact needed to build the project, so I've ~~moved that to `nativeBuildInputs`~~ incorporated changes from #451261.

I've also replaced `meson test --print-errorlogs` with `mesonCheckPhase`, which is a little bit cleaner.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
