### PR TITLE
postgresqlPackages.anonymizer: fix maintainer pings

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -23,7 +23,8 @@ buildPgrxExtension {
 
   passthru.tests = nixosTests.postgresql.anonymizer.passthru.override postgresql;
 
-  meta = lib.getAttrs [ "homepage" "teams" "license" ] pg-dump-anon.meta // {
+  meta = {
+    inherit (pg-dump-anon.meta) homepage teams license;
     description = "Extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database";
   };
 }


### PR DESCRIPTION
Because of `lib.getAttrs`, `postgresqlPackages.anonymizer.meta.teamsPosition` returned the path to `lib/attrsets.nix`. This caused maintainer pings for that file for the maintainers of `postgresqlPackages.anonymizer`.

Using regular `inherit` syntax moves the definition of the `teams` attribute in the right file and fixes the maintainer pings.

---

This was introduced as early as https://github.com/NixOS/nixpkgs/pull/297155, but the pings only happen when a change to `lib.attrsets` causes `postgresqlPackages.anonymizer` to rebuild, which is a rare case triggered by #456905 / #456898. 

## Things done

- [x] Confirmed the correct `meta.teamsPosition` in `nix repl`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
