### PR TITLE
python3Packages.hass-nabucasa: 1.1.1 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -9,6 +9,7 @@
   cryptography,
   fetchFromGitHub,
   freezegun,
+  josepy,
   pycognito,
   pyjwt,
   pytest-aiohttp,
@@ -20,13 +21,15 @@
   setuptools,
   snitun,
   syrupy,
+  voluptuous,
   webrtc-models,
   xmltodict,
+  yarl,
 }:
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "1.1.1";
+  version = "1.5.1";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -35,7 +38,7 @@ buildPythonPackage rec {
     owner = "nabucasa";
     repo = "hass-nabucasa";
     tag = version;
-    hash = "sha256-4wqlV3stqbraiDBp/g5XNMiUR8SsmGggqXlq6MXXgbM=";
+    hash = "sha256-BYRVr8YWYG+6vmCFCEJH0v2s+EpefDxmcBMHkXHRCrA=";
   };
 
   postPatch = ''
@@ -58,11 +61,14 @@ buildPythonPackage rec {
     attrs
     ciso8601
     cryptography
+    josepy
     pycognito
     pyjwt
     sentence-stream
     snitun
+    voluptuous
     webrtc-models
+    yarl
   ];
 
   nativeCheckInputs = [
@@ -73,11 +79,6 @@ buildPythonPackage rec {
     pytestCheckHook
     syrupy
     xmltodict
-  ];
-
-  disabledTests = [
-    # mock time 10800s (3h) vs 43200s (12h)
-    "test_subscription_reconnection_handler_renews_and_starts"
   ];
 
   pythonImportsCheck = [ "hass_nabucasa" ];

--- a/pkgs/development/python-modules/sentence-stream/default.nix
+++ b/pkgs/development/python-modules/sentence-stream/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "sentence-stream";
-  version = "1.2.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OHF-Voice";
     repo = "sentence-stream";
     tag = "v${version}";
-    hash = "sha256-xGxgGOl8PM5Nc7ApeiRKdaKeoxsc/a7oBF+Ld+vtYDo=";
+    hash = "sha256-KCKOiY2x+gj02PR0ps2e5Ei6o17tk5ujgCTr3/fkV0Y=";
   };
 
   build-system = [
@@ -26,10 +26,6 @@ buildPythonPackage rec {
 
   dependencies = [
     regex
-  ];
-
-  pythonRelaxDeps = [
-    "regex"
   ];
 
   nativeCheckInputs = [
@@ -42,7 +38,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    description = "A small sentence splitter for text streams";
+    description = "Small sentence splitter for text streams";
     homepage = "https://github.com/OHF-Voice/sentence-stream";
     changelog = "https://github.com/OHF-Voice/sentence-stream/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;


### PR DESCRIPTION
Diff: https://github.com/NabuCasa/hass-nabucasa/compare/1.1.1...1.5.1

Changelog:
https://github.com/NabuCasa/hass-nabucasa/releases/tag/1.1.2
           https://github.com/NabuCasa/hass-nabucasa/releases/tag/1.2.0
           https://github.com/NabuCasa/hass-nabucasa/releases/tag/1.3.0
           https://github.com/NabuCasa/hass-nabucasa/releases/tag/1.4.0
           https://github.com/NabuCasa/hass-nabucasa/releases/tag/1.5.0
           https://github.com/NabuCasa/hass-nabucasa/releases/tag/1.5.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
