### PR TITLE
warp-plus: 1.2.6-unstable-2025-09-13 -> 1.2.6-unstable-2025-10-28

### DIFF
--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
 
   nix-update-script,
@@ -8,7 +8,9 @@
   warp-plus,
 }:
 
-buildGoModule rec {
+# fails with go 1.25, downgrade to 1.24
+# error tls.ConnectionState: struct field count mismatch: 17 vs 16
+buildGo124Module (finalAttrs: {
   pname = "warp-plus";
   version = "1.2.6-unstable-2025-10-28";
 
@@ -23,8 +25,7 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
   ];
 
   patches = [
@@ -59,4 +60,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "warp-plus";
   };
-}
+})

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
 
   nix-update-script,
-  testers,
-  warp-plus,
+  versionCheckHook,
 }:
 
 # fails with go 1.25, downgrade to 1.24
@@ -45,15 +44,14 @@ buildGo124Module (finalAttrs: {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  passthru = {
-    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
-    tests.version = testers.testVersion {
-      package = warp-plus;
-      command = "warp-plus version";
-    };
-  };
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
+    changelog = "https://github.com/bepass-org/warp-plus/releases";
     description = "Warp + Psiphon, an anti censorship utility for Iran";
     homepage = "https://github.com/bepass-org/warp-plus";
     license = lib.licenses.mit;

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule rec {
   pname = "warp-plus";
-  version = "1.2.6-unstable-2025-09-13";
+  version = "1.2.6-unstable-2025-10-28";
 
   src = fetchFromGitHub {
     owner = "bepass-org";
     repo = "warp-plus";
-    rev = "4af9b2abfc4e79dceea41ac577f1683f62f57b8c";
-    hash = "sha256-7i/06Qn+BRH/bWel9OvgVUAZZSwL2Euv179JDJNn2EE=";
+    rev = "3653f7519d2a08a36222accff6899522bb8b03d0";
+    hash = "sha256-T0YTxQ7iciv5i7lw+bU00B6iYquzBwzYkAlOGZiKeWc=";
   };
 
   vendorHash = "sha256-GmxiQk50iQoH2J/qUVvl9RBz6aIQp8RURqTzrl6NdCY=";


### PR DESCRIPTION
closes #456807 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
