### PR TITLE
ledfx: 2.0.111 -> 2.1.0

### DIFF
--- a/pkgs/by-name/le/ledfx/package.nix
+++ b/pkgs/by-name/le/ledfx/package.nix
@@ -16,6 +16,13 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-N9EHK0GVohFCjEKsm3g4h+4XWfzZO1tzdd2z5IN1YjI=";
   };
 
+  postPatch = ''
+    substituteInPlace tests/conftest.py \
+      --replace-fail '"uv",' "" \
+      --replace-fail '"run",' "" \
+      --replace-fail '"ledfx",' "\"$out/bin/ledfx\","
+  '';
+
   pythonRelaxDeps = true;
 
   pythonRemoveDeps = [
@@ -29,43 +36,49 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   dependencies = with python3.pkgs; [
+    # sorted like in pyproject.toml in upstream
+    numpy
+    cffi
     aiohttp
     aiohttp-cors
     aubio
     certifi
-    flux-led
-    python-dotenv
-    icmplib
-    mss
     multidict
-    netifaces2
-    numpy
     openrgb-python
     paho-mqtt
-    pillow
     psutil
-    pybase64
     pyserial
     pystray
-    python-mbedtls
-    python-osc
     python-rtmidi
-    # rpi-ws281x # not packaged
     requests
     sacn
-    samplerate
     sentry-sdk
-    setuptools
     sounddevice
-    stupidartnet
-    uvloop
-    vnoise
+    samplerate
+    icmplib
     voluptuous
     zeroconf
+    pillow
+    flux-led
+    python-osc
+    pybase64
+    mss
+    uvloop
+    stupidartnet
+    python-dotenv
+    vnoise
+    netifaces2
+    packaging
   ];
 
-  # Project has no tests
-  doCheck = false;
+  optional-dependencies = {
+    hue = with pyproject.pkgs; [ python-mbedtls ];
+  };
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    pytest-asyncio
+  ];
 
   meta = {
     description = "Network based LED effect controller with support for advanced real-time audio effects";

--- a/pkgs/by-name/le/ledfx/package.nix
+++ b/pkgs/by-name/le/ledfx/package.nix
@@ -1,17 +1,19 @@
 {
   lib,
-  fetchPypi,
+  fetchFromGitHub,
   python3,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "ledfx";
-  version = "2.0.111";
+  version = "2.1.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-b6WHulQa1er0DpMfeJLqqb4z8glUt1dHvvNigXgrf7Y=";
+  src = fetchFromGitHub {
+    owner = "LedFx";
+    repo = "LedFx";
+    tag = "v${version}";
+    hash = "sha256-N9EHK0GVohFCjEKsm3g4h+4XWfzZO1tzdd2z5IN1YjI=";
   };
 
   pythonRelaxDeps = true;


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
