### PR TITLE
transmissionic: init at 1.8.0

### DIFF
--- a/pkgs/by-name/tr/transmissionic/package.nix
+++ b/pkgs/by-name/tr/transmissionic/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage rec {
+  pname = "transmissionic";
+  version = "v1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "6c65726f79";
+    repo = "Transmissionic";
+    rev = version;
+    hash = "sha256-ROJljJuNqViNs2axQppxpbDByDL82yhbGIDDV9UQeZ8=";
+  };
+
+  npmDepsHash = "sha256-/Px6vthVCBw0vLhkeMNZ5VuZQWSr+iglYn4lUxKNEvE=";
+
+  npmBuildScript = "build:webui";
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+    touch $out/default.json
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Remote for Transmission Daemon";
+    homepage = "https://github.com/6c65726f79/Transmissionic";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      stackptr
+    ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/tr/transmissionic/package.nix
+++ b/pkgs/by-name/tr/transmissionic/package.nix
@@ -3,14 +3,14 @@
   buildNpmPackage,
   fetchFromGitHub,
 }:
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "transmissionic";
-  version = "v1.8.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "6c65726f79";
     repo = "Transmissionic";
-    rev = version;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ROJljJuNqViNs2axQppxpbDByDL82yhbGIDDV9UQeZ8=";
   };
 
@@ -26,13 +26,11 @@ buildNpmPackage rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Remote for Transmission Daemon";
     homepage = "https://github.com/6c65726f79/Transmissionic";
-    license = licenses.mit;
-    maintainers = with maintainers; [
-      stackptr
-    ];
-    platforms = platforms.all;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stackptr ];
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Adds Transmissionic, a web UI for [transmission](https://transmissionbt.com).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
