### PR TITLE
kloak: init at 0.5.6-1 + module init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10683,6 +10683,12 @@
     github = "hxtmdev";
     githubId = 7771007;
   };
+  hydrafog = {
+    email = "surfinwave@proton.me";
+    github = "hydrafog";
+    githubId = 240524466;
+    name = "hydrafog";
+  };
   hypersw = {
     email = "baltic@hypersw.net";
     github = "hypersw";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1473,6 +1473,7 @@
   ./services/security/intune.nix
   ./services/security/jitterentropy-rngd.nix
   ./services/security/kanidm.nix
+  ./services/security/kloak.nix
   ./services/security/munge.nix
   ./services/security/nginx-sso.nix
   ./services/security/oauth2-proxy-nginx.nix

--- a/nixos/modules/services/security/kloak.nix
+++ b/nixos/modules/services/security/kloak.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.kloak;
+in
+{
+  options.services.kloak = {
+    enable = lib.mkEnableOption "kloak, a keystroke-level online anonymization kernel";
+
+    package = lib.mkPackageOption pkgs "kloak" { };
+
+    extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = lib.literalExpression ''
+        [
+          "--delay"
+          "100"
+          "--start-delay"
+          "500"
+        ]
+      '';
+      description = ''
+        Extra arguments passed to the kloak daemon.
+        Available options include:
+        - --delay: Maximum delay of released events in milliseconds (default: 100)
+        - --start-delay: Time to wait before startup in milliseconds (default: 500)
+        - --color: Virtual mouse cursor color in AARRGGBB format (default: ffff0000)
+        - --natural-scrolling: Enable natural scrolling (true|false, default: false)
+        - --esc-key-combo: Key combination to terminate kloak (default: KEY_RIGHTSHIFT,KEY_ESC)
+
+        See kloak --help for more details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.kloak = {
+      description = "Kloak Keystroke-Level Online Anonymization Kernel";
+      documentation = [ "https://github.com/Whonix/kloak" ];
+      after = [ "local-fs.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.escapeShellArgs ([ "${lib.getExe cfg.package}" ] ++ cfg.extraArgs);
+        Restart = "on-failure";
+        RestartSec = 2;
+
+        # Security hardening
+        User = "root";
+        CapabilityBoundingSet = [
+          "CAP_SYS_ADMIN"
+          "CAP_SYS_RAWIO"
+        ];
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/kl/kloak/package.nix
+++ b/pkgs/by-name/kl/kloak/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libevdev,
+  libinput,
+  libxkbcommon,
+  wayland,
+  wayland-scanner,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kloak";
+  version = "0.5.6-1";
+
+  src = fetchFromGitHub {
+    owner = "Whonix";
+    repo = "kloak";
+    tag = version;
+    hash = "sha256-ddSfEnEp7E+hZTrYXghv1Tf/u6dbx4pp/cUOS6Ksje0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libevdev
+    libinput
+    libxkbcommon
+    wayland
+  ];
+
+  # Skip the pkg-config check in the Makefile since we know it's available
+  preBuild = ''
+    # The Makefile uses 'which' to check for pkg-config, but we don't need this check
+    # since Nix guarantees pkg-config is available via nativeBuildInputs
+    substituteInPlace Makefile \
+      --replace-fail 'ifeq (, $(shell which $(PKG_CONFIG)))' 'ifeq (, )' \
+      --replace-fail '$(error pkg-config not installed!)' ""
+  '';
+
+  installFlags = [
+    "prefix=$(out)"
+    "apparmor_dir=$(out)/etc/apparmor.d"
+  ];
+
+  meta = {
+    description = "Keystroke-level online anonymization kernel that obfuscates typing behavior";
+    longDescription = ''
+      kloak is a privacy tool that makes keystroke biometrics less effective.
+      This is accomplished by obfuscating the time intervals between key press
+      and release events, which are typically used to identify users based on
+      their typing behavior.
+    '';
+    homepage = "https://github.com/Whonix/kloak";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ hydrafog ];
+    mainProgram = "kloak";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description

This PR adds kloak, a keystroke-level online anonymization kernel designed for wlroots-based Wayland compositors.

kloak is a privacy tool that obfuscates typing behavior by injecting jitter into input events, making keystroke biometrics less effective for user identification. It works by adding random delays to key press and release events, which prevents timing-based fingerprinting of users based on their typing patterns.

**Important**: kloak only works with wlroots-based Wayland compositors (Sway, Hyprland, etc.) and will NOT work with X11.

This PR includes:
- Package derivation at `pkgs/by-name/kl/kloak/package.nix`
- NixOS module at `nixos/modules/services/security/kloak.nix`
- Comprehensive systemd security hardening

Homepage: https://github.com/Whonix/kloak

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (not applicable - Wayland only)
  - [ ] aarch64-darwin (not applicable - Wayland only)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`

- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking. (N/A - new package)
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
