### PR TITLE
python3Packages.holistic-trace-analysis: disable tests that can fail/hang on Darwin

### DIFF
--- a/pkgs/development/python-modules/holistic-trace-analysis/default.nix
+++ b/pkgs/development/python-modules/holistic-trace-analysis/default.nix
@@ -54,6 +54,13 @@ buildPythonPackage rec {
     # Fails under Python 3.12 on Darwin with I/O errors
     # Permission denied: '/tmp/path_does_not_exist/...'
     "test_critical_path_overlaid_trace"
+    # Permission error: [Errno 1] Operation not permitted
+    "test_get_mtia_aten_op_kernels_and_delay_inference_single_rank"
+    # No cuda on Darwin, can cause hangs in nixpkgs-review
+    "test_frequent_cuda_kernel_sequences"
+    "test_get_cuda_kernel_launch_stats_for_h100"
+    "test_get_cuda_kernel_launch_stats_inference_single_rank"
+    "test_get_cuda_kernel_launch_stats_training_multiple_ranks"
   ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
Found a test that fails in the sandbox and Darwin and several CUDA tests that don't apply to Darwin (and will hang in `nixpkgs-review` when python 3.12 and python3.13 versions build simultaneously). Disabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
