### PR TITLE
aliases: remove hacky workaround for warnings on strings

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -230,11 +230,6 @@ let
       arg: lib.warn msg (v arg)
     else if lib.isList v then
       map (lib.warn msg) v
-    else if lib.isString v then
-      # Unlike the other cases, this changes the type of the value and
-      # is therefore a breaking change for some code, but it’s the best
-      # we can do.
-      { __toString = lib.warn msg (lib.const v); }
     else
       # Can’t do better than this, and a `throw` would be more
       # disruptive for users…


### PR DESCRIPTION
This causes confusing eval errors when not using these values (here: `system`) in a string interpolation context.

The change will potentially be noisy for nix search. If we want a deprecation period for this attribute instead of just throwing immediately, we will have to accept this, at least temporarily.

Fixes https://github.com/NixOS/nixpkgs/pull/456527#discussion_r2478979686.

## Things done

- [x] Tested in `nix repl`. It's a string. A real string.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
