### PR TITLE
python3Packages.locust: 2.37.14 -> 2.42.1 (incl. upgrades of dependencies)

### DIFF
--- a/pkgs/development/python-modules/locust-cloud/default.nix
+++ b/pkgs/development/python-modules/locust-cloud/default.nix
@@ -10,7 +10,11 @@
   python-engineio,
   python-socketio,
   requests,
+  gevent-websocket,
   tomli,
+  flask,
+  requests-mock,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -40,7 +44,32 @@ buildPythonPackage rec {
     tomli
   ];
 
+  nativeCheckInputs = [
+    flask
+    gevent-websocket
+    pytestCheckHook
+    requests-mock
+  ];
+
   pythonImportsCheck = [ "locust_cloud" ];
+
+  preCheck = ''
+    export LOCUSTCLOUD_USERNAME=dummy
+    export LOCUSTCLOUD_PASSWORD=dummy
+  '';
+
+  disabledTests = [
+    # AssertionError
+    "test_recursive_imports"
+    "test_from_import_file"
+  ];
+
+  disabledTestPaths = [
+    # Tests require network access
+    "tests/web_login_test.py"
+    "tests/cloud_test.py"
+    "tests/websocket_test.py"
+  ];
 
   meta = {
     description = "Hosted version of Locust to run distributed load tests";

--- a/pkgs/development/python-modules/locust-cloud/default.nix
+++ b/pkgs/development/python-modules/locust-cloud/default.nix
@@ -42,7 +42,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Hosted version of Locust to run distributed load tests";
-    homepage = "https://www.locust.cloud/";
+    homepage = "https://github.com/locustcloud/locust-cloud";
+    changelog = "https://github.com/locustcloud/locust-cloud/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ magicquark ];
   };

--- a/pkgs/development/python-modules/locust-cloud/default.nix
+++ b/pkgs/development/python-modules/locust-cloud/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "locust-cloud";
-  version = "1.27.0";
+  version = "1.27.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "locustcloud";
     repo = "locust-cloud";
     tag = version;
-    hash = "sha256-K69VIyQggwWQQoMld0JpzmtJRQc6HYrKAGA6E9O69MQ=";
+    hash = "sha256-7k1IZNBVkz+E5WW/wZWpB+yl/W7ONuHlUM8wOKvu0ow=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/locust-cloud/default.nix
+++ b/pkgs/development/python-modules/locust-cloud/default.nix
@@ -1,11 +1,11 @@
 {
+  lib,
   buildPythonPackage,
   configargparse,
   fetchFromGitHub,
   gevent,
   hatch-vcs,
   hatchling,
-  lib,
   platformdirs,
   python-engineio,
   python-socketio,
@@ -39,6 +39,8 @@ buildPythonPackage rec {
     requests
     tomli
   ];
+
+  pythonImportsCheck = [ "locust_cloud" ];
 
   meta = {
     description = "Hosted version of Locust to run distributed load tests";

--- a/pkgs/development/python-modules/locust/default.nix
+++ b/pkgs/development/python-modules/locust/default.nix
@@ -18,6 +18,7 @@
   locust-cloud,
   psutil,
   pyquery,
+  pytest,
   pyzmq,
   requests,
   retry,
@@ -27,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "locust";
-  version = "2.37.14";
+  version = "2.42.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "locustio";
     repo = "locust";
     tag = version;
-    hash = "sha256-16pMl72OIZlAi6jNx0qv0TO9RTm6O9CgiE84sndsEhc=";
+    hash = "sha256-yyG4HVti0BAcGWQHID799YfkCEIBmpTkUUm8QzXMivc=";
   };
 
   postPatch = ''
@@ -65,6 +66,7 @@ buildPythonPackage rec {
     "flask-login"
     # version 6.0.1 is listed as 0.0.1 in the dependency check and 0.0.1 is not >= 3.0.10
     "flask-cors"
+    "requests"
   ];
 
   dependencies = [
@@ -81,6 +83,7 @@ buildPythonPackage rec {
     requests
     tomli
     werkzeug
+    pytest
   ];
 
   pythonImportsCheck = [ "locust" ];

--- a/pkgs/development/python-modules/locust/webui.nix
+++ b/pkgs/development/python-modules/locust/webui.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   missingHashes = ./missing-hashes.json;
   yarnOfflineCache = yarn-berry.fetchYarnBerryDeps {
     inherit (finalAttrs) src missingHashes;
-    hash = "sha256-FbKaU3wezuvcn98FOcUZbmoot/iHtmeStp4n0dNwFYA=";
+    hash = "sha256-dxt7rRA6kh0msjy3DAUvtj7LoE7vEaf4pmP2B95HoeY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -18,11 +18,12 @@
 
   # tests
   msgpack,
-  pytest7CheckHook,
+  pytestCheckHook,
   simple-websocket,
   uvicorn,
   redis,
   valkey,
+  pytest-asyncio,
 
 }:
 
@@ -55,11 +56,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     msgpack
-    pytest7CheckHook
+    pytestCheckHook
     uvicorn
     simple-websocket
     redis
     valkey
+    pytest-asyncio
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -21,19 +21,21 @@
   pytest7CheckHook,
   simple-websocket,
   uvicorn,
+  redis,
+  valkey,
 
 }:
 
 buildPythonPackage rec {
   pname = "python-socketio";
-  version = "5.13.0";
+  version = "5.14.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-socketio";
     tag = "v${version}";
-    hash = "sha256-iOipxGALYOXLvUwn6OSjLCMZoUl7u4S5eCktUgcs/X0=";
+    hash = "sha256-2zts0gkwAoUCC8S1UDg0PlBaFH23jTv04hgGblHSX7c=";
   };
 
   build-system = [ setuptools ];
@@ -56,6 +58,8 @@ buildPythonPackage rec {
     pytest7CheckHook
     uvicorn
     simple-websocket
+    redis
+    valkey
   ]
   ++ lib.flatten (lib.attrValues optional-dependencies);
 


### PR DESCRIPTION
This updates locust to version 2.42.1. For this also updates of locust-cloud and python-socketio had been necessary.

This merge request makes https://github.com/NixOS/nixpkgs/pull/448754 fully and https://github.com/NixOS/nixpkgs/pull/455521 partially superfluous.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
