### PR TITLE
windows.dlfcn: 1.3.1 -> 1.4.2; modernise

### DIFF
--- a/pkgs/os-specific/windows/dlfcn/default.nix
+++ b/pkgs/os-specific/windows/dlfcn/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dlfcn";
-  version = "1.3.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "dlfcn-win32";
     repo = "dlfcn-win32";
     tag = "v${version}";
-    hash = "sha256-ljVTMBiGp8TPufrQcK4zQtcVH1To4zcfBAbUOb+v910=";
+    hash = "sha256-kLY8vvHTT02gENPlVvyDyR0ULC8NA+E/P6mWtU6MbBY=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/os-specific/windows/dlfcn/default.nix
+++ b/pkgs/os-specific/windows/dlfcn/default.nix
@@ -12,17 +12,17 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dlfcn-win32";
     repo = "dlfcn-win32";
-    rev = "v${version}";
-    sha256 = "sha256-ljVTMBiGp8TPufrQcK4zQtcVH1To4zcfBAbUOb+v910=";
+    tag = "v${version}";
+    hash = "sha256-ljVTMBiGp8TPufrQcK4zQtcVH1To4zcfBAbUOb+v910=";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/dlfcn-win32/dlfcn-win32";
     description = "Set of functions that allows runtime dynamic library loading";
-    license = licenses.mit;
-    platforms = platforms.windows;
-    maintainers = with maintainers; [ marius851000 ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.windows;
+    maintainers = with lib.maintainers; [ marius851000 ];
   };
 }

--- a/pkgs/os-specific/windows/dlfcn/default.nix
+++ b/pkgs/os-specific/windows/dlfcn/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   cmake,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/dlfcn-win32/dlfcn-win32";


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **windows.dlfcn: modernise**
- **windows.dlfcn: set update script**
- **windows.dlfcn: 1.3.1 -> 1.4.2**
  - fixes #456640

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
