### PR TITLE
linux: cleanup common-config after 5.4 drop

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -77,7 +77,7 @@ let
       # FIXME: figure out how to actually make BTFs reproducible instead
       # See https://github.com/NixOS/nixpkgs/pull/181456 for details.
       MODULE_ALLOW_BTF_MISMATCH = whenAtLeast "5.18" (option yes);
-      BPF_LSM = whenAtLeast "5.7" (option yes);
+      BPF_LSM = option yes;
       DEBUG_KERNEL = yes;
       DEBUG_DEVRES = no;
       DYNAMIC_DEBUG = yes;
@@ -154,10 +154,10 @@ let
       CPU_FREQ_STAT = yes;
 
       # Enable CPU energy model for scheduling
-      ENERGY_MODEL = whenAtLeast "5.0" yes;
+      ENERGY_MODEL = yes;
 
       # Enable thermal interface netlink API
-      THERMAL_NETLINK = whenAtLeast "5.9" yes;
+      THERMAL_NETLINK = yes;
 
       # Prefer power-efficient workqueue implementation to per-CPU workqueues,
       # which is slightly slower, but improves battery life.
@@ -182,24 +182,24 @@ let
       X86_INTEL_PSTATE = yes;
       X86_AMD_PSTATE = whenAtLeast "5.17" yes;
       # Intel DPTF (Dynamic Platform and Thermal Framework) Support
-      ACPI_DPTF = whenAtLeast "5.10" yes;
+      ACPI_DPTF = yes;
 
       # Required to bring up some Bay Trail devices properly
       I2C = yes;
       I2C_DESIGNWARE_CORE = yes;
       I2C_DESIGNWARE_PLATFORM = yes;
-      PMIC_OPREGION = whenAtLeast "5.10" yes;
-      INTEL_SOC_PMIC = whenAtLeast "5.10" yes;
-      BYTCRC_PMIC_OPREGION = whenAtLeast "5.10" yes;
-      CHTCRC_PMIC_OPREGION = whenAtLeast "5.10" yes;
-      XPOWER_PMIC_OPREGION = whenAtLeast "5.10" yes;
-      BXT_WC_PMIC_OPREGION = whenAtLeast "5.10" yes;
-      INTEL_SOC_PMIC_CHTWC = whenAtLeast "5.10" yes;
-      CHT_WC_PMIC_OPREGION = whenAtLeast "5.10" yes;
-      INTEL_SOC_PMIC_CHTDC_TI = whenAtLeast "5.10" yes;
-      CHT_DC_TI_PMIC_OPREGION = whenAtLeast "5.10" yes;
-      MFD_TPS68470 = whenBetween "5.10" "5.13" yes;
-      TPS68470_PMIC_OPREGION = whenAtLeast "5.10" yes;
+      PMIC_OPREGION = yes;
+      INTEL_SOC_PMIC = yes;
+      BYTCRC_PMIC_OPREGION = yes;
+      CHTCRC_PMIC_OPREGION = yes;
+      XPOWER_PMIC_OPREGION = yes;
+      BXT_WC_PMIC_OPREGION = yes;
+      INTEL_SOC_PMIC_CHTWC = yes;
+      CHT_WC_PMIC_OPREGION = yes;
+      INTEL_SOC_PMIC_CHTDC_TI = yes;
+      CHT_DC_TI_PMIC_OPREGION = yes;
+      MFD_TPS68470 = whenOlder "5.13" yes;
+      TPS68470_PMIC_OPREGION = yes;
 
       # Enable Intel thermal hardware feedback
       INTEL_HFI_THERMAL = whenAtLeast "5.18" yes;
