### PR TITLE
ente-desktop: 1.7.14 -> 1.7.15, mark as broken on darwin

### DIFF
--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   nodejs,
-  electron_37,
+  electron_38,
   yarnConfigHook,
   copyDesktopItems,
   vips,
@@ -15,12 +15,12 @@
   imagemagick,
 }:
 let
-  electron = electron_37;
+  electron = electron_38;
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ente-desktop";
-  version = "1.7.14";
+  version = "1.7.15";
 
   src = fetchFromGitHub {
     owner = "ente-io";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
       "web"
     ];
     tag = "photosd-v${finalAttrs.version}";
-    hash = "sha256-UtKXg3SZxHo18VKuVP7W40SfZfa9ni+QJ7+GvGWptSA=";
+    hash = "sha256-QnJp+oHkRsb/uMobA33Hgo2VOzfDFDtJ6vchCAzyb+c=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/desktop";
@@ -39,13 +39,13 @@ stdenv.mkDerivation (finalAttrs: {
   offlineCache = fetchYarnDeps {
     name = "ente-desktop-${finalAttrs.version}-offline-cache";
     inherit (finalAttrs) src sourceRoot;
-    hash = "sha256-6o5TaqlgEQWZjde5cthiSVLVy5JiCHXApn7uXBWmTo0=";
+    hash = "sha256-dnjTH68lNqSD/RIiaYdip0U8a2RXCNanqF05WnhzjEA=";
   };
   webOfflineCache = fetchYarnDeps {
     name = "ente-desktop-${finalAttrs.version}-web-offline-cache";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/web";
-    hash = "sha256-gwOeznAp4nGu4spilkFl8Dbmdye3Wg8VnBLroSdUjUo=";
+    hash = "sha256-m+7woB5XnOPDMLpoIBui1GxeW1BOms18SKJ8vaJcv68=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -145,5 +145,6 @@ stdenv.mkDerivation (finalAttrs: {
       iedame
     ];
     platforms = lib.platforms.all;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
https://github.com/ente-io/ente/compare/photosd-v1.7.14...photosd-v1.7.15

upstream finally bumped to electron 38

As per https://github.com/NixOS/nixpkgs/pull/456852#issuecomment-3465772652 and https://github.com/NixOS/nixpkgs/issues/452858, marking as broken on darwin. To be fixed in a separate PR.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
