### PR TITLE
jetbrains: 2025.2.3 -> 2025.2.4

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,10 +11,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "364502648a5f1480bd06a00ee410968d224f96b263c78f5148614063f7bc3961",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3.tar.gz",
-      "build_number": "252.26830.83"
+      "version": "2025.2.4",
+      "sha256": "72c89e91f6636aa53930288fe02466e5e09a50a3c8b6ed5ad2f69b35ec9bacc5",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.4.tar.gz",
+      "build_number": "252.27397.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -100,10 +100,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "1cfc4e756007c5a8b749c0848e4c050303aeeaabc0917f19732d908201b69446",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3.tar.gz",
-      "build_number": "252.26830.109"
+      "version": "2025.2.4",
+      "sha256": "cd428f7d6db5055cd2594c3d1ef91241843d263cb6301369d3121a847ffb6589",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.4.tar.gz",
+      "build_number": "252.27397.121"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -116,10 +116,10 @@
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "b96846e7257d14ef38154017cdbe9c63c66d19b59e94ad096db2c9ae2380103b",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3.tar.gz",
-      "build_number": "252.26830.136"
+      "version": "2025.2.4",
+      "sha256": "3da078b5e68bac2283c0dd60fe3ff17d6025d92d6237bc6fab74f1f35ff6fbe5",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.4.tar.gz",
+      "build_number": "252.27397.120"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
@@ -150,10 +150,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "e4cc668cb1e0cf5b976ab8eb3997388f1e7cc673e51af3f3c6afa3666a9c47b6",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3-aarch64.tar.gz",
-      "build_number": "252.26830.83"
+      "version": "2025.2.4",
+      "sha256": "b89010db5272eb6490a0084bd3247c9de657ffd0d12a827147f2c77a406f85b5",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.4-aarch64.tar.gz",
+      "build_number": "252.27397.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -239,10 +239,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "bd03e42b3a04cc1e1b234333285873746bd4d04bf3746fb62b171334a168e976",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3-aarch64.tar.gz",
-      "build_number": "252.26830.109"
+      "version": "2025.2.4",
+      "sha256": "75c38a2bd94e31200fc4e3a6cfad83b35c65d36c9d61b9a7b208e3ec82f8c81a",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.4-aarch64.tar.gz",
+      "build_number": "252.27397.121"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -255,10 +255,10 @@
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2025.2.3",
-      "sha256": "5ffdff2a6617fcc75b68a145bc9dce14a71d0d9dc31a1adde5c8630d954a370d",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3-aarch64.tar.gz",
-      "build_number": "252.26830.136"
+      "version": "2025.2.4",
+      "sha256": "03052ead61bd13eaa616d1126add5b6b6fa9dbc6ef591109b358005d5b630606",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.4-aarch64.tar.gz",
+      "build_number": "252.27397.120"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
@@ -289,10 +289,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2025.2.3",
-      "sha256": "4763233873139a0adf8c5cb285ace830eb0be363bb132de2f7ac4b4c1a58b2f2",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3.dmg",
-      "build_number": "252.26830.83"
+      "version": "2025.2.4",
+      "sha256": "04383caba9ba670841dd336e546f2027b28286d23ea30298e66f422fbc081272",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.4.dmg",
+      "build_number": "252.27397.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -378,10 +378,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.2.3",
-      "sha256": "09717e33d640052143492fe7e4485c93218c04c9efc1615e8f0d5dbdb4fe5526",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3.dmg",
-      "build_number": "252.26830.109"
+      "version": "2025.2.4",
+      "sha256": "f8cabc370393b6be2bd244413fd5692714c02e11cf24eb9c32438367d2895750",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.4.dmg",
+      "build_number": "252.27397.121"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -394,10 +394,10 @@
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2025.2.3",
-      "sha256": "7c9e08ded178f233cabc8b0bebdda8504ef10a6afaf1856b33da582d69ca378d",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3.dmg",
-      "build_number": "252.26830.136"
+      "version": "2025.2.4",
+      "sha256": "71f0735c546b659d4d1ed9ce58411848146ac0216b4b971583ce682311e9e075",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.4.dmg",
+      "build_number": "252.27397.120"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
@@ -428,10 +428,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2025.2.3",
-      "sha256": "87d1b9d0188ee540ce26572d648a4a7ef1b2b2d90c18227932a28d9d263b58df",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.3-aarch64.dmg",
-      "build_number": "252.26830.83"
+      "version": "2025.2.4",
+      "sha256": "7bdef6d73e0edfbc5ef02b7e74e5508e5b18a9c21afb5ba82488527d837e2a94",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.2.4-aarch64.dmg",
+      "build_number": "252.27397.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -517,10 +517,10 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.2.3",
-      "sha256": "67c9c8f73844d9705c8e64f03afc659ef3146caccc079f183a758b0d7666a468",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.3-aarch64.dmg",
-      "build_number": "252.26830.109"
+      "version": "2025.2.4",
+      "sha256": "e6bd0a07f5922c05c73d9170bbaa2219534fa8e5350b99f37c6a4bc9eb7c0870",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.4-aarch64.dmg",
+      "build_number": "252.27397.121"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
@@ -533,10 +533,10 @@
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2025.2.3",
-      "sha256": "3ebf05feabd5858df21b0215dec39142427b4df50d929c0d94751425478d295d",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.3-aarch64.dmg",
-      "build_number": "252.26830.136"
+      "version": "2025.2.4",
+      "sha256": "8bad55d714d388c115c0d35c297eb5bdb140bc024b2bf602efc8d07a3327cad9",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.2.4-aarch64.dmg",
+      "build_number": "252.27397.120"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -18,15 +18,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip"
       },
       "name": "ideavim"
