### PR TITLE
devilutionx: 1.5.4 -> 1.5.5

### DIFF
--- a/pkgs/by-name/de/devilutionx/package.nix
+++ b/pkgs/by-name/de/devilutionx/package.nix
@@ -76,6 +76,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "@assets@" "$out/share/diasurgical/devilutionx/"
   '';
 
+  cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/by-name/de/devilutionx/package.nix
+++ b/pkgs/by-name/de/devilutionx/package.nix
@@ -12,7 +12,9 @@
   SDL2_image,
   SDL_audiolib,
   simpleini,
+  flac,
   fmt,
+  libogg,
   libpng,
   libtiff,
   libwebp,
@@ -45,20 +47,20 @@ let
     owner = "diasurgical";
     repo = "libzt";
     fetchSubmodules = true;
-    rev = "d6c6a069a5041a3e89594c447ced3f15d77618b8";
-    sha256 = "sha256-ttRJLfaGHzhS4jd8db7BNPWROCti3ZxuRouqsL/M5ew=";
+    rev = "1a9d83b8c4c2bdcd7ea6d8ab1dd2771b16eb4e13";
+    sha256 = "sha256-/A77ZM4s+br1hYa0OBdjXcWXUXYG+GiEYcW8VB+UJHo=";
   };
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "devilutionx";
-  version = "1.5.4";
+  version = "1.5.5";
 
   src = fetchFromGitHub {
     owner = "diasurgical";
     repo = "devilutionX";
     tag = finalAttrs.version;
-    hash = "sha256-F23MTe7vMOgIBH6qm7X1+8gIMmN9E+d/GZnFsQZt2cM=";
+    hash = "sha256-XfHpKERYZ+VCeWx95568FEEZ4UZg3Z4abA8mG4kHjy0=";
   };
 
   patches = [ ./add-nix-share-path-to-mpq-search.patch ];
@@ -83,7 +85,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     bzip2
+    flac
     fmt
+    libogg
     libpng
     libtiff
     libwebp

--- a/pkgs/by-name/sm/smpq/package.nix
+++ b/pkgs/by-name/sm/smpq/package.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_KDE" false)
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/st/stormlib/package.nix
+++ b/pkgs/by-name/st/stormlib/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "WITH_LIBTOMCRYPT" true)
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
   ];
 
   strictDeps = true;


### PR DESCRIPTION
Update to [1.5.5](https://github.com/diasurgical/DevilutionX/releases/tag/1.5.5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
