### PR TITLE
Add MDIO tools and netlink out-of-tree kernel module

### DIFF
--- a/pkgs/by-name/md/mdio-tools/package.nix
+++ b/pkgs/by-name/md/mdio-tools/package.nix
@@ -1,0 +1,41 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  lib,
+  libmnl,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mdio-tools";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "wkz";
+    repo = "mdio-tools";
+    tag = finalAttrs.version;
+    hash = "sha256-NomChJrYwMDPXNw5r2p11kGfYUvJBHCdLXy1SA8kOaM=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [ libmnl ];
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail "git describe --always --dirty --tags" "echo ${finalAttrs.version}"
+  '';
+
+  meta = {
+    description = "Low-level debug tools for MDIO devices";
+    homepage = "https://github.com/wkz/mdio-tools";
+    changelog = "https://github.com/wkz/mdio-tools/blob/${finalAttrs.src.rev}/ChangeLog.md";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.jmbaur ];
+    mainProgram = "mdio";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/os-specific/linux/mdio-netlink/default.nix
+++ b/pkgs/os-specific/linux/mdio-netlink/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+  kernel,
+  mdio-tools,
+}:
+
+stdenv.mkDerivation {
+  pname = "mdio-netlink";
+  version = "${mdio-tools.version}-${kernel.version}";
+
+  inherit (mdio-tools) src;
+  sourceRoot = "source/kernel";
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.commonMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "Netlink support for MDIO devices";
+    homepage = "https://github.com/wkz/mdio-tools";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.jmbaur ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -558,6 +558,8 @@ in
 
         mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
+        mdio-netlink = callPackage ../os-specific/linux/mdio-netlink { };
+
         mwprocapture = callPackage ../os-specific/linux/mwprocapture { };
 
         mxu11x0 = callPackage ../os-specific/linux/mxu11x0 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
