### PR TITLE
doxx: 0-unstable-2025-08-18 -> 0.1.2

### DIFF
--- a/pkgs/by-name/do/doxx/package.nix
+++ b/pkgs/by-name/do/doxx/package.nix
@@ -26,8 +26,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rm $out/bin/generate_test_docs
   '';
 
-  doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/do/doxx/package.nix
+++ b/pkgs/by-name/do/doxx/package.nix
@@ -2,25 +2,32 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "doxx";
-  version = "0-unstable-2025-08-18";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "bgreenwell";
     repo = "doxx";
-    rev = "5c957470de1fa937cf96cd847286e2d3ee37cbee";
-    hash = "sha256-ZCvb8FnGdpzEDqYCIFjg+hiO3OZNnZ2+dSDVLx+crTU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V0pBeh9u6iNt6hS1MpUau6nYBdfn9bELhR0GAMqTRmc=";
   };
 
-  cargoHash = "sha256-1i+IAQc55HYrqJm3Hx0frphSQp7jYGa6i0eOvHVMdCI=";
+  cargoHash = "sha256-WsV6IGKO3mwAXtqXHu+CP1dQ/tw1jsuZlfSZx4L2WIM=";
+
+  # https://github.com/bgreenwell/doxx/issues/65
+  checkFlags = [ "--skip=terminal_image::tests::test_renderer_creation" ];
 
   postInstall = ''
     rm $out/bin/generate_test_docs
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -34,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       capabilities.
     '';
     homepage = "https://github.com/bgreenwell/doxx";
-    changelog = "https://github.com/bgreenwell/doxx/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/bgreenwell/doxx/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "doxx";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
