### PR TITLE
config.{allow,block}listedLicenses: fixups

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -269,6 +269,8 @@
 
 - Added `gitConfig` and `gitConfigFile` option to the nixpkgs `config`, to allow for setting a default `gitConfigFile` for all `fetchgit` invocations.
 
+- Added options for `allowlistedLicenses` and `blocklistedLicenses` to the nixpkgs `config`. Options for `whitelistedLicenses` and `blacklistedLicenses` were also introduce to avoid changing the behavior of evaluation; these options should not be used because they deprecated and will be removed in a future release.
+
 - The `dockerTools.streamLayeredImage` builder now uses a better algorithm for generating layered docker images, such that much more sharing is possible when the number of store paths exceeds the layer limit. It gives each of the largest store paths its own layer and adds dependencies to those layers when they aren't used elsewhere.
 
 - The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -13,6 +13,7 @@ let
     literalExpression
     mapAttrsToList
     mkOption
+    mkRenamedOptionModuleWith
     optionals
     types
     ;
@@ -373,6 +374,19 @@ let
 
 in
 {
+
+  imports = [
+    (mkRenamedOptionModuleWith {
+      from = [ "whitelistedLicenses" ];
+      to = [ "allowlistedLicenses" ];
+      sinceRelease = 2511;
+    })
+    (mkRenamedOptionModuleWith {
+      from = [ "blacklistedLicenses" ];
+      to = [ "blocklistedLicenses" ];
+      sinceRelease = 2511;
+    })
+  ];
 
   freeformType =
     let

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -235,7 +235,10 @@ let
         `allowUnfree` is enabled. It is not a generic allowlist for all types of licenses.
       '';
       default = [ ];
-      type = types.listOf (types.attrsOf types.anything);
+      # NOTE: The type should be `types.listOf (types.attrsOf types.anything)` -- however, this causes infinite
+      # recursion when `config` is a function because bootstrapping the package set requires evaluating licenses.
+      # For now, we use types.raw, the same type used by `freeformType`.
+      type = types.raw;
       example = literalExpression ''
         with lib.licenses; [
           amd
@@ -250,7 +253,10 @@ let
         applies to all licenses.
       '';
       default = [ ];
-      type = types.listOf (types.attrsOf types.anything);
+      # NOTE: The type should be `types.listOf (types.attrsOf types.anything)` -- however, this causes infinite
+      # recursion when `config` is a function because bootstrapping the package set requires evaluating licenses.
+      # For now, we use types.raw, the same type used by `freeformType`.
+      type = types.raw;
       example = literalExpression ''
         with lib.licenses; [
           agpl3Only


### PR DESCRIPTION
As title.

Hot-fix for #456994.

Ideally this wouldn't cause infinite recursion, but I don't have the bandwidth to investigate that right now. Using `types.raw` is fine (that's the default for values which don't have an option here) and lets us keep the module documentation.

Additionally, introduces module options for `blacklistedLicenses` and `whitelistedLicenses` through `mkRenamedOptionModuleWith`, continuing the work started in #114127 by creating warnings when used in future releases. This also reverts the unintentional breaking change introduced by https://github.com/NixOS/nixpkgs/commit/f5deefd4631e6062a2b84c62f1eb6d0c1a8e4ccfc which removed usage of `blacklistedLicenses` and `whitelistedLicenses` from `check-meta.nix`.

EDIT: `mkRenamedOptionModuleWith` is incompatible with `types.raw` when the aliased module supplies a default because `types.raw` prevents merging: https://github.com/NixOS/nixpkgs/pull/457038#issuecomment-3474599126.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
