### PR TITLE
Revert "solvespace: use system mimalloc (#450858)"

### DIFF
--- a/pkgs/by-name/so/solvespace/package.nix
+++ b/pkgs/by-name/so/solvespace/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   wrapGAppsHook3,
@@ -24,7 +23,6 @@
   libspnav,
   libthai,
   libxkbcommon,
-  mimalloc,
   pangomm,
   pcre,
   util-linuxMinimal, # provides libmount
@@ -43,13 +41,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-sSDht8pBrOG1YpsWfC/CLTTWh2cI5pn2PXGH900Z0yA=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/solvespace/files/solvespace-3.1-use-system-mimalloc.patch";
-      hash = "sha256-XEeh6vb4fYsTmAro1ZR/8NyFl+Y+S+m/Lx+tA7o2omM=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -76,7 +67,6 @@ stdenv.mkDerivation rec {
     libspnav
     libthai
     libxkbcommon
-    mimalloc
     pangomm
     pcre
     util-linuxMinimal


### PR DESCRIPTION
This reverts commit 6e123b592e1beeba99dce1230158ef121c192f9b (PR https://github.com/NixOS/nixpkgs/pull/450858 ), reversing changes made to dab90ffd8384d821ce638a6b46352b59bb600b8a.

That PR did not actually fix this build as the cmake policy was changed in a prior commit https://github.com/NixOS/nixpkgs/commit/38bc34e8c29c855bdf8a280f6b6f858ef9264ee3

The PR introduced a lot of crashes due to the mimalloc version set in nixpkgs known to not work with solvespace, see https://github.com/solvespace/solvespace/issues/1632

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
