### PR TITLE
haruna: 1.4.0 -> 1.6.0

### DIFF
--- a/pkgs/by-name/ha/haruna/package.nix
+++ b/pkgs/by-name/ha/haruna/package.nix
@@ -4,21 +4,23 @@
   fetchFromGitLab,
   cmake,
   ffmpeg-headless,
+  kdsingleapplication,
+  libass,
   kdePackages,
   pkg-config,
   qt6,
   yt-dlp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "haruna";
-  version = "1.4.0";
+  version = "1.6.0";
 
   src = fetchFromGitLab {
     owner = "multimedia";
     repo = "haruna";
-    rev = "v${version}";
-    hash = "sha256-7983qZ7c3i8Ilyvu36t02zeIcVO96PXGNLH3wq6JsvI=";
+    rev = "v${finalAttrs.finalPackage.version}";
+    hash = "sha256-pAFO6zclJNmHD91ady0vlnBg6ebSWMzJq7TZN/uBGnM=";
     domain = "invent.kde.org";
   };
 
@@ -34,6 +36,8 @@ stdenv.mkDerivation rec {
     yt-dlp
 
     ffmpeg-headless
+    kdsingleapplication
+    libass
     kdePackages.kconfig
     kdePackages.kcoreaddons
     kdePackages.kdeclarative
@@ -55,6 +59,8 @@ stdenv.mkDerivation rec {
     qt6.wrapQtAppsHook
   ];
 
+  env.LANG = "C.UTF-8";
+
   meta = {
     homepage = "https://invent.kde.org/multimedia/haruna";
     description = "Open source video player built with Qt/QML and libmpv";
@@ -73,4 +79,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "haruna";
   };
-}
+})


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc