### PR TITLE
juledoc: init at 0.0.0-unstable-2025-09-09

### DIFF
--- a/pkgs/by-name/ju/juledoc/package.nix
+++ b/pkgs/by-name/ju/juledoc/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  julec,
+  clangStdenv,
+  fetchFromGitHub,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "juledoc";
+  version = "0.0.0-unstable-2025-09-09";
+
+  src = fetchFromGitHub {
+    owner = "julelang";
+    repo = "juledoc";
+    rev = "3461147f4630104999bb895bdd8e60f40ca23aaf";
+    hash = "sha256-0HuMWdoDoq2SgQhOnn6UnWXe2Js7/466cP2XpjvO5dw=";
+  };
+
+  nativeBuildInputs = [ julec.hook ];
+
+  JULE_OUT_NAME = "juledoc";
+
+  meta = {
+    description = "Official documentation generator for the Jule programming language";
+    homepage = "https://manual.jule.dev/tools/juledoc";
+    license = lib.licenses.bsd3;
+    mainProgram = "juledoc";
+    inherit (julec.meta) platforms maintainers;
+  };
+})


### PR DESCRIPTION
JuleDoc is an official documentation generator tool for the Jule programming language.
https://github.com/julelang/juledoc
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
