### PR TITLE
tuxvdmtool: init at 0-unstable-2026-01-26

### DIFF
--- a/pkgs/by-name/tu/tuxvdmtool/package.nix
+++ b/pkgs/by-name/tu/tuxvdmtool/package.nix
@@ -1,0 +1,31 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "tuxvdmtool";
+  version = "0-unstable-2026-01-26";
+
+  src = fetchFromGitHub {
+    owner = "AsahiLinux";
+    repo = "tuxvdmtool";
+    rev = "9a23e6260db4f721ffcebba13b604c1fbeb9191b";
+    hash = "sha256-Jo0lz3AEnaIKEpHSCTxQK/0jRdJR/a453PGXPAUJDXs=";
+  };
+
+  cargoHash = "sha256-bnBtchG87ya7nlf20Zv3htnZDN5jv29DKY+8nx5CK5o=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Apple Silicon to Apple Silicon VDM utility";
+    homepage = "https://github.com/AsahiLinux/tuxvdmtool";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "tuxvdmtool";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
