### PR TITLE
linuxPackages.nvidiaPackages.vulkan_beta: 580.94.03 -> 580.94.06

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -101,11 +101,11 @@ rec {
   # Vulkan developer beta driver
   # See here for more information: https://developer.nvidia.com/vulkan-driver
   vulkan_beta = generic rec {
-    version = "580.94.03";
+    version = "580.94.06";
     persistencedVersion = "580.95.05";
     settingsVersion = "580.95.05";
-    sha256_64bit = "sha256-RYU50xfIyrvk57o7/SIsVr34nkLaMm5WZPXQfWTreIE=";
-    openSha256 = "sha256-PEHr6heOBP+0JjcmUpDv6JlT0aAvzoWijsEsm/DD3rs=";
+    sha256_64bit = "sha256-UtOthZ5h/UN5dMSrO2MFwWktLRiW6LE5VR1yg04D/bE=";
+    openSha256 = "sha256-mti+bJ1EyZnjAxdJtJQuyLWNKs7R+NJiBy1y+c2cqBQ=";
     settingsSha256 = "sha256-F2wmUEaRrpR1Vz0TQSwVK4Fv13f3J9NJLtBe4UP2f14=";
     persistencedSha256 = "sha256-QCwxXQfG/Pa7jSTBB0xD3lsIofcerAWWAHKvWjWGQtg=";
     url = "https://developer.nvidia.com/downloads/vulkan-beta-${lib.concatStrings (lib.splitVersion version)}-linux";


### PR DESCRIPTION
- October 24th, 2025 - Windows 581.71, Linux 580.94.06
  - New:
    - [VK_KHR_maintenance10](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_maintenance10.html)
    - [VK_EXT_memory_decompression](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_memory_decompression.html)
    - [VK_EXT_shader_64bit_indexing](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_64bit_indexing.html)
    - [VK_EXT_shader_uniform_buffer_unsized_array](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_shader_uniform_buffer_unsized_array.html)
  - Fixes:
    - Fix device lost that sometimes occured after rendering to non-zero 2D slice of a 3D image
    - Fix regression when submitting to a device group using the wrong devices

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
