### PR TITLE
librechat: 0.7.8 -> 0.7.9

### DIFF
--- a/pkgs/by-name/li/librechat/0004-logs-v079.patch
+++ b/pkgs/by-name/li/librechat/0004-logs-v079.patch
@@ -1,0 +1,26 @@
+diff --git a/packages/data-schemas/src/config/meiliLogger.ts b/packages/data-schemas/src/config/meiliLogger.ts
+index 0d4d39475..c38560d35 100644
+--- a/packages/data-schemas/src/config/meiliLogger.ts
++++ b/packages/data-schemas/src/config/meiliLogger.ts
+@@ -2,7 +2,7 @@ import path from 'path';
+ import winston from 'winston';
+ import 'winston-daily-rotate-file';
+ 
+-const logDir = path.join(__dirname, '..', '..', '..', 'api', 'logs');
++const logDir = path.join('.', 'logs');
+ 
+ const { NODE_ENV, DEBUG_LOGGING = 'false' } = process.env;
+ 
+diff --git a/packages/data-schemas/src/config/winston.ts b/packages/data-schemas/src/config/winston.ts
+index 7e5287296..dd68614bc 100644
+--- a/packages/data-schemas/src/config/winston.ts
++++ b/packages/data-schemas/src/config/winston.ts
+@@ -3,7 +3,7 @@ import winston from 'winston';
+ import 'winston-daily-rotate-file';
+ import { redactFormat, redactMessage, debugTraverse, jsonTruncateFormat } from './parsers';
+ 
+-const logDir = path.join(__dirname, '..', '..', '..', 'api', 'logs');
++const logDir = path.join('.', 'logs');
+ 
+ const { NODE_ENV, DEBUG_LOGGING, CONSOLE_JSON, DEBUG_CONSOLE } = process.env;
+ 


### PR DESCRIPTION
Updated LibreChat to 0.7.9, including necessary changes to fix build and runtime errors.
I have built it successfully from nixpkgs but also deployed it on a NixOS machine and it is working fine.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
