### PR TITLE
protonmail-bridge-gui: add Qt 6.10 compatibility patches

### DIFF
--- a/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
@@ -12,8 +12,12 @@
   gtest,
   sentry-native,
   protonmail-bridge,
+  fetchpatch2,
 }:
 
+let
+  guiSourcePath = "internal/frontend/bridge-gui";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "protonmail-bridge-gui";
 
@@ -22,6 +26,18 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Use `gtest` from Nixpkgs to allow an offline build
     ./use-nix-googletest.patch
+    # fix: qt6_generate_deploy_app_script deprecated keyword
+    (fetchpatch2 {
+      url = "https://github.com/daniel-fahey/proton-bridge/commit/9b282369523ce2aabcf95369a2ed3867efb5a4ac.patch?full_index=1";
+      relative = guiSourcePath;
+      hash = "sha256-CGBelsplAqLI+6GtDR+VELfVsLoHPN0324gfZ3obKpI=";
+    })
+    # fix: make libQt6WaylandEglClientHwIntegration conditional for Qt 6.10
+    (fetchpatch2 {
+      url = "https://github.com/daniel-fahey/proton-bridge/commit/7823fe4904186253798fc633724988d43dd642e0.patch?full_index=1";
+      relative = guiSourcePath;
+      hash = "sha256-2heMfZdXLL8/uyM0jZ860Jw76c+gHtc0G6pWmIRCONY=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -44,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     sentry-native
   ];
 
-  sourceRoot = "${finalAttrs.src.name}/internal/frontend/bridge-gui";
+  sourceRoot = "${finalAttrs.src.name}/${guiSourcePath}";
 
   postPatch = ''
     # Bypass `vcpkg` by deleting lines that `include` BridgeSetup.cmake


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/456408


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
