### PR TITLE
Revert "nixos/services.openvpn: add package option"

### DIFF
--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -11,6 +11,8 @@ let
 
   cfg = config.services.openvpn;
 
+  inherit (pkgs) openvpn;
+
   makeOpenVPNJob =
     cfg: name:
     let
@@ -75,7 +77,7 @@ let
         pkgs.net-tools
       ];
 
-      serviceConfig.ExecStart = "@${cfg.package}/sbin/openvpn openvpn --suppress-timestamps --config ${configFile}";
+      serviceConfig.ExecStart = "@${openvpn}/sbin/openvpn openvpn --suppress-timestamps --config ${configFile}";
       serviceConfig.Restart = "always";
       serviceConfig.Type = "notify";
     };
@@ -163,8 +165,6 @@ in
                 `config = "config /path/to/config.ovpn"`
               '';
             };
-
-            package = lib.mkPackageOption pkgs "openvpn" { };
 
             up = mkOption {
               default = "";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#354301.

It fails to evaluate due to undefined variable `openvpn` in `environments.systemPackage`.