### PR TITLE
Add a distrobox package without the /nix mount

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12111,6 +12111,12 @@
     githubId = 547031;
     name = "Johan Herland";
   };
+  jhgalino = {
+    email = "github@jhgalino.com";
+    github = "jhgalino";
+    githubId = 38009312;
+    name = "John Henry Galino";
+  };
   jhh = {
     email = "jeff@j3ff.io";
     github = "jhh";

--- a/pkgs/by-name/di/distrobox-unnixed/package.nix
+++ b/pkgs/by-name/di/distrobox-unnixed/package.nix
@@ -1,0 +1,57 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  wget,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "distrobox";
+  version = "1.8.2.0";
+
+  src = fetchFromGitHub {
+    owner = "89luca89";
+    repo = "distrobox";
+    rev = finalAttrs.version;
+    hash = "sha256-uwJD7HsWoQ/LxYL0mSSxMni676qqEnMHndpL01M5ySE=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [
+    # https://github.com/89luca89/distrobox/issues/408
+    ./relative-default-icon.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    ./install -P $out
+
+    runHook postInstall
+  '';
+
+  # https://github.com/89luca89/distrobox/issues/407
+  postFixup = ''
+    wrapProgram "$out/bin/distrobox-generate-entry" \
+      --prefix PATH ":" ${lib.makeBinPath [ wget ]}
+  '';
+
+  meta = with lib; {
+    description = "Wrapper around podman or docker to create and start containers";
+    longDescription = ''
+      Use any linux distribution inside your terminal. Enable both backward and
+      forward compatibility with software and freedom to use whatever distribution
+      you’re more comfortable with. This package removes the /nix mount on the original
+      distrobox package.
+    '';
+    homepage = "https://distrobox.it/";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jhgalino ];
+  };
+})

--- a/pkgs/by-name/di/distrobox-unnixed/relative-default-icon.patch
+++ b/pkgs/by-name/di/distrobox-unnixed/relative-default-icon.patch
@@ -1,0 +1,26 @@
+diff --git a/distrobox-generate-entry b/distrobox-generate-entry
+index 65fcea0..8d57e4e 100755
+--- a/distrobox-generate-entry
++++ b/distrobox-generate-entry
+@@ -51,7 +51,7 @@ container_manager="autodetect"
+ container_name_default="my-distrobox"
+ delete=0
+ icon="auto"
+-icon_default="${XDG_DATA_HOME:-${HOME}/.local/share}/icons/terminal-distrobox-icon.svg"
++icon_default="terminal-distrobox-icon"
+ verbose=0
+ online=0
+ version="1.8.0"
+@@ -335,12 +335,6 @@ if [ "${icon}" = "auto" ]; then
+ 
+ 	icon_url="$(echo "${DISTRO_ICON_MAP}" | grep "${container_distro}:" | cut -d':' -f2-)"
+ 
+-	# Distro not found in our map, fallback to generic icon
+-	if [ -z "${icon_url}" ]; then
+-		icon_url="https://raw.githubusercontent.com/89luca89/distrobox/main/icons/terminal-distrobox-icon.svg"
+-		container_distro="terminal-distrobox-icon"
+-	fi
+-
+ 	if [ -n "${icon_url}" ] && [ "${download}" != "null" ]; then
+ 		icon_extension="${icon_url##*.}"
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is the same as the distrobox package currently on nixpkgs, but without `/nix` mounted by default on new distroboxes. This change enables users of distrobox on NixOS to install Nix inside the distrobox by letting them choose which directory to use as the `/nix` mount.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