@@ -69,15 +69,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
       },
       "name": "stringmanipulation"
@@ -100,15 +100,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
       },
       "name": "handlebars-mustache"
@@ -131,15 +131,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": "https://plugins.jetbrains.com/files/6954/861041/Kotlin-252.26199.169-IJ.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/6954/870901/Kotlin-252.26830.84-IJ.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/6954/882364/Kotlin-252.27397.103-IJ.zip"
       },
       "name": "kotlin"
@@ -162,15 +162,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": null,
-        "252.26830.109": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/6981/871946/ini-252.26830.99.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/6981/882710/ini-252.27397.112.zip"
       },
       "name": "ini"
@@ -193,15 +193,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
@@ -224,15 +224,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
       },
       "name": "grep-console"
@@ -255,15 +255,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
       },
       "name": "file-watchers"
@@ -297,15 +297,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
       },
       "name": "cucumber-for-java"
@@ -346,13 +346,13 @@
       ],
       "builds": {
         "251.25410.129": null,
-        "252.26830.109": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7322/866568/python-ce-252.26830.24.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7322/882365/python-ce-252.27397.103.zip"
       },
       "name": "python-community-edition"
@@ -375,15 +375,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip"
       },
       "name": "asciidoc"
@@ -406,15 +406,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26199.587": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.26830.46": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.27397.100": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.27397.103": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.27397.106": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.27397.109": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.27397.112": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "252.27397.92": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
@@ -437,15 +437,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7499/875436/gittoolbox-600.1.12_243-signed.zip"
       },
       "name": "gittoolbox"
@@ -468,15 +468,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": null,
-        "252.26830.109": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/7724/871939/clouds-docker-impl-252.26830.99.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/7724/882712/clouds-docker-impl-252.27397.112.zip"
       },
       "name": "docker"
@@ -499,15 +499,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip"
       },
       "name": "graphql"
@@ -529,14 +529,14 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": null,
-        "252.26830.109": null,
         "252.26830.46": null,
-        "252.26830.83": null,
         "252.27397.100": null,
         "252.27397.103": null,
         "252.27397.106": null,
         "252.27397.109": null,
         "252.27397.112": null,
+        "252.27397.114": null,
+        "252.27397.121": null,
         "252.27397.92": null
       },
       "name": "-deprecated-rust"
@@ -558,14 +558,14 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": null,
-        "252.26830.109": null,
         "252.26830.46": null,
-        "252.26830.83": null,
         "252.27397.100": null,
         "252.27397.103": null,
         "252.27397.106": null,
         "252.27397.109": null,
         "252.27397.112": null,
+        "252.27397.114": null,
+        "252.27397.121": null,
         "252.27397.92": null
       },
       "name": "-deprecated-rust-beta"
@@ -588,15 +588,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": null,
-        "252.26830.109": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/8195/871151/toml-252.26830.93.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/8195/882551/toml-252.27397.109.zip"
       },
       "name": "toml"
@@ -630,15 +630,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": "https://plugins.jetbrains.com/files/8554/854483/featuresTrainer-252.26199.84.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/8554/871926/featuresTrainer-252.26830.95.zip"
       },
       "name": "ide-features-trainer"
@@ -661,15 +661,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
       },
       "name": "nixidea"
