### PR TITLE
protonvpn-gui: 4.9.7 -> 4.12.0

### DIFF
--- a/pkgs/applications/networking/protonvpn-gui/default.nix
+++ b/pkgs/applications/networking/protonvpn-gui/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonApplication rec {
   pname = "protonvpn-gui";
-  version = "4.9.7";
+  version = "4.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "proton-vpn-gtk-app";
     tag = "v${version}";
-    hash = "sha256-xpMXpYLLui+1bjK72VPhUT6T/sYpoqN2Jz6sczKJO5U=";
+    hash = "sha256-pDTzqTiGAisVEHwez526z9C9GzNkMWl6Cui8E6siIXo=";
   };
 
   nativeBuildInputs = [
@@ -68,7 +68,7 @@ buildPythonApplication rec {
     mkdir -p $out/share/{applications,pixmaps}
 
     # Fix the desktop file to correctly identify the wrapped app and show the icon during runtime
-    substitute ${src}/rpmbuild/SOURCES/protonvpn-app.desktop $out/share/applications/protonvpn-app.desktop \
+    substitute ${src}/rpmbuild/SOURCES/proton.vpn.app.gtk.desktop $out/share/applications/proton.vpn.app.gtk.desktop \
       --replace-fail "StartupWMClass=protonvpn-app" "StartupWMClass=.protonvpn-app-wrapped"
     install -Dm 644 ${src}/rpmbuild/SOURCES/proton-vpn-logo.svg $out/share/pixmaps
   '';

--- a/pkgs/development/python-modules/proton-core/default.nix
+++ b/pkgs/development/python-modules/proton-core/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "proton-core";
-  version = "0.4.0";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-core";
     tag = "v${version}";
-    hash = "sha256-EZsPw2kPgY42MQxrXt7yAtCNSmSNN5AYxx7SllwsbvA=";
+    hash = "sha256-ZT/LkppzeEDGs9aOCx561fA1EgAShPCnMs8c05mgF0k=";
   };
 
   build-system = [ setuptools ];
@@ -58,6 +58,7 @@ buildPythonPackage rec {
     # No working transports found
     "test_auto_works_on_prod"
     "test_ping"
+    "test_raw_ping"
     "test_successful"
     "test_without_pinning"
     # Failed assertions

--- a/pkgs/development/python-modules/proton-keyring-linux/default.nix
+++ b/pkgs/development/python-modules/proton-keyring-linux/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "proton-keyring-linux";
-  version = "0.2.0";
+  version = "0.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-keyring-linux";
     tag = "v${version}";
-    hash = "sha256-wT+0S3dGanLwqRrpCooAwy/RDyZDn1aEdJ7eWvwVfiY=";
+    hash = "sha256-deld1MjuTjgjXBCUuDzYABRjN4gT1mz+duV0Qj4IWCg=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/proton-vpn-api-core/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-api-core/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   cryptography,
+  fido2,
   setuptools,
   jinja2,
   proton-core,
@@ -20,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-api-core";
-  version = "0.42.5";
+  version = "4.13.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-api-core";
     rev = "v${version}";
-    hash = "sha256-sSLBo2nTn7rvtSZqCWZLwca5DRIgqSkImRM6U6/xJ70=";
+    hash = "sha256-DJXKfUkV0ojL9UjM6cyFAOkdYhzZZU9L3z1ARjIQnUI=";
   };
 
   build-system = [
@@ -37,6 +38,7 @@ buildPythonPackage rec {
   dependencies = [
     cryptography
     distro
+    fido2
     jinja2
     pynacl
     proton-core

--- a/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
@@ -5,6 +5,7 @@
   python,
   buildPythonPackage,
   cargo,
+  pypaInstallHook,
   rustPlatform,
 }:
 
@@ -36,6 +37,7 @@ buildPythonPackage rec {
   cargoBuildType = "release";
   nativeBuildInputs = [
     cargo
+    pypaInstallHook
     rustPlatform.cargoSetupHook
     rustPlatform.cargoBuildHook
   ];
@@ -45,14 +47,10 @@ buildPythonPackage rec {
     rustPlatform.cargoCheckHook
   ];
 
-  installPhase = ''
-    runHook preInstall
-
-    # manually install the python binding
-    mkdir -p $out/${python.sitePackages}/proton/vpn/
-    cp ./target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/libpython_proton_vpn_local_agent.so $out/${python.sitePackages}/proton/vpn/local_agent.so
-
-    runHook postInstall
+  postBuild = ''
+    ${python.interpreter} scripts/build_wheel.py
+    mkdir -p ./dist
+    cp ./target/*.whl ./dist
   '';
 
   pythonImportsCheck = [ "proton.vpn.local_agent" ];
@@ -62,6 +60,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/ProtonVPN/python-proton-vpn-local-agent";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ sebtm ];
+    maintainers = with lib.maintainers; [
+      sebtm
+      rapiteanu
+    ];
   };
 }

--- a/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-local-agent";
-  version = "1.4.8";
+  version = "1.6.0";
   pyproject = false;
   withDistOutput = false;
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-local-agent";
     rev = version;
-    hash = "sha256-AHY2b0JaYaLhgnNkTsm9ERkw0s0NWnpbPAPgw+r2Gz4=";
+    hash = "sha256-rk3wi6q0UDuwh5yhLBqdLYsJxVqhlI+Yc7HZsiAU1Y8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -29,7 +29,7 @@ buildPythonPackage rec {
       src
       sourceRoot
       ;
-    hash = "sha256-zzUZsF0R0QGhxe4To6xSHYUVJTIDddf+UdTJg7E9Ef8=";
+    hash = "sha256-jjSkPgGp3Yvypnlrt9pV1F/K3o2doNteQs1rwr5fhnM=";
   };
 
   sourceRoot = "${src.name}/python-proton-vpn-local-agent";

--- a/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-network-manager";
-  version = "0.12.14";
+  version = "0.13.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-network-manager";
     tag = "v${version}";
-    hash = "sha256-flZeEdmGXsSFHtlm6HrBtuwOcYJFjWmkMvGgnHL4cPw=";
+    hash = "sha256-VMaj85oFxLkloR6hdeRHwVTBl44Mx5WEjOl9FnLf8+w=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update the package and it's dependencies to the latest version.
This commit changes the installation method of proton-vpn-local-agent to also install the wheel information so that other packages can use it as dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