@@ -251,11 +251,9 @@ let
     # Include the CFQ I/O scheduler in the kernel, rather than as a
     # module, so that the initrd gets a good I/O scheduler.
     scheduler = {
-      IOSCHED_CFQ = whenOlder "5.0" yes; # Removed in 5.0-RC1
       BLK_CGROUP = yes; # required by CFQ"
       BLK_CGROUP_IOLATENCY = yes;
       BLK_CGROUP_IOCOST = yes;
-      IOSCHED_DEADLINE = whenOlder "5.0" yes; # Removed in 5.0-RC1
       MQ_IOSCHED_DEADLINE = yes;
       BFQ_GROUP_IOSCHED = yes;
       MQ_IOSCHED_KYBER = yes;
@@ -379,13 +377,13 @@ let
       INET_DIAG_DESTROY = lib.mkDefault yes;
 
       # IPsec over TCP
-      INET_ESPINTCP = whenAtLeast "5.8" yes;
-      INET6_ESPINTCP = whenAtLeast "5.8" yes;
+      INET_ESPINTCP = yes;
+      INET6_ESPINTCP = yes;
 
       # enable multipath-tcp
-      MPTCP = whenAtLeast "5.6" yes;
-      MPTCP_IPV6 = whenAtLeast "5.6" yes;
-      INET_MPTCP_DIAG = whenAtLeast "5.9" (lib.mkDefault module);
+      MPTCP = yes;
+      MPTCP_IPV6 = yes;
+      INET_MPTCP_DIAG = lib.mkDefault module;
 
       # Kernel TLS
       TLS = module;
@@ -444,14 +442,8 @@ let
       RTL8XXXU_UNTESTED = option yes;
 
       RTW88 = module;
-      RTW88_8822BE = lib.mkMerge [
-        (whenOlder "5.8" yes)
-        (whenAtLeast "5.8" module)
-      ];
-      RTW88_8822CE = lib.mkMerge [
-        (whenOlder "5.8" yes)
-        (whenAtLeast "5.8" module)
-      ];
+      RTW88_8822BE = module;
+      RTW88_8822CE = module;
     };
 
     fb = {
@@ -483,7 +475,7 @@ let
       FONT_8x8 = yes;
       FONT_8x16 = yes;
       # High DPI font
-      FONT_TER16x32 = whenAtLeast "5.0" yes;
+      FONT_TER16x32 = yes;
     };
 
     video =
@@ -494,7 +486,7 @@ let
           || isPower64
           || isS390x
           || isx86_64
-          || (lib.versionAtLeast version "5.7" && isAarch64)
+          || isAarch64
           || (lib.versionAtLeast version "6.11" && isRiscV64)
         );
       in
@@ -530,18 +522,15 @@ let
         DRM_DP_AUX_CHARDEV = whenOlder "6.10" yes;
         DRM_DISPLAY_DP_AUX_CHARDEV = whenAtLeast "6.10" yes;
         # amdgpu display core (DC) support
-        DRM_AMD_DC_DCN1_0 = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "5.6" yes);
-        DRM_AMD_DC_DCN2_0 = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "5.6" yes);
-        DRM_AMD_DC_DCN2_1 = lib.mkIf stdenv.hostPlatform.isx86 (whenOlder "5.6" yes);
-        DRM_AMD_DC_DCN3_0 = lib.mkIf (with stdenv.hostPlatform; isx86) (whenBetween "5.9" "5.11" yes);
+        DRM_AMD_DC_DCN3_0 = lib.mkIf (with stdenv.hostPlatform; isx86) (whenOlder "5.11" yes);
         DRM_AMD_DC_DCN = lib.mkIf (with stdenv.hostPlatform; isx86 || isPower64) (
           whenBetween "5.11" "6.4" yes
         );
         # Not available when using clang
         # See: https://github.com/torvalds/linux/blob/172a9d94339cea832d89630b89d314e41d622bd8/drivers/gpu/drm/amd/display/Kconfig#L14
         DRM_AMD_DC_FP = lib.mkIf (!stdenv.cc.isClang) (whenAtLeast "6.4" yes);
-        DRM_AMD_DC_HDCP = whenBetween "5.5" "6.4" yes;
-        DRM_AMD_DC_SI = whenAtLeast "5.10" yes;
+        DRM_AMD_DC_HDCP = whenOlder "6.4" yes;
+        DRM_AMD_DC_SI = yes;
 
         # Enable AMD Audio Coprocessor support for HDMI outputs
         DRM_AMD_ACP = yes;
@@ -567,7 +556,7 @@ let
 
         # Enable HDMI-CEC receiver support
         RC_CORE = yes;
-        MEDIA_CEC_RC = whenAtLeast "5.10" yes;
+        MEDIA_CEC_RC = yes;
 
         # Enable CEC over DisplayPort
         DRM_DP_CEC = whenOlder "6.10" yes;
@@ -619,48 +608,43 @@ let
       SND_HDA_RECONFIG = yes; # Support reconfiguration of jack functions
       # Support configuring jack functions via fw mechanism at boot
       SND_HDA_PATCH_LOADER = yes;
