### PR TITLE
mesa: Only build OpenCL stuff on platforms where it works, fix build on ppc64

### DIFF
--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -117,6 +117,10 @@ stdenv.mkDerivation {
     mainProgram = "llvm-spirv";
     license = lib.licenses.ncsa;
     platforms = lib.platforms.unix;
+    # Issues with endianness handling outside of LE, in this + SPIRV-Tools + glslang
+    # https://github.com/KhronosGroup/SPIRV-Tools/issues/5595
+    # https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2397
+    badPlatforms = lib.platforms.bigEndian;
     maintainers = with lib.maintainers; [ gloaming ];
     broken = !(versions ? ${llvmMajor});
   };

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -54,18 +54,15 @@
   # We enable as many drivers as possible here, to build cross tools
   # and support emulation use cases (emulated x86_64 on aarch64, etc)
   galliumDrivers ? [
-    "asahi" # Apple AGX
     "crocus" # Intel legacy
     "d3d12" # WSL emulated GPU (aka Dozen)
     "ethosu" # ARM Ethos NPU
     "etnaviv" # Vivante GPU designs (mostly NXP/Marvell SoCs)
     "freedreno" # Qualcomm Adreno (all Qualcomm SoCs)
     "i915" # Intel extra legacy
-    "iris" # new Intel (Broadwell+)
     "lima" # ARM Mali 4xx
     "llvmpipe" # software renderer
     "nouveau" # Nvidia
-    "panfrost" # ARM Mali Midgard and up (T/G series)
     "r300" # very old AMD
     "r600" # less old AMD
     "radeonsi" # new AMD (GCN+)
@@ -77,20 +74,29 @@
     "vc4" # Broadcom VC4 (Raspberry Pi 0-3)
     "virgl" # QEMU virtualized GPU (aka VirGL)
     "zink" # generic OpenGL over Vulkan, experimental
+  ]
+  # See platformOpenCLWorks
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform spirv-llvm-translator) [
+    "asahi" # Apple AGX
+    "iris" # new Intel (Broadwell+)
+    "panfrost" # ARM Mali Midgard and up (T/G series)
   ],
   vulkanDrivers ? [
     "amd" # AMD (aka RADV)
-    "asahi" # Apple AGX
     "broadcom" # Broadcom VC5 (Raspberry Pi 4, aka V3D)
     "freedreno" # Qualcomm Adreno (all Qualcomm SoCs)
     "gfxstream" # Android virtualized GPU
-    "imagination" # PowerVR Rogue (currently N/A)
     "intel_hasvk" # Intel Haswell/Broadwell, "legacy" Vulkan driver (https://www.phoronix.com/news/Intel-HasVK-Drop-Dead-Code)
-    "intel" # new Intel (aka ANV)
     "microsoft-experimental" # WSL virtualized GPU (aka DZN/Dozen)
+    "swrast" # software renderer (aka Lavapipe)
+  ]
+  # See platformOpenCLWorks
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform spirv-llvm-translator) [
+    "asahi" # Apple AGX
+    "imagination" # PowerVR Rogue (currently N/A)
+    "intel" # new Intel (aka ANV)
     "nouveau" # Nouveau (aka NVK)
     "panfrost" # ARM Mali Midgard and up (T/G series)
-    "swrast" # software renderer (aka Lavapipe)
   ]
   ++
     lib.optionals
@@ -141,6 +147,9 @@ let
 
   needNativeCLC = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
+  # See spirv-llvm-translator.meta.badPlatforms for details
+  platformOpenCLWorks = lib.meta.availableOn stdenv.hostPlatform spirv-llvm-translator;
+
   common = import ./common.nix { inherit lib fetchFromGitLab; };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -168,9 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
-    # OpenCL drivers pull in ~1G of extra LLVM stuff, so don't install them
-    # if the user didn't explicitly ask for it
-    "opencl"
     # the Dozen drivers depend on libspirv2dxil, but link it statically, and
     # libspirv2dxil itself is pretty chonky, so relocate it to its own output in
     # case anything wants to use it at some point
