### PR TITLE
kgeotag: 1.8.0-unstable-2025-07-25 -> 1.8.0-unstable-2025-11-01 (fix crash on startup)

### DIFF
--- a/pkgs/by-name/kg/kgeotag/package.nix
+++ b/pkgs/by-name/kg/kgeotag/package.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation {
   pname = "kgeotag";
-  version = "1.8.0-unstable-2025-07-25";
+  version = "1.8.0-unstable-2025-11-01";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     repo = "kgeotag";
     owner = "graphics";
-    rev = "b2b140e8f72ab37bad3729bea527203324d12131";
-    hash = "sha256-jUcKm4IPQt2JiZUmIjMJ9EG0kDjzoPGjzBPMHZ6j9lM=";
+    rev = "879418eb57e96beb5be3e3a69d0bab2b666b7c7f";
+    hash = "sha256-RFC8UMrURn2vsTRjPFyLNlsep/PWRadkRkS7aFtTlKE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
`kgeotagui.rc` was not included in the output but is required to run kgeotag.
It must be located under `~/.local/share/kxmlgui5/kgeotag/kgeotagui.rc` or similar xdg data location.

[setupGUI](https://api.kde.org/kxmlguiwindow.html#setupGUI-1) is called by kgeotag ([MainWindow.cpp#L176](https://invent.kde.org/graphics/kgeotag/-/blob/1f09ed355771c7e2ec7c2c50640cbc5e4047a1be/src/MainWindow.cpp#L176)) and the software crashes a couple of lines later due to the missing rc file.

The file search is implemented here: [kxmlguiclient.cpp#L220](https://github.com/KDE/kxmlgui/blob/01ea0abb57ebff1d0b7a36d5f9b0145ceb2209e5/src/kxmlguiclient.cpp#L220).

Without this change, kgeotag crashes at startup on my system:

```
...
marble_lib: Style reset requested.
marble_lib: In MarbleMap the property  "license" was set to  false
marble_lib: "license" to false
kf.xmlgui: cannot find .rc file "kgeotagui.rc" for component "kgeotag"
Received signal 11 SEGV_MAPERR 000000000008
#0 0x7fffee658a85 base::debug::CollectStackTrace()
#1 0x7fffee63c1c6 base::debug::StackTrace::StackTrace()
#2 0x7fffee659279 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#3 0x7fffe4e414b0 (/nix/store/g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66/lib/libc.so.6+0x414af)
#4 0x7fffe6da82a4 QMenu::menuAction()
#5 0x000000476eec MainWindow::MainWindow()
#6 0x00000042951b main
#7 0x7fffe4e2a47e __libc_start_call_main
#8 0x7fffe4e2a539 __libc_start_main_alias_2
#9 0x00000042c7b5 _start
  r8: 0000000000000000  r9: 0000000000000000 r10: 0000000000000000 r11: 0000000000000000
 r12: 0000000000000000 r13: 00007fffe546f920 r14: 00007ffffffd1650 r15: 00007ffffffd1630
  di: 0000000000000000  si: 0000000000000000  bp: 00000000015aee90  bx: 00007ffffffd1670
  dx: 0000000000000000  ax: 0000000000000000  cx: 0000000000000000  sp: 00007ffffffd15d8
  ip: 00007fffe6da82a4 efl: 0000000000010246 cgf: 002b000000000033 erf: 0000000000000004
 trp: 000000000000000e msk: 0000000000000000 cr2: 0000000000000008
[end of stack trace]
Segmentation fault (core dumped)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

~~Will check this in the next few days. So far I have a working local clone of the package [in my nix config](https://github.com/ede1998/nix-config/commit/d143936f0cfe9dfda5fdc236bcf4db310574f40a).~~

Checked the "things done" list. (Also simplified [my local adaption](https://github.com/ede1998/nix-config/commit/c5aed102c73c6303012b372f667f26f8530f4911) of the package)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
