### PR TITLE
vesktop: build libvesktop

### DIFF
--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -9,8 +9,11 @@
   copyDesktopItems,
   vencord,
   electron,
+  glib,
   libicns,
   pipewire,
+  pkg-config,
+  python3,
   libpulseaudio,
   autoPatchelfHook,
   pnpm_10,
@@ -44,6 +47,53 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Vn+Imarp1OTPfe/PoMgFHU5eWnye5Oa+qoGZaTxOUmU=";
   };
 
+  libvesktop = stdenv.mkDerivation (finalAttrs': {
+    pname = "libvesktop";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${finalAttrs'.src.name}/packages/libvesktop";
+
+    pnpmDeps = pnpm_10.fetchDeps {
+      inherit (finalAttrs')
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      fetcherVersion = 2;
+      hash = "sha256-0WlkDPoxTVWe4h22UBswwWHF513hBHpYjhbZNnHhiZQ=";
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_10.configHook
+      python3
+    ];
+
+    buildInputs = [
+      glib
+      pkg-config
+    ];
+
+    env.npm_config_nodedir = nodejs;
+
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 build/Release/vesktop.node $out/lib/vesktop/vesktop.node
+
+      runHook postInstall
+    '';
+  });
+
   nativeBuildInputs = [
     nodejs
     pnpm_10.configHook
@@ -76,6 +126,11 @@ stdenv.mkDerivation (finalAttrs: {
       inherit vencord;
     }
   );
+
+  postPatch = ''
+    substituteInPlace scripts/build/build.mts \
+      --replace-fail "./packages/libvesktop/build/Release/vesktop.node" "$libvesktop/lib/vesktop/vesktop.node"
+  '';
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
@@ -169,7 +224,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit (finalAttrs) pnpmDeps;
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "libvesktop"
+      ];
+    };
   };
 
   meta = {

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -89,7 +89,7 @@ in
 
             # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
             # any pnpm command would fail in that directory, the following disables this
-            pushd ..
+            pushd /
             pnpm config set manage-package-manager-versions false
             popd
 

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -32,7 +32,8 @@ pnpmConfigHook() {
 
     # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
     # any pnpm command would fail in that directory, the following disables this
-    pushd ..
+    # We are assuming that / does not contain a pnpm workspace
+    pushd /
     pnpm config set manage-package-manager-versions false
     popd
 


### PR DESCRIPTION
Since 1.6.0 vesktop has a native lib for dbus stuff.

See https://github.com/Vencord/Vesktop/pull/1180

This PR builds the lib instead of using the prebuilt binaries in the repo

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
