### PR TITLE
mathpix-snipping-tool: 03.00.0072 -> 03.00.0138

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2658,6 +2658,12 @@
     github = "Axler1";
     githubId = 69816272;
   };
+  axodentally = {
+    name = "Henri Wagner";
+    email = "axo@frankfurt.ccc.de";
+    github = "axodentally";
+    githubId = 24368475;
+  };
   ayazhafiz = {
     email = "ayaz.hafiz.1@gmail.com";
     github = "hafiz";

--- a/pkgs/by-name/ma/mathpix-snipping-tool/package.nix
+++ b/pkgs/by-name/ma/mathpix-snipping-tool/package.nix
@@ -5,11 +5,11 @@
 }:
 let
   pname = "mathpix-snipping-tool";
-  version = "03.00.0072";
+  version = "03.00.0138";
 
   src = fetchurl {
     url = "https://download.mathpix.com/linux/Mathpix_Snipping_Tool-x86_64.v${version}.AppImage";
-    sha256 = "1igg8wnshmg9f23qqw1gqb85h1aa3461c1n7dmgw6sn4lrrrh5ms";
+    sha256 = "sha256-29iLdrWxqLL7uRfHae8Mq+w9yaGtM9Y5vRLzYESgzBs=";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };

--- a/pkgs/by-name/ma/mathpix-snipping-tool/package.nix
+++ b/pkgs/by-name/ma/mathpix-snipping-tool/package.nix
@@ -2,6 +2,7 @@
   appimageTools,
   lib,
   fetchurl,
+  makeWrapper,
 }:
 let
   pname = "mathpix-snipping-tool";
@@ -17,17 +18,24 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
 
     cp -r ${appimageContents}/usr/share/icons $out/share
+
+    wrapProgram $out/bin/${pname} --set QT_QPA_PLATFORM xcb
   '';
 
   meta = with lib; {
     description = "OCR tool to convert pictures to LaTeX";
     homepage = "https://mathpix.com/";
     license = licenses.unfree;
-    maintainers = [ maintainers.hiro98 ];
+    maintainers = [
+      maintainers.hiro98
+      maintainers.axodentally
+    ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "mathpix-snipping-tool";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

-->
Update ancient mathpix version to current one.
Also apply fix for wayland environments and add myself as a maintainer (fixes https://github.com/NixOS/nixpkgs/issues/414692)

The fix I applied works great for using mathpix on Gnome, but I did not try any other desktop environment / compositor. So testing is appreciated here! Although it probably will not be worse than what is currently offered in the repo.

Changelog can be found here: https://mathpix.com/docs/snip/changelog#windows although mathpix did not update the linux changelog for quite some time and the windows changelog is also a few (or one?) version behind.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
