### PR TITLE
mcpelauncher-client: fix sdl3 audio

### DIFF
--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -98,7 +98,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "USE_OWN_CURL" false)
     (lib.cmakeBool "ENABLE_DEV_PATHS" false)
     (lib.cmakeFeature "GAMEWINDOW_SYSTEM" "GLFW")
-    (lib.cmakeBool "USE_SDL3_AUDIO" false)
+    (lib.cmakeBool "SDL3_VENDORED" false)
     (lib.cmakeBool "BUILD_WEBVIEW" withQtWebview)
     (lib.cmakeBool "XAL_WEBVIEW_USE_CLI" (!withQtWebview))
     (lib.cmakeBool "XAL_WEBVIEW_USE_QT" withQtWebview)


### PR DESCRIPTION
Fixed audio by [disabling vendoring SDL3](https://github.com/NixOS/nixpkgs/issues/380493#issuecomment-3456745728) in cmake flags. `USE_SDL3_AUDIO` was also omitted in order for this to work.

Partially addresses #380493.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
