### PR TITLE
fetchFromGitHub: pass `owner`, `repo`, `rev`, `tag` to `mkDerivation` and make `rev` and `tag` overridable with `<pkg>.overrideAttrs`

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -62,7 +62,7 @@ lib.makeOverridable (
           rev ? null,
           name ? urlToName {
             inherit url;
-            rev = lib.revOrTag rev finalAttrs.tag;
+            rev = lib.revOrTag finalAttrs.revCustom finalAttrs.tag;
             # when rootDir is specified, avoid invalidating the result when rev changes
             append = if rootDir != "" then "-${lib.strings.sanitizeDerivationName rootDir}" else "";
           },
@@ -174,9 +174,10 @@ lib.makeOverridable (
               gitConfigFile
               ;
             inherit tag;
+            revCustom = rev;
             rev = getRevWithTag {
               inherit (finalAttrs) tag;
-              inherit rev;
+              rev = finalAttrs.revCustom;
             };
 
             postHook =

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -30,6 +30,9 @@ lib.makeOverridable (
       # Passed via `passthru`
       "tag"
 
+      # Additional stdenv.mkDerivation arguments from derived fetchers.
+      "derivationArgs"
+
       # Hashes, handled by `lib.fetchers.withNormalizedHash`
       # whose outputs contain outputHash* attributes.
       "hash"
@@ -84,6 +87,10 @@ lib.makeOverridable (
           rootDir ? "",
           # GIT_CONFIG_GLOBAL (as a file)
           gitConfigFile ? config.gitConfigFile,
+          # Additional stdenvNoCC.mkDerivation arguments.
+          # It is typically for derived fetchers to pass down additional arguments,
+          # and the specified arguments have lower precedence than other mkDerivation arguments.
+          derivationArgs ? { },
         }:
 
         /*
@@ -135,7 +142,8 @@ lib.makeOverridable (
           throw
             "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
         else
-          {
+          derivationArgs
+          // {
             inherit name;
 
             builder = ./builder.sh;

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -227,3 +227,6 @@ lib.makeOverridable (
     inheritFunctionArgs = false;
   }
 )
+// {
+  inherit getRevWithTag;
+}

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -42,9 +42,6 @@ lib.makeOverridable (
     constructDrv = stdenvNoCC.mkDerivation;
 
     excludeDrvArgNames = [
-      # Passed via `passthru`
-      "tag"
-
       # Additional stdenv.mkDerivation arguments from derived fetchers.
       "derivationArgs"
 
@@ -65,7 +62,7 @@ lib.makeOverridable (
           rev ? null,
           name ? urlToName {
             inherit url;
-            rev = lib.revOrTag rev tag;
+            rev = lib.revOrTag rev finalAttrs.tag;
             # when rootDir is specified, avoid invalidating the result when rev changes
             append = if rootDir != "" then "-${lib.strings.sanitizeDerivationName rootDir}" else "";
           },
@@ -176,7 +173,11 @@ lib.makeOverridable (
               rootDir
               gitConfigFile
               ;
-            rev = getRevWithTag { inherit tag rev; };
+            inherit tag;
+            rev = getRevWithTag {
+              inherit (finalAttrs) tag;
+              inherit rev;
+            };
 
             postHook =
               if netrcPhase == null then
@@ -216,7 +217,6 @@ lib.makeOverridable (
 
             passthru = {
               gitRepoUrl = url;
-              inherit tag;
             }
             // passthru;
           }

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -113,6 +113,7 @@ lib.makeOverridable (
     revWithTag = if tag != null then "refs/tags/${tag}" else rev;
 
     fetcherArgs =
+      finalAttrs:
       passthruAttrs
       // (
         if useFetchGit then
@@ -127,6 +128,12 @@ lib.makeOverridable (
               ;
             url = gitRepoUrl;
             inherit passthru;
+            derivationArgs = {
+              inherit
+                owner
+                repo
+                ;
+            };
           }
           // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
         else
@@ -139,7 +146,7 @@ lib.makeOverridable (
             url =
               if private then
                 let
-                  endpoint = "/repos/${owner}/${repo}/tarball/${revWithTag}";
+                  endpoint = "/repos/${finalAttrs.owner}/${finalAttrs.repo}/tarball/${revWithTag}";
                 in
                 if githubBase == "github.com" then
                   "https://api.github.com${endpoint}"
@@ -148,7 +155,12 @@ lib.makeOverridable (
               else
                 "${baseUrl}/archive/${revWithTag}.tar.gz";
             extension = "tar.gz";
-
+            derivationArgs = {
+              inherit
+                owner
+                repo
+                ;
+            };
             passthru = {
               inherit gitRepoUrl;
             }

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -11,7 +11,8 @@ lib.makeOverridable (
     repo,
     tag ? null,
     rev ? null,
-    name ? repoRevToNameMaybe repo (lib.revOrTag rev tag) "github",
+    # TODO(@ShamrockLee): Add back after reconstruction with lib.extendMkDerivation
+    # name ? repoRevToNameMaybe finalAttrs.repo (lib.revOrTag finalAttrs.revCustom finalAttrs.tag) "github",
     fetchSubmodules ? false,
     leaveDotGit ? null,
     deepClone ? false,
@@ -176,7 +177,10 @@ lib.makeOverridable (
       )
       // privateAttrs
       // {
-        inherit name;
+        # TODO(@ShamrockLee): Change back to `inherit name;` after reconstruction with lib.extendMkDerivation
+        name =
+          args.name
+            or (repoRevToNameMaybe finalAttrs.repo (lib.revOrTag finalAttrs.revCustom finalAttrs.tag) "github");
         meta = newMeta;
       };
   in

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -159,6 +159,7 @@ lib.makeOverridable (
               inherit
                 owner
                 repo
+                tag
                 ;
             };
             passthru = {
@@ -176,7 +177,6 @@ lib.makeOverridable (
 
   fetcher fetcherArgs
   // {
-    inherit owner repo tag;
     rev = revWithTag;
   }
 )

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -158,12 +158,12 @@ lib.makeOverridable (
       // privateAttrs
       // {
         inherit name;
+        meta = newMeta;
       };
   in
 
   fetcher fetcherArgs
   // {
-    meta = newMeta;
     inherit owner repo tag;
     rev = revWithTag;
   }

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -129,6 +129,7 @@ lib.makeOverridable (
             inherit passthru;
             derivationArgs = {
               inherit
+                githubBase
                 owner
                 repo
                 ;
@@ -159,6 +160,7 @@ lib.makeOverridable (
             extension = "tar.gz";
             derivationArgs = {
               inherit
+                githubBase
                 owner
                 repo
                 tag

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -110,8 +110,6 @@ lib.makeOverridable (
 
     gitRepoUrl = "${baseUrl}.git";
 
-    revWithTag = if tag != null then "refs/tags/${tag}" else rev;
-
     fetcherArgs =
       finalAttrs:
       passthruAttrs
@@ -137,6 +135,9 @@ lib.makeOverridable (
           }
           // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
         else
+          let
+            revWithTag = finalAttrs.rev;
+          in
           {
             # Use the API endpoint for private repos, as the archive URI doesn't
             # support access with GitHub's fine-grained access tokens.
@@ -161,6 +162,11 @@ lib.makeOverridable (
                 repo
                 tag
                 ;
+              rev = fetchgit.getRevWithTag {
+                inherit (finalAttrs) tag;
+                rev = finalAttrs.revCustom;
+              };
+              revCustom = rev;
             };
             passthru = {
               inherit gitRepoUrl;
@@ -176,7 +182,4 @@ lib.makeOverridable (
   in
 
   fetcher fetcherArgs
-  // {
-    rev = revWithTag;
-  }
 )

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -60,6 +60,9 @@ lib.extendMkDerivation {
     # Passed via passthru
     "url"
 
+    # Additional stdenv.mkDerivation arguments from derived fetchers.
+    "derivationArgs"
+
     # Hash attributes will be map to the corresponding outputHash*
     "hash"
     "sha1"
@@ -139,6 +142,11 @@ lib.extendMkDerivation {
 
       # Additional packages needed as part of a fetch
       nativeBuildInputs ? [ ],
+
+      # Additional stdenvNoCC.mkDerivation arguments.
+      # It is typically for derived fetchers to pass down additional arguments,
+      # and the specified arguments have lower precedence than other mkDerivation arguments.
+      derivationArgs ? { },
     }@args:
 
     let
@@ -228,7 +236,8 @@ lib.extendMkDerivation {
           "${lib.head mirrorList}${lib.elemAt mirrorSplit 1}";
     in
 
-    {
+    derivationArgs
+    // {
       name =
         if pname != null && version != null then
           "${finalAttrs.pname}-${finalAttrs.version}"

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -20,7 +20,7 @@ lib.extendMkDerivation {
   excludeDrvArgNames = [
     "extraPostFetch"
 
-    # TODO(@ShamrockLee): Move these arguments to derivationArgs when available.
+    # Pass via derivationArgs
     "extension"
     "stripRoot"
   ];
@@ -48,8 +48,8 @@ lib.extendMkDerivation {
 
     let
       tmpFilename =
-        if extension != null then
-          "download.${extension}"
+        if finalAttrs.extension != null then
+          "download.${finalAttrs.extension}"
         else
           baseNameOf (if url != "" then url else builtins.head urls);
     in
@@ -81,7 +81,7 @@ lib.extendMkDerivation {
         chmod -R +w "$unpackDir"
       ''
       + (
-        if stripRoot then
+        if finalAttrs.stripRoot then
           ''
             if [ $(ls -A "$unpackDir" | wc -l) != 1 ]; then
               echo "error: zip file must contain a single file or directory."
@@ -109,5 +109,12 @@ lib.extendMkDerivation {
       '';
       # ^ Remove non-owner write permissions
       # Fixes https://github.com/NixOS/nixpkgs/issues/38649
+
+      derivationArgs = {
+        inherit
+          extension
+          stripRoot
+          ;
+      };
     };
 }

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -42,6 +42,11 @@ lib.extendMkDerivation {
       # an appropriate unpacking tool.
       extension ? null,
 
+      # Additional stdenvNoCC.mkDerivation arguments.
+      # It is typically for derived fetchers to pass down additional arguments,
+      # and the specified arguments have lower precedence than other mkDerivation arguments.
+      derivationArgs ? { },
+
       # the rest are given to fetchurl as is
       ...
     }@args:
@@ -110,7 +115,7 @@ lib.extendMkDerivation {
       # ^ Remove non-owner write permissions
       # Fixes https://github.com/NixOS/nixpkgs/issues/38649
 
-      derivationArgs = {
+      derivationArgs = derivationArgs // {
         inherit
           extension
           stripRoot


### PR DESCRIPTION
This PR adds the `derivationArgs` argument to fetchers like `fetchurl`, `fetchzip`, and `fetchgit` for derived fetchers to pass down default arguments to `stdenvNoCC.mkDerivation`.

Contrasting to previous works to preserve those attributes after `<pkg>.overrideAttrs` using `passtru`, this PR passes them directly down `stdenv.mkDerivation` and make them overridable as, e.g., `tag` instead of `passthru.tag`. Even with a larger diff, it could better address #444503 and #370418 from the overriding perspective.

This PR surpasses:
- #294329
- #370432
- #455637

Detail:
- `fetchurl`, `fetchzip`, and `fetchgit`: Add argument `derivationArgs`
  It takes derivationArgs from extended build helpers and pass them all the way down `stdenvNoCC.mkDerivation`.
  Their precedence are lower than any other arguments specified by the current build helper or by the user.
- `fetchzip`: Pass arguments `extension` and `stripRoot` down `mkDerivation` via `derivationArgs`, and make them overridable with `<pkg>.overrideAttrs`.
- `fetchgit`: Make `tag` and `rev` overridable with `<pkg>.overrideAttrs` as `tag` and `revCustom`.
  - Pass `tag` directly to `mkDerivation` instead of via `passthru.tag`.
  - Pass `rev` to `mkDerivation` as `revCustom` (since `revWithHash` has been passed as `rev`).
  - Make other arguments observe the `tag` and `revCustom` overridden via `<pkg>.overrideAttrs`, i.e., `finalAttrs.tag` and `finalAttrs.revCustom`.
- `fetchgit`: Abstract, simplify, and expose `getRevWithHash`
  - Abstract the `revWithTag` construction as `getRevWithHash`.
  - Simplify the conditional expression. The number of branch condition stays the same when either one of `tag` and `rev` is specified, and only increase when both unspecified (which is a rare edge-case).
  - Expose the helper function `getRevWithTag` as `fetchgit.getRevWithTag` so that other fetchers can form this value the same way.
- Fix how `fetchFromGitHub` handle its `owner`, `repo`, `rev`, `tag`, and `meta` arguments, making them equally overridable whether the backend fetcher is `fetchzip` or `fetchgit`.
  - Pass `meta` properly via `fetcherArgs`.
  - Add `finalAttrs` to `fetcherArgs` to utilize `fetchurl` and `fetchgit`'s fixed-point arguments support, as a workaround before `fetchFromGitHub` itself are reconstructed with `lib.extendMkDerivation`.
  - Pass `owner` and `repo` to `mkDerivation` via `derivationArgs`. We can start fixing their overriding after `lib.extendMkDerivation` reconstruction.
  - Make `tag` and `rev` pass the same way as `fetchzip` does when using the `fetchzip` backend, with the help of `derivationArgs`:
    ```nix
    finalAttrs:
    let
      revWithTag = finalAttrs.rev;
    in
    {
      derivationArgs = {
        inherit tag;
        revCustom = rev;
        rev = fetchgit.getRevWithTag {
          inherit (finalAttrs) tag;
          rev = finalAttrs.revCustom;
        };
      };
      # Other fetcher arguments using `revWithTag`
    }
    ```
- Move `name` specification temporarily down the `fetcherArg` so as to reference from `finalAttrs`. We can move it back during reconstruction with `lib.extendMkDerivation`.
- Pass `githubBase` with `derivationArgs` to prevent rebuilds when we make it overridable in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
