### PR TITLE
various: fix maintainer teams

### DIFF
--- a/nixos/tests/nominatim.nix
+++ b/nixos/tests/nominatim.nix
@@ -11,8 +11,8 @@ in
   name = "nominatim";
   meta = {
     maintainers = with lib.teams; [
-      geospatial
-      ngi
+      geospatial.members
+      ngi.members
     ];
   };
 

--- a/pkgs/by-name/py/pyroscope/package.nix
+++ b/pkgs/by-name/py/pyroscope/package.nix
@@ -56,7 +56,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/grafana/pyroscope";
     changelog = "https://github.com/grafana/pyroscope/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    maintainers = [ lib.teams.mercury ];
+    teams = [ lib.teams.mercury ];
     mainProgram = "pyroscope";
   };
 })

--- a/pkgs/development/python-modules/rpy2-rinterface/default.nix
+++ b/pkgs/development/python-modules/rpy2-rinterface/default.nix
@@ -74,6 +74,6 @@ buildPythonPackage rec {
     description = "Python interface to R";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib; [ teams.sage ];
+    teams = with lib.teams; [ sage ];
   };
 }

--- a/pkgs/development/rocm-modules/6/miopen/test-frugally-deep-model-loading.nix
+++ b/pkgs/development/rocm-modules/6/miopen/test-frugally-deep-model-loading.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Test that frugally-deep can load MIOpen model files";
-    maintainers = with lib.teams; [ rocm ];
+    teams = with lib.teams; [ rocm ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
The maintainers field currently expects actual maintainers only, not entire teams. These can be added via `meta.teams` or via `<team>.members` for NixOS tests, which don't support teams, yet.

The package in by-name is broken in a way that will make it impossible to get changes to it pass CI - because the same package's maintainers will always be evaluated on the target branch. So this PR will need to bypass the queue to be merged.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
