### PR TITLE
platformio: fix missing pyparsing

### DIFF
--- a/pkgs/by-name/pl/platformio-core/package.nix
+++ b/pkgs/by-name/pl/platformio-core/package.nix
@@ -79,6 +79,7 @@ buildPythonApplication rec {
     marshmallow
     pip
     pyelftools
+    pyparsing
     pyserial
     pyyaml
     requests


### PR DESCRIPTION
Platformio threw an exeption while compiling a minimal program:

```
CMake Error at /home/polyfloyd/.platformio/packages/framework-espidf/tools/cmake/build.cmake:620 (message):
  Traceback (most recent call last):

    File "<frozen runpy>", line 198, in _run_module_as_main
    File "<frozen runpy>", line 88, in _run_code
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_manager/prepare_components/__main__.py", line 4, in <module>
      from .prepare import main
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_manager/prepare_components/prepare.py", line 14, in <module>
      from idf_component_manager.core import ComponentManager
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_manager/core.py", line 21, in <module>
      from idf_component_manager.utils import ComponentSource, print_info, print_warn
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_manager/utils.py", line 10, in <module>
      from idf_component_tools.manifest.constants import SLUG_REGEX
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_tools/manifest/__init__.py", line 10, in <module>
      from .metadata import Metadata
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_tools/manifest/metadata.py", line 7, in <module>
      from .schemas import flatten_manifest_file_keys, serialize_list_of_list_of_strings
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_tools/manifest/schemas.py", line 11, in <module>
      from .models import Manifest
    File "/home/polyfloyd/.platformio/penv/.espidf-5.4.2/lib/python3.13/site-packages/idf_component_tools/manifest/models.py", line 20, in <module>
      from pyparsing import ParseException

  ModuleNotFoundError: No module named 'pyparsing'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