@@ -692,15 +692,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip"
       },
       "name": "gherkin"
@@ -723,15 +723,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
       },
       "name": "-env-files"
@@ -765,15 +765,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "252.26199.587": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26830.109": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26830.136": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.26830.46": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
-        "252.26830.83": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.27397.100": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.27397.103": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.27397.106": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.27397.109": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.27397.112": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.27397.114": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.27397.120": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
+        "252.27397.121": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar",
         "252.27397.92": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
       },
       "name": "ansi-highlighter-premium"
@@ -796,15 +796,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
@@ -827,15 +827,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
       },
       "name": "randomness"
@@ -858,15 +858,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip"
       },
       "name": "csv-editor"
@@ -889,15 +889,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/10080/867937/intellij-rainbow-brackets-2025.3.5.zip"
       },
       "name": "rainbow-brackets"
@@ -920,15 +920,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
@@ -951,15 +951,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
@@ -981,14 +981,14 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
       },
       "name": "go-template"
@@ -1011,15 +1011,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/11058/878842/Extra_Icons-2025.1.16.zip"
       },
       "name": "extra-icons"
@@ -1042,15 +1042,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/11349/879073/aws-toolkit-jetbrains-standalone-3.97.251.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/11349/879071/aws-toolkit-jetbrains-standalone-3.97.252.zip"
       },
       "name": "aws-toolkit"
@@ -1060,7 +1060,7 @@
         "rider"
       ],
       "builds": {
-        "252.26830.109": "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip"
+        "252.27397.121": "https://plugins.jetbrains.com/files/12024/834783/ReSharperPlugin.CognitiveComplexity-2025.2.0.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1082,15 +1082,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
       },
       "name": "vscode-keymap"
@@ -1113,15 +1113,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
       },
       "name": "eclipse-keymap"
@@ -1144,15 +1144,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
@@ -1175,15 +1175,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
       },
       "name": "visual-studio-keymap"
@@ -1206,15 +1206,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
@@ -1237,15 +1237,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
       },
       "name": "protocol-buffers"
@@ -1268,15 +1268,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26199.587": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26830.109": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26830.136": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.26830.46": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "252.26830.83": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.27397.100": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.27397.103": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.27397.106": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.27397.109": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.27397.112": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.27397.114": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.27397.120": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.27397.121": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "252.27397.92": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
@@ -1299,15 +1299,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26199.587": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26830.109": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26830.136": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.26830.46": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "252.26830.83": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.27397.100": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.27397.103": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.27397.106": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.27397.109": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.27397.112": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.27397.114": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.27397.120": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.27397.121": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "252.27397.92": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
@@ -1330,15 +1330,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26199.587": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26830.109": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26830.136": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.26830.46": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "252.26830.83": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.27397.100": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.27397.103": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.27397.106": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.27397.109": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.27397.112": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.27397.114": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.27397.120": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "252.27397.121": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "252.27397.92": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
       },
       "name": "which-key"
@@ -1361,15 +1361,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/16604/878839/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.15.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
@@ -1392,15 +1392,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/17718/882517/github-copilot-intellij-1.5.59-243.zip"
       },
       "name": "github-copilot"
@@ -1423,15 +1423,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
@@ -1454,15 +1454,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip"
       },
       "name": "catppuccin-theme"
@@ -1485,15 +1485,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/18824/865849/CodeGlancePro-2.0.0-signed.zip"
       },
       "name": "codeglance-pro"
@@ -1516,15 +1516,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.26199.587": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
-        "252.26830.109": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
-        "252.26830.136": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.26830.46": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
-        "252.26830.83": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.27397.100": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.27397.103": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.27397.106": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.27397.109": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.27397.112": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
+        "252.27397.114": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
+        "252.27397.120": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
+        "252.27397.121": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar",
         "252.27397.92": "https://plugins.jetbrains.com/files/18922/881168/GerryThemes.jar"
       },
       "name": "gerry-themes"
@@ -1547,15 +1547,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
@@ -1578,15 +1578,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
       },
       "name": "mermaid"
@@ -1609,15 +1609,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
@@ -1640,15 +1640,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip"
       },
       "name": "code-complexity"
@@ -1671,15 +1671,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
@@ -1696,13 +1696,13 @@
         "webstorm"
       ],
       "builds": {
-        "252.26830.109": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip"
       },
       "name": "dev-containers"