-      SND_HDA_CODEC_CA0132_DSP = whenOlder "5.7" yes; # Enable DSP firmware loading on Creative Soundblaster Z/Zx/ZxR/Recon
       SND_HDA_CODEC_CS8409 = whenAtLeast "6.6" module; # Cirrus Logic HDA Bridge CS8409
       SND_OSSEMUL = yes;
       SND_USB_CAIAQ_INPUT = yes;
       SND_USB_AUDIO_MIDI_V2 = whenAtLeast "6.5" yes;
       # Enable Sound Open Firmware support
     }
-    //
-      lib.optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" && lib.versionAtLeast version "5.5")
-        {
-          SND_SOC_INTEL_SOUNDWIRE_SOF_MACH = whenAtLeast "5.10" module;
-          SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES = whenAtLeast "5.10" yes; # dep of SOF_MACH
-          SND_SOC_SOF_INTEL_SOUNDWIRE_LINK = whenBetween "5.10" "5.11" yes; # dep of SOF_MACH
-          SND_SOC_SOF_TOPLEVEL = yes;
-          SND_SOC_SOF_ACPI = module;
-          SND_SOC_SOF_PCI = module;
-          SND_SOC_SOF_APOLLOLAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_APOLLOLAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_CANNONLAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_CANNONLAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_COFFEELAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_COFFEELAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_COMETLAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_COMETLAKE_H_SUPPORT = whenOlder "5.8" yes;
-          SND_SOC_SOF_COMETLAKE_LP_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_ELKHARTLAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_ELKHARTLAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_GEMINILAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_GEMINILAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_HDA_AUDIO_CODEC = yes;
-          SND_SOC_SOF_HDA_COMMON_HDMI_CODEC = whenOlder "5.7" yes;
-          SND_SOC_SOF_HDA_LINK = yes;
-          SND_SOC_SOF_ICELAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_ICELAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_INTEL_TOPLEVEL = yes;
-          SND_SOC_SOF_JASPERLAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_JASPERLAKE_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_MERRIFIELD = whenAtLeast "5.12" module;
-          SND_SOC_SOF_MERRIFIELD_SUPPORT = whenOlder "5.12" yes;
-          SND_SOC_SOF_TIGERLAKE = whenAtLeast "5.12" module;
-          SND_SOC_SOF_TIGERLAKE_SUPPORT = whenOlder "5.12" yes;
-        };
+    // lib.optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux") {
+      SND_SOC_INTEL_SOUNDWIRE_SOF_MACH = module;
+      SND_SOC_INTEL_USER_FRIENDLY_LONG_NAMES = yes; # dep of SOF_MACH
+      SND_SOC_SOF_INTEL_SOUNDWIRE_LINK = whenOlder "5.11" yes; # dep of SOF_MACH
+      SND_SOC_SOF_TOPLEVEL = yes;
+      SND_SOC_SOF_ACPI = module;
+      SND_SOC_SOF_PCI = module;
+      SND_SOC_SOF_APOLLOLAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_APOLLOLAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_CANNONLAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_CANNONLAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_COFFEELAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_COFFEELAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_COMETLAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_COMETLAKE_LP_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_ELKHARTLAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_ELKHARTLAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_GEMINILAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_GEMINILAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_HDA_AUDIO_CODEC = yes;
+      SND_SOC_SOF_HDA_LINK = yes;
+      SND_SOC_SOF_ICELAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_ICELAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_INTEL_TOPLEVEL = yes;
+      SND_SOC_SOF_JASPERLAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_JASPERLAKE_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_MERRIFIELD = whenAtLeast "5.12" module;
+      SND_SOC_SOF_MERRIFIELD_SUPPORT = whenOlder "5.12" yes;
+      SND_SOC_SOF_TIGERLAKE = whenAtLeast "5.12" module;
+      SND_SOC_SOF_TIGERLAKE_SUPPORT = whenOlder "5.12" yes;
+    };
 
     usb = {
       USB = yes; # compile USB core into kernel, so we can use USB_SERIAL_CONSOLE before modules
@@ -680,7 +664,7 @@ let
       USB_SERIAL = yes;
       USB_SERIAL_GENERIC = yes; # USB Generic Serial Driver
       USB_SERIAL_CONSOLE = yes; # Allow using USB serial adapter as console
-      U_SERIAL_CONSOLE = whenAtLeast "5.10" yes; # Allow using USB gadget as console
+      U_SERIAL_CONSOLE = yes; # Allow using USB gadget as console
     };
 
     # Filesystem options - in particular, enable extended attributes and
@@ -730,11 +714,9 @@ let
 
       F2FS_FS = module;
       F2FS_FS_SECURITY = option yes;
