### PR TITLE
importNpmLock: fix handling of git url

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -4,6 +4,7 @@
   stdenv,
   callPackages,
   runCommand,
+  linkFarm,
   cctools,
 }:
 
@@ -205,6 +206,7 @@ lib.fix (self: {
       packageLock ? importJSON (npmRoot + "/package-lock.json"),
       nodejs,
       derivationArgs ? { },
+      packageSourceOverrides ? { },
     }:
     stdenv.mkDerivation (
       {
@@ -214,7 +216,12 @@ lib.fix (self: {
         dontUnpack = true;
 
         npmDeps = self.importNpmLock {
-          inherit npmRoot package packageLock;
+          inherit
+            npmRoot
+            package
+            packageLock
+            packageSourceOverrides
+            ;
         };
 
         package = toJSON package;

--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -168,6 +168,12 @@ lib.fix (self: {
         }
         // lib.optionalAttrs (package ? devDependencies) {
           devDependencies = mapPackageDependencies package.devDependencies;
+        }
+        // lib.optionalAttrs (package ? overrides) {
+          overrides = mapPackageDependencies package.overrides;
+        }
+        // lib.optionalAttrs (package ? resolutions) {
+          resolutions = mapPackageDependencies package.resolutions;
         };
 
       pname = package.name or "unknown";

--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -31,12 +31,15 @@ let
       if module ? "resolved" && module.resolved != null then
         (
           let
-            # Parse scheme from URL
-            mUrl = match "(.+)://(.+)" module.resolved;
-            scheme = elemAt mUrl 0;
+            # Parse scheme, URL, and optional fragment from URL (e.g., "git+ssh://...#hash")
+            urlParts = match "(.+)://([^#]+)#?(.*)" module.resolved;
+            scheme = elemAt urlParts 0;
+            urlWithoutFragment = elemAt urlParts 1;
+            fragment = elemAt urlParts 2;
+            isGit = lib.hasPrefix "git" scheme;
           in
           (
-            if mUrl == null then
+            if urlParts == null then
               (
                 assert npmRoot != null;
                 {
@@ -51,13 +54,30 @@ let
                 }
                 // fetcherOpts
               ))
-            else if lib.hasPrefix "git" module.resolved then
-              (fetchGit (
-                {
-                  url = module.resolved;
-                }
-                // fetcherOpts
-              ))
+            else if isGit then
+              (
+                let
+                  url = "${scheme}://${urlWithoutFragment}";
+                  hasRev = fragment != "";
+
+                  gitSrc = fetchGit (
+                    {
+                      inherit url;
+                    }
+                    // lib.optionalAttrs hasRev { rev = fragment; }
+                    // fetcherOpts
+                  );
+
+                  # Wrap the source in a tarball because directories have different semantics
+                  # (transitive dependencies aren't installed)
+                  pname = module.name or "package";
+                  version = module.version or "0.0.0";
+                in
+                # Prepend package/ to the files to match the format expected by npm
+                runCommand "${pname}-${version}.tgz" { } ''
+                  tar czf $out --transform 's,^,package/,' -C ${gitSrc} .
+                ''
+              )
             else
               throw "Unsupported URL scheme: ${scheme}"
           )

--- a/pkgs/build-support/node/import-npm-lock/hooks/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/hooks/default.nix
@@ -4,6 +4,7 @@
   makeSetupHook,
   srcOnly,
   nodejs,
+  jq,
 }:
 {
   npmConfigHook = makeSetupHook {
@@ -13,6 +14,7 @@
       nodeGyp = "${nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js";
       canonicalizeSymlinksScript = ./canonicalize-symlinks.js;
       storePrefix = builtins.storeDir;
+      jq = lib.getExe jq;
     };
   } ./npm-config-hook.sh;
 

--- a/pkgs/build-support/node/import-npm-lock/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/import-npm-lock/hooks/npm-config-hook.sh
@@ -1,70 +1,86 @@
 # shellcheck shell=bash
 
 npmConfigHook() {
-    echo "Executing npmConfigHook"
+  echo "Executing npmConfigHook"
 
-    if [ -n "${npmRoot-}" ]; then
-      pushd "$npmRoot"
+  if [ -n "${npmRoot-}" ]; then
+    pushd "$npmRoot"
+  fi
+
+  if [ -z "${npmDeps-}" ]; then
+    echo "Error: 'npmDeps' should be set when using npmConfigHook."
+    exit 1
+  fi
+
+  echo "Configuring npm"
+
+  export HOME="$TMPDIR"
+  export npm_config_nodedir="@nodeSrc@"
+  export npm_config_node_gyp="@nodeGyp@"
+  npm config set offline true
+  npm config set progress false
+  npm config set fund false
+
+  echo "Installing patched package.json/package-lock.json"
+
+  # Save original package.json/package-lock.json for closure size reductions.
+  # The patched one contains store paths we don't want at runtime.
+  mv package.json .package.json.orig
+  if test -f package-lock.json; then # Not all packages have package-lock.json.
+    mv package-lock.json .package-lock.json.orig
+  fi
+  cp --no-preserve=mode "${npmDeps}/package.json" package.json
+  cp --no-preserve=mode "${npmDeps}/package-lock.json" package-lock.json
+
+  echo "Installing dependencies"
+
+  if ! npm install --ignore-scripts $npmInstallFlags "${npmInstallFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    echo
+    echo "ERROR: npm failed to install dependencies"
+    echo
+    echo "Here are a few things you can try, depending on the error:"
+    echo '1. Set `npmFlags = [ "--legacy-peer-deps" ]`'
+    echo
+
+    exit 1
+  fi
+
+  patchShebangs node_modules
+
+  npm rebuild $npmRebuildFlags "${npmRebuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
+
+  patchShebangs node_modules
+
+  # Canonicalize symlinks from relative paths to the Nix store.
+  node @canonicalizeSymlinksScript@ @storePrefix@
+
+  if [ -n "${npmRoot-}" ]; then
+    popd
+  fi
+
+  echo "Finished npmConfigHook"
+}
+
+npmConfigPostInstallHook() {
+  if [ -n "${npmRoot-}" ]; then
+    pushd "$npmRoot"
+  fi
+
+  # Revert to pre-patched package.json/package-lock.json in output for closure size reduction
+  if [ -f .package.json.orig ]; then
+    local packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' .package.json.orig)"
+    if [ -d "$packageOut" ]; then
+      cp --no-preserve=mode .package.json.orig "$packageOut/package.json"
+      if [ -f .package-lock.json.orig ]; then
+        cp --no-preserve=mode .package-lock.json.orig "$packageOut/package-lock.json"
+      fi
     fi
+  fi
 
-    if [ -z "${npmDeps-}" ]; then
-        echo "Error: 'npmDeps' should be set when using npmConfigHook."
-        exit 1
-    fi
-
-    echo "Configuring npm"
-
-    export HOME="$TMPDIR"
-    export npm_config_nodedir="@nodeSrc@"
-    export npm_config_node_gyp="@nodeGyp@"
-    npm config set offline true
-    npm config set progress false
-    npm config set fund false
-
-    echo "Installing patched package.json/package-lock.json"
-
-    # Save original package.json/package-lock.json for closure size reductions.
-    # The patched one contains store paths we don't want at runtime.
-    mv package.json .package.json.orig
-    if test -f package-lock.json; then # Not all packages have package-lock.json.
-        mv package-lock.json .package-lock.json.orig
-    fi
-    cp --no-preserve=mode "${npmDeps}/package.json" package.json
-    cp --no-preserve=mode "${npmDeps}/package-lock.json" package-lock.json
-
-    echo "Installing dependencies"
-
-    if ! npm install --ignore-scripts $npmInstallFlags "${npmInstallFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
-        echo
-        echo "ERROR: npm failed to install dependencies"
-        echo
-        echo "Here are a few things you can try, depending on the error:"
-        echo '1. Set `npmFlags = [ "--legacy-peer-deps" ]`'
-        echo
-
-        exit 1
-    fi
-
-    patchShebangs node_modules
-
-    npm rebuild $npmRebuildFlags "${npmRebuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
-
-    patchShebangs node_modules
-
-    # Canonicalize symlinks from relative paths to the Nix store.
-    node @canonicalizeSymlinksScript@ @storePrefix@
-
-    # Revert to pre-patched package.json/package-lock.json for closure size reductions
-    mv .package.json.orig package.json
-    if test -f ".package-lock.json.orig"; then
-        mv .package-lock.json.orig package-lock.json
-    fi
-
-    if [ -n "${npmRoot-}" ]; then
-      popd
-    fi
-
-    echo "Finished npmConfigHook"
+  if [ -n "${npmRoot-}" ]; then
+    popd
+  fi
 }
 
 postConfigureHooks+=(npmConfigHook)
+postInstallHooks+=(npmConfigPostInstallHook)

--- a/pkgs/build-support/node/test/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/test/import-npm-lock/default.nix
@@ -1,0 +1,4 @@
+{ callPackage }:
+
+{
+}

--- a/pkgs/build-support/node/test/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/test/import-npm-lock/default.nix
@@ -1,4 +1,5 @@
 { callPackage }:
 
 {
+  overrides = callPackage ./overrides { };
 }

--- a/pkgs/build-support/node/test/import-npm-lock/overrides/default.nix
+++ b/pkgs/build-support/node/test/import-npm-lock/overrides/default.nix
@@ -1,0 +1,22 @@
+{
+  buildNpmPackage,
+  importNpmLock,
+}:
+
+let
+  src = ./package;
+in
+buildNpmPackage {
+  pname = "overrides-test";
+  version = "1.0.0";
+
+  inherit src;
+
+  npmDeps = importNpmLock {
+    npmRoot = src;
+  };
+
+  npmConfigHook = importNpmLock.npmConfigHook;
+
+  dontNpmBuild = true;
+}

--- a/pkgs/build-support/node/test/import-npm-lock/overrides/package/package-lock.json
+++ b/pkgs/build-support/node/test/import-npm-lock/overrides/package/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "overrides-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "overrides-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "is-number": "^6.0.0",
+        "is-odd": "^3.0.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-6.0.0.tgz",
+      "integrity": "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-odd": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz",
+      "integrity": "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  }
+}

--- a/pkgs/build-support/node/test/import-npm-lock/overrides/package/package.json
+++ b/pkgs/build-support/node/test/import-npm-lock/overrides/package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "overrides-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-number": "^6.0.0",
+    "is-odd": "^3.0.0"
+  },
+  "overrides": {
+    "is-number": "^6.0.0"
+  }
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -164,6 +164,7 @@ with pkgs;
 
   buildRustCrate = recurseIntoAttrs (callPackage ../build-support/rust/build-rust-crate/test { });
   importCargoLock = recurseIntoAttrs (callPackage ../build-support/rust/test/import-cargo-lock { });
+  importNpmLock = recurseIntoAttrs (callPackage ../build-support/node/test/import-npm-lock { });
 
   vim = callPackage ./vim { };
 


### PR DESCRIPTION
Currently using `importNpmLock` with a git dependency fails with the following error:
```
       error: Failed to fetch git repository git+ssh://git@github.com/org/repo-name.git#commit-sha-here : fatal: remote error:
         is not a valid repository name
       Visit https://support.github.com/ for help
```

The whole value for the `resolved` field is passed as a url, but the [current lock file format](https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json) indicates that the resolved field should be the full git url with commit sha.

## Things done

Parses the resolved url and passes the commit sha to fetchGit

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
