### PR TITLE
python3Packages.torchao: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -104,6 +104,52 @@ buildPythonPackage rec {
 
     # FileNotFoundError: [Errno 2] No such file or directory: 'checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth'
     "test_gptq_mt"
+
+    # KeyError: '_guards_fn
+    "test_add"
+    "test_add_relu"
+    "test_allow_exported_model_train_eval"
+    "test_allow_exported_model_train_eval_idempotent"
+    "test_conv2d"
+    "test_disallow_eval_train"
+    "test_dynamic_linear"
+    "test_fold_bn_erases_bn_node"
+    "test_fold_bn_erases_bn_node"
+    "test_maxpool2d"
+    "test_move_exported_model_bn_device_cpu"
+    "test_move_exported_model_dropout"
+    "test_move_exported_model_dropout_inplace"
+    "test_preserve_nn_module_stack"
+    "test_qat_bn_conv2d"
+    "test_qat_conv2d"
+    "test_qat_conv2d_binary"
+    "test_qat_conv2d_binary2"
+    "test_qat_conv2d_binary_unary"
+    "test_qat_conv2d_unary"
+    "test_qat_conv_bn_bias_derived_qspec"
+    "test_qat_conv_bn_fusion"
+    "test_qat_conv_bn_fusion_literal_args"
+    "test_qat_conv_bn_fusion_no_conv_bias"
+    "test_qat_conv_bn_per_channel_weight_bias"
+    "test_qat_conv_bn_relu_fusion"
+    "test_qat_conv_bn_relu_fusion_no_conv_bias"
+    "test_qat_conv_transpose_bn"
+    "test_qat_conv_transpose_bn_relu"
+    "test_qat_per_channel_weight_custom_dtype"
+    "test_qat_preserve_source_fn_stack"
+    "test_qat_qconv2d"
+    "test_qat_qconv2d_add"
+    "test_qat_qconv2d_add_relu"
+    "test_qat_qconv2d_hardswish"
+    "test_qat_qconv2d_hardtanh"
+    "test_qat_qconv2d_relu"
+    "test_qat_qconv2d_relu6"
+    "test_qat_qconv2d_silu"
+    "test_qat_update_shared_qspec"
+    "test_qdq"
+    "test_qdq_per_channel"
+    "test_reentrant"
+    "test_static_linear"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # AssertionError: tensor(False) is not true
@@ -135,6 +181,10 @@ buildPythonPackage rec {
     # RuntimeError: No packed_weights_format was selected
     "TestIntxOpaqueTensor"
     "test_accuracy_kleidiai"
+
+    # RuntimeError: quantized engine NoQEngine is not supported
+    "test_smooth_linear_cpu"
+    "test_smooth_linear_edge_cases"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # Flaky: [gw0] node down: keyboard-interrupt


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

More likely a regression caused by the [torch update PR](https://github.com/NixOS/nixpkgs/pull/456704).

```
            for node in reversed(pattern_graph.nodes):
                if node.op != "placeholder" and node.op != "output":
>                   gn = match.nodes_map[node]
                         ^^^^^^^^^^^^^^^^^^^^^
E                   KeyError: '_guards_fn\n\nTo execute this test, run the following from the base repo dir:\n    python test/quantization/pt2e/test_x86inductor_quantizer.py TestQuantizePT2EX86Inductor.test_qat_conv2d_unary\n\nThis message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0'

/nix/store/9fdbg2zsy8rcmbgf3jiz1zvbqabild3f-python3.13-torch-2.9.0/lib/python3.13/site-packages/torch/fx/subgraph_rewriter.py:419: KeyError
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