-      F2FS_FS_COMPRESSION = whenAtLeast "5.6" yes;
+      F2FS_FS_COMPRESSION = yes;
       UDF_FS = module;
 
-      NFSD_V2_ACL = whenOlder "5.10" yes;
-      NFSD_V3 = whenOlder "5.10" yes;
       NFSD_V3_ACL = yes;
       NFSD_V4 = yes;
       NFSD_V4_SECURITY_LABEL = yes;
@@ -815,10 +797,9 @@ let
 
       SECURITY_DMESG_RESTRICT = yes;
 
-      RANDOM_TRUST_CPU = lib.mkIf (
-        with stdenv.hostPlatform;
-        isPower64 || isS390 || isx86 || (lib.versionAtLeast version "5.6" && isAarch64)
-      ) (whenOlder "6.2" yes); # allow RDRAND to seed the RNG
+      RANDOM_TRUST_CPU = lib.mkIf (with stdenv.hostPlatform; isPower64 || isS390 || isx86 || isAarch64) (
+        whenOlder "6.2" yes
+      ); # allow RDRAND to seed the RNG
       RANDOM_TRUST_BOOTLOADER = whenOlder "6.2" yes; # allow the bootloader to seed the RNG
 
       MODULE_SIG = no; # r13y, generates a random key during build and bakes it in
@@ -941,7 +922,7 @@ let
       STACK_TRACER = yes;
       UPROBE_EVENTS = option yes;
       BPF_SYSCALL = yes;
-      BPF_UNPRIV_DEFAULT_OFF = whenBetween "5.10" "5.16" yes;
+      BPF_UNPRIV_DEFAULT_OFF = whenOlder "5.16" yes;
       BPF_EVENTS = yes;
       FUNCTION_PROFILER = yes;
       RING_BUFFER_BENCHMARK = no;
@@ -1035,7 +1016,7 @@ let
       ZRAM_BACKEND_ZSTD = whenAtLeast "6.12" yes;
       ZRAM_DEF_COMP_ZSTD = whenAtLeast "5.11" yes;
       ZSWAP = option yes;
-      ZSWAP_COMPRESSOR_DEFAULT_ZSTD = whenAtLeast "5.7" (lib.mkOptionDefault yes);
+      ZSWAP_COMPRESSOR_DEFAULT_ZSTD = lib.mkOptionDefault yes;
       ZPOOL = whenOlder "6.18" yes;
       ZSMALLOC = option yes;
     };
@@ -1065,8 +1046,7 @@ let
       LOCK_TORTURE_TEST = option no;
       MTD_TESTS = option no;
       NOTIFIER_ERROR_INJECTION = option no;
-      RCU_PERF_TEST = whenOlder "5.9" no;
-      RCU_SCALE_TEST = whenAtLeast "5.10" no;
+      RCU_SCALE_TEST = no;
       TEST_ASYNC_DRIVER_PROBE = option no;
       WW_MUTEX_SELFTEST = option no;
       XZ_DEC_TEST = option no;
@@ -1086,7 +1066,7 @@ let
       let
         # Use zstd for kernel compression if 64-bit and newer than 5.9, otherwise xz.
         # i686 issues: https://github.com/NixOS/nixpkgs/pull/117961#issuecomment-812106375
-        useZstd = stdenv.buildPlatform.is64bit && lib.versionAtLeast version "5.9";
+        useZstd = stdenv.buildPlatform.is64bit;
       in
       {
         # stdenv.hostPlatform.linux-kernel.target assumes uncompressed on RISC-V.
@@ -1181,9 +1161,9 @@ let
         BLK_SED_OPAL = yes;
 
         # Enable support for block layer inline encryption
-        BLK_INLINE_ENCRYPTION = whenAtLeast "5.8" yes;
+        BLK_INLINE_ENCRYPTION = yes;
         # ...but fall back to CPU encryption if unavailable
-        BLK_INLINE_ENCRYPTION_FALLBACK = whenAtLeast "5.8" yes;
+        BLK_INLINE_ENCRYPTION_FALLBACK = yes;
 
         BSD_PROCESS_ACCT_V3 = yes;
 
@@ -1213,7 +1193,7 @@ let
 
         EFI = lib.mkIf stdenv.hostPlatform.isEfi yes;
         EFI_STUB = yes; # EFI bootloader in the bzImage itself
-        EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER = whenOlder "6.2" (whenAtLeast "5.8" yes); # initrd kernel parameter for EFI
+        EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER = whenOlder "6.2" yes; # initrd kernel parameter for EFI
 
         # Generic compression support for EFI payloads
         # Add new platforms only after they have been verified to build and boot.
@@ -1261,7 +1241,7 @@ let
         NVME_TCP_TLS = whenAtLeast "6.7" yes;
 
         NVME_TARGET = module;
-        NVME_TARGET_PASSTHRU = whenAtLeast "5.9" yes;
+        NVME_TARGET_PASSTHRU = yes;
         NVME_TARGET_AUTH = whenAtLeast "6.0" yes;
         NVME_TARGET_TCP_TLS = whenAtLeast "6.7" yes;
 
@@ -1271,7 +1251,7 @@ let
           || isPower64
           || isS390x
           || isx86_64
-          || (lib.versionAtLeast version "5.7" && isAarch64)
+          || isAarch64
           || (lib.versionAtLeast version "6.11" && isRiscV64)
         ) yes;
 
