### PR TITLE
whisparr 2.0.0.1282 -> 3.0.1.1319

### DIFF
--- a/pkgs/by-name/wh/whisparr/package.nix
+++ b/pkgs/by-name/wh/whisparr/package.nix
@@ -29,16 +29,16 @@ let
     ."${system}" or (throw "Unsupported system: ${system}");
   hash =
     {
-      arm64-linux-hash = "sha256-AGERhD8EiTkaXw7GWVaWPFVuQkclSarNOGMgs+6zxfI=";
-      arm64-osx-hash = "sha256-AUZoAAEmgrb1A7OKLc7QOliGTgctD9MuM9rqNWQ3ySM=";
-      x64-linux-hash = "sha256-ZRbV1nxAIiHUL8DzmlAJRcFOnl5t8+ur3zXhw29mUfk=";
-      x64-osx-hash = "sha256-WfR0x89wQNAiLYX1Dg5AsEuiqHSX9IhhxEOoVuPjRH8=";
+      arm64-linux-hash = "sha256-J0YTkb7okYRK0mEqP75i4opdg3SwBhjZA6gKbWGQgOs=";
+      arm64-osx-hash = "sha256-cjgZMGdvd/0ZgRvXn16KrN9Xkz/b6F/YYUY2DPiquqE=";
+      x64-linux-hash = "sha256-xPDtIeb5I6Pyc0D1b3WIF9L5oTuuT9cHdgiKC2Gmd5k=";
+      x64-osx-hash = "sha256-niW7hGs46VKMXXV5pW63KN/w/dOC31riKkEKmU4twWE=";
     }
     ."${arch}-${os}-hash";
 in
 stdenv.mkDerivation rec {
   pname = "whisparr";
-  version = "2.0.0.1282";
+  version = "3.0.1.1319";
 
   src = fetchurl {
     name = "${pname}-${arch}-${os}-${version}.tar.gz";

--- a/pkgs/by-name/wh/whisparr/update.sh
+++ b/pkgs/by-name/wh/whisparr/update.sh
@@ -22,7 +22,7 @@ updateHash()
   hashKey="${system}-hash"
 
   echo "Updating the hash for the \`${system}\` system..."
-  url="https://whisparr.servarr.com/v1/update/nightly/updatefile?runtime=netcore&version=${version}&arch=${arch}&os=${os}"
+  url="https://whisparr.servarr.com/v1/update/eros/updatefile?runtime=netcore&version=${version}&arch=${arch}&os=${os}"
   hash=$(nix-prefetch-url --type sha256 --name "whisparr-$system-$version.tar.gz" "$url")
   sriHash="$(nix --extra-experimental-features nix-command hash to-sri --type sha256 "$hash")"
 
@@ -36,7 +36,7 @@ echo "Current version: \`$currentVersion\`."
 
 echo "Fetching the latest version..."
 latestVersion=$(
-  curl -s "https://whisparr.servarr.com/v1/update/nightly/changes?runtime=netcore&os=linux" |
+  curl -s "https://whisparr.servarr.com/v1/update/eros/changes?runtime=netcore&os=linux" |
   jq -r .[0].version
 )
 


### PR DESCRIPTION
Resolves: https://github.com/NixOS/nixpkgs/issues/456635
Updated the update script to the Eros branch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
