### PR TITLE
python3Packages.apache-beam: 2.68.0 -> 2.69.0

### DIFF
--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -19,6 +19,7 @@
   # dependencies
   beartype,
   crcmod,
+  cryptography,
   dill,
   fastavro,
   fasteners,
@@ -63,14 +64,14 @@
 
 buildPythonPackage rec {
   pname = "apache-beam";
-  version = "2.68.0";
+  version = "2.69.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "beam";
     tag = "v${version}";
-    hash = "sha256-ENtvgu9qT1OPsDqFJQzKgIATE7F+S5I+AfoBT2iEL8M=";
+    hash = "sha256-7trrdGQ9jkzG+5/PyBMvHXjR0B4HjOxBhUuxXEcKkLg=";
   };
 
   sourceRoot = "${src.name}/sdks/python";
@@ -123,6 +124,7 @@ buildPythonPackage rec {
   dependencies = [
     beartype
     crcmod
+    cryptography
     dill
     fastavro
     fasteners
@@ -254,9 +256,14 @@ buildPythonPackage rec {
     "test_reshuffle_custom_window_preserves_metadata_1"
     "test_reshuffle_default_window_preserves_metadata_1"
 
-    # AttributeError: 'MaybeReshuffle' object has no attribute 'side_inputs'
-    # https://github.com/apache/beam/issues/33854
+    # Dill version 0.3.1.1 is required when using pickle_library=dill.
+    # Other versions of dill are untested with Apache Beam.
+    "LocalCombineFnLifecycleTest_0_dill"
+    "LocalCombineFnLifecycleTest_2_dill"
     "test_runner_overrides_default_pickler"
+
+    # Require internet access
+    "test_local_jar_fallback_to_google_maven_mirror"
 
     # AssertionError: Lists differ
     "test_default_resources"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/apache/beam/compare/v2.68.0...v2.69.0
Changelog: https://github.com/apache/beam/blob/v2.69.0/CHANGES.md

cc @ndl

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc