### PR TITLE
lib.attrsets.getOutput: return package as-is when output is missing

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -366,6 +366,8 @@
 
 - `lib.types.string` has been removed. See [this pull request](https://github.com/NixOS/nixpkgs/pull/66346) for better alternative types like `lib.types.str`.
 
+- `lib.attrsets.getOutput` and all functions based on it (`getFirstOutput`, `getBin`, `getLib`, `getStatic`, `getDev`, `getInclude`, `getMan`, `chooseDevOutputs`) no longer default to the `out` output if the requested output is not found. Instead, they now return the package as-is. This change was prompted by inadvertent breakage caused by using these functions on members of dependency arrays provided to `mkDerivation`, which uses `getDev` to preferentially select the `dev` output of each package. Since these functions selected the `out` output as a fallback, packages missing outputs yielded packages with `outputSpecified` set to `true`, preventing `mkDerivation` from using the `dev` output. As a result, builds would fail because development dependencies were never brought into scope.
+
 - `lib.modules.defaultPriority` has been removed, please use `lib.modules.defaultOverridePriority` instead.
 
 - `lib.attrsets.cartesianProductOfSets` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.cartesianProduct` instead.


### PR DESCRIPTION
From the changelog entry:

> `lib.attrsets.getOutput` and all functions based on it (`getFirstOutput`, `getBin`, `getLib`, `getStatic`, `getDev`, `getInclude`, `getMan`, `chooseDevOutputs`) no longer default to the `out` output if the requested output is not found. Instead, they now return the package as-is. This change was prompted by inadvertent breakage caused by using these functions on members of dependency arrays provided to `mkDerivation`, which uses `getDev` to preferentially select the `dev` output of each package. Since these functions selected the `out` output as a fallback, packages missing outputs yielded packages with `outputSpecified` set to `true`, preventing `mkDerivation` from using the `dev` output. As a result, builds would fail because development dependencies were never brought into scope.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
