### PR TITLE
fromager: 0.59.0 -> 0.68.1; fix tests

### DIFF
--- a/pkgs/by-name/fr/fromager/package.nix
+++ b/pkgs/by-name/fr/fromager/package.nix
@@ -53,6 +53,11 @@ python3.pkgs.buildPythonApplication rec {
     "fromager"
   ];
 
+  disabledTestPaths = [
+    # Depends on wheel.cli module that is private since wheel 0.46.0
+    "tests/test_wheels.py"
+  ];
+
   meta = {
     description = "Wheel maker";
     homepage = "https://pypi.org/project/fromager/";

--- a/pkgs/by-name/fr/fromager/package.nix
+++ b/pkgs/by-name/fr/fromager/package.nix
@@ -2,18 +2,19 @@
   lib,
   python3,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "fromager";
-  version = "0.59.0";
+  version = "0.68.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-wheel-build";
     repo = "fromager";
     tag = version;
-    hash = "sha256-aKoZKpzgJ3e5JRYSSeLmLlji1Fj8omxvwGZfNXDOhLs=";
+    hash = "sha256-7NM8hRsMnnHWxzjwNv/cLIm9iOUsUEzoCwPuFUN8+hk=";
   };
 
   build-system = with python3.pkgs; [
@@ -39,7 +40,7 @@ python3.pkgs.buildPythonApplication rec {
     stevedore
     tomlkit
     tqdm
-    virtualenv
+    uv
     wheel
   ];
 
@@ -47,6 +48,8 @@ python3.pkgs.buildPythonApplication rec {
     pytestCheckHook
     requests-mock
     twine
+    uv
+    writableTmpDirAsHomeHook
   ];
 
   pythonImportsCheck = [
@@ -56,6 +59,12 @@ python3.pkgs.buildPythonApplication rec {
   disabledTestPaths = [
     # Depends on wheel.cli module that is private since wheel 0.46.0
     "tests/test_wheels.py"
+  ];
+
+  disabledTests = [
+    # Accessing pypi.org (not allowed in sandbox)
+    "test_get_build_backend_dependencies"
+    "test_get_build_sdist_dependencies"
   ];
 
   meta = {


### PR DESCRIPTION
- **fromager: fix tests**
- **fromager: 0.59.0 -> 0.68.1**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
