### PR TITLE
bencher, bencher-console: init at 0.5.8

### DIFF
--- a/pkgs/by-name/be/bencher-console/package.nix
+++ b/pkgs/by-name/be/bencher-console/package.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  rustPlatform,
+  fetchNpmDeps,
+
+  bencher,
+  binaryen,
+  cargo,
+  clang,
+  lld,
+  makeWrapper,
+  nodejs,
+  npmHooks,
+  rustc,
+  wasm-bindgen-cli_0_2_100,
+  wasm-pack,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bencher-console";
+  version = bencher.version;
+
+  inherit (bencher) meta src;
+
+  npmRoot = "services/console";
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-npm-deps";
+    inherit (finalAttrs) version src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
+    hash = "sha256-bOy+H5JLOw4LmPkogeyBLYGe61PuHdQgxgJRHux83ro=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = bencher.cargoHash;
+  };
+
+  nativeBuildInputs = [
+    binaryen
+    cargo
+    clang
+    lld
+    nodejs
+    npmHooks.npmConfigHook
+    rustc
+    rustPlatform.cargoSetupHook
+    wasm-bindgen-cli_0_2_100
+    wasm-pack
+    makeWrapper
+  ];
+  buildPhase = ''
+    runHook preBuild
+
+    cd services/console
+
+    substituteInPlace astro.config.mjs \
+      --replace-fail '// import node from "@astrojs/node";' 'import node from "@astrojs/node";' \
+      --replace-fail 'adapter: undefined' 'adapter: node({mode: "standalone"})'
+
+    wasm-pack build ../../lib/bencher_valid --target web --release --no-default-features --features wasm
+
+    npm run build
+
+    substituteInPlace dist/server/entry.mjs \
+      --replace-fail 'file:///build/source/services/console/dist/client' "file://$out/client" \
+      --replace-fail 'file:///build/source/services/console/dist/server' "file://$out/server"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    sed -i '1s|^|#!/usr/bin/env node\n|' dist/server/entry.mjs
+    chmod +x  dist/server/entry.mjs
+    patchShebangs dist/server/entry.mjs
+
+    mkdir -p $out
+    cp -r dist/{client,server} node_modules $out
+
+    makeWrapper $out/server/entry.mjs $out/bin/bencher-console \
+      --set-default IS_BENCHER_CLOUD false \
+      --set-default GOOGLE_ANALYTICS_ID "" \
+      --set-default PUBLIC_SENTRY_DSN "" \
+      --set-default BENCHER_API_URL "https://localhost:61016"
+  '';
+})

--- a/pkgs/by-name/be/bencher/package.nix
+++ b/pkgs/by-name/be/bencher/package.nix
@@ -18,6 +18,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bencher";
   version = "0.5.8";
 
+  # When updating, also make sure to update npmDeps.hash in bencher-console!
   src = fetchFromGitHub {
     owner = "bencherdev";
     repo = "bencher";

--- a/pkgs/by-name/be/bencher/package.nix
+++ b/pkgs/by-name/be/bencher/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+  rustPlatform,
+
+  fontconfig,
+  mold,
+  pkg-config,
+
+  withCli ? true,
+  withApi ? true,
+}:
+assert withCli || withApi;
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bencher";
+  version = "0.5.8";
+
+  src = fetchFromGitHub {
+    owner = "bencherdev";
+    repo = "bencher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Nz+j8Iwjy4Ziw/L8D7SK3AFRIWP4QQyu63mQnc7dh4o=";
+  };
+
+  cargoHash = "sha256-3jiBz1gWO9klTeXMqVL16qczJptPf9HVksitiGversI=";
+
+  cargoBuildFlags = lib.cli.toGNUCommandLine { } {
+    package =
+      lib.optionals withApi [
+        "bencher_api"
+      ]
+      ++ lib.optionals withCli [
+        "bencher_cli"
+      ];
+  };
+
+  # The default features include `plus` which has a custom license
+  buildNoDefaultFeatures = true;
+
+  # does dlopen() libfontconfig during tests and at runtime
+  RUSTFLAGS = lib.optionalString stdenv.targetPlatform.isElf "-C link-arg=-Wl,--add-needed,${fontconfig.lib}/lib/libfontconfig.so";
+
+  nativeBuildInputs = [
+    # .cargo/config.toml selects mold
+    mold
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+  ];
+
+  postInstall = ''
+    mv $out/bin/api $out/bin/bencher-api
+  '';
+
+  meta = {
+    description = "Suite of continuous benchmarking tools";
+    homepage = "https://bencher.dev";
+    changelog = "https://github.com/bencherdev/bencher/releases/tag/v${finalAttrs.version}";
+    license = [
+      lib.licenses.asl20
+      lib.licenses.mit
+    ];
+    maintainers = with lib.maintainers; [
+      flokli
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "bencher";
+  };
+})


### PR DESCRIPTION
This adds the [Bencher](https://bencher.dev) CLI, API server and web frontend (console).

Initially requested in https://github.com/NixOS/nixpkgs/issues/390884.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
