### PR TITLE
electrum: fix building, update 4.6.0 -> 4.6.2

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -24,14 +24,24 @@ in
 python3.pkgs.buildPythonApplication rec {
   pname = "electrum";
   version = "4.6.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
     hash = "sha256-ZrwzAeeMNrs6KzLGDg5oBF7E+GGLYCVczO6R18TKRuE=";
   };
 
-  build-system = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    protobuf
+    python3.pkgs.pythonRelaxDepsHook
+  ]
+  ++ lib.optionals enableQt [
+    wrapQtAppsHook
+  ];
   buildInputs = lib.optional (stdenv.hostPlatform.isLinux && enableQt) qtwayland;
 
   dependencies =
@@ -72,6 +82,15 @@ python3.pkgs.buildPythonApplication rec {
       pyqt6
       qdarkstyle
     ];
+
+  pythonRelaxDeps = [
+    "attrs"
+    "dnspython"
+  ];
+
+  pythonRemoveDeps = [
+    "protobuf"
+  ];
 
   checkInputs =
     with python3.pkgs;

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -23,12 +23,12 @@ let
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "electrum";
-  version = "4.6.0";
+  version = "4.6.2";
   format = "setuptools";
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    hash = "sha256-aQqZXyfqFgc1j2r836eaaayOmSzDijHlYXmF+OBw418=";
+    hash = "sha256-ZrwzAeeMNrs6KzLGDg5oBF7E+GGLYCVczO6R18TKRuE=";
   };
 
   build-system = [ protobuf ] ++ lib.optionals enableQt [ wrapQtAppsHook ];

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -7,6 +7,7 @@
   python3,
   zbar,
   enableQt ? true,
+  enablePythonEcdsa ? false,
   callPackage,
   qtwayland,
 }:
@@ -56,12 +57,16 @@ python3.pkgs.buildPythonApplication rec {
       electrum-ecc
       # plugins
       ledger-bitcoin
+      cbor2
+      pyserial
+    ]
+    ++ lib.optionals enablePythonEcdsa [
+      # enablePythonEcdsa gates plugins known to pull in python-ecdsa, which we
+      # avoid by default due to CVE-2024-23342.
       ckcc-protocol
       keepkey
       trezor
       bitbox02
-      cbor2
-      pyserial
     ]
     ++ lib.optionals enableQt [
       pyqt6


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In the master of `nixpkgs`, Electrum fails to build:

```
$ nix build .#electrum
error: Package ‘python3.13-ecdsa-0.19.1’ in /nix/store/q8r9hxrb181ksv6kj0bqd2ca53griq66-source/pkgs/development/python-modules/ecdsa/default.nix:43 is marked as insecure, refusing to 
evaluate.
```

After fixing this I found that it fails tests and starting the app because of missing protobuf files. Fixed this as well in a separate commit.

## Things done

### Disable python-ecdsa by default
    
Some Electrum plugins use python-ecdsa which is known to be vulnerable (CVE-2024-23342). In this commit these plugins are disabled. It is possible to re-enable it via option `enablePythonEcdsa`.
    
The list of affected plugins:
     - ckcc-protocol
     - keepkey
     - trezor
     - bitbox02

### Generated protobuf files
    
Starting from version 4.3.1, source-only Electrum tarball excludes generated protobuf files.
    
Build generated protobuf file from electrum/paymentrequest.proto.

Tests and wrappers include protobuf dependencies to start successfully.

### Version update

4.6.0 -> 4.6.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
