### PR TITLE
nixos/prometheus: init qBittorrent exporter

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -154,6 +154,8 @@
 
 - [Beszel](https://beszel.dev), a lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [`services.beszel.agent`](options.html#opt-services.beszel.agent.enable) and [`services.beszel.hub`](options.html#opt-services.beszel.hub.enable).
 
+- [prometheus-qbittorrent-exporter](https://github.com/martabal/qbittorrent-exporter), Prometheus exporter for qBittorrent. Available as [services.prometheus.exporters.qbittorrent](options.html#opt-services.prometheus.exporters.qbittorrent).
+
 - [Spoolman](https://github.com/Donkie/Spoolman), a inventory management system for Filament spools. Available as [services.spoolman](#opt-services.spoolman.enable).
 
 - [Temporal](https://temporal.io/), a durable execution platform that enables

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -110,6 +110,7 @@ let
         "process"
         "pve"
         "py-air-control"
+        "qbittorrent"
         "rasdaemon"
         "redis"
         "restic"

--- a/nixos/modules/services/monitoring/prometheus/exporters/qbittorrent.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/qbittorrent.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.qbittorrent;
+  inherit (lib)
+    mkOption
+    mkPackageOption
+    optionalAttrs
+    ;
+  inherit (lib.types)
+    str
+    path
+    attrsOf
+    nullOr
+    ;
+in
+{
+  port = 8090;
+
+  extraOpts = {
+    package = mkPackageOption pkgs "prometheus-qbittorrent-exporter" { };
+
+    url = mkOption {
+      type = nullOr str;
+      default = "http://localhost:8080";
+      description = ''
+        Url where qBittorrent is running.
+      '';
+    };
+
+    username = mkOption {
+      type = nullOr str;
+      default = "admin";
+      description = ''
+        qBittorrent username.
+      '';
+    };
+
+    environment = mkOption {
+      type = attrsOf str;
+      default = { };
+      description = ''
+        All available environment variables can be found in the
+        [`README.md`](https://github.com/martabal/qbittorrent-exporter?tab=readme-ov-file#environment-variables).
+
+        Some variables can also be set through the module options:
+
+        - `EXPORTER_PORT` via `port`
+        - `QBITTORRENT_BASE_URL` via `url`
+        - `QBITTORRENT_USERNAME` via `username`
+        - `QBITTORRENT_PASSWORD_FILE` via `passwordFile`
+      '';
+      example = {
+        EXPORTER_PATH = "/metrics2";
+        QBITTORRENT_TIMEOUT = "10";
+        ENABLE_TRACKER = "true";
+        ENABLE_INCREASED_CARDINALITY = "true";
+      };
+    };
+
+    passwordFile = mkOption {
+      type = nullOr path;
+      description = ''
+        Path to a file containing the qBittorrent password. Systemd's
+        LoadCredential functionality will make it accessible to the service.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = "${cfg.package}/bin/qbit-exp";
+      LoadCredential = lib.mkIf (cfg.passwordFile != null) "qbitPass:${cfg.passwordFile}";
+    };
+    environment = {
+      EXPORTER_PORT = toString cfg.port;
+    }
+    // optionalAttrs (cfg.url != null) {
+      QBITTORRENT_BASE_URL = cfg.url;
+    }
+    // optionalAttrs (cfg.username != null) {
+      QBITTORRENT_USERNAME = cfg.username;
+    }
+    // optionalAttrs (cfg.passwordFile != null) {
+      QBITTORRENT_PASSWORD_FILE = "%d/qbitPass";
+    }
+    // cfg.environment;
+  }
+  // optionalAttrs config.services.qbittorrent.enable {
+    after = [ "qbittorrent.service" ];
+    requires = [ "qbittorrent.service" ];
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1390,6 +1390,43 @@ let
       '';
     };
 
+    qbittorrent = {
+      exporterConfig = {
+        enable = true;
+        port = 8091;
+        username = "user";
+        url = "http://localhost:8088";
+        environment = {
+          ENABLE_TRACKER = "false";
+        };
+        # Don't do this in practice, it will put the password in the nix store.
+        passwordFile = pkgs.writeText "qbit.env" "adminadmin";
+      };
+      metricProvider = {
+        services.qbittorrent = {
+          enable = true;
+          webuiPort = 8088;
+          serverConfig = {
+            Preferences = {
+              WebUI = {
+                Username = "user";
+                # password: "adminadmin" as ByteArray
+                Password_PBKDF2 = "@ByteArray(6DIf26VOpTCYbgNiO6DAFQ==:e6241eaAWGzRotQZvVA5/up9fj5wwSAThLgXI2lVMsYTu1StUgX9MgmElU3Sa/M8fs+zqwZv9URiUOObjqJGNw==)";
+              };
+            };
+          };
+        };
+      };
+      exporterTest = # python
+        ''
+          wait_for_unit("qbittorrent.service")
+          wait_for_unit("prometheus-qbittorrent-exporter.service")
+          wait_for_open_port(8088)
+          wait_for_open_port(8091)
+          succeed("curl -sSf localhost:8091/metrics | grep qbittorrent_app_version")
+        '';
+    };
+
     redis = {
       exporterConfig = {
         enable = true;


### PR DESCRIPTION
With prometheus-qbittorrent-exporter being merge (https://github.com/NixOS/nixpkgs/pull/440033) we can now add the exporter module. 

The package allows for setting a lot of options via environment variables. For the most important/common environment variables options are available in the module. Others can be set via the `environment` option. 

For those that want to try it out, add the following lines to your config:

```
disabledModules = [ "services/monitoring/prometheus/exporters.nix" ];

  imports = [
    "${inputs.prom-qbit}/nixos/modules/services/monitoring/prometheus/exporters.nix"
  ];
```

and the following line to `flake.nix`:

```
prom-qbit.url = "github:undefined-landmark/nixpkgs/qbit-exp-module";
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
