### PR TITLE
python313Packages.monai-deploy: mark broken

### DIFF
--- a/pkgs/development/python-modules/monai-deploy/default.nix
+++ b/pkgs/development/python-modules/monai-deploy/default.nix
@@ -9,6 +9,7 @@
   pytestCheckHook,
   pythonOlder,
   setuptools,
+  tritonclient,
   typeguard,
   versioneer,
 }:
@@ -17,8 +18,6 @@ buildPythonPackage rec {
   pname = "monai-deploy";
   version = "3.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Project-MONAI";
@@ -43,6 +42,7 @@ buildPythonPackage rec {
     numpy
     networkx
     colorama
+    tritonclient
     typeguard
   ];
 
@@ -64,12 +64,13 @@ buildPythonPackage rec {
     # like highdicom and pydicom
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Framework and tools to design, develop and verify AI applications in healthcare imaging";
     mainProgram = "monai-deploy";
     homepage = "https://monai.io/deploy.html";
     changelog = "https://github.com/Project-MONAI/monai-deploy-app-sdk/blob/main/docs/source/release_notes/${src.tag}.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ bcdarwin ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    broken = true; # requires holoscan and holoscan-cli, not in Nixpkgs
   };
 }


### PR DESCRIPTION
Package was broken in a recent mass update as it now depends on NVIDIA holoscan and holoscan-cli, which are not in Nixpkgs. Reverting also seems suboptimal as the previously working version of MONAI Deploy is quite dated.

ZHF: #457852

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
