### PR TITLE
jj-fzf: 0.33.0 -> 0.34.0, fix missing runtime dependencies

### DIFF
--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -39,7 +39,8 @@ stdenv.mkDerivation rec {
 
     # Fix Makefile to use absolute path for env
     substituteInPlace Makefile.mk \
-      --replace-fail "/usr/bin/env" "${lib.getExe' coreutils "env"}"\n  '';
+      --replace-fail "/usr/bin/env" "${lib.getExe coreutils \"env\"}"
+  '';
 
   buildPhase = ''
     runHook preBuild
@@ -72,7 +73,7 @@ stdenv.mkDerivation rec {
       --replace-fail 'readonly SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"' "readonly SCRIPT_DIR=\"$out/libexec/jj-fzf\""
 
     wrapProgram $out/bin/jj-fzf \
-      --prefix PATH : ${lib.makeBinPath buildInputs}
+      --prefix PATH : "${lib.makeBinPath buildInputs}"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -1,4 +1,19 @@
-{ lib, bashInteractive, coreutils, fetchFromGitHub, fzf, gawk, gnused, jujutsu, makeWrapper, pandoc, python3, stdenv, util-linux, installShellFiles, }
+{
+  lib,
+  bashInteractive,
+  coreutils,
+  fetchFromGitHub,
+  fzf,
+  gawk,
+  gnused,
+  jujutsu,
+  makeWrapper,
+  pandoc,
+  python3,
+  stdenv,
+  util-linux,
+  installShellFiles,
+}
 
 stdenv.mkDerivation rec {
   pname = "jj-fzf";
@@ -59,7 +74,7 @@ stdenv.mkDerivation rec {
 
     # Install helper scripts and libraries to libexec
     install -D -t $out/libexec/jj-fzf preflight.sh version.sh
-    cp -r lib $out/libexec/jj-fzf/;
+    cp -r lib $out/libexec/jj-fzf/
 
     # Install documentation
     installManPage doc/jj-fzf.1

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -8,30 +8,95 @@
   gnused,
   jujutsu,
   makeWrapper,
+  pandoc,
+  python3,
   stdenv,
+  util-linux,
 }:
 
 stdenv.mkDerivation rec {
   pname = "jj-fzf";
-  version = "0.33.0";
+  version = "0.34.0";
 
   src = fetchFromGitHub {
     owner = "tim-janik";
     repo = "jj-fzf";
-    tag = "v${version}";
-    hash = "sha256-iVgX2Lu06t1pCQl5ZGgl3+lTv4HAPKbD/83STDtYhdU=";
+    rev = "v${version}";
+    hash = "sha256-aJyKVMg/yI2CmAx5TxN0w670Rq26ESdLzESgh8Jr4nE=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    pandoc
+  ];
 
-  dontConfigure = true;
-  dontBuild = true;
+  buildInputs = [
+    bashInteractive
+    coreutils
+    fzf
+    gawk
+    gnused
+    jujutsu
+    python3
+    util-linux
+  ];
+
+  postPatch = ''
+    # Fix shebangs in all shell scripts
+    patchShebangs --build version.sh preflight.sh jj-fzf
+
+    # Patch scripts in lib directory
+    if [ -d lib ]; then
+      patchShebangs --build lib
+    fi
+
+    # Fix Makefile to use absolute path for env
+    substituteInPlace Makefile.mk \
+      --replace-fail "/usr/bin/env" "${lib.getExe' coreutils "env"}"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Ensure all build tools are in PATH
+    export PATH=${
+      lib.makeBinPath [
+        bashInteractive
+        coreutils
+        fzf
+        gawk
+        gnused
+        jujutsu
+        python3
+        util-linux
+      ]
+    }:$PATH
+
+    # Generate the manual page
+    make doc/jj-fzf.1
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
+
+    # Install main script
     install -D jj-fzf $out/bin/jj-fzf
-    substituteInPlace $out/bin/jj-fzf \
-      --replace-fail "/usr/bin/env bash" "${lib.getExe bashInteractive}"
+
+    # Install required dependencies
+    install -D preflight.sh $out/bin/preflight.sh
+    install -D version.sh $out/bin/version.sh
+
+    # Install lib directory and its contents
+    mkdir -p $out/bin/lib
+    cp -r lib/* $out/bin/lib/
+
+    # Install documentation
+    mkdir -p $out/share/man/man1
+    install -D doc/jj-fzf.1 $out/share/man/man1/jj-fzf.1
+
+    # Wrap with dependencies
     wrapProgram $out/bin/jj-fzf \
       --prefix PATH : ${
         lib.makeBinPath [
@@ -41,8 +106,11 @@ stdenv.mkDerivation rec {
           gawk
           gnused
           jujutsu
+          python3
+          util-linux
         ]
       }
+
     runHook postInstall
   '';
 
@@ -51,6 +119,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/tim-janik/jj-fzf";
     license = licenses.mpl20;
     maintainers = with maintainers; [ bbigras ];
-    platforms = platforms.all;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tim-janik";
     repo = "jj-fzf";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-aJyKVMg/yI2CmAx5TxN0w670Rq26ESdLzESgh8Jr4nE=";
   };
 

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
 
     # Fix Makefile to use absolute path for env
     substituteInPlace Makefile.mk \
-      --replace-fail "/usr/bin/env" "${lib.getExe coreutils \"env\"}"
+      --replace-fail "/usr/bin/env" "${lib.getExe' coreutils "env"}"
   '';
 
   buildPhase = ''

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -29,8 +29,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     pandoc
-    python3
-    util-linux
     installShellFiles
   ];
 

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
     gawk
     gnused
     jujutsu
+    python3
+    util-linux
   ];
 
   postPatch = ''

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -13,7 +13,7 @@
   stdenv,
   util-linux,
   installShellFiles,
-}
+}:
 
 stdenv.mkDerivation rec {
   pname = "jj-fzf";


### PR DESCRIPTION
## Description

Fixes the jj-fzf package which was missing critical runtime dependencies and files. The current package only installs the main script, but jj-fzf requires several additional files to function properly.

## Changes

### Version Update
- Bumped version from 0.33.0 to 0.34.0

### Added Missing Dependencies
- **pandoc**: Required to generate man page during build
- **python3**: Required by `lib/gen-message.py` helper script
- **util-linux**: Provides `column` command used by the tool

### Build Process Improvements

#### postPatch Phase
- Fixed shebangs in main scripts (version.sh, preflight.sh, jj-fzf)
- Fixed shebangs in all lib/ directory scripts
- Patched Makefile.mk to use absolute path for env instead of /usr/bin/env

#### buildPhase
- Added proper build phase to generate documentation
- Runs `make doc/jj-fzf.1` to create manual page

#### installPhase Enhancements
- Installed preflight.sh helper script (sourced by main script)
- Installed version.sh helper script (referenced by --version flag)
- Installed complete lib/ directory with all helper scripts
- Installed generated manual page to proper location ($out/share/man/man1/)

#### Runtime Dependencies
- Updated wrapProgram to include python3 and util-linux in PATH

### Other Changes
- Changed platforms from `platforms.all` to `platforms.unix` (more appropriate for shell scripts)

## Testing

Successfully built and tested locally with `nix build .#jj-fzf`. Build log shows:
- All shebangs properly patched
- Manual page generated successfully
- All required files installed
- No runtime errors

## Impact

Without these fixes, jj-fzf fails at runtime with errors about missing files (lib/setup.sh, preflight.sh, etc.).

## CC

@bbigras (current maintainer)