### PR TITLE
dua: 2.32.0 -> 2.32.2, use finalAttrs pattern, adopt

### DIFF
--- a/pkgs/by-name/du/dua/package.nix
+++ b/pkgs/by-name/du/dua/package.nix
@@ -46,6 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       figsoda
       killercup
+      defelo
     ];
     mainProgram = "dua";
   };

--- a/pkgs/by-name/du/dua/package.nix
+++ b/pkgs/by-name/du/dua/package.nix
@@ -6,14 +6,14 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dua";
   version = "2.32.0";
 
   src = fetchFromGitHub {
     owner = "Byron";
     repo = "dua-cli";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-u8g7X/70ZsZF6vUiVnisItwSMiNXgiAdOXqGUT34EaY=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
@@ -32,9 +32,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=interactive::app::tests::unit::it_can_handle_ending_traversal_without_reaching_the_top"
   ];
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
@@ -43,7 +41,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Tool to conveniently learn about the disk usage of directories";
     homepage = "https://github.com/Byron/dua-cli";
-    changelog = "https://github.com/Byron/dua-cli/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/Byron/dua-cli/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       figsoda
@@ -51,4 +49,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "dua";
   };
-}
+})

--- a/pkgs/by-name/du/dua/package.nix
+++ b/pkgs/by-name/du/dua/package.nix
@@ -8,13 +8,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dua";
-  version = "2.32.0";
+  version = "2.32.2";
 
   src = fetchFromGitHub {
     owner = "Byron";
     repo = "dua-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u8g7X/70ZsZF6vUiVnisItwSMiNXgiAdOXqGUT34EaY=";
+    hash = "sha256-MB5uePy32jTvOtkQKcP9peFPqwR68E+NZ7UGMuLx8Eo=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     postFetch = ''
@@ -22,10 +22,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   };
 
-  cargoHash = "sha256-6WjaKGCnEoHCIDqMHtp/dpdHbrUe2XOxCtstQCuXPyc=";
+  cargoHash = "sha256-6H0x6I3nkCezu4/Hguv0XTdl+3QiyPL8Ue1rqTQU7VA=";
 
   checkFlags = [
     # Skip interactive tests
+    "--skip=interactive::app::tests::journeys_readonly::quit_instantly_when_nothing_marked"
+    "--skip=interactive::app::tests::journeys_readonly::quit_requires_two_presses_when_items_marked"
     "--skip=interactive::app::tests::journeys_readonly::simple_user_journey_read_only"
     "--skip=interactive::app::tests::journeys_with_writes::basic_user_journey_with_deletion"
     "--skip=interactive::app::tests::unit::it_can_handle_ending_traversal_reaching_top_but_skipping_levels"


### PR DESCRIPTION
Changelog: https://github.com/Byron/dua-cli/blob/v2.32.2/CHANGELOG.md
Diff: https://github.com/Byron/dua-cli/compare/v2.32.0...v2.32.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
