### PR TITLE
USWM: Add option to pass args to the compositor

### DIFF
--- a/nixos/modules/programs/wayland/uwsm.nix
+++ b/nixos/modules/programs/wayland/uwsm.nix
@@ -16,7 +16,7 @@ let
         [Desktop Entry]
         Name=${opts.prettyName} (UWSM)
         Comment=${opts.comment}
-        Exec=${lib.getExe cfg.package} start -F ${opts.binPath}
+        Exec=${lib.getExe cfg.package} start -F -- ${opts.binPath} ${lib.strings.escapeShellArgs opts.extraArgs}
         Type=Application
       '';
       destination = "/share/wayland-sessions/${opts.name}-uwsm.desktop";
@@ -84,6 +84,13 @@ in
                 '';
                 example = "/run/current-system/sw/bin/ExampleCompositor";
               };
+              extraArgs = lib.mkOption {
+                type = with lib.types; listOf str;
+                default = [ ];
+                description = ''
+                  Extra command-line arguments pass to to the compsitor.
+                '';
+              };
             };
           }
         )
@@ -117,7 +124,12 @@ in
         name: value:
         mk_uwsm_desktop_entry {
           inherit name;
-          inherit (value) prettyName comment binPath;
+          inherit (value)
+            prettyName
+            comment
+            binPath
+            extraArgs
+            ;
         }
       ) cfg.waylandCompositors;
     };


### PR DESCRIPTION
As this is not possible with the binPath
https://github.com/Vladimir-csp/uwsm?tab=readme-ov-file#syntax-and-behavior


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@JohnRTitor 
