### PR TITLE
[Backport release-25.05] warp-plus: 1.2.6-unstable-2025-08-13 -> 1.2.6-unstable-2025-10-28

### DIFF
--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule rec {
   pname = "warp-plus";
-  version = "1.2.6-unstable-2025-08-13";
+  version = "1.2.6-unstable-2025-09-13";
 
   src = fetchFromGitHub {
     owner = "bepass-org";
     repo = "warp-plus";
-    rev = "08d43e9e4c079534e47ba19fb2965c968c9621b2";
-    hash = "sha256-MHz8b1whSzUJO0YogxMPuXMaQRfR+xxSYhFxq412EmE=";
+    rev = "4af9b2abfc4e79dceea41ac577f1683f62f57b8c";
+    hash = "sha256-7i/06Qn+BRH/bWel9OvgVUAZZSwL2Euv179JDJNn2EE=";
   };
 
   vendorHash = "sha256-GmxiQk50iQoH2J/qUVvl9RBz6aIQp8RURqTzrl6NdCY=";

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
 
   nix-update-script,
@@ -8,7 +8,9 @@
   warp-plus,
 }:
 
-buildGoModule rec {
+# fails with go 1.25, downgrade to 1.24
+# error tls.ConnectionState: struct field count mismatch: 17 vs 16
+buildGo124Module (finalAttrs: {
   pname = "warp-plus";
   version = "1.2.6-unstable-2025-10-28";
 
@@ -23,8 +25,7 @@ buildGoModule rec {
 
   ldflags = [
     "-s"
-    "-w"
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
   ];
 
   patches = [
@@ -59,4 +60,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "warp-plus";
   };
-}
+})

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
 
   nix-update-script,
-  testers,
-  warp-plus,
+  versionCheckHook,
 }:
 
 # fails with go 1.25, downgrade to 1.24
@@ -45,15 +44,14 @@ buildGo124Module (finalAttrs: {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  passthru = {
-    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
-    tests.version = testers.testVersion {
-      package = warp-plus;
-      command = "warp-plus version";
-    };
-  };
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
+    changelog = "https://github.com/bepass-org/warp-plus/releases";
     description = "Warp + Psiphon, an anti censorship utility for Iran";
     homepage = "https://github.com/bepass-org/warp-plus";
     license = lib.licenses.mit;

--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule rec {
   pname = "warp-plus";
-  version = "1.2.6-unstable-2025-09-13";
+  version = "1.2.6-unstable-2025-10-28";
 
   src = fetchFromGitHub {
     owner = "bepass-org";
     repo = "warp-plus";
-    rev = "4af9b2abfc4e79dceea41ac577f1683f62f57b8c";
-    hash = "sha256-7i/06Qn+BRH/bWel9OvgVUAZZSwL2Euv179JDJNn2EE=";
+    rev = "3653f7519d2a08a36222accff6899522bb8b03d0";
+    hash = "sha256-T0YTxQ7iciv5i7lw+bU00B6iYquzBwzYkAlOGZiKeWc=";
   };
 
   vendorHash = "sha256-GmxiQk50iQoH2J/qUVvl9RBz6aIQp8RURqTzrl6NdCY=";


### PR DESCRIPTION
Manual backport of #443825 and #456918 

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-10-05T08%3A53%3A44Z#changes-acceptable-for-releases).
  - Even as a non-committer, if you find that it is not acceptable, leave a comment.