@@ -184,6 +190,11 @@ stdenv.mkDerivation (finalAttrs: {
     # - for a cross build (needNativeCLC = true), we provide mesa with `*-clc`
     #   binaries, so it skips building & installing any new CLC files.
     "cross_tools"
+  ]
+  ++ lib.optionals platformOpenCLWorks [
+    # OpenCL drivers pull in ~1G of extra LLVM stuff, so don't install them
+    # if the user didn't explicitly ask for it
+    "opencl"
   ];
 
   # Keep build-ids so drivers can use them for caching, etc.
@@ -227,7 +238,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "clang-libdir" "${lib.getLib llvmPackages.clang-unwrapped}/lib")
 
     # Rusticl, new OpenCL frontend
-    (lib.mesonBool "gallium-rusticl" true)
+    (lib.mesonBool "gallium-rusticl" platformOpenCLWorks)
     (lib.mesonOption "gallium-rusticl-enable-drivers" "auto")
 
     # Enable more sensors in gallium-hud
@@ -248,10 +259,13 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "video-codecs" "all")
   ]
   ++ lib.optionals (!needNativeCLC) [
-    # Build and install extra tools for cross
-    (lib.mesonOption "tools" "asahi,panfrost")
     (lib.mesonBool "install-mesa-clc" true)
     (lib.mesonBool "install-precomp-compiler" true)
+  ]
+  # These need OpenCL / libclc support
+  ++ lib.optionals (!needNativeCLC && platformOpenCLWorks) [
+    # Build and install extra tools for cross
+    (lib.mesonOption "tools" "asahi,panfrost")
   ]
   ++ lib.optionals needNativeCLC [
     (lib.mesonOption "mesa-clc" "system")
@@ -283,9 +297,7 @@ stdenv.mkDerivation (finalAttrs: {
     llvmPackages.clang-unwrapped
     llvmPackages.libllvm
     lm_sensors
-    mesa-libclc
     python3Packages.python # for shebang
-    spirv-llvm-translator
     udev
     vulkan-loader
     wayland
@@ -296,6 +308,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withValgrind [
     valgrind-light
+  ]
+  ++ lib.optionals platformOpenCLWorks [
+    mesa-libclc
+    spirv-llvm-translator
   ];
 
   depsBuildBuild = [
@@ -346,10 +362,14 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput bin/pco_clc $cross_tools
     moveToOutput bin/vtn_bindgen2 $cross_tools
 
+  ''
+  + lib.optionalString platformOpenCLWorks ''
     moveToOutput "lib/lib*OpenCL*" $opencl
     # Construct our own .icd file that contains an absolute path.
     mkdir -p $opencl/etc/OpenCL/vendors/
     echo $opencl/lib/libRusticlOpenCL.so > $opencl/etc/OpenCL/vendors/rusticl.icd
+  ''
+  + ''
 
     moveToOutput bin/spirv2dxil $spirv2dxil
     moveToOutput "lib/libspirv_to_dxil*" $spirv2dxil
@@ -381,7 +401,16 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --host --update $out/bin/*
 
     # add RPATH here so Zink can find libvulkan.so
-    patchelf --add-rpath ${vulkan-loader}/lib $out/lib/libgallium*.so $opencl/lib/libRusticlOpenCL.so
+    patchelf --add-rpath ${vulkan-loader}/lib ${
+      lib.strings.concatStringsSep " " (
+        [
+          "$out/lib/libgallium*.so"
+        ]
+        ++ lib.optionals platformOpenCLWorks [
+          "$opencl/lib/libRusticlOpenCL.so"
+        ]
+      )
+    }
   '';
 
   passthru = {


### PR DESCRIPTION
OpenCL support doesn't work when building natively on non-LE platforms: https://catfox.life/2024/11/29/the-complexities-of-enabling-opencl-support/

Eventually, the SPIRV stuff that comes before this might need to be marked broken on non-LE just to communicate this properly. But the first place where I've directly stumbled into this is when building `mesa`.

OpenCL stuff is only needed when building [specific drivers](https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-25.2.5/meson.build?ref_type=tags#L800-822), so we need to exclude those when this option is set to false.

(this is untested beyond "it builds", I'm not super familiar with all this stuff)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
