### PR TITLE
saga: fix build with cudaSupport

### DIFF
--- a/pkgs/by-name/sa/saga/package.nix
+++ b/pkgs/by-name/sa/saga/package.nix
@@ -1,47 +1,51 @@
 {
-  stdenv,
   lib,
+  stdenv,
   fetchurl,
-  # native
+
+  # nativeBuildInputs
   cmake,
-  desktopToDarwinBundle,
   dos2unix,
   pkg-config,
   wrapGAppsHook3,
-  # not native
-  gdal,
-  wxGTK32,
-  proj,
-  libsForQt5,
+  # darwin-specific
+  desktopToDarwinBundle,
+
+  # buildInputs
   curl,
-  libiodbc,
-  xz,
-  libharu,
-  opencv,
-  vigra,
-  pdal,
-  libpq,
-  unixODBC,
-  poppler,
-  hdf5,
-  netcdf,
-  sqlite,
-  qhull,
-  giflib,
-  libsvm,
   fftw,
+  gdal,
+  giflib,
+  hdf5,
+  libharu,
+  libiodbc,
+  libpq,
+  libsForQt5,
+  libsvm,
+  opencv,
+  pdal,
+  proj,
+  qhull,
+  vigra,
+  wxGTK32,
+  xz,
+  # darwin-specific
+  netcdf,
+  poppler,
+  sqlite,
+  unixODBC,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "saga";
   version = "9.10.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/saga-gis/saga-${version}.tar.gz";
+    url = "mirror://sourceforge/saga-gis/saga-${finalAttrs.version}.tar.gz";
     hash = "sha256-xsXOB4WCzkZhH/mIYEUQNiQ9NnX+0CF2IcWkmwEJBUA=";
   };
 
-  sourceRoot = "saga-${version}/saga-gis";
+  sourceRoot = "saga-${finalAttrs.version}/saga-gis";
 
   postPatch = ''
     dos2unix src/saga_core/saga_gui/res/org.saga_gis.saga_gui.desktop
@@ -50,37 +54,42 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     dos2unix
-    wrapGAppsHook3
     pkg-config
+    wrapGAppsHook3
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
+  ];
 
   buildInputs = [
     curl
-    libsForQt5.dxflib
     fftw
-    libsvm
-    hdf5
     gdal
-    wxGTK32
+    giflib
+    hdf5
+    libharu
+    libiodbc
+    libpq
+    libsForQt5.dxflib
+    libsvm
+    opencv
     pdal
     proj
-    libharu
-    opencv
-    vigra
-    libpq
-    libiodbc
-    xz
     qhull
-    giflib
+    vigra
+    wxGTK32
+    xz
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
   ]
   # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
   # for why the have additional buildInputs on darwin
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    unixODBC
-    poppler
     netcdf
+    poppler
     sqlite
+    unixODBC
   ];
 
   cmakeFlags = [
@@ -90,7 +99,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "System for Automated Geoscientific Analyses";
     homepage = "https://saga-gis.sourceforge.io";
-    changelog = "https://sourceforge.net/p/saga-gis/wiki/Changelog%20${version}/";
+    changelog = "https://sourceforge.net/p/saga-gis/wiki/Changelog%20${finalAttrs.version}/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       michelk
@@ -99,4 +108,4 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.geospatial ];
     platforms = with lib.platforms; unix;
   };
-}
+})

--- a/pkgs/by-name/sa/saga/package.nix
+++ b/pkgs/by-name/sa/saga/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  config,
   fetchurl,
 
   # nativeBuildInputs
@@ -8,6 +9,8 @@
   dos2unix,
   pkg-config,
   wrapGAppsHook3,
+  # cuda-specific
+  cudaPackages,
   # darwin-specific
   desktopToDarwinBundle,
 
@@ -34,6 +37,8 @@
   poppler,
   sqlite,
   unixODBC,
+
+  cudaSupport ? config.cudaSupport,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -56,6 +61,9 @@ stdenv.mkDerivation (finalAttrs: {
     dos2unix
     pkg-config
     wrapGAppsHook3
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     desktopToDarwinBundle


### PR DESCRIPTION
## Things done

Currently fails on `master` when built with `config.cudaSupport = true`:
```
CMake Error at /nix/store/5bn5f4ivqf4xn19khh4kcg4ngnjs6spg-cmake-4.1.2/share/cmake-4.1/Modules/FindCUDAToolkit.cmake:890 (message):
  Could not find nvcc, please set CUDAToolkit_ROOT.
Call Stack (most recent call first):
  /nix/store/26sdy4wcwgba0ai0x1sb6rg5s2v7grxa-opencv-4.12.0/lib/cmake/opencv4/OpenCVConfig.cmake:86 (find_package)
  /nix/store/26sdy4wcwgba0ai0x1sb6rg5s2v7grxa-opencv-4.12.0/lib/cmake/opencv4/OpenCVConfig.cmake:108 (find_host_package)
  src/tools/imagery/imagery_opencv/CMakeLists.txt:32 (find_package)
```

cc @michelk @mpickering

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
