### PR TITLE
elan: use bundled clang and ld.lld

### DIFF
--- a/pkgs/by-name/el/elan/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/by-name/el/elan/0001-dynamically-patchelf-binaries.patch
@@ -1,8 +1,8 @@
 diff --git a/src/elan-dist/src/component/package.rs b/src/elan-dist/src/component/package.rs
-index c51e76d..ae8159e 100644
+index 89ff5ce..91784b3 100644
 --- a/src/elan-dist/src/component/package.rs
 +++ b/src/elan-dist/src/component/package.rs
-@@ -56,6 +56,52 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
+@@ -51,6 +51,51 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
          entry
              .unpack(&full_path)
              .chain_err(|| ErrorKind::ExtractingPackage)?;
@@ -13,45 +13,44 @@ index c51e76d..ae8159e 100644
 +}
 +
 +fn nix_patch_if_needed(dest_path: &Path) -> Result<()> {
++    use std::os::unix::fs::PermissionsExt;
++
 +    let is_bin = matches!(dest_path.parent(), Some(p) if p.ends_with("bin"));
-+    if !is_bin { return Ok(()) }
++    if !is_bin {
++        return Ok(());
++    }
 +    let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
 +        .arg("--set-interpreter")
 +        .arg("@dynamicLinker@")
 +        .arg(dest_path)
 +        .output();
 +
-+    if dest_path.file_name() == Some(::std::ffi::OsStr::new("leanc")) {
-+        use std::os::unix::fs::PermissionsExt;
-+        let new_path = dest_path.with_extension("orig");
-+        ::std::fs::rename(dest_path, &new_path)?;
-+        ::std::fs::write(dest_path, r#"#! @shell@
-+dir="$(dirname "${BASH_SOURCE[0]}")"
-+# use bundled libraries, but not bundled compiler that doesn't know about NIX_LDFLAGS
-+LEAN_CC="${LEAN_CC:-@cc@}" exec -a "$0" "$dir/leanc.orig" "$@" -L"$dir/../lib"
-+"#)?;
-+        ::std::fs::set_permissions(dest_path, ::std::fs::Permissions::from_mode(0o755))?;
-+    } else if dest_path.file_name() == Some(::std::ffi::OsStr::new("lake")) {
-+        // since Lean 4.16.0, `lake` calls `LEAN_CC` directly instead of through `leanc`
-+        use std::os::unix::fs::PermissionsExt;
-+        ::std::fs::write(dest_path.with_file_name("cc"), r#"#! @shell@
-+dir="$(dirname "${BASH_SOURCE[0]}")"
-+# use bundled libraries, but not bundled compiler that doesn't know about NIX_LDFLAGS
-+exec "@cc@" "$@" -L"$dir/../lib"
-+"#)?;
-+        ::std::fs::set_permissions(dest_path.with_file_name("cc"), ::std::fs::Permissions::from_mode(0o755))?;
-+
-+        let new_path = dest_path.with_extension("orig");
-+        ::std::fs::rename(dest_path, &new_path)?;
-+        ::std::fs::write(dest_path, r#"#! @shell@
-+dir="$(dirname "${BASH_SOURCE[0]}")"
-+# use custom `cc`
-+LEAN_CC="${LEAN_CC:-"$dir/cc"}" exec -a "$0" "$dir/lake.orig" "$@"
-+"#)?;
++    if dest_path.file_name() == Some(::std::ffi::OsStr::new("ld.lld")) {
++        // https://github.com/NixOS/nixpkgs/blob/0ea2f6d48ce952cc86f7104f8a51ad61fa9b6aad/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch#L17
++        // ld.lld must keep the same binary name, or else it won't work.
++        // It also has a relative runpath, so it can't be in a subdirectory.
++        let unwrapped_dir = dest_path.parent().unwrap().with_file_name("bin-unwrapped");
++        let unwrapped_path = unwrapped_dir.join("ld.lld");
++        ::std::fs::create_dir_all(unwrapped_dir)?;
++        ::std::fs::rename(dest_path, &unwrapped_path)?;
++        let mut ld_wrapper_path = std::env::current_exe()?
++            .parent()
++            .ok_or("failed to get parent directory")?
++            .with_file_name("nix-support");
++        ld_wrapper_path.push("ld-wrapper.sh");
++        let wrapped_script = format!(
++            r#"#!/usr/bin/env bash
++set -eu -o pipefail +o posix
++shopt -s nullglob
++export PROG="$(dirname "$0")-unwrapped/ld.lld"
++"{}" $@"#,
++            ld_wrapper_path.to_string_lossy(),
++        );
++        ::std::fs::write(dest_path, wrapped_script)?;
 +        ::std::fs::set_permissions(dest_path, ::std::fs::Permissions::from_mode(0o755))?;
 +    } else if dest_path.file_name() == Some(::std::ffi::OsStr::new("llvm-ar")) {
 +        ::std::fs::remove_file(dest_path)?;
 +        ::std::os::unix::fs::symlink("@ar@", dest_path)?;
      }
-
+ 
      Ok(())

--- a/pkgs/by-name/el/elan/add-flags.sh
+++ b/pkgs/by-name/el/elan/add-flags.sh
@@ -1,0 +1,37 @@
+# See cc-wrapper for comments.
+var_templates_list=(
+    NIX_IGNORE_LD_THROUGH_GCC
+    NIX_LDFLAGS
+    NIX_LDFLAGS_BEFORE
+    NIX_DYNAMIC_LINKER
+    NIX_LDFLAGS_AFTER
+    NIX_LDFLAGS_HARDEN
+    NIX_HARDENING_ENABLE
+)
+var_templates_bool=(
+    NIX_SET_BUILD_ID
+    NIX_DONT_SET_RPATH
+)
+
+accumulateRoles
+
+for var in "${var_templates_list[@]}"; do
+    mangleVarList "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
+done
+for var in "${var_templates_bool[@]}"; do
+    mangleVarBool "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
+done
+
+if [ -e @out@/nix-support/libc-ldflags ]; then
+    NIX_LDFLAGS_@suffixSalt@+=" $(< @out@/nix-support/libc-ldflags)"
+fi
+
+if [ -z "$NIX_DYNAMIC_LINKER_@suffixSalt@" ] && [ -e @out@/nix-support/ld-set-dynamic-linker ]; then
+    NIX_DYNAMIC_LINKER_@suffixSalt@="$(< @out@/nix-support/dynamic-linker)"
+fi
+
+if [ -e @out@/nix-support/libc-ldflags-before ]; then
+    NIX_LDFLAGS_BEFORE_@suffixSalt@="$(< @out@/nix-support/libc-ldflags-before) $NIX_LDFLAGS_BEFORE_@suffixSalt@"
+fi
+
+export NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@=1

--- a/pkgs/by-name/el/elan/add-hardening.sh
+++ b/pkgs/by-name/el/elan/add-hardening.sh
@@ -1,0 +1,52 @@
+declare -a hardeningLDFlags=()
+
+declare -A hardeningEnableMap=()
+
+# Intentionally word-split in case 'NIX_HARDENING_ENABLE' is defined in Nix. The
+# array expansion also prevents undefined variables from causing trouble with
+# `set -u`.
+for flag in ${NIX_HARDENING_ENABLE_@suffixSalt@-}; do
+  hardeningEnableMap["$flag"]=1
+done
+
+# Remove unsupported flags.
+for flag in @hardening_unsupported_flags@; do
+  unset -v "hardeningEnableMap[$flag]"
+done
+
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
+  declare -a allHardeningFlags=(relro bindnow)
+  declare -A hardeningDisableMap=()
+
+  # Determine which flags were effectively disabled so we can report below.
+  for flag in "${allHardeningFlags[@]}"; do
+    if [[ -z "${hardeningEnableMap[$flag]-}" ]]; then
+      hardeningDisableMap[$flag]=1
+    fi
+  done
+
+  printf 'HARDENING: disabled flags:' >&2
+  (( "${#hardeningDisableMap[@]}" )) && printf ' %q' "${!hardeningDisableMap[@]}" >&2
+  echo >&2
+
+  if (( "${#hardeningEnableMap[@]}" )); then
+    echo 'HARDENING: Is active (not completely disabled with "all" flag)' >&2;
+  fi
+fi
+
+for flag in "${!hardeningEnableMap[@]}"; do
+  case $flag in
+    relro)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling relro >&2; fi
+      hardeningLDFlags+=('-z' 'relro')
+      ;;
+    bindnow)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling bindnow >&2; fi
+      hardeningLDFlags+=('-z' 'now')
+      ;;
+    *)
+      # Ignore unsupported. Checked in Nix that at least *some*
+      # tool supports each flag.
+      ;;
+  esac
+done

--- a/pkgs/by-name/el/elan/darwin-sdk-setup.bash
+++ b/pkgs/by-name/el/elan/darwin-sdk-setup.bash
@@ -1,0 +1,16 @@
+accumulateRoles
+
+# Only set up `DEVELOPER_DIR` if a default darwin min version is set,
+# which is a signal that we're targetting darwin.
+if [[ "@darwinMinVersion@" ]]; then
+    # `DEVELOPER_DIR` is used to dynamically locate libSystem (and the SDK frameworks) based on the SDK at that path.
+    mangleVarSingle DEVELOPER_DIR ${role_suffixes[@]+"${role_suffixes[@]}"}
+
+    # Allow wrapped compilers to do something useful when no `DEVELOPER_DIR` is set, which can happen when
+    # the compiler is run outside of a stdenv or intentionally in an environment with no environment variables set.
+    export DEVELOPER_DIR=${DEVELOPER_DIR_@suffixSalt@:-@fallback_sdk@}
+
+    # xcbuild needs `SDKROOT` to be the name of the SDK, which it sets in its own wrapper,
+    # but compilers expect it to point to the absolute path.
+    export SDKROOT="$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+fi

--- a/pkgs/by-name/el/elan/ld-wrapper.sh
+++ b/pkgs/by-name/el/elan/ld-wrapper.sh
@@ -1,0 +1,296 @@
+#! @shell@
+set -eu -o pipefail +o posix
+shopt -s nullglob
+
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
+path_backup="$PATH"
+
+# phase separation makes this look useless
+# shellcheck disable=SC2157
+if [ -n "@coreutils_bin@" ]; then
+    PATH="@coreutils_bin@/bin"
+fi
+
+source @out@/nix-support/utils.bash
+
+source @out@/nix-support/darwin-sdk-setup.bash
+
+if [ -z "${NIX_BINTOOLS_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
+    source @out@/nix-support/add-flags.sh
+fi
+
+
+# Optionally filter out paths not refering to the store.
+expandResponseParams "$@"
+
+# NIX_LINK_TYPE is set if ld has been called through our cc wrapper. We take
+# advantage of this to avoid both recalculating it, and also repeating other
+# processing cc wrapper has already done.
+if [[ -n "${NIX_LINK_TYPE_@suffixSalt@:-}" ]]; then
+    linkType=$NIX_LINK_TYPE_@suffixSalt@
+else
+    linkType=$(checkLinkType "${params[@]}")
+fi
+
+if [[ "${NIX_ENFORCE_PURITY:-}" = 1 && -n "${NIX_STORE:-}"
+        && ( -z "$NIX_IGNORE_LD_THROUGH_GCC_@suffixSalt@" || -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ) ]]; then
+    rest=()
+    nParams=${#params[@]}
+    declare -i n=0
+
+    while (( "$n" < "$nParams" )); do
+        p=${params[n]}
+        p2=${params[n+1]:-} # handle `p` being last one
+        if [ "${p:0:3}" = -L/ ] && badPathWithDarwinSdk "${p:2}"; then
+            skip "${p:2}"
+        elif [ "$p" = -L ] && badPathWithDarwinSdk "$p2"; then
+            n+=1; skip "$p2"
+        elif [ "$p" = -rpath ] && badPath "$p2"; then
+            n+=1; skip "$p2"
+        elif [ "$p" = -dynamic-linker ] && badPath "$p2"; then
+            n+=1; skip "$p2"
+        elif [ "$p" = -syslibroot ] && [ $p2 == // ]; then
+            # When gcc is built on darwin --with-build-sysroot=/
+            # produces '-syslibroot //' linker flag. It's a no-op,
+            # which does not introduce impurities.
+            n+=1; skip "$p2"
+        elif [ "${p:0:10}" = /LIBPATH:/ ] && badPath "${p:9}"; then
+            reject "${p:9}"
+        # We need to not match LINK.EXE-style flags like
+        # /NOLOGO or /LIBPATH:/nix/store/foo
+        elif [[ $p =~ ^/[^:]*/ ]] && badPath "$p"; then
+            reject "$p"
+        elif [ "${p:0:9}" = --sysroot ]; then
+            # Our ld is not built with sysroot support (Can we fix that?)
+            :
+        else
+            rest+=("$p")
+        fi
+        n+=1
+    done
+    # Old bash empty array hack
+    params=(${rest+"${rest[@]}"})
+fi
+
+
+source @out@/nix-support/add-hardening.sh
+
+extraAfter=()
+extraBefore=(${hardeningLDFlags[@]+"${hardeningLDFlags[@]}"})
+
+if [ -z "${NIX_LINK_TYPE_@suffixSalt@:-}" ]; then
+    extraAfter+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_@suffixSalt@))
+    extraBefore+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_BEFORE_@suffixSalt@))
+
+    # By adding dynamic linker to extraBefore we allow the users set their
+    # own dynamic linker as NIX_LD_FLAGS will override earlier set flags
+    if [[ "$linkType" == dynamic && -n "$NIX_DYNAMIC_LINKER_@suffixSalt@" ]]; then
+        extraBefore+=("-dynamic-linker" "$NIX_DYNAMIC_LINKER_@suffixSalt@")
+    fi
+fi
+
+extraAfter+=($(filterRpathFlags "$linkType" $NIX_LDFLAGS_AFTER_@suffixSalt@))
+
+# These flags *must not* be pulled up to -Wl, flags, so they can't go in
+# add-flags.sh. They must always be set, so must not be disabled by
+# NIX_LDFLAGS_SET.
+if [ -e @out@/nix-support/add-local-ldflags-before.sh ]; then
+    source @out@/nix-support/add-local-ldflags-before.sh
+fi
+
+
+# Three tasks:
+#
+#   1. Find all -L... switches for rpath
+#
+#   2. Find relocatable flag for build id.
+#
+#   3. Choose 32-bit dynamic linker if needed
+declare -a libDirs
+declare -A libs
+declare -i relocatable=0 link32=0
+
+linkerOutput="a.out"
+
+if
+    [ "$NIX_DONT_SET_RPATH_@suffixSalt@" != 1 ] \
+        || [ "$NIX_SET_BUILD_ID_@suffixSalt@" = 1 ] \
+        || [ -e @out@/nix-support/dynamic-linker-m32 ]
+then
+    prev=
+    # Old bash thinks empty arrays are undefined, ugh.
+    for p in \
+        ${extraBefore+"${extraBefore[@]}"} \
+        ${params+"${params[@]}"} \
+        ${extraAfter+"${extraAfter[@]}"}
+    do
+        case "$prev" in
+            -L)
+                libDirs+=("$p")
+                ;;
+            -l)
+                libs["lib${p}.so"]=1
+                ;;
+            -m)
+                # Presumably only the last `-m` flag has any effect.
+                case "$p" in
+                    elf_i386) link32=1;;
+                    *)        link32=0;;
+                esac
+                ;;
+            -dynamic-linker | -plugin)
+                # Ignore this argument, or it will match *.so and be added to rpath.
+                ;;
+            *)
+                case "$p" in
+                    -L/*)
+                        libDirs+=("${p:2}")
+                        ;;
+                    -l?*)
+                        libs["lib${p:2}.so"]=1
+                        ;;
+                    "${NIX_STORE:-}"/*.so | "${NIX_STORE:-}"/*.so.*)
+                        # This is a direct reference to a shared library.
+                        libDirs+=("${p%/*}")
+                        libs["${p##*/}"]=1
+                        ;;
+                    -r | --relocatable | -i)
+                        relocatable=1
+                esac
+                ;;
+        esac
+        prev="$p"
+    done
+fi
+
+# Determine linkerOutput
+prev=
+for p in \
+    ${extraBefore+"${extraBefore[@]}"} \
+    ${params+"${params[@]}"} \
+    ${extraAfter+"${extraAfter[@]}"}
+do
+    case "$prev" in
+        -o)
+            # Informational for post-link-hook
+            linkerOutput="$p"
+            ;;
+        *)
+            ;;
+    esac
+    prev="$p"
+done
+
+if [[ "$link32" == "1" && "$linkType" == dynamic && -e "@out@/nix-support/dynamic-linker-m32" ]]; then
+    # We have an alternate 32-bit linker and we're producing a 32-bit ELF, let's
+    # use it.
+    extraAfter+=(
+        '-dynamic-linker'
+        "$(< @out@/nix-support/dynamic-linker-m32)"
+    )
+fi
+
+# Add all used dynamic libraries to the rpath.
+if [[ "$NIX_DONT_SET_RPATH_@suffixSalt@" != 1 && "$linkType" != static-pie ]]; then
+    # For each directory in the library search path (-L...),
+    # see if it contains a dynamic library used by a -l... flag.  If
+    # so, add the directory to the rpath.
+    # It's important to add the rpath in the order of -L..., so
+    # the link time chosen objects will be those of runtime linking.
+    declare -A rpaths
+    for dir in ${libDirs+"${libDirs[@]}"}; do
+        # If the path is in the store, do not resolve any symlinks and add it to the rpath.
+        # Resolving symlinks in the store breaks bootstrapping, see issue #454199.
+        # If it is outside the store, resolve symlinks step by step until it falls
+        # into the store or it becomes not a symlink.
+        # Always canonicalize the path before checking it is in the store or not.
+        if dir2=$(realpath -s "$dir"); then
+            dir="$dir2"
+        else
+            continue
+        fi
+        while [ -z "${rpaths[$dir]:-}" ] && [[ "$dir" != "${NIX_STORE:-}"/* ]] && [ -L "$dir" ]; do
+            if dir2=$(readlink "$dir"); then
+                dir="dir2"
+            else
+                break
+            fi
+            if dir2=$(realpath -s "$dir"); then
+                dir="dir2"
+            else
+                break
+            fi
+        done
+        # If the path turns out to be outside the store, we do not add it to rpath.
+        # This typically happens for libraries in /tmp that are later
+        # copied to $out/lib. If not, we're screwed.
+        if [ -n "${rpaths[$dir]:-}" ] || [[ "$dir" != "${NIX_STORE:-}"/* ]]; then
+            continue
+        fi
+        for path in "$dir"/*; do
+            file="${path##*/}"
+            if [ "${libs[$file]:-}" ]; then
+                # This library may have been provided by a previous directory,
+                # but if that library file is inside an output of the current
+                # derivation, it can be deleted after this compilation and
+                # should be found in a later directory, so we add all
+                # directories that contain any of the libraries to rpath.
+                rpaths["$dir"]=1
+                extraAfter+=(-rpath "$dir")
+                break
+            fi
+        done
+    done
+
+fi
+
+# Only add --build-id if this is a final link. FIXME: should build gcc
+# with --enable-linker-build-id instead?
+#
+# Note: `lld` interprets `--build-id` to mean `--build-id=fast`; GNU ld defaults
+# to SHA1.
+if [ "$NIX_SET_BUILD_ID_@suffixSalt@" = 1 ] && ! (( "$relocatable" )); then
+    extraAfter+=(--build-id="${NIX_BUILD_ID_STYLE:-sha1}")
+fi
+
+# if a ld-wrapper-hook exists, run it.
+if [[ -e @out@/nix-support/ld-wrapper-hook ]]; then
+    linker=@prog@
+    source @out@/nix-support/ld-wrapper-hook
+fi
+
+# Optionally print debug info.
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
+    # Old bash workaround, see above.
+    echo "extra flags before to @prog@:" >&2
+    printf "  %q\n" ${extraBefore+"${extraBefore[@]}"}  >&2
+    echo "original flags to @prog@:" >&2
+    printf "  %q\n" ${params+"${params[@]}"} >&2
+    echo "extra flags after to @prog@:" >&2
+    printf "  %q\n" ${extraAfter+"${extraAfter[@]}"} >&2
+fi
+
+PATH="$path_backup"
+# Old bash workaround, see above.
+
+if (( "${NIX_LD_USE_RESPONSE_FILE:-@use_response_file_by_default@}" >= 1 )); then
+    responseFile=$(@mktemp@ "${TMPDIR:-/tmp}/ld-params.XXXXXX")
+    trap '@rm@ -f -- "$responseFile"' EXIT
+    printf "%q\n" \
+       ${extraBefore+"${extraBefore[@]}"} \
+       ${params+"${params[@]}"} \
+       ${extraAfter+"${extraAfter[@]}"} > "$responseFile"
+    @prog@ "@$responseFile"
+else
+    @prog@ \
+        ${extraBefore+"${extraBefore[@]}"} \
+        ${params+"${params[@]}"} \
+        ${extraAfter+"${extraAfter[@]}"}
+fi
+
+if [ -e "@out@/nix-support/post-link-hook" ]; then
+    source @out@/nix-support/post-link-hook
+fi

--- a/pkgs/by-name/el/elan/package.nix
+++ b/pkgs/by-name/el/elan/package.nix
@@ -3,7 +3,7 @@
   lib,
   runCommand,
   patchelf,
-  makeWrapper,
+  makeBinaryWrapper,
   pkg-config,
   curl,
   runtimeShell,
@@ -12,6 +12,7 @@
   fetchFromGitHub,
   rustPlatform,
   libiconv,
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -28,8 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-JzyDVFp1lGPk1IK6CLQMBcJi5yCVD9x1iXtN0wlOF3g=";
 
   nativeBuildInputs = [
+    makeBinaryWrapper
     pkg-config
-    makeWrapper
+    writableTmpDirAsHomeHook
   ];
 
   env.OPENSSL_NO_VENDOR = 1;
@@ -74,12 +76,39 @@ rustPlatform.buildRustPackage (finalAttrs: {
     popd
 
     # tries to create .elan
-    export HOME=$(mktemp -d)
     mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
     $out/bin/elan completions bash > "$out/share/bash-completion/completions/elan"
     $out/bin/elan completions fish > "$out/share/fish/vendor_completions.d/elan.fish"
     $out/bin/elan completions zsh >  "$out/share/zsh/site-functions/_elan"
+
+    # https://github.com/NixOS/nixpkgs/blob/cae2bb97b01c4c77849e46a41a22e0a62926fc0f/pkgs/development/tools/rust/rustup/default.nix#L131-L140
+    mkdir -p $out/nix-support
+    substituteAll ${./utils.bash} $out/nix-support/utils.bash
+    substituteAll ${./darwin-sdk-setup.bash} $out/nix-support/darwin-sdk-setup.bash
+    substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
+    substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
+    export prog='$PROG'
+    export use_response_file_by_default=0
+    substituteAll ${./ld-wrapper.sh} $out/nix-support/ld-wrapper.sh
+    chmod +x $out/nix-support/ld-wrapper.sh
+
+    # Ensure that the ld.lld wrapper sets the interpreter path, not clang.
+    touch $out/nix-support/ld-set-dynamic-linker
+    cp ${stdenv.cc}/nix-support/dynamic-linker $out/nix-support/dynamic-linker
+    sed -i 's|extraBefore+=("-dynamic-linker"|extraAfter+=("-dynamic-linker"|' $out/nix-support/ld-wrapper.sh
   '';
+
+  # https://github.com/NixOS/nixpkgs/blob/cae2bb97b01c4c77849e46a41a22e0a62926fc0f/pkgs/development/tools/rust/rustup/default.nix#L143-L152
+  env = {
+    inherit (stdenv.cc.bintools)
+      expandResponseParams
+      shell
+      suffixSalt
+      wrapperName
+      coreutils_bin
+      ;
+    hardening_unsupported_flags = "";
+  };
 
   meta = {
     description = "Small tool to manage your installations of the Lean theorem prover";

--- a/pkgs/by-name/el/elan/update_wrapper_scripts.sh
+++ b/pkgs/by-name/el/elan/update_wrapper_scripts.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+cp \
+  ../../../build-support/wrapper-common/utils.bash \
+  ../../../build-support/wrapper-common/darwin-sdk-setup.bash \
+  ../../../build-support/bintools-wrapper/add-flags.sh \
+  ../../../build-support/bintools-wrapper/add-hardening.sh \
+  ../../../build-support/bintools-wrapper/ld-wrapper.sh \
+  .

--- a/pkgs/by-name/el/elan/utils.bash
+++ b/pkgs/by-name/el/elan/utils.bash
@@ -1,0 +1,186 @@
+# Accumulate suffixes for taking in the right input parameters with the `mangle*`
+# functions below. See setup-hook for details.
+accumulateRoles() {
+    declare -ga role_suffixes=()
+    if [ "${NIX_@wrapperName@_TARGET_BUILD_@suffixSalt@:-}" ]; then
+        role_suffixes+=('_FOR_BUILD')
+    fi
+    if [ "${NIX_@wrapperName@_TARGET_HOST_@suffixSalt@:-}" ]; then
+        role_suffixes+=('')
+    fi
+    if [ "${NIX_@wrapperName@_TARGET_TARGET_@suffixSalt@:-}" ]; then
+        role_suffixes+=('_FOR_TARGET')
+    fi
+}
+
+mangleVarListGeneric() {
+    local sep="$1"
+    shift
+    local var="$1"
+    shift
+    local -a role_suffixes=("$@")
+
+    local outputVar="${var}_@suffixSalt@"
+    declare -gx "$outputVar"+=''
+    # For each role we serve, we accumulate the input parameters into our own
+    # cc-wrapper-derivation-specific environment variables.
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
+        if [ -v "$inputVar" ]; then
+            export "${outputVar}+=${!outputVar:+$sep}${!inputVar}"
+        fi
+    done
+}
+
+mangleVarList() {
+    mangleVarListGeneric " " "$@"
+}
+
+mangleVarBool() {
+    local var="$1"
+    shift
+    local -a role_suffixes=("$@")
+
+    local outputVar="${var}_@suffixSalt@"
+    declare -gxi "${outputVar}+=0"
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
+        if [ -v "$inputVar" ]; then
+            # "1" in the end makes `let` return success error code when
+            # expression itself evaluates to zero.
+            # We don't use `|| true` because that would silence actual
+            # syntax errors from bad variable values.
+            let "${outputVar} |= ${!inputVar:-0}" "1"
+        fi
+    done
+}
+
+# Combine a singular value from all roles. If multiple roles are being served,
+# and the value differs in these roles then the request is impossible to
+# satisfy and we abort immediately.
+mangleVarSingle() {
+    local var="$1"
+    shift
+    local -a role_suffixes=("$@")
+
+    local outputVar="${var}_@suffixSalt@"
+    for suffix in "${role_suffixes[@]}"; do
+        local inputVar="${var}${suffix}"
+        if [ -v "$inputVar" ]; then
+            if [ -v "$outputVar" ]; then
+                if [ "${!outputVar}" != "${!inputVar}" ]; then
+                    {
+                        echo "Multiple conflicting values defined for $outputVar"
+                        echo "Existing value is ${!outputVar}"
+                        echo "Attempting to set to ${!inputVar} via $inputVar"
+                    } >&2
+
+                    exit 1
+                fi
+            else
+                declare -gx ${outputVar}="${!inputVar}"
+            fi
+        fi
+    done
+}
+
+skip() {
+    if (( "${NIX_DEBUG:-0}" >= 1 )); then
+        echo "skipping impure path $1" >&2
+    fi
+}
+
+reject() {
+    echo "impure path \`$1' used in link" >&2
+    exit 1
+}
+
+
+# Checks whether a path is impure.  E.g., `/lib/foo.so' is impure, but
+# `/nix/store/.../lib/foo.so' isn't.
+badPath() {
+    local p=$1
+
+    # Relative paths are okay (since they're presumably relative to
+    # the temporary build directory).
+    if [ "${p:0:1}" != / ]; then return 1; fi
+
+    # Otherwise, the path should refer to the store or some temporary
+    # directory (including the build directory).
+    test \
+        "$p" != "/dev/null" -a \
+        "${p#"${NIX_STORE}"}"     = "$p" -a \
+        "${p#"${NIX_BUILD_TOP}"}" = "$p" -a \
+        "${p#/tmp}"               = "$p" -a \
+        "${p#"${TMP:-/tmp}"}"     = "$p" -a \
+        "${p#"${TMPDIR:-/tmp}"}"  = "$p" -a \
+        "${p#"${TEMP:-/tmp}"}"    = "$p" -a \
+        "${p#"${TEMPDIR:-/tmp}"}" = "$p"
+}
+
+# Like `badPath`, but handles paths that may be interpreted relative to
+# `$SDKROOT` on Darwin. For example, `-L/usr/lib/swift` is interpreted
+# as `-L$SDKROOT/usr/lib/swift` when `$SDKROOT` is set and
+# `$SDKROOT/usr/lib/swift` exists.
+badPathWithDarwinSdk() {
+    path=$1
+    if [[ "@darwinMinVersion@" ]]; then
+        sdkPath=$SDKROOT/$path
+        if [[ -e $sdkPath ]]; then
+            path=$sdkPath
+        fi
+    fi
+    badPath "$path"
+}
+
+expandResponseParams() {
+    declare -ga params=("$@")
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == @* ]]; then
+            # phase separation makes this look useless
+            # shellcheck disable=SC2157
+            if [ -x "@expandResponseParams@" ]; then
+                # params is used by caller
+                #shellcheck disable=SC2034
+                readarray -d '' params < <("@expandResponseParams@" "$@")
+                return 0
+            fi
+        fi
+    done
+}
+
+checkLinkType() {
+    local arg
+    type="dynamic"
+    for arg in "$@"; do
+        if [[ "$arg" = -static ]]; then
+            type="static"
+        elif [[ "$arg" = -static-pie ]]; then
+            type="static-pie"
+        fi
+    done
+    echo "$type"
+}
+
+# When building static-pie executables we cannot have rpath
+# set. At least glibc requires rpath to be empty
+filterRpathFlags() {
+    local linkType=$1 ret i
+    shift
+
+    if [[ "$linkType" == "static-pie" ]]; then
+        while [[ "$#" -gt 0 ]]; do
+            i="$1"; shift 1
+            if [[ "$i" == -rpath ]]; then
+                # also skip its argument
+                shift
+            else
+                ret+=("$i")
+            fi
+        done
+    else
+        ret=("$@")
+    fi
+    echo "${ret[@]}"
+}


### PR DESCRIPTION
Previously, elan would use gcc and its linker from the stdenv. This PR changes it to instead use the patched and bundled clang and ld.lld. (elan downloads and patches toolchain binaries similar to rustup.) This should fix building some projects that are setting clang-specific compiler flags, and make the output more reproducible across platforms.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
