### PR TITLE
mate.libmateweather: 1.28.0 -> 1.28.1

### DIFF
--- a/pkgs/desktops/mate/libmateweather/default.nix
+++ b/pkgs/desktops/mate/libmateweather/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
+  autoconf-archive,
   autoreconfHook,
-  fetchurl,
   pkg-config,
   gettext,
   glib,
@@ -12,15 +13,18 @@
   gtk-doc,
   libsoup_3,
   tzdata,
+  mate-common,
   mateUpdateScript,
 }:
 stdenv.mkDerivation rec {
   pname = "libmateweather";
-  version = "1.28.0";
+  version = "1.28.1";
 
-  src = fetchurl {
-    url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "VUNz3rWzk7nYSydd0spmyaSi0ObskgRPq4qlPjAy0rU=";
+  src = fetchFromGitHub {
+    owner = "mate-desktop";
+    repo = "libmateweather";
+    tag = "v${version}";
+    hash = "sha256-W0p4+OMr2sgkQP10DGjZLf2VTSGa2A+5ey+nYBr+HJQ=";
   };
 
   patches = [
@@ -31,12 +35,15 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [
+    autoconf-archive
     autoreconfHook # the libsoup patch changes the autoconf file
     pkg-config
     gettext
     glib # glib-compile-schemas
+    gtk3 # gtk-update-icon-cache
     gtk-doc # required for autoconf
     libxml2 # xmllint
+    mate-common # mate-compiler-flags.m4 macros
   ];
 
   buildInputs = [

--- a/pkgs/desktops/mate/libmateweather/libsoup_3_support.patch
+++ b/pkgs/desktops/mate/libmateweather/libsoup_3_support.patch
@@ -351,7 +351,7 @@ index 7bc24fc..d470822 100644
  
      loc = info->location;
  
-     searchkey = g_strdup_printf ("<raw_text>%s", loc->code);
+     searchkey = g_strdup_printf ("<raw_text>METAR %s", loc->code);
 -    p = strstr (msg->response_body->data, searchkey);
 -    g_free (searchkey);
 +
@@ -398,7 +398,7 @@ index 7bc24fc..d470822 100644
      }
  
 -    msg = soup_form_request_new (
--        "GET", "https://aviationweather.gov/cgi-bin/data/dataserver.php",
+-        "GET", "https://aviationweather.gov/api/data/dataserver",
 +    query = soup_form_encode (
          "dataSource", "metars",
          "requestType", "retrieve",
@@ -409,7 +409,7 @@ index 7bc24fc..d470822 100644
          NULL);
 -    soup_session_queue_message (info->session, msg, metar_finish, info);
 +    msg = soup_message_new_from_encoded_form (
-+        "GET", "https://aviationweather.gov/cgi-bin/data/dataserver.php",
++        "GET", "https://aviationweather.gov/api/data/dataserver",
 +        query);
 +    soup_session_send_and_read_async (info->session, msg, G_PRIORITY_DEFAULT,
 +                                      NULL, metar_finish, info);


### PR DESCRIPTION
https://github.com/mate-desktop/libmateweather/compare/v1.28.0...v1.28.1



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

