### PR TITLE
lynix: minor cleanups

### DIFF
--- a/pkgs/by-name/ly/lynis/package.nix
+++ b/pkgs/by-name/ly/lynis/package.nix
@@ -7,15 +7,15 @@
   installShellFiles,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lynis";
   version = "3.1.6";
 
   src = fetchFromGitHub {
     owner = "CISOfy";
     repo = "lynis";
-    rev = version;
-    sha256 = "sha256-f1iV9OBkycrwP3ydjaGMX45JIBtzZKHEJqnEoVuZPu4=";
+    tag = finalAttrs.version;
+    hash = "sha256-XMgC6KjkLgjSOBHBx7WM7C2Vm3Z/lto7CFs10kIxwZc=";
   };
 
   nativeBuildInputs = [
@@ -28,10 +28,11 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -d $out/bin $out/share/lynis/plugins
-    cp -r include db default.prf $out/share/lynis/
-    cp -a lynis $out/bin
-    wrapProgram "$out/bin/lynis" --prefix PATH : ${lib.makeBinPath [ gawk ]}
+    install -d $out/bin $out/share/lynis
+    install -Dm555 -t $out/libexec lynis
+    cp -r include db default.prf plugins $out/share/lynis/
+    makeWrapper "$out/libexec/lynis" "$out/bin/lynis" \
+      --prefix PATH : ${lib.makeBinPath [ gawk ]}
 
     installManPage lynis.8
     installShellCompletion --bash --name lynis.bash \
@@ -44,6 +45,6 @@ stdenv.mkDerivation rec {
     homepage = "https://cisofy.com/lynis/";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.ryneeverett ];
+    maintainers = with lib.maintainers; [ ryneeverett ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Minor cleanups. It's that wonderful "get my local changes into nixpkgs before the next release" time of year.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
