### PR TITLE
novnc: add run time deps to PATH

### DIFF
--- a/pkgs/by-name/no/novnc/package.nix
+++ b/pkgs/by-name/no/novnc/package.nix
@@ -1,6 +1,11 @@
 {
   lib,
   python3,
+  coreutils-full,
+  gnugrep,
+  hostname,
+  ps,
+  makeWrapper,
   stdenv,
   replaceVars,
   fetchFromGitHub,
@@ -30,10 +35,23 @@ stdenv.mkDerivation rec {
     substituteAllInPlace utils/novnc_proxy
   '';
 
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  runtimeDeps = [
+    coreutils-full
+    gnugrep
+    hostname
+    ps
+  ];
+
   installPhase = ''
     runHook preInstall
 
     install -Dm755 utils/novnc_proxy "$out/bin/novnc"
+    wrapProgram "$out/bin/novnc" --prefix PATH : ${lib.makeBinPath runtimeDeps}
+
     install -dm755 "$out/share/webapps/novnc/"
     cp -a app core po vendor vnc.html karma.conf.js package.json vnc_lite.html "$out/share/webapps/novnc/"
 


### PR DESCRIPTION
This PR adds missing runtime dependencies to `novnc`. The shell script depends on some (really common) binaries to be present. Currently, the package is not self-contained. `novnc` does not work in restricted environments (think systemd service etc.)

Before this PR:
<img width="1098" height="198" alt="image" src="https://github.com/user-attachments/assets/ab569dcf-46c8-4ce1-b7ee-d5b140376eba" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
