### PR TITLE
wl-shimeji: init at 0.0.2-unstable-2025-10-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21711,6 +21711,12 @@
     githubId = 1973389;
     name = "Reuben D'Netto";
   };
+  readf0x = {
+    name = "Jean";
+    email = "readf0x@duck.com";
+    github = "readf0x";
+    githubId = 57838054;
+  };
   rebmit = {
     name = "Lu Wang";
     email = "rebmit@rebmit.moe";

--- a/pkgs/by-name/wl/wl-shimeji/package.nix
+++ b/pkgs/by-name/wl/wl-shimeji/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  pkg-config,
+  which,
+  python3,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
+  libarchive,
+  uthash,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wl-shimeji";
+  version = "0.0.2-unstable-2025-10-28";
+
+  src = fetchFromGitHub {
+    owner = "CluelessCatBurger";
+    repo = "wl_shimeji";
+    rev = "bf0150a313c3df271d249d3e14a17b48193f67e8";
+    hash = "sha256-ag3MHyyfo+2yZxPSBZgBsVZ4a6nLSv1KMUcYS34lIiM=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+    python3
+  ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wayland-scanner
+    uthash
+    libarchive
+    (python3.withPackages (ps: [ ps.pillow ]))
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  installFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  postPatch = ''
+    substituteInPlace systemd/wl_shimeji.service \
+      --replace-fail "/usr/bin" "$out"
+  '';
+
+  meta = {
+    description = "Shimeji reimplementation for Wayland in C";
+    homepage = "https://github.com/CluelessCatBurger/wl_shimeji/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ readf0x ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add wl-shimeji, a wayland shimeji implementation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