@@ -1313,7 +1293,7 @@ let
 
         HWMON = yes;
         THERMAL_HWMON = yes; # Hardware monitoring support
-        NVME_HWMON = whenAtLeast "5.5" yes; # NVMe drives temperature reporting
+        NVME_HWMON = yes; # NVMe drives temperature reporting
         UEVENT_HELPER = no;
 
         USERFAULTFD = yes;
@@ -1346,7 +1326,7 @@ let
           || isPower64
           || isS390x
           || isx86_64
-          || (lib.versionAtLeast version "5.7" && isAarch64)
+          || isAarch64
           || (lib.versionAtLeast version "6.11" && isRiscV64)
         ) yes;
 
@@ -1387,15 +1367,15 @@ let
         };
         ANDROID_BINDER_IPC = {
           optional = true;
-          tristate = whenAtLeast "5.0" "y";
+          tristate = "y";
         };
         ANDROID_BINDERFS = {
           optional = true;
-          tristate = whenAtLeast "5.0" "y";
+          tristate = "y";
         };
         ANDROID_BINDER_DEVICES = {
           optional = true;
-          freeform = whenAtLeast "5.0" "binder,hwbinder,vndbinder";
+          freeform = "binder,hwbinder,vndbinder";
         };
 
         TASKSTATS = yes;
@@ -1408,7 +1388,7 @@ let
 
         # > CONFIG_KUNIT should not be enabled in a production environment. Enabling KUnit disables Kernel Address-Space Layout Randomization (KASLR), and tests may affect the state of the kernel in ways not suitable for production.
         # https://www.kernel.org/doc/html/latest/dev-tools/kunit/start.html
-        KUNIT = whenAtLeast "5.5" no;
+        KUNIT = no;
 
         # Set system time from RTC on startup and resume
         RTC_HCTOSYS = option yes;
@@ -1418,7 +1398,7 @@ let
 
         # Enable generic kernel watch queues
         # See https://docs.kernel.org/core-api/watch_queue.html
-        WATCH_QUEUE = whenAtLeast "5.8" yes;
+        WATCH_QUEUE = yes;
       }
       //
         lib.optionalAttrs
@@ -1437,7 +1417,7 @@ let
               || isPower
               || isS390
               || isx86
-              || (lib.versionAtLeast version "5.7" && isAarch64)
+              || isAarch64
               || (lib.versionAtLeast version "6.11" && isRiscV)
             ) yes;
             HOTPLUG_CPU = yes;
@@ -1458,8 +1438,7 @@ let
             CROS_EC_I2C = module;
             CROS_EC_SPI = module;
             CROS_KBD_LED_BACKLIGHT = module;
-            MFD_CROS_EC = whenOlder "5.10" module;
-            TCG_TIS_SPI_CR50 = whenAtLeast "5.5" yes;
+            TCG_TIS_SPI_CR50 = yes;
           }
       //
         lib.optionalAttrs
@@ -1521,7 +1500,7 @@ let
         CHROMEOS_PSTORE = module;
 
         # Enable x86 resource control
-        X86_CPU_RESCTRL = whenAtLeast "5.0" yes;
+        X86_CPU_RESCTRL = yes;
 
         # Enable TSX on CPUs where it's not vulnerable
         X86_INTEL_TSX_MODE_AUTO = yes;


### PR DESCRIPTION
Cleanup of configs for kernels older than 5.10.z after a943d89fb0228aced3f9007fe8cbf605001c38ba

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
