### PR TITLE
squid: 7.2 -> 7.3

### DIFF
--- a/pkgs/by-name/sq/squid/package.nix
+++ b/pkgs/by-name/sq/squid/package.nix
@@ -16,25 +16,17 @@
   cppunit,
   ipv6 ? true,
   nixosTests,
-  fetchpatch,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "squid";
-  version = "7.2";
+  version = "7.3";
 
   src = fetchurl {
     url = "https://github.com/squid-cache/squid/releases/download/SQUID_${
       builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }/squid-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Xgd74dg6nmls6NDZ5yOxJzFSIHoJFAS+aKS5qeGMcAM=";
+    hash = "sha256-2twqmjkmzhs7q+qnp9eyHLsIkCWHbao/XBnn62OR3c0=";
   };
-
-  patches = lib.optional (lib.versionOlder finalAttrs.version "7.2.0") (fetchpatch {
-    # Merged upstream PR; fixes the issue of rejecting domain names starting with digits
-    # To remove when 7.3 is released (or 7.2.1, but that doesn't seem likely)
-    url = "https://patch-diff.githubusercontent.com/raw/squid-cache/squid/pull/2283.patch";
-    hash = "sha256-HLGmzrAH5y1sFfFnVeeegRihyn+N7csGX9lVqmCDIHc=";
-  });
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
Refer to the upstream changelog for specific details:
https://github.com/squid-cache/squid/releases/tag/SQUID_7_3

For nixpkgs this notably includes a regression fix that was previously included with a patch. If this release is okay then we can also likely backport it to 25.05 to succeed #456449.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
