### PR TITLE
lib.teams.formatter: Link with GitHub team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -351,17 +351,7 @@ with lib.maintainers;
   };
 
   formatter = {
-    members = [
-      piegames
-      infinisil
-      das_j
-      _0x4A6F
-      MattSturgeon
-      jfly
-      Sereja313
-    ];
-    scope = "Nix formatting team: https://nixos.org/community/teams/formatting/";
-    shortName = "Nix formatting team";
+    github = "nix-formatting";
   };
 
   freedesktop = {


### PR DESCRIPTION
Towards #456365, follow-up to #456496

## Things done

- [x] Checked that the members match
- [x] Adjusted the GitHub team description to not lose any info, it will be synced next time

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
