### PR TITLE
mgmt: unstable-2022-10-24 -> 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13283,6 +13283,13 @@
     githubId = 34152449;
     name = "Karl Hallsby";
   };
+  karpfediem = {
+    name = "Karpfen";
+    github = "karpfediem";
+    githubId = 11753414;
+    email = "nixos@karpfen.dev";
+    matrix = "@karpfen:matrix.org";
+  };
   kashw2 = {
     email = "supra4keanu@hotmail.com";
     github = "kashw2";

--- a/pkgs/by-name/mg/mgmt/package.nix
+++ b/pkgs/by-name/mg/mgmt/package.nix
@@ -52,11 +52,14 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  meta = with lib; {
+  meta = {
     description = "Next generation distributed, event-driven, parallel config management";
     homepage = "https://mgmtconfig.com";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ urandom ];
+    maintainers = with lib.maintainers; [
+      urandom
+      karpfediem
+    ];
     mainProgram = "mgmt";
   };
 })

--- a/pkgs/by-name/mg/mgmt/package.nix
+++ b/pkgs/by-name/mg/mgmt/package.nix
@@ -10,28 +10,24 @@
   pkg-config,
   ragel,
 }:
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "mgmt";
-  version = "unstable-2022-10-24";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "purpleidea";
     repo = "mgmt";
-    rev = "d8820fa1855668d9e0f7a7829d9dd0d122b2c5a9";
-    hash = "sha256-jurZvEtiaTjWeDkmCJDIFlTzR5EVglfoDxkFgOilo8s=";
+    tag = finalAttrs.version;
+    hash = "sha256-Qi9KkWzFOqmUp5CSHxzQabQ8bVnBbxxKS/W6aLBTv6k=";
   };
 
-  # patching must be done in prebuild, so it is shared with goModules
-  # see https://github.com/NixOS/nixpkgs/issues/208036
-  preBuild = ''
-    for file in `find -name Makefile -type f`; do
-      substituteInPlace $file --replace "/usr/bin/env " ""
-    done
+  vendorHash = "sha256-XZTDqN5nQqze41Y/jOhT3mFHXeR2oPjXpz7CJuPOi8k=";
 
-    substituteInPlace lang/types/Makefile \
-      --replace "unset GOCACHE && " ""
+  postPatch = ''
     patchShebangs misc/header.sh
-    make lang funcgen
+  '';
+  preBuild = ''
+    make lang resources funcgen
   '';
 
   buildInputs = [
@@ -50,19 +46,17 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X main.program=mgmt"
-    "-X main.version=${version}"
+    "-X main.program=${finalAttrs.pname}"
+    "-X main.version=${finalAttrs.version}"
   ];
 
   subPackages = [ "." ];
 
-  vendorHash = "sha256-Dtqy4TILN+7JXiHKHDdjzRTsT8jZYG5sPudxhd8znXY=";
-
   meta = with lib; {
     description = "Next generation distributed, event-driven, parallel config management";
     homepage = "https://mgmtconfig.com";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ urandom ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ urandom ];
     mainProgram = "mgmt";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Resolves https://github.com/NixOS/nixpkgs/issues/453975

Updated mgmt from unstable-2022-10-24 -> 1.0.1

Release Notes for 1.0.0
https://github.com/purpleidea/mgmt/blob/master/docs/release-notes/1.0.0
https://github.com/purpleidea/mgmt/releases/tag/1.0.0

Release Notes for 1.0.1
https://github.com/purpleidea/mgmt/blob/master/docs/release-notes/1.0.1
https://github.com/purpleidea/mgmt/releases/tag/1.0.1

Release 1.0.1 contains a fix so `mgmt` compiles under go1.25 (https://github.com/purpleidea/mgmt/commit/307660e9bceebe4c6b6bb9676e8f7e6427e24c36) .
This fix addresses the same build failure as seen in https://github.com/NixOS/nixpkgs/issues/453975.

I've also added myself to the package's maintainer list since i am contributor to mgmt and personally have interest keeping it up to date here in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
