### PR TITLE
nixos/ddccontrol: enable hardware.i2c and mention its group

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -96,6 +96,8 @@
 
 - `spidermonkey_91` has been removed, as it has been EOL since September 2022.
 
+- `ddccontrol` service now enables `hardware.i2c` by default, and adds `ddcci_backlight` to the kernel modules, based on [experiences reported on discourse](https://discourse.nixos.org/t/brightness-control-of-external-monitors-with-ddcci-backlight/8639/).
+
 - The license of duckstation has changed from `gpl3Only` to `cc-by-nc-nd-40` making it unfree in newer releases. The `duckstation` package has been overhauled to support the new releases and `duckstation-bin` has been aliased to `duckstation` to support darwin binary builds.
 
 - `hiawata` has been removed, due to lack of active development upstream, lack of maintainership downstream and upcoming security issues.

--- a/nixos/modules/services/hardware/ddccontrol.nix
+++ b/nixos/modules/services/hardware/ddccontrol.nix
@@ -14,15 +14,25 @@ in
 
   options = {
     services.ddccontrol = {
-      enable = lib.mkEnableOption "ddccontrol for controlling displays";
+      enable = lib.mkEnableOption ''
+        ddccontrol for controlling displays.
+
+        This [enables `hardware.i2c`](#opt-hardware.i2c.enable), so note to add
+        yourself to [`hardware.i2c.group`](#opt-hardware.i2c.group).
+      '';
     };
   };
 
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+    boot.kernelModules = [
+      "ddcci_backlight"
+    ];
     # Load the i2c-dev module
-    boot.kernelModules = [ "i2c_dev" ];
+    hardware.i2c = {
+      enable = true;
+    };
 
     # Give users access to the "gddccontrol" tool
     environment.systemPackages = [

--- a/nixos/modules/services/hardware/ddccontrol.nix
+++ b/nixos/modules/services/hardware/ddccontrol.nix
@@ -10,6 +10,8 @@ let
 in
 
 {
+  meta.maintainers = with lib.maintainers; [ doronbehar ];
+
   ###### interface
 
   options = {

--- a/nixos/modules/services/hardware/ddccontrol.nix
+++ b/nixos/modules/services/hardware/ddccontrol.nix
@@ -22,6 +22,13 @@ in
         This [enables `hardware.i2c`](#opt-hardware.i2c.enable), so note to add
         yourself to [`hardware.i2c.group`](#opt-hardware.i2c.group).
       '';
+      package =
+        lib.mkPackageOption pkgs
+          "package with which to control brightness; added also to [services.dbus.packages](#opt-services.dbus.packages)."
+          {
+            default = [ "ddccontrol" ];
+            example = [ "ddcutil-service" ];
+          };
     };
   };
 
@@ -36,17 +43,16 @@ in
       enable = true;
     };
 
-    # Give users access to the "gddccontrol" tool
     environment.systemPackages = [
-      pkgs.ddccontrol
+      cfg.package
     ];
 
     services.dbus.packages = [
-      pkgs.ddccontrol
+      cfg.package
     ];
 
     systemd.packages = [
-      pkgs.ddccontrol
+      cfg.package
     ];
   };
 }

--- a/pkgs/by-name/dd/ddccontrol-db/package.nix
+++ b/pkgs/by-name/dd/ddccontrol-db/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ddccontrol";
     repo = "ddccontrol-db";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-r87zucuHnWbvaqg++xI3s3Tghz80auQBgUxJzu7nmqU=";
   };
 

--- a/pkgs/by-name/dd/ddccontrol-db/package.nix
+++ b/pkgs/by-name/dd/ddccontrol-db/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       pakhfn
+      doronbehar
     ];
   };
 }

--- a/pkgs/by-name/dd/ddccontrol-db/package.nix
+++ b/pkgs/by-name/dd/ddccontrol-db/package.nix
@@ -30,11 +30,13 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Monitor database for DDCcontrol";
     homepage = "https://github.com/ddccontrol/ddccontrol-db";
-    license = licenses.gpl2;
-    platforms = platforms.linux;
-    maintainers = [ lib.maintainers.pakhfn ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      pakhfn
+    ];
   };
 }

--- a/pkgs/by-name/dd/ddccontrol-db/package.nix
+++ b/pkgs/by-name/dd/ddccontrol-db/package.nix
@@ -8,14 +8,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ddccontrol-db";
   version = "20251102";
 
   src = fetchFromGitHub {
     owner = "ddccontrol";
     repo = "ddccontrol-db";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-r87zucuHnWbvaqg++xI3s3Tghz80auQBgUxJzu7nmqU=";
   };
 
@@ -40,4 +40,4 @@ stdenv.mkDerivation rec {
       doronbehar
     ];
   };
