### PR TITLE
tests.overriding: refactor and allow non-bool expected value

### DIFF
--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -43,24 +43,24 @@ let
     in
     {
       repeatedOverrides-pname = {
-        expr = repeatedOverrides.pname == "a-better-hello-with-blackjack";
-        expected = true;
+        expr = repeatedOverrides.pname;
+        expected = "a-better-hello-with-blackjack";
       };
       repeatedOverrides-entangled-pname = {
-        expr = repeatedOverrides.entangled.pname == "a-better-figlet-with-blackjack";
-        expected = true;
+        expr = repeatedOverrides.entangled.pname;
+        expected = "a-better-figlet-with-blackjack";
       };
       overriding-using-only-attrset = {
-        expr = (pkgs.hello.overrideAttrs { pname = "hello-overriden"; }).pname == "hello-overriden";
-        expected = true;
+        expr = (pkgs.hello.overrideAttrs { pname = "hello-overriden"; }).pname;
+        expected = "hello-overriden";
       };
       overriding-using-only-attrset-no-final-attrs = {
         name = "overriding-using-only-attrset-no-final-attrs";
         expr =
           ((stdenvNoCC.mkDerivation { pname = "hello-no-final-attrs"; }).overrideAttrs {
             pname = "hello-no-final-attrs-overridden";
-          }).pname == "hello-no-final-attrs-overridden";
-        expected = true;
+          }).pname;
+        expected = "hello-no-final-attrs-overridden";
       };
     };
 
@@ -118,16 +118,16 @@ let
         expected = true;
       };
       extendMkDerivation-helloLocal-plain-equivalence = {
-        expr = helloLocal.drvPath == helloLocalPlain.drvPath;
-        expected = true;
+        expr = helloLocal.drvPath;
+        expected = helloLocalPlain.drvPath;
       };
       extendMkDerivation-helloLocal-finalAttrs = {
-        expr = helloLocal.bar == "ab";
-        expected = true;
+        expr = helloLocal.bar;
+        expected = "ab";
       };
       extendMkDerivation-helloLocal-specialArg = {
-        expr = hiLocal.greeting == "Hi!";
-        expected = true;
+        expr = hiLocal.greeting;
+        expected = "Hi!";
       };
     };
 
@@ -152,27 +152,35 @@ let
     in
     {
       hash-outputHash-equivalence = {
-        expr = ruamel_0_17_21-src.outputHash == ruamel_0_17_21-hash;
-        expected = true;
+        expr = ruamel_0_17_21-src.outputHash;
+        expected = ruamel_0_17_21-hash;
       };
 
       hash-overridability-outputHash = {
-        expr = ruamel_0_17_21-src-by-overriding.outputHash == ruamel_0_17_21-hash;
-        expected = true;
+        expr = ruamel_0_17_21-src-by-overriding.outputHash;
+        expected = ruamel_0_17_21-hash;
       };
 
       hash-overridability-drvPath = {
-        expr =
-          lib.isString ruamel_0_17_21-src-by-overriding.drvPath
-          && ruamel_0_17_21-src-by-overriding.drvPath == ruamel_0_17_21-src.drvPath;
-        expected = true;
+        expr = [
+          (lib.isString ruamel_0_17_21-src-by-overriding.drvPath)
+          ruamel_0_17_21-src-by-overriding.drvPath
+        ];
+        expected = [
+          true
+          ruamel_0_17_21-src.drvPath
+        ];
       };
 
       hash-overridability-outPath = {
-        expr =
-          lib.isString ruamel_0_17_21-src-by-overriding.outPath
-          && ruamel_0_17_21-src-by-overriding.outPath == ruamel_0_17_21-src.outPath;
-        expected = true;
+        expr = [
+          (lib.isString ruamel_0_17_21-src-by-overriding.outPath)
+          ruamel_0_17_21-src-by-overriding.outPath
+        ];
+        expected = [
+          true
+          ruamel_0_17_21-src.outPath
+        ];
       };
     };
 
@@ -249,44 +257,32 @@ let
       pet-vendored = pet-foo.overrideAttrs { vendorHash = null; };
     in
     {
-      buildGoModule-overrideAttrs = {
-        expr =
-          lib.all
-            (
-              attrPath:
-              let
-                attrPathPretty = lib.concatStringsSep "." attrPath;
-                valueNative = lib.getAttrFromPath attrPath pet_0_4_0;
-                valueOverridden = lib.getAttrFromPath attrPath pet_0_4_0-overridden;
-              in
-              lib.warnIfNot (valueNative == valueOverridden)
-                "pet_0_4_0.${attrPathPretty} (${valueNative}) does not equal pet_0_4_0-overridden.${attrPathPretty} (${valueOverridden})"
-                true
-            )
-            [
-              [ "drvPath" ]
-              [ "name" ]
-              [ "pname" ]
-              [ "version" ]
-              [ "vendorHash" ]
-              [
-                "goModules"
-                "drvPath"
-              ]
-              [
-                "goModules"
-                "name"
-              ]
-              [
-                "goModules"
-                "outputHash"
-              ]
-            ];
-        expected = true;
-      };
+      buildGoModule-overrideAttrs =
+        let
+          getComparingAttrs = p: {
+            inherit (p)
+              drvPath
+              name
+              pname
+              version
+              vendorHash
+              ;
+            goModules = {
+              inherit (p.goModules)
+                drvPath
+                name
+                outPath
+                ;
+            };
+          };
+        in
+        {
+          expr = getComparingAttrs pet_0_4_0-overridden;
+          expected = getComparingAttrs pet_0_4_0;
+        };
       buildGoModule-goModules-overrideAttrs = {
-        expr = pet-foo.goModules.FOO == "foo";
-        expected = true;
+        expr = pet-foo.goModules.FOO;
+        expected = "foo";
       };
       buildGoModule-goModules-overrideAttrs-vendored = {
         expr = lib.isString pet-vendored.drvPath;


### PR DESCRIPTION
- Refactor test package generation:
  - Use Nix languages equality operator to compare `expr` and `expected` at evaluation time, instead of comparing their string-interpolation at build time.
  - Use structured attributes to pass `testResults` instead of dumping all the values into `buildCommand`.
  - Aside from `passthru.tests`, add `passthru.failures` for `lib.runTest`-generated list of failed tests, similar to `lib/tests/misc`.
- Refactor test cases
  - Change all tests in the form
    ```nix
    {
      expr = realExpr == realExpected;
      expected = true;
    }
    ```
    to
    ```nix
    {
      expr = realExpr;
      expected = realExpected;
    }
    ```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