@@ -1714,9 +1714,9 @@
         "rust-rover"
       ],
       "builds": {
-        "252.26830.136": "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip",
-        "252.27397.103": "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip"
+        "252.27397.103": "https://plugins.jetbrains.com/files/22407/883703/intellij-rust-252.27397.120.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/22407/883703/intellij-rust-252.27397.120.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/22407/883703/intellij-rust-252.27397.120.zip"
       },
       "name": "rust"
     },
@@ -1738,15 +1738,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip"
       },
       "name": "continue"
@@ -1769,15 +1769,15 @@
       "builds": {
         "251.25410.129": null,
         "252.26199.587": "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip"
       },
       "name": "gitlab"
@@ -1800,15 +1800,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip"
       },
       "name": "catppuccin-icons"
@@ -1831,15 +1831,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
@@ -1862,15 +1862,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/23806/867921/Oxocarbon-1.4.7.zip"
       },
       "name": "oxocarbon"
@@ -1893,15 +1893,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/23927/878837/Extra_IDE_Tweaks_Subscription-2025.1.14.zip"
       },
       "name": "extra-ide-tweaks"
@@ -1924,15 +1924,15 @@
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.26199.587": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
-        "252.26830.109": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
-        "252.26830.136": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.26830.46": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
-        "252.26830.83": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.27397.100": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.27397.103": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.27397.106": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.27397.109": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.27397.112": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
+        "252.27397.114": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
+        "252.27397.120": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
+        "252.27397.121": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip",
         "252.27397.92": "https://plugins.jetbrains.com/files/24559/878844/Extra_Tools_Pack-2025.1.18.zip"
       },
       "name": "extra-tools-pack"
@@ -1950,14 +1950,14 @@
         "webstorm"
       ],
       "builds": {
-        "252.26830.109": null,
-        "252.26830.136": null,
         "252.26830.46": null,
-        "252.26830.83": null,
         "252.27397.100": null,
         "252.27397.103": null,
         "252.27397.109": null,
         "252.27397.112": null,
+        "252.27397.114": null,
+        "252.27397.120": null,
+        "252.27397.121": null,
         "252.27397.92": null
       },
       "name": "nix-lsp"
@@ -1978,15 +1978,15 @@
       ],
       "builds": {
         "251.25410.129": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
-        "252.26830.109": null,
-        "252.26830.136": null,
         "252.26830.46": null,
-        "252.26830.83": null,
         "252.27397.100": null,
         "252.27397.103": null,
         "252.27397.106": null,
         "252.27397.109": null,
         "252.27397.112": null,
+        "252.27397.114": null,
+        "252.27397.120": null,
+        "252.27397.121": null,
         "252.27397.92": null
       },
       "name": "markdtask"
@@ -2032,7 +2032,7 @@
     "https://plugins.jetbrains.com/files/21667/818221/code-complexity-plugin-1.6.3.zip": "sha256-8agNBVenqaV9DlvRmFP7ul3IZfj9Dij8v/h8QMUb72E=",
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/828479/clouds-docker-gateway-252.25557.34.zip": "sha256-uwonawWIgXi9OXZlQaZl/GDt/iHqsyAKV7ifCgcMqWU=",
-    "https://plugins.jetbrains.com/files/22407/875264/intellij-rust-252.26830.136.zip": "sha256-6UI1p3SzOgdQg7NjWQJv7r6qAVcTOktwTkuvO7/b5ls=",
+    "https://plugins.jetbrains.com/files/22407/883703/intellij-rust-252.27397.120.zip": "sha256-gpfWoNR/RiWe36Og5eL9MROtrqKVlZRHxVqeFCaS7lo=",
     "https://plugins.jetbrains.com/files/22707/878331/continue-intellij-extension-1.0.48.zip": "sha256-7553kxXry5sEJJn+Za4RsfUJGn/roAap8qDkaHjhfXQ=",
     "https://plugins.jetbrains.com/files/22857/856960/vcs-gitlab-IU-252.26199.97-IU.zip": "sha256-dJM8j5aLWD6elv46HtXUhPvYWTdAE77m/jwRqztIwDk=",
     "https://plugins.jetbrains.com/files/22857/871944/vcs-gitlab-IU-252.26830.99-IU.zip": "sha256-bTqJlTkoOyBm370Ks6kFpvxzRJJ7CSucT298YBQtl/M=",


### PR DESCRIPTION
Update all bin IDEs to latest (2025.2.4 for most)
`jetbrains.plugins.tests.empty` and `jetbrains.plugins.tests.empty` built successfully

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
