### PR TITLE
nixos/anubis: deprecate legacy runtime directory

### DIFF
--- a/nixos/tests/anubis.nix
+++ b/nixos/tests/anubis.nix
@@ -39,72 +39,6 @@ in
     ryand56
   ];
 
-  nodes.machineLegacy =
-    { config, pkgs, ... }:
-    {
-      services.anubis = {
-        defaultOptions = {
-          botPolicy = builtins.fromJSON legacyBotPolicyJSON;
-          settings = {
-            DIFFICULTY = 3;
-            USER_DEFINED_DEFAULT = true;
-          };
-        };
-
-        instances."".settings = {
-          TARGET = "http://localhost:8080";
-          DIFFICULTY = 5;
-          USER_DEFINED_INSTANCE = true;
-        };
-
-        instances."tcp" = {
-          user = "anubis-tcp";
-          group = "anubis-tcp";
-          settings = {
-            TARGET = "http://localhost:8080";
-            BIND = "127.0.0.1:9000";
-            BIND_NETWORK = "tcp";
-            METRICS_BIND = "127.0.0.1:9001";
-            METRICS_BIND_NETWORK = "tcp";
-          };
-        };
-      };
-
-      users.users.nginx.extraGroups = [ config.users.groups.anubis.name ];
-      services.nginx = {
-        enable = true;
-        recommendedProxySettings = true;
-        virtualHosts."basic.localhost".locations = {
-          "/".proxyPass = "http://unix:${config.services.anubis.instances."".settings.BIND}";
-          "/metrics".proxyPass = "http://unix:${config.services.anubis.instances."".settings.METRICS_BIND}";
-        };
-
-        virtualHosts."tcp.localhost".locations = {
-          "/".proxyPass = "http://${config.services.anubis.instances."tcp".settings.BIND}";
-          "/metrics".proxyPass = "http://${config.services.anubis.instances."tcp".settings.METRICS_BIND}";
-        };
-
-        # emulate an upstream with nginx, listening on tcp and unix sockets.
-        virtualHosts."upstream.localhost" = {
-          default = true; # make nginx match this vhost for `localhost`
-          listen = [
-            { addr = "unix:/run/nginx/nginx.sock"; }
-            {
-              addr = "localhost";
-              port = 8080;
-            }
-          ];
-          locations."/" = {
-            tryFiles = "$uri $uri/index.html =404";
-            root = pkgs.runCommand "anubis-test-upstream" { } ''
-              mkdir $out
-              echo "it works" >> $out/index.html
-            '';
-          };
-        };
-      };
-    };
-
   nodes.machine =
     { config, pkgs, ... }:
     {
@@ -131,8 +65,6 @@ in
           TARGET = "http://localhost:8080";
           DIFFICULTY = 5;
           USER_DEFINED_INSTANCE = true;
-          BIND = "/run/anubis/anubis/anubis.sock";
-          METRICS_BIND = "/run/anubis/anubis/anubis-metrics.sock";
         };
 
         instances."tcp" = {
@@ -150,16 +82,12 @@ in
         instances."another-unix-listen" = {
           settings = {
             TARGET = "http://localhost:8080";
-            BIND = "/run/anubis/anubis-another-unix-listen/anubis.sock";
-            METRICS_BIND = "/run/anubis/anubis-another-unix-listen/anubis-metrics.sock";
           };
         };
 
         instances."unix-upstream" = {
           group = "nginx";
           settings = {
-            BIND = "/run/anubis/anubis-unix-upstream/anubis.sock";
-            METRICS_BIND = "/run/anubis/anubis-unix-upstream/anubis-metrics.sock";
             TARGET = "unix:///run/nginx/nginx.sock";
           };
         };
@@ -168,8 +96,6 @@ in
           botPolicy = null;
           settings = {
             TARGET = "http://localhost:8080";
-            BIND = "/run/anubis/anubis-botPolicy-default/anubis.sock";
-            METRICS_BIND = "/run/anubis/anubis-botPolicy-default/anubis-metrics.sock";
           };
         };
 
@@ -177,8 +103,6 @@ in
           settings = {
             TARGET = "http://localhost:8080";
             POLICY_FNAME = "/etc/anubis-botPolicy.json";
-            BIND = "/run/anubis/anubis-botPolicy-file/anubis.sock";
-            METRICS_BIND = "/run/anubis/anubis-botPolicy-file/anubis-metrics.sock";
           };
         };
       };
@@ -233,61 +157,43 @@ in
     };
 
   testScript = ''
-    with subtest("Legacy anubis service configuration: supports only a single RuntimeDirectory"):
-      for unit in ["nginx", "anubis", "anubis-tcp"]:
-        machineLegacy.wait_for_unit(unit + ".service")
+    for unit in ["nginx", "anubis", "anubis-another-unix-listen", "anubis-tcp", "anubis-unix-upstream"]:
+      machine.wait_for_unit(unit + ".service")
 
-      machineLegacy.wait_for_open_unix_socket("/run/anubis/anubis.sock")
-      machineLegacy.wait_for_open_unix_socket("/run/anubis/anubis-metrics.sock")
+    for port in [9000, 9001]:
+      machine.wait_for_open_port(port)
 
