### PR TITLE
ciscoPacketTracer9: init at 9.0.0

### DIFF
--- a/pkgs/by-name/ci/ciscoPacketTracer9/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer9/package.nix
@@ -1,0 +1,90 @@
+{
+  appimageTools,
+  dpkg,
+  lib,
+  libpng,
+  libxkbfile,
+  requireFile,
+  stdenvNoCC,
+  version ? "9.0.0",
+}:
+
+let
+  pname = "ciscoPacketTracer9";
+
+  appimage = stdenvNoCC.mkDerivation {
+    pname = "ciscoPacketTracer9-appimage";
+    inherit version;
+
+    src =
+      let
+        sources = {
+          "9.0.0" = {
+            name = "CiscoPacketTracer_900_Ubuntu_64bit.deb";
+            hash = "sha256-3ZrA1Mf8N9y2j2J/18fm+m1CAMFEklJuVhi5vRcu2SA=";
+          };
+        };
+      in
+      requireFile {
+        inherit (sources."${version}") name hash;
+        url = "https://www.netacad.com/resources/lab-downloads";
+      };
+
+    nativeBuildInputs = [
+      dpkg
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      cp opt/pt/packettracer.AppImage $out
+
+      runHook postInstall
+    '';
+  };
+
+in
+appimageTools.wrapType2 rec {
+  inherit pname version;
+  src = appimage;
+
+  extraPkgs = _: [
+    libpng
+    libxkbfile
+  ];
+
+  extraBwrapArgs = [
+    # fixes launch on wayland when the user sets QT_QPA_PLATFORM=wayland:
+    # "Fatal: This application failed to start because no Qt platform plugin could be initialized."
+    "--setenv QT_QPA_PLATFORM xcb"
+  ];
+
+  extraInstallCommands =
+    let
+      contents = appimageTools.extract { inherit pname version src; };
+    in
+    ''
+      mv $out/bin/${pname} $out/bin/packettracer9
+
+      install -Dm444 ${contents}/CiscoPacketTracer-9.0.0.desktop $out/share/applications/cisco-packet-tracer-9.desktop
+      install -Dm444 ${contents}/CiscoPacketTracerPtsa-9.0.0.desktop $out/share/applications/cisco-packet-tracer-ptsa-9.desktop
+      substituteInPlace $out/share/applications/* \
+        --replace-fail "Exec=@EXEC_PATH@" "Exec=packettracer9" \
+        --replace-fail "Icon=app" "Icon=cisco-packet-tracer-9"
+
+      install -Dm444 ${contents}/usr/share/icons/hicolor/48x48/apps/app.png $out/share/icons/hicolor/48x48/apps/cisco-packet-tracer-9.png
+      cp -r ${contents}/usr/share/icons/gnome/48x48/mimetypes $out/share/icons/hicolor/48x48/
+    '';
+
+  meta = {
+    description = "Network simulation tool from Cisco";
+    homepage = "https://www.netacad.com/courses/packet-tracer";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      gepbird
+    ];
+    mainProgram = "packettracer9";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/475698.

This is the next version of an existing package, [ciscoPacketTracer8](https://github.com/NixOS/nixpkgs/blob/a0e533108991c29f46bc9a66313689d55b675189/pkgs/by-name/ci/ciscoPacketTracer8/package.nix).
The main changes are newer dependencies (e.g. qt5 -> qt6, no more vulnerable qt web engine) and instead of upstream distributing a "regular" deb file that has all the binaries and libraries, we get a deb file that has an appimage. Inside the appimage, the files are similar to what is in version 8's deb.

If you want to try and run this without registering an account, I recommend downloading 9.0.0 from [here](https://www.computernetworkingnotes.com/ccna-study-guide/download-packet-tracer-for-windows-and-linux.html).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
