### PR TITLE
nixos/borgbackup: Add option createCommand

### DIFF
--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -98,7 +98,7 @@ in
             dumpCommand = pkgs.writeScript "createTarArchive" ''
               ${lib.getExe pkgs.gnutar} cf - ${dataDir}
             '';
-            dumpCommandProducesTar = true;
+            createCommand = "import-tar";
             repo = localTarRepo;
             # Make sure in import-tar mode encryption flags are still respected.
             encryption = {

--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -9,6 +9,7 @@ let
   keepFile = "important_file";
   keepFileData = "important_data";
   localRepo = "/root/back:up";
+  localTarRepo = "/root/backup-tar";
   # a repository on a file system which is not mounted automatically
   localRepoMount = "/noAutoMount";
   archiveName = "my_archive";
@@ -47,7 +48,7 @@ in
 
   nodes = {
     client =
-      { ... }:
+      { lib, pkgs, ... }:
       {
         virtualisation.fileSystems.${localRepoMount} = {
           device = "tmpfs";
@@ -91,6 +92,20 @@ in
             encryption.mode = "none";
             wrapper = null;
             startAt = [ ];
+          };
+
+          localTar = {
+            dumpCommand = pkgs.writeScript "createTarArchive" ''
+              ${lib.getExe pkgs.gnutar} cf - ${dataDir}
+            '';
+            dumpCommandProducesTar = true;
+            repo = localTarRepo;
+            # Make sure in import-tar mode encryption flags are still respected.
+            encryption = {
+              mode = "repokey";
+              inherit passphrase;
+            };
+            startAt = [ ]; # Do not run automatically
           };
 
           remote = {
@@ -230,6 +245,19 @@ in
 
         # Make sure disabling wrapper works
         client.fail("command -v borg-job-localMount")
+
+    with subtest("localTar"):
+        borg = "BORG_PASSPHRASE='${passphrase}' borg"
+        client.systemctl("start --wait borgbackup-job-localTar")
+        client.fail("systemctl is-failed borgbackup-job-localTar")
+        archiveName, = client.succeed("{} list --format '{{archive}}{{NL}}' '${localTarRepo}'".format(borg)).strip().split("\n")
+        # Since excludes are not supported by import-tar, we expect to find exclude file, too
+        client.succeed(
+            "{} list '${localTarRepo}::{}' | grep -qF '${excludeFile}'".format(borg, archiveName)
+        )
+        # Make sure keepFile has the correct content
+        client.succeed("{} extract '${localTarRepo}::{}'".format(borg, archiveName))
+        assert "${keepFileData}" in client.succeed("cat ${dataDir}/${keepFile}")
 
     with subtest("remote"):
         borg = "BORG_RSH='ssh -oStrictHostKeyChecking=no -i /root/id_ed25519' borg"


### PR DESCRIPTION
Add an option `service.borgbackup.jobs.<name>.createCommand` that allows using `borg import-tar` rather than `borg create` to import an archive.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
