### PR TITLE
clive: adapt version format to fix update notifier

### DIFF
--- a/pkgs/by-name/cl/clive/package.nix
+++ b/pkgs/by-name/cl/clive/package.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   ];
 
   ldflags = [
-    "-X github.com/koki-develop/clive/cmd.version=${version}"
+    "-X github.com/koki-develop/clive/cmd.version=v${version}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to fix false-positive alerts in update notifier which reported in https://github.com/NixOS/nixpkgs/pull/448737#issuecomment-3369046951.

The leading "v" is required by golang.org/x/mod/semver.

- https://cs.opensource.google/go/x/mod/+/master:semver/semver.go;l=6-7;drc=5517a715a62aaf2d2ab02e64ce67586c60767e8f
- https://github.com/koki-develop/clive/blob/114553637cf71500c673267ceab7194e06ee2951/.goreleaser.yaml#L10
- https://github.com/koki-develop/clive/blob/114553637cf71500c673267ceab7194e06ee2951/cmd/notify.go#L45-L46
- https://github.com/koki-develop/clive/blob/114553637cf71500c673267ceab7194e06ee2951/internal/util/version.go#L3

If testing the behavior, we should remove the cache before each run.

```console
> rm "$XDG_CACHE_HOME/clive/release.json"
> nix run .#clive -- --version
clive version v0.12.12
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @MisileLab @Sigmanificient 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
