### PR TITLE
maintainers: retire coroa

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5239,12 +5239,6 @@
     githubId = 3077118;
     name = "David McFarland";
   };
-  coroa = {
-    email = "jonas@chaoflow.net";
-    github = "coroa";
-    githubId = 2552981;
-    name = "Jonas Hörsch";
-  };
   costrouc = {
     email = "chris.ostrouchov@gmail.com";
     github = "costrouc";

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -192,7 +192,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://quodlibet.readthedocs.io/en/latest";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      coroa
       pbogdan
     ];
   };

--- a/pkgs/by-name/au/autorandr/package.nix
+++ b/pkgs/by-name/au/autorandr/package.nix
@@ -82,7 +82,7 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/phillipberndt/autorandr/";
     description = "Automatically select a display configuration based on connected devices";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ coroa ];
+    maintainers = [ ];
     platforms = platforms.unix;
     mainProgram = "autorandr";
   };

--- a/pkgs/by-name/ga/gammu/package.nix
+++ b/pkgs/by-name/ga/gammu/package.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation rec {
     description = "Command line utility and library to control mobile phones";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = [ maintainers.coroa ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/li/libunibreak/package.nix
+++ b/pkgs/by-name/li/libunibreak/package.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
     description = "Implementation of line breaking and word breaking algorithms as in the Unicode standard";
     license = licenses.zlib;
     platforms = platforms.unix;
-    maintainers = [ maintainers.coroa ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Inactive since 2013. cc #456457

@coroa It's been more than a decade, I assume we can retire you safely. If not you have a week to speak up.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