-      # Default unix socket mode with 1 instance listening on unix sockets.
-      machineLegacy.succeed('curl -f http://localhost:8080 | grep "it works"')
-      machineLegacy.succeed('curl -f http://basic.localhost | grep "it works"')
-      machineLegacy.succeed('curl -f http://basic.localhost -H "User-Agent: Mozilla" | grep anubis')
-      machineLegacy.succeed('curl -f http://basic.localhost/metrics | grep anubis_challenges_issued')
+    machine.wait_for_open_unix_socket("/run/anubis/anubis/anubis.sock")
+    machine.wait_for_open_unix_socket("/run/anubis/anubis/anubis-metrics.sock")
+    for instance in ["another-unix-listen", "unix-upstream"]:
+      machine.wait_for_open_unix_socket(f"/run/anubis/anubis-{instance}/anubis.sock")
+      machine.wait_for_open_unix_socket(f"/run/anubis/anubis-{instance}/anubis-metrics.sock")
 
-      # TCP mode.
-      machineLegacy.succeed('curl -f http://tcp.localhost -H "User-Agent: Mozilla" | grep anubis')
-      machineLegacy.succeed('curl -f http://tcp.localhost/metrics | grep anubis_challenges_issued')
+    machine.succeed('curl -f http://basic.localhost | grep "it works"')
+    machine.succeed('curl -f http://basic.localhost -H "User-Agent: Mozilla" | grep anubis')
+    machine.succeed('curl -f http://basic.localhost/metrics | grep anubis_challenges_issued')
 
-    with subtest("Dedicated RuntimeDirectory"):
-      for unit in ["nginx", "anubis", "anubis-another-unix-listen", "anubis-tcp", "anubis-unix-upstream"]:
-        machine.wait_for_unit(unit + ".service")
+    machine.succeed('curl -f http://another-unix-listen.localhost -H "User-Agent: Mozilla" | grep anubis')
+    machine.succeed('curl -f http://another-unix-listen.localhost/metrics | grep anubis_challenges_issued')
 
-      for port in [9000, 9001]:
-        machine.wait_for_open_port(port)
+    # Upstream is a unix socket mode.
+    machine.succeed('curl -f http://unix.localhost/index.html | grep "it works"')
 
-      machine.wait_for_open_unix_socket("/run/anubis/anubis/anubis.sock")
-      machine.wait_for_open_unix_socket("/run/anubis/anubis/anubis-metrics.sock")
-      for instance in ["another-unix-listen", "unix-upstream"]:
-        machine.wait_for_open_unix_socket(f"/run/anubis/anubis-{instance}/anubis.sock")
-        machine.wait_for_open_unix_socket(f"/run/anubis/anubis-{instance}/anubis-metrics.sock")
+    # Default user-defined environment variables.
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_DEFAULT"')
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_DEFAULT"')
 
-      machine.succeed('curl -f http://basic.localhost | grep "it works"')
-      machine.succeed('curl -f http://basic.localhost -H "User-Agent: Mozilla" | grep anubis')
-      machine.succeed('curl -f http://basic.localhost/metrics | grep anubis_challenges_issued')
+    # Instance-specific user-specified environment variables.
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_INSTANCE"')
+    machine.fail('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_INSTANCE"')
 
-      machine.succeed('curl -f http://another-unix-listen.localhost -H "User-Agent: Mozilla" | grep anubis')
-      machine.succeed('curl -f http://another-unix-listen.localhost/metrics | grep anubis_challenges_issued')
+    # Make sure defaults don't overwrite themselves.
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "DIFFICULTY=5"')
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "DIFFICULTY=3"')
 
-      # Upstream is a unix socket mode.
-      machine.succeed('curl -f http://unix.localhost/index.html | grep "it works"')
-
-      # Default user-defined environment variables.
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_DEFAULT"')
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_DEFAULT"')
-
-      # Instance-specific user-specified environment variables.
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "USER_DEFINED_INSTANCE"')
-      machine.fail('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "USER_DEFINED_INSTANCE"')
-
-      # Make sure defaults don't overwrite themselves.
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "DIFFICULTY=5"')
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis-tcp.service | grep "DIFFICULTY=3"')
-
-      # Check correct BotPolicy settings are applied
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "POLICY_FNAME=/nix/store"')
-      machine.fail('cat /run/current-system/etc/systemd/system/anubis-botPolicy-default.service | grep "POLICY_FNAME="')
-      machine.succeed('cat /run/current-system/etc/systemd/system/anubis-botPolicy-file.service | grep "POLICY_FNAME=/etc/anubis-botPolicy.json"')
+    # Check correct BotPolicy settings are applied
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis.service | grep "POLICY_FNAME=/nix/store"')
+    machine.fail('cat /run/current-system/etc/systemd/system/anubis-botPolicy-default.service | grep "POLICY_FNAME="')
+    machine.succeed('cat /run/current-system/etc/systemd/system/anubis-botPolicy-file.service | grep "POLICY_FNAME=/etc/anubis-botPolicy.json"')
   '';
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/437667 added support for a dedicated runtime directory per anubis instance and preserved support for the legacy `/run/anubis` runtime directory.  

The release 25.11 warned users that `services.anubis.instances.<name>.settings.BIND` and `services.anubis.instances.<name>.settings.METRICS_BIND` should be updated according to the new runtime directory path.  

This PR drops the support for the legacy runtime directory and updates the default values of `BIND` and `METRICS_BIND`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
