### PR TITLE
tpm2-pkcs11: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/by-name/tp/tpm2-pkcs11-abrmd/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11-abrmd/package.nix
@@ -1,0 +1,5 @@
+{
+  tpm2-pkcs11,
+  ...
+}@args:
+tpm2-pkcs11.abrmd.override args

--- a/pkgs/by-name/tp/tpm2-pkcs11/disable-java-integration.patch
+++ b/pkgs/by-name/tp/tpm2-pkcs11/disable-java-integration.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile-integration.am b/Makefile-integration.am
-index e2255de..3cea1d8 100644
+index 01c3408..b515784 100644
 --- a/Makefile-integration.am
 +++ b/Makefile-integration.am
 @@ -7,7 +7,6 @@ integration_scripts = \
@@ -9,8 +9,8 @@ index e2255de..3cea1d8 100644
 -    test/integration/pkcs11-javarunner.sh.java \
      test/integration/nss-tests.sh \
      test/integration/ptool-link.sh.nosetup \
-     test/integration/python-pkcs11.sh
-@@ -110,13 +109,5 @@ test_integration_pkcs_lockout_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+     test/integration/ptool-link-persistent.sh.nosetup \
+@@ -111,13 +110,5 @@ test_integration_pkcs_lockout_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
  test_integration_pkcs_lockout_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
  test_integration_pkcs_lockout_int_SOURCES = test/integration/pkcs-lockout.int.c test/integration/test.c
  
@@ -25,16 +25,18 @@ index e2255de..3cea1d8 100644
  endif
  # END INTEGRATION
 diff --git a/configure.ac b/configure.ac
-index 1ec6eb4..7a0a8ee 100644
+index 104cf12..ccade64 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -258,13 +258,6 @@ AC_ARG_ENABLE(
+@@ -259,15 +259,6 @@ AC_ARG_ENABLE(
      [build and execute integration tests])],,
    [enable_integration=no])
  
 -# Test for Java compiler and interpreter without throwing fatal errors (since
 -# these macros are defined using AC_DEFUN they cannot be called conditionally)
--m4_pushdef([AC_MSG_ERROR], [have_javac=no])
+-# Test for javac by checking JAVAC variable since have_javac is not quite stable
+-# across versions of ax_prog_javac.m4 that provides AX_PROG_JAVAC
+-m4_pushdef([AC_MSG_ERROR], [true])
 -AX_PROG_JAVAC()
 -AX_PROG_JAVA()
 -m4_popdef([AC_MSG_ERROR])
@@ -42,11 +44,11 @@ index 1ec6eb4..7a0a8ee 100644
  AC_DEFUN([integration_test_checks], [
  
    AC_CHECK_PROG([tpm2_createprimary], [tpm2_createprimary], [yes], [no])
-@@ -382,13 +375,6 @@ AC_DEFUN([integration_test_checks], [
+@@ -385,13 +376,6 @@ AC_DEFUN([integration_test_checks], [
          [AC_MSG_ERROR([Integration tests enabled but tss2_provision executable not found.])])
    ])
  
--  AS_IF([test "x$have_javac" = "xno"],
+-  AS_IF([test -z "$JAVAC"],
 -    [AC_MSG_ERROR([Integration tests enabled but no Java compiler was found])])
 -  AX_CHECK_CLASS([org.junit.Assert], ,
 -    [AC_MSG_ERROR([Integration tests enabled but JUnit not found, try setting CLASSPATH])])
@@ -55,4 +57,4 @@ index 1ec6eb4..7a0a8ee 100644
 -
    AC_SUBST([ENABLE_INTEGRATION], [$enable_integration])
  ]) # end function integration_test_checks
-  
+ 

--- a/pkgs/by-name/tp/tpm2-pkcs11/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11/package.nix
@@ -16,6 +16,7 @@
   opensc,
   openssh,
   openssl,
+  nix-update-script,
   nss,
   p11-kit,
   patchelf,
@@ -45,13 +46,13 @@ let
 in
 chosenStdenv.mkDerivation (finalAttrs: {
   pname = "tpm2-pkcs11";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "tpm2-software";
     repo = "tpm2-pkcs11";
     tag = finalAttrs.version;
-    hash = "sha256-W74ckrpK7ypny1L3Gn7nNbOVh8zbHavIk/TX3b8XbI8=";
+    hash = "sha256-o0a5MiFqLH7SuHG/BEtPVGOaDoV+kCu2l1MCHt5rWFc=";
   };
 
   # Disable Java‐based tests because of missing dependencies
@@ -242,6 +243,7 @@ chosenStdenv.mkDerivation (finalAttrs: {
         fapi-abrmd
         ;
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update from 1.9.1 to 1.9.2. Init tpm2-pkcs11-abrmd so it gets cached by Hydra.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
