### PR TITLE
tarts: 0.1.16-unstable -> 0.1.24

### DIFF
--- a/pkgs/by-name/ta/tarts/package.nix
+++ b/pkgs/by-name/ta/tarts/package.nix
@@ -3,18 +3,18 @@
   rustPlatform,
   fetchFromGitHub,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tarts";
-  version = "0.1.16-unstable-2025-05-04";
+  version = "0.1.24";
 
   src = fetchFromGitHub {
     owner = "oiwn";
     repo = "tarts";
-    rev = "8560a63dda8e5ffd5fdd96a1f7687f8f12d36022";
-    hash = "sha256-d06FL0khcI2LUMbrUo3tmQn97pNFIVefPWlxWFSUJ+E=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-whkDHgxrHkmYX6hji+z8mc964lQxllaidV8clJhvDqw=";
   };
 
-  cargoHash = "sha256-DLIBVl7CzhEYjAnkJmLHSlUoXCNos8YPHfSz9rs99/8=";
+  cargoHash = "sha256-IZyjwbx7V0kPkmD9r8qrqp4nrJg8g6tepw5bvWlLZBE=";
 
   meta = {
     description = "Screen saves and visual effects for your terminal";
@@ -23,4 +23,4 @@ rustPlatform.buildRustPackage {
     maintainers = [ lib.maintainers.awwpotato ];
     mainProgram = "tarts";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
