### PR TITLE
dfir_ntfs: init at 1.1.19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14216,6 +14216,12 @@
 
     keys = [ { fingerprint = "5A9A 1C9B 2369 8049 3B48  CF5B 81A1 5409 4816 2372"; } ];
   };
+  kyubai = {
+    name = "Matthias Riegel";
+    email = "nixpkgs@verriegelt.net";
+    github = "kyubai";
+    githubId = 34755366;
+  };
   l0b0 = {
     email = "victor@engmark.name";
     github = "l0b0";

--- a/pkgs/by-name/df/dfir_ntfs/package.nix
+++ b/pkgs/by-name/df/dfir_ntfs/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  runCommand,
+}:
+python3.pkgs.buildPythonPackage rec {
+  pname = "dfir_ntfs";
+  version = "1.1.19";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "msuhanov";
+    repo = "dfir_ntfs";
+    tag = "${version}";
+    hash = "sha256-iZd8qFLm77Fv8iUAB5M75u9a3SSBHqUEtZ8CPq8g7Ps=";
+  };
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  propagatedBuildInputs = [ python3.pkgs.llfuse ];
+
+  passthru.tests.pytest =
+    runCommand "dfir_ntfs-tests"
+      {
+        nativeBuildInputs = [ python3.pkgs.pytest ];
+        inherit src;
+      }
+      ''
+        unpackPhase
+        cd source
+        pytest -vv | tee result.log
+        mkdir -p $out
+        cp result.log $out/
+      '';
+
+  meta = {
+    description = "NTFS/FAT parser for digital forensics & incident response";
+    homepage = "https://github.com/msuhanov/dfir_ntfs";
+    changelog = "https://github.com/msuhanov/dfir_ntfs/blob/${version}/ChangeLog";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.kyubai ];
+  };
+}


### PR DESCRIPTION
This pr creates a package, which can be used to parse NTFS and FAT data structures.
https://github.com/msuhanov/dfir_ntfs

The package tests use test data provided by NIST, which are located in the dfir_ntfs upstream.
The license seems free on first glance, but I'm not sure wheter we need to mention it, or exclude the package tests.
Maybe someone has more insight on that.
https://spdx.org/licenses/NIST-Software.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (couldn't test fat_parser on real data, but ntfs_parser and vsc_mount work)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
