### PR TITLE
k3s: use correct package for user namespace support

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -68,7 +68,7 @@ lib:
   socat,
   sqlite,
   stdenv,
-  su,
+  shadow,
   systemdMinimal,
   util-linuxMinimal,
   yq-go,
@@ -373,7 +373,7 @@ buildGoModule (finalAttrs: {
     conntrack-tools
     runc
     bash
-    su
+    shadow # kubelet wants 'getsubids' when using user namespaces
   ];
 
   k3sKillallDeps = [


### PR DESCRIPTION


As mentioned in #440973, kubelet needs the binary `getsubids` at runtime in order to use user namespaces.

search.nixos.org said that the package `su` included `getsubids`, but that package is actually an alias for `shadow.su`, and only includes the binary `su`.

This PR fixes that mistake to include the full `shadow` package at runtime that includes `getsubuids`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
