### PR TITLE
[release-25.05] python3Packages.keras: 3.9.2 -> 3.11.3, backport security patches

### DIFF
--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.10.0";
+  version = "3.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     tag = "v${version}";
-    hash = "sha256-N0RlXnmSYJvD4/a47U4EjMczw1VIyereZoPicjgEkAI=";
+    hash = "sha256-jyNOL5u+XVVqChD7Fs3yJCcW14bTvitiQa4H4DTeja0=";
   };
 
   build-system = [
@@ -82,9 +82,10 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # NameError: name 'MockRemat' is not defined
-    # https://github.com/keras-team/keras/issues/21126
-    "test_functional_model_with_remat"
+    # Require unpackaged `grain`
+    "test_fit_with_data_adapter_grain_dataloader"
+    "test_fit_with_data_adapter_grain_datast"
+    "test_fit_with_data_adapter_grain_datast_with_len"
 
     # Tries to install the package in the sandbox
     "test_keras_imports"
@@ -94,6 +95,9 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
+    # Require unpackaged `grain`
+    "keras/src/trainers/data_adapters/grain_dataset_adapter_test.py"
+
     # These tests succeed when run individually, but crash within the full test suite:
     # ImportError: /nix/store/4bw0x7j3wfbh6i8x3plmzknrdwdzwfla-abseil-cpp-20240722.1/lib/libabsl_cord_internal.so.2407.0.0:
     # undefined symbol: _ZN4absl12lts_2024072216strings_internal13StringifySink6AppendESt17basic_string_viewIcSt11char_traitsIcEE

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.11.2";
+  version = "3.11.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     tag = "v${version}";
-    hash = "sha256-VRza7ElCPjdMeo4LH0WSBD8WdzxojJStGXlf1pbP3b0=";
+    hash = "sha256-J/NPLR9ShKhvHDU0/NpUNp95RViS2KygqvnuDHdwiP0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   setuptools,
@@ -44,6 +45,27 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-J/NPLR9ShKhvHDU0/NpUNp95RViS2KygqvnuDHdwiP0=";
   };
+
+  # The two following patches mitigate CVE breaches.
+  # The patches are part of the keras 3.12.0 release.
+  # We choose to backport the relevant commits instead of updating keras to 3.12.0 as this latest
+  # release includes breaking changes.
+  patches = [
+    # Fixes CVE-2025-12058
+    # https://github.com/advisories/GHSA-mq84-hjqx-cwf2
+    (fetchpatch2 {
+      name = "patch-CVE-2025-12058";
+      url = "https://github.com/keras-team/keras/commit/61ac8c1e51862c471dee7b49029c356f55531487.patch";
+      hash = "sha256-tvWYde3AERV1w3gvQ70NNLo0xNxgyZFzf5LF48Axymg=";
+    })
+    # Fixes CVE-2025-12060
+    # https://github.com/advisories/GHSA-28jp-44vh-q42h
+    (fetchpatch2 {
+      name = "patch-CVE-2025-12060";
+      url = "https://github.com/keras-team/keras/commit/47fcb397ee4caffd5a75efd1fa3067559594e951.patch";
+      hash = "sha256-tiBRXGp+PHiY0VXCdcpmpq4PHORvREVpr/QfQcwqJdk=";
+    })
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.9.2";
+  version = "3.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     tag = "v${version}";
-    hash = "sha256-mxQHqApyxO57zo/lK8p9xWEdEgkXF89yX/+pPBUlbwE=";
+    hash = "sha256-N0RlXnmSYJvD4/a47U4EjMczw1VIyereZoPicjgEkAI=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "keras";
-  version = "3.11.1";
+  version = "3.11.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "keras-team";
     repo = "keras";
     tag = "v${version}";
-    hash = "sha256-jyNOL5u+XVVqChD7Fs3yJCcW14bTvitiQa4H4DTeja0=";
+    hash = "sha256-VRza7ElCPjdMeo4LH0WSBD8WdzxojJStGXlf1pbP3b0=";
   };
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Update `keras` to `3.11.3`, the latest release that does not include breaking changes
  - Diff: https://github.com/keras-team/keras/compare/v3.9.2...v3.11.3
  - Changelog: https://github.com/keras-team/keras/releases/tag/v3.11.3
- Apply two patches from `3.12.0` that mitigate security breaches:
  - [CVE-2025-12058](https://github.com/advisories/GHSA-mq84-hjqx-cwf2), fixed by https://github.com/keras-team/keras/commit/61ac8c1e51862c471dee7b49029c356f55531487
  - [CVE-2025-12060](https://github.com/advisories/GHSA-28jp-44vh-q42h), fixed by https://github.com/keras-team/keras/commit/47fcb397ee4caffd5a75efd1fa3067559594e951


cc @LeSuisse

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
