### PR TITLE
gfxreconstruct: 1.0.4 -> 1.0.4-unstable-2025-10-30

### DIFF
--- a/pkgs/by-name/gf/gfxreconstruct/package.nix
+++ b/pkgs/by-name/gf/gfxreconstruct/package.nix
@@ -18,23 +18,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gfxreconstruct";
-  version = "1.0.4";
+  version = "1.0.4-unstable-2025-10-30";
 
   src = fetchFromGitHub {
     owner = "LunarG";
     repo = "gfxreconstruct";
-    tag = "v${version}";
-    hash = "sha256-MuCdJoBFxKwDCOCltlU3oBS9elFS6F251dHjHcIb4Jg=";
+    rev = "4f1fa3aa9870b00404e6597283b2032a885303b3";
+    hash = "sha256-HwGmtkVQJirKikb37A/dQeEr3AWmqJMfBj46UKsS5m8=";
     fetchSubmodules = true;
   };
-
-  cmakeFlags = [
-    # The CMakeLists.txt is actually 3.10 compatible, but it specifies 3.5 as `CMAKE_VERSION_MINIMUM`
-    "-DCMAKE_POLICY_VERSION_MINIMUM=3.10"
-  ];
-
-  # Workaround for "error: ... class std::__cxx11::wstring_convert' is deprecated [-Werror=deprecated-declarations]"
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   buildInputs = [
     libX11
@@ -72,6 +64,9 @@ stdenv.mkDerivation rec {
       --prefix VK_ADD_LAYER_PATH : "$out/share/vulkan/explicit_layer.d"
     wrapProgram $out/bin/gfxrecon-replay \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+
+    # Remove unrelated files that got installed
+    rm -r $out/lib/{cmake,pkgconfig}
   '';
 
   meta = {


### PR DESCRIPTION
There has been no release supporting cmake 4 (and no general release in the last year), so update to the latest commit.

Fixes the build with cmake 4.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
