### PR TITLE
cairo: fix the eval on `mingwW64`

### DIFF
--- a/pkgs/by-name/ca/cairo/package.nix
+++ b/pkgs/by-name/ca/cairo/package.nix
@@ -100,8 +100,10 @@ stdenv.mkDerivation (
             linux = "true";
             freebsd = "true";
             netbsd = "false";
+            windows = "false";
           }
-          .${stdenv.hostPlatform.parsed.kernel.name} or (throw "Unknown value for ipc_rmid_deferred_release")
+          .${stdenv.hostPlatform.parsed.kernel.name}
+            or (throw "Unknown value for ipc_rmid_deferred_release on ${stdenv.hostPlatform.parsed.kernel.name}")
         }
       ''}"
     ];


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/issues/456516
user reported eval fails as:

    $ nix build --no-link -f. pkgsCross.mingwW64.cairo
    error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'cairo-x86_64-w64-mingw32-1.18.4'
         whose name attribute is located at pkgs/stdenv/generic/make-derivation.nix:544:13

       … while evaluating attribute 'mesonFlags' of derivation 'cairo-x86_64-w64-mingw32-1.18.4'
         at pkgs/stdenv/generic/make-derivation.nix:824:11:
          823|           cmakeFlags = makeCMakeFlags attrs;
          824|           mesonFlags = makeMesonFlags attrs;
             |           ^
          825|         }

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Unknown value for ipc_rmid_deferred_release

The change will not fix `cairo` build on `windows` but at least will report unsupported dependencies.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
