### PR TITLE
nixos/tests/dep-scan: update vdb assets

### DIFF
--- a/nixos/tests/dep-scan.nix
+++ b/nixos/tests/dep-scan.nix
@@ -31,16 +31,16 @@
     # the program will try to download them at runtime.
     # https://github.com/owasp-dep-scan/dep-scan/issues/443
     environment.etc."vdb/data.index.vdb6".source = pkgs.fetchurl {
-      url = "https://huggingface.co/datasets/AppThreat/vdb/resolve/72377024f9742c6e700a113fc7059b18f738081c/app-2y/data.index.vdb6";
-      hash = "sha256-/9RIL6KVwmUmcKteOhWlnzjtZzGUbmRzua5o4Z8Mu9I=";
+      url = "https://huggingface.co/datasets/AppThreat/vdb/resolve/40609f230dd7c83178e054e0219c367b49a2c920/app-2y/data.index.vdb6";
+      hash = "sha256-UyE0xiLT0T4ygBdEvDi4VQW/vxwalN6YV9EJ9RoLYy4=";
     };
     environment.etc."vdb/data.vdb6".source = pkgs.fetchurl {
-      url = "https://huggingface.co/datasets/AppThreat/vdb/resolve/72377024f9742c6e700a113fc7059b18f738081c/app-2y/data.vdb6";
-      hash = "sha256-6gCftnjal9ZMXV+25fVANdJRuI/CN083OOnc8yA5TTw=";
+      url = "https://huggingface.co/datasets/AppThreat/vdb/resolve/40609f230dd7c83178e054e0219c367b49a2c920/app-2y/data.vdb6";
+      hash = "sha256-k5QIowFD8H/hwaRz1p8RXlFEIrKjnFUtxtZTfD67B+U=";
     };
     environment.etc."vdb/vdb.meta".source = pkgs.fetchurl {
-      url = "https://huggingface.co/datasets/AppThreat/vdb/resolve/72377024f9742c6e700a113fc7059b18f738081c/app-2y/vdb.meta";
-      hash = "sha256-i0oI3ODrmm8PF9UGJ9gy9QzQ0SKjLo9DdqYX/kqoHak=";
+      url = "https://huggingface.co/datasets/AppThreat/vdb/resolve/40609f230dd7c83178e054e0219c367b49a2c920/app-2y/vdb.meta";
+      hash = "sha256-eQB0dHlNw31sKsRcVUByhIfuIN35+m3VAcBHIfusNPY=";
     };
     environment.variables = {
       VDB_HOME = "/tmp/vdb";


### PR DESCRIPTION
From https://github.com/ngi-nix/ngipkgs/pull/1734#discussion_r2479354973

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
