### PR TITLE
python3Packages.executorch: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -1,0 +1,205 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  gitMinimal,
+
+  # build-system
+  certifi,
+  cmake,
+  packaging,
+  pyyaml,
+  setuptools,
+  zstd,
+
+  # dependencies
+  # coremltools, (unpackaged)
+  expecttest,
+  flatbuffers,
+  hydra-core,
+  hypothesis,
+  kgb,
+  mpmath,
+  numpy,
+  omegaconf,
+  pandas,
+  parameterized,
+  pytorch-tokenizers,
+  ruamel-yaml,
+  scikit-learn,
+  sympy,
+  tabulate,
+  torch,
+  torchao,
+  typing-extensions,
+
+  # tests
+  pytest-json-report,
+  pytest-rerunfailures,
+  pytestCheckHook,
+  torchaudio,
+  torchtune,
+  transformers,
+  writableTmpDirAsHomeHook,
+  yaspin,
+}:
+buildPythonPackage rec {
+  pname = "executorch";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "executorch";
+    tag = "v${version}";
+
+    # The ExecuTorch repo must be cloned into a directory named exactly `executorch`.
+    # See https://github.com/pytorch/executorch/issues/6475 for progress on a fix for this restriction.
+    name = "executorch";
+
+    fetchSubmodules = true;
+    hash = "sha256-WirvB+Tjh7HQK3m41/5xr8VThJAk+Cw7+cQAusWUCFM=";
+  };
+  # src = /home/gaetan/nix/nixpkgs-packages/executorch;
+
+  postPatch =
+    # Hardcode the default flatc binary path to the nixpkgs flatc
+    ''
+      substituteInPlace exir/_serialize/_flatbuffer.py \
+        --replace-fail \
+          'flatc_path = "flatc"' \
+          'flatc_path = "${lib.getExe pkgs.flatbuffers}"'
+    ''
+    # Relax build-system dependencies
+    + ''
+      substituteInPlace pyproject.toml \
+        --replace-fail '"pip>=23",' "" \
+        --replace-fail "cmake>=3.29,<4.0.0" "cmake"
+    ''
+    # CMake 4 dropped support of versions lower than 3.5, versions lower than 3.10 are deprecated.
+    # https://github.com/NixOS/nixpkgs/issues/445447
+    + ''
+      substituteInPlace backends/xnnpack/third-party/pthreadpool/CMakeLists.txt \
+        --replace-fail \
+          "CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)" \
+          "CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)"
+    '';
+
+  env = {
+    BUILD_VERSION = version;
+  };
+
+  build-system = [
+    certifi
+    cmake
+    packaging
+    pyyaml
+    setuptools
+    zstd
+  ];
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    gitMinimal
+  ];
+
+  pythonRemoveDeps = [
+    # unpackaged
+    "coremltools"
+
+    # Test dependencies that should not be listed in runtime dependencies
+    "pytest"
+    "pytest-json-report"
+    "pytest-rerunfailures"
+    "pytest-xdist"
+  ];
+  pythonRelaxDeps = [
+    "torchao"
+  ];
+  dependencies = [
+    # coremltools (unpackaged)
+    expecttest
+    flatbuffers
+    hydra-core
+    hypothesis
+    kgb
+    mpmath
+    numpy
+    omegaconf
+    packaging
+    pandas
+    parameterized
+    pytorch-tokenizers
+    pyyaml
+    ruamel-yaml
+    scikit-learn
+    sympy
+    tabulate
+    torch
+    torchao
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "executorch" ];
+
+  nativeCheckInputs = [
+    pytest-json-report
+    pytest-rerunfailures
+    pytestCheckHook
+    torchaudio
+    torchtune
+    transformers
+    writableTmpDirAsHomeHook
+    yaspin
+  ];
+
+  disabledTestPaths = [
+    # Require unpackaged coremltools
+    "backends/apple/coreml/*"
+    "export/tests/test_target_recipes.py"
+
+    # Try to download models from HuggingFace hub
+    "extension/llm/tokenizers/test/test_hf_tokenizer.py"
+  ];
+
+  disabledTests = [
+    # RuntimeError: Failed to execute method forward, error: 0x20
+    # [method.cpp:70] Backend BackendWithCompilerDemo is not registered
+    "test_compatibility_in_runtime"
+    "test_compatibility_in_runtime_edge_program_manager"
+    "test_emit_lowered_backend_module_end_to_end"
+    "test_multi_method_end_to_end"
+
+    # AssertionError (Numerical comparison fails)
+    "test_sdpa_with_cache_seq_len_13"
+    "test_sdpa_with_custom_quantized_seq_len_130_gqa"
+
+    # Try to download models from the internet
+    "test_all_models_with_recipes"
+    "test_dl3_export_to_executorch"
+    "test_efficient_sam_export_to_executorch"
+    "test_ic3_export_to_executorch"
+    "test_mobilenet_v3"
+    "test_mobilenet_v3_xnnpack"
+    "test_mv2_export_to_executorch"
+    "test_mv3_export_to_executorch"
+    "test_resnet18_export_to_executorch"
+    "test_resnet50_export_to_executorch"
+    "test_vit_export_to_executorch"
+  ];
+
+  meta = {
+    description = "On-device AI across mobile, embedded and edge for PyTorch";
+    homepage = "https://github.com/pytorch/executorch";
+    changelog = "https://github.com/pytorch/executorch/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    badPlatforms = [
+      # Many tests segfault. Supporting this platform will need additional work
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5051,6 +5051,8 @@ self: super: with self; {
 
   executor = callPackage ../development/python-modules/executor { };
 
+  executorch = callPackage ../development/python-modules/executorch { };
+
   exif = callPackage ../development/python-modules/exif { };
 
   exifread = callPackage ../development/python-modules/exifread { };


### PR DESCRIPTION
## Things done

Add [executorch](https://github.com/pytorch/executorch), PyTorch's unified solution for deploying AI models on-device.

Depends on:
- https://github.com/NixOS/nixpkgs/pull/460929
- https://github.com/NixOS/nixpkgs/pull/460933

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
