### PR TITLE
git-tools: init at 2025.08

### DIFF
--- a/pkgs/by-name/gi/git-tools/package.nix
+++ b/pkgs/by-name/gi/git-tools/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+  bash,
+  git,
+  python3,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "git-tools";
+  version = "2025.08";
+
+  src = fetchFromGitHub {
+    owner = "MestreLion";
+    repo = "git-tools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DuhvepcDXk+UTFbvmv5V/EGP9ZEnHBYk7ARm/z0gTLY=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  buildInputs = [
+    bash
+    git
+    python3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 git-* -t "$out"/bin
+
+    for exe in "$out"/bin/*; do
+        wrapProgram "$exe" \
+            --prefix PATH : "$out"/bin:${lib.makeBinPath finalAttrs.buildInputs}
+    done
+
+    runHook postInstall
+  '';
+  postInstall = ''
+    installManPage \
+      man1/*.1
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/git-restore-mtime";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/MestreLion/git-tools/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Assorted git tools, including git-restore-mtime";
+    homepage = "https://github.com/MestreLion/git-tools";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ aduh95 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/MestreLion/git-tools

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