-}
+})

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ddccontrol";
     repo = "ddccontrol";
-    rev = version;
+    tag = version;
     sha256 = "sha256-qyD6i44yH3EufIW+LA/LBMW20Tejb49zvsDfv6YFD6c=";
   };
 

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -53,11 +53,11 @@ stdenv.mkDerivation rec {
     intltoolize --force
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Program used to control monitor parameters by software";
     homepage = "https://github.com/ddccontrol/ddccontrol";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ pakhfn ];
   };
 }

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -11,14 +11,14 @@
   ddccontrol-db,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ddccontrol";
   version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "ddccontrol";
     repo = "ddccontrol";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-qyD6i44yH3EufIW+LA/LBMW20Tejb49zvsDfv6YFD6c=";
   };
 
@@ -60,4 +60,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ pakhfn ];
   };
-}
+})

--- a/pkgs/by-name/dd/ddccontrol/package.nix
+++ b/pkgs/by-name/dd/ddccontrol/package.nix
@@ -58,6 +58,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/ddccontrol/ddccontrol";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ pakhfn ];
+    maintainers = with lib.maintainers; [
+      pakhfn
+      doronbehar
+    ];
   };
 })

--- a/pkgs/by-name/dd/ddcutil-service/package.nix
+++ b/pkgs/by-name/dd/ddcutil-service/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  pkg-config,
+
+  # buildInputs
+  glib,
+  ddcutil,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ddcutil-service";
+  version = "1.0.14";
+
+  src = fetchFromGitHub {
+    owner = "digitaltrails";
+    repo = "ddcutil-service";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-IZ6s9z0zxMZT7qd+yuQJGLnKc1WISIvhJlIGsM/Dw3w=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    ddcutil
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "A Dbus ddcutil server for control of DDC Monitors/VDUs";
+    homepage = "https://github.com/digitaltrails/ddcutil-service";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "ddcutil-service";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/vd/vdu_controls/package.nix
+++ b/pkgs/by-name/vd/vdu_controls/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchpatch,
+  qt6,
+  copyDesktopItems,
+  installShellFiles,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "vdu_controls";
+  version = "2.4.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "digitaltrails";
+    repo = "vdu_controls";
+    rev = "v${version}";
+    hash = "sha256-aapODSWPB98I/ieUTXIO7nrd11VY9SmFpsVR1ketsZU=";
+  };
+
+  patches = [
+    # Standardize installation with pypa/build. See:
+    # https://github.com/digitaltrails/vdu_controls/pull/120
+    (fetchpatch {
+      url = "https://github.com/digitaltrails/vdu_controls/commit/ef2ed07398fc88ccc18a11da3cf5ea1500a03cb6.patch";
+      hash = "sha256-W0Iv3RXQFnHAzaXHh6ZvGARN4ShsNgOhg9FTpbvnfLo=";
+    })
+  ];
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.sphinx
+  ];
+  # Replace FHS paths with out paths. Unfortunately it will be pretty hard to
+  # change this behavior upstream, as they barely use any packaging system
+  # whatsoever.
+  preBuild = ''
+    substituteInPlace vdu_controls.py \
+        --replace-fail /usr/share/vdu_controls $out/share/vdu_controls
+  '';
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    copyDesktopItems
+    installShellFiles
+  ];
+  desktopItems = "vdu_controls.desktop";
+  postInstall = ''
+    install -Dm066 vdu_controls.png $out/share/icons/hicolor/256x256/apps/vdu_controls.png
+    make -C docs man
+    installManPage docs/_build/man/vdu_controls.1
+    mkdir -p $out/share/vdu_controls
+    cp -r icons $out/share/vdu_controls
+    cp -r sample-scripts $out/share/vdu_controls
+    cp -r translations $out/share/vdu_controls
+  '';
+
+  dependencies = [
+    python3.pkgs.pyqt6
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwayland
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "VDU controls - a control panel for monitor brightness/contrast";
+    homepage = "https://github.com/digitaltrails/vdu_controls";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "vdu_controls";
+  };
+}


### PR DESCRIPTION
Other commits in this PR (purely semantics)

- **ddccontrol: no with lib; in meta**
- **ddccontrol: use tag in src**
- **ddccontrol: use finalAttrs pattern**
- **ddccontrol: add doronbehar as co-maintainer**
- **ddccontrol-db: no with lib; in meta**
- **ddccontrol-db: add doronbehar as co-maintainer**
- **ddccontrol-db: use finalAttrs pattern**
- **ddccontrol-db: use tag in src**

See also:

https://discourse.nixos.org/t/brightness-control-of-external-monitors-with-ddcci-backlight/8639/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
