### PR TITLE
Update winbox version and hashes in package.nix

### DIFF
--- a/pkgs/by-name/wi/winbox4/package.nix
+++ b/pkgs/by-name/wi/winbox4/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "winbox";
-  version = "4.0beta21";
+  version = "4.0beta35";
 
   metaCommon = {
     description = "Graphical configuration utility for RouterOS-based devices";
@@ -23,13 +23,13 @@ let
   x86_64-zip = callPackage ./build-from-zip.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-Uoawz+CW1JLVOEoxSF49WpF31VuUDWK4q9tl1qAwS/c=";
+    hash = "sha256-gmFAxa9ogFwbSZ9yOCkDzHDoRwc3FRx/HS9/yqdUpZc=";
   };
 
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-PCdN5z77RU5WgYzk2h/ou2OeswZQl32FfxozEZ8ZlTo=";
+    hash = "sha256-FeUEr9Kpu92NDOyp8inpSvx42xRboHb/Ey3Bo4S91S0=";
   };
 in
 (if stdenvNoCC.hostPlatform.isDarwin then x86_64-dmg else x86_64-zip).overrideAttrs (oldAttrs: {


### PR DESCRIPTION
Updated package versions and tested locally.

```
What's new in 4.0beta35 (2025-Oct-13 10:14):

*) ui: fix bar graphs for LTE signals
*) windows: fix loading settings when opening new window (also fixes infinite open loop)

What's new in 4.0beta33:

*) table: fix incorrect sort in tree-structured tables
*) table: update flag style
*) table: fix some column default positions (tx/rx/fp columns added as last)
*) table: remove collapse mode for Comment column
*) settings: provide option to position Comment column in front or back
    - if columns reordered, then setting not actual in that table anymore
*) form: send data only when there are changes or new object
    - highlight apply/ok buttons to indicate if there are changes or errors
*) form: show comment,icon,flag in dropdown field for supported items
*) form: add support for some items to be bold in dropdown field (used only by legacy wireless frequency field)
*) form: show better error text with hexadecimal field type
*) form: widget: correctly load some optional values (e.g. IPv6/ND/Prefixes 6to4 Interface)
*) form: add support for optional fields with optional values (e.g. used by Wifi Arp Timeout field)
*) terminal: fix rare crash on special escape sequence
*) fix discovery/mac-connect on some situations where 169.254.*.* address is used
*) fix some potential special cases on torch commands to not stop on error
*) ui: add support for fields with clickable URL
*) ui: do not show shadow for expanded mdi windows
*) ui: do not show error message when there is no address database file (happens when not using Saved list or on first launch)
*) ui: change Files upload/download progress panel for better ux with many files
    - show 1st progressbar for current file status, 2nd progressbar for total file count progress
*) fix field validations for some complex address fields with VRF
*) update some field error texts
*) update support for new field types (used by future RouterOS versions)

What's new in 4.0beta30:

*) login panel: add option to set Saved routers database password
*) login panel: add "Move" feature for Saved routers database
    - also show current database path in table's status bar
*) login panel: add option to Export user database
*) login panel: update style for decrypt form panel
*) login panel: fix changing to RoMON tab automatically when connected to RoMON
*) widgets: force password field character to "bullet" unicode
    - Manrope on Windows otherwise has very slow first render
*) ui: add support for bar graphs in table and form
*) ui: do not allow mdi windows to go out of viewport
*) form: add/restore support for grid layout (torch/traceroute/quickset)
*) form: fix some bitrate fields with big numbers (firewall/hotspot/queues)
*) form: do not stretch inline buttons (quickset)
*) form: add support for table and linked fields (quickset)
*) form: fix first field autofocus for some types and also autofocus Saved router database password field
*) fix crash when creating cloud backup file when there is error
*) fix crash when copying not added object in ordered table
*) consider field values depending on dynamic tab's state
    - table: show empty column values of dynamically hidden tab (e.g. bridge IGMP snooping)
    - form: do not send/package fields of dynamically hidden tab
*) tooltip: keep showing when mouse hovered over tooltip
*) table: elide text in status bar if width too small

What's new in 4.0beta29:

*) table: implement large row count limits (for tables that support it)
    - allow to "freeze/pause" any table data update
*) table: reduce content height calculation delay for auto scrolling tables
*) table: increase performance when closing files subtree with many elements
*) ui: allow open new instance for query type windows (e.g. Ping/Traceroute)
*) ui: remember field values for action/torch type of sub windows
    - values are restored until router session is disconnected
*) ui: improve combobox UX
    - open popup on editable combobox only when clicking indicator (or up/down keyboard)
    - fix reopening popup when focusing with mouse for first time
    - fix again that prevents selecting disabled records
*) fix digit grouping on numbers exceeding 1 billion
*) fix crash when selecting User Manager -> Generate Voucher
*) terminal: accept Ctrl+D and close window when state is (Disconnected)
*) terminal: correctly accept some symbols with InputMethod (dead/special key)
    - problem was observed only on MacOS
*) macos: set correctly target minimal version 12.0
*) form: fix missing Actions in Certificate template objects
    - also fixes action order on some generic objects
*) form: implement range type field optional value setting (e.g. Packet Size for Traffic-Generator/Stream)

What's new in 4.0beta26:

*) files: add support for downloading directory from Files table
    - also fix downloading file without adding it in subdirectory
*) files: fix uploading empty file to RouterOS
*) form: restore "New..." title for objects which are being added
*) form: accept enter key on action type of panels (Start/Stop)
*) graphs: rewrite graphs drawing to new engine which uses GPU rendering
    - uses less CPU
    - renders better quality fonts
    - dropping dependency reduced executable size by ~10MiB
*) graphs: implement Y axis max value back scaling
*) graphs: show latest curve values, show values on mouse hover
    - also freeze graph updating while mouse is pressed
*) table: add multi-column sorting (add secondary sorts with Shift+click)
*) table: add support for column auto resize with separator double click
*) table: fix unnecessary column resize when clicking on separator, but not yet moving mouse
    - also fix first ignored click on header after column resize
*) table: fix updating records in some very rare cases
    - seems to be affected only by new File handler
*) table: fix missing port field filter (for IP:port type of fields)
*) ui: fix app update "Release notes" text clipping
*) ui: fix render quality on some global popups, because it were positioned on decimal coordinates
*) ui: fix missing field borders in table filter panel in dark mode
*) ui: fix text clipping in Resources panel for CPU field when value is "100 %"
*) ui: prevent selecting disabled record in combobox with Space key
    - e.g. selecting disabled RoMON Neighbors in Login panel
*) ui: disable font ligatures for regular font
*) ui: update style of read-only checkbox
*) widgets: trim text when pasting into one-line type widget fields
*) remove debug print when selecting record in Saved table (also printed user password)
*) add clear button in Login panel for RoMON agent field

What's new in 4.0beta24:

*) add "open in new window" feature in Login panel
    - add "open in new" checkbox
    - perform connect when pressing Enter while using keyboard in "Saved" table
    - selecting multiple records from "Saved" table automatically enables "open in new window" mode
*) allow to specify workspace from command line as 4th argument
*) add "RoMON Agent" field in Login panel (stored in Saved list)
    - also supports opening in multiple new OS windows
*) pass UI current state (settings) when opening new OS window
    - current global/login/table settings are applied immediately to opened window
*) change some font weights and color
*) reduce input widgets default height by 2px
*) fix potential crash on disconnect
*) fix table flags font weight
*) fix terminal missing bold by including variable format font file
*) disconnect view when RoMON end-device rebooted
*) add RoMON agent info in windows OS title
*) restore selected tab in Login view when disconnecting from RoMON
*) add multi select + connect feature for Neigbors table
*) fix crash on very rare cases when ros sends notifies in specific order
*) align dragged inner windows to whole pixels (macos has visual bugs)
*) show "New Winbox" and "Global settings" top buttons in Reconnect panel

What's new in 4.0beta23:

*) add dynamic form field syntax validation
    - tooltips for form labels
    - edited fields now indicated with blue label
*) add tooltips for some buttons
*) add tooltips for tables
    - active flags
    - cells with truncated values
    - header with truncated values
    - cells containing extra information (e.g. netmask)
*) add hover info for some form fields
    - similar to WinBox v3, but now field must be focused
*) add outline for checkbox and radio button widgets
*) minor icon color changes

What's new in 4.0beta22:

*) correctly show limited entry count in Ping form
*) do not sort radio buttons by text and improve UI style
*) make certain drop-down menus editable (e.g. legacy wireless Frequency property)
*) add support for new RouterOS field types
*) fix legacy Wireless "Setup Repeater" action
*) fix some complex field read-only states
*) do not apply default configuration to objects received from RouterOS or copied objects
*) form: layout checkboxes in available width if column count not defined
*) accept Enter/Esc keyboard actions while connecting in Login panel or Reconnect panel
*) terminal: fix output in some cases when using top command through /container/shell
*) prevent opening read-only with empty array widget
*) do not show empty buttons in form panel with empty names
*) fix crash when closing connection with table filter opened
*) terminal: ignore legacy shift-out (SO) character
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
