### PR TITLE
ecwolf: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/by-name/ec/ecwolf/package.nix
+++ b/pkgs/by-name/ec/ecwolf/package.nix
@@ -20,23 +20,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ecwolf";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromBitbucket {
     owner = "ecwolf";
     repo = "ecwolf";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-V2pSP8i20zB50WtUMujzij+ISSupdQQ/oCYYrOaTU1g=";
+    hash = "sha256-T5K6B2fWMKMLB/662p/YLEv0Od9n0vUakznyoOnr0kI=";
   };
-
-  patches = [
-    # Fixes build with gcc >= 14. Shouldn't be needed for ecwolf versions > 1.4.1.
-    (fetchpatch {
-      name = "tmemory.h-const-correctness.patch";
-      url = "https://bitbucket.org/ecwolf/ecwolf/commits/400aaf96a36a14ab8eab18a670ba6439046f3bb0/raw";
-      hash = "sha256-2YwHEctBPyprs0DVsazimGEgmiCba24zh2dFfw9tOnU=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -57,15 +48,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   # ECWolf installs its binary to the games/ directory, but Nix only adds bin/
   # directories to the PATH.
-  postInstall =
-    lib.optionalString stdenv.hostPlatform.isLinux ''
-      mv "$out/games" "$out/bin"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      mkdir -p $out/{Applications,bin}
-      cp -R ecwolf.app $out/Applications
-      makeWrapper $out/{Applications/ecwolf.app/Contents/MacOS,bin}/ecwolf
-    '';
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/{Applications,bin}
+    cp -R ecwolf.app $out/Applications
+    makeWrapper $out/{Applications/ecwolf.app/Contents/MacOS,bin}/ecwolf
+  '';
 
   passthru.updateScript =
     let


### PR DESCRIPTION
Release notes: <https://maniacsvault.net/entry93>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `2f530fd78ee5a89ba0ceabff4fb3e4971788603b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>ecwolf</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
