### PR TITLE
python3Packages.watergate-local-api: 2024.4.1 -> 2025.1.0

### DIFF
--- a/pkgs/development/python-modules/watergate-local-api/default.nix
+++ b/pkgs/development/python-modules/watergate-local-api/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "watergate-local-api";
-  version = "2024.4.1";
+  version = "2025.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "watergate-ai";
     repo = "watergate-local-api-python";
     tag = version;
-    hash = "sha256-zEbujtXTXjRRzpNdowh7xjBvCxwp7Z1QYRm6ZM8rFR8=";
+    hash = "sha256-px1vtWGW9JlU9ZXvmTq9YXZDmWIU0xYy3KOyamGyY74=";
   };
 
   build-system = [ setuptools ];
@@ -36,6 +36,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/watergate-ai/watergate-local-api-python/releases/tag/${src.tag}";
     description = "Python package to interact with the Watergate Local API";
     homepage = "https://github.com/watergate-ai/watergate-local-api-python";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Diff: https://github.com/watergate-ai/watergate-local-api-python/compare/2024.4.1...2025.1.0

Changelog: https://github.com/watergate-ai/watergate-local-api-python/releases/tag/2025.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
