### PR TITLE
haraka: init at 3.1.1

### DIFF
--- a/pkgs/by-name/ha/haraka/package.nix
+++ b/pkgs/by-name/ha/haraka/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  python3,
+}:
+
+buildNpmPackage rec {
+  pname = "haraka";
+  version = "3.1.1-unstable-2025-10-27";
+
+  src = fetchFromGitHub {
+    owner = "haraka";
+    repo = "Haraka";
+    # `release` branch has lock files, tagged revisions don't
+    rev = "d20509f060127a9428737583d8ed2ceffc8df928";
+    hash = "sha256-6hkmnOulDZpHk63t0btH7eN9jomToEmMu0vINdbiPBI=";
+  };
+
+  npmDepsHash = "sha256-wpkFXWAGnEnZ/fkNUDD5e+/SaNzdSNPi6eNELKe/AKs=";
+
+  dontNpmBuild = true;
+
+  nativeBuildInputs = [
+    python3
+  ];
+
+  meta = {
+    changelog = "https://github.com/haraka/Haraka/blob/${src.rev}/Changes.md";
+    description = "Fast, highly extensible, and event driven SMTP server";
+    homepage = "https://haraka.github.io/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiara ];
+  };
+}


### PR DESCRIPTION
[haraka](https://haraka.github.io/) is a nodejs SMTP server with a plugin architecture.
note that this also has quite some plug-ins, which are not included yet in this PR.

supersedes #251994 (/cc @farcaller).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
