### PR TITLE
[nixos-25.05] vaultwarden: 1.33.2 -> 1.34.3, vaultwarden.webvault: 2025.1.1 -> 2025.7.0.0 

### DIFF
--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -53,45 +53,38 @@ let
               driver = Firefox(options=options)
 
               driver.implicitly_wait(20)
-              driver.get('http://localhost:8080/#/register')
+              driver.get('http://localhost:8080/#/signup')
 
               wait = WebDriverWait(driver, 10)
 
               wait.until(EC.title_contains("Vaultwarden Web"))
 
-              driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_email').send_keys(
+              driver.find_element(By.CSS_SELECTOR, 'input#register-start_form_input_email').send_keys(
                   '${userEmail}'
               )
-              driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_name').send_keys(
+              driver.find_element(By.CSS_SELECTOR, 'input#register-start_form_input_name').send_keys(
                   'A Cat'
               )
-              driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_master-password').send_keys(
+              driver.find_element(By.XPATH, "//button[contains(., 'Continue')]").click()
+              driver.find_element(By.CSS_SELECTOR, 'input#input-password-form_new-password').send_keys(
                   '${userPassword}'
               )
-              driver.find_element(By.CSS_SELECTOR, 'input#register-form_input_confirm-master-password').send_keys(
+              driver.find_element(By.CSS_SELECTOR, 'input#input-password-form_confirm-new-password').send_keys(
                   '${userPassword}'
               )
-              if driver.find_element(By.CSS_SELECTOR, 'input#checkForBreaches').is_selected():
-                  driver.find_element(By.CSS_SELECTOR, 'input#checkForBreaches').click()
+              if driver.find_element(By.XPATH, '//input[@formcontrolname="checkForBreaches"]').is_selected():
+                  driver.find_element(By.XPATH, '//input[@formcontrolname="checkForBreaches"]').click()
 
               driver.find_element(By.XPATH, "//button[contains(., 'Create account')]").click()
 
-              wait.until_not(EC.title_contains("Create account"))
+              wait.until_not(EC.title_contains("Set a strong password"))
 
-              driver.find_element(By.XPATH, "//button[contains(., 'Continue')]").click()
+              click_when_unobstructed((By.XPATH, "//button[contains(., 'New item')]"))
 
-              driver.find_element(By.XPATH, '//input[@type="password"]').send_keys(
-                  '${userPassword}'
-              )
-              driver.find_element(By.XPATH, "//button[contains(., 'Log in with master password')]").click()
-
-              click_when_unobstructed((By.CSS_SELECTOR, 'button#newItemDropdown'))
-              driver.find_element(By.XPATH, "//button[contains(., 'Item')]").click()
-
-              driver.find_element(By.CSS_SELECTOR, 'input#name').send_keys(
+              driver.find_element(By.XPATH, '//input[@formcontrolname="name"]').send_keys(
                   'secrets'
               )
-              driver.find_element(By.CSS_SELECTOR, 'input#loginPassword').send_keys(
+              driver.find_element(By.XPATH, '//input[@formcontrolname="password"]').send_keys(
                   '${storedPassword}'
               )
 

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -69,7 +69,7 @@ let
               driver.find_element(By.CSS_SELECTOR, 'input#input-password-form_new-password').send_keys(
                   '${userPassword}'
               )
-              driver.find_element(By.CSS_SELECTOR, 'input#input-password-form_confirm-new-password').send_keys(
+              driver.find_element(By.CSS_SELECTOR, 'input#input-password-form_new-password-confirm').send_keys(
                   '${userPassword}'
               )
               if driver.find_element(By.XPATH, '//input[@formcontrolname="checkForBreaches"]').is_selected():

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -236,7 +236,6 @@ builtins.mapAttrs (k: v: makeVaultwardenTest k v) {
       with subtest("Check that backup exists"):
           server.succeed('[ -d "/srv/backups/vaultwarden" ]')
           server.succeed('[ -f "/srv/backups/vaultwarden/db.sqlite3" ]')
-          server.succeed('[ -d "/srv/backups/vaultwarden/attachments" ]')
           server.succeed('[ -f "/srv/backups/vaultwarden/rsa_key.pem" ]')
           # Ensure only the db backed up with the backup command exists and not the other db files.
           server.succeed('[ ! -f "/srv/backups/vaultwarden/db.sqlite3-shm" ]')

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -210,9 +210,6 @@ let
                   output = json.loads(client.succeed(f"bw --nointeraction --raw --session {key} list items"))
 
                   assert output[0]['login']['password'] == "${storedPassword}"
-
-              with subtest("Check systemd unit hardening"):
-                  server.log(server.succeed("systemd-analyze security vaultwarden.service | grep -v ✓"))
             '';
       }
     );

--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -19,16 +19,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.33.2";
+  version = "1.34.1";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
     rev = version;
-    hash = "sha256-Lu3/qVTi5Eedcm+3XlHAAJ1nPHm9hW4HZncQKmzDdoo=";
+    hash = "sha256-SVEQX+uAYb4/qFQZRm2khOi8ti76v3F5lRnUgoHk8wA=";
   };
 
-  cargoHash = "sha256-T/ehLSPJmEuQYhotK12iqXQSe5Ke8+dkr9PVDe4Kmis=";
+  cargoHash = "sha256-Or259iQP89Ptf/XHpkHD08VDyCk/nQcFlyoKRUUQKt0=";
 
   # used for "Server Installed" version in admin panel
   env.VW_VERSION = version;

--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -19,16 +19,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.34.2";
+  version = "1.34.3";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
     rev = version;
-    hash = "sha256-hY1kAVkoNFwFrUUZGhPApTKuIPz07K337fDWOmbnWik=";
+    hash = "sha256-Dj0ySVRvBZ/57+UHas3VI8bi/0JBRqn0IW1Dq+405J0=";
   };
 
-  cargoHash = "sha256-SDwpatqTzbM6vbuH7u7F5Xvg2p+XFV9m02jKKMEoEr8=";
+  cargoHash = "sha256-4sDagd2XGamBz1XvDj4ycRVJ0F+4iwHOPlj/RglNDqE=";
 
   # used for "Server Installed" version in admin panel
   env.VW_VERSION = version;

--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -19,16 +19,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.34.1";
+  version = "1.34.2";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
     rev = version;
-    hash = "sha256-SVEQX+uAYb4/qFQZRm2khOi8ti76v3F5lRnUgoHk8wA=";
+    hash = "sha256-hY1kAVkoNFwFrUUZGhPApTKuIPz07K337fDWOmbnWik=";
   };
 
-  cargoHash = "sha256-Or259iQP89Ptf/XHpkHD08VDyCk/nQcFlyoKRUUQKt0=";
+  cargoHash = "sha256-SDwpatqTzbM6vbuH7u7F5Xvg2p+XFV9m02jKKMEoEr8=";
 
   # used for "Server Installed" version in admin panel
   env.VW_VERSION = version;

--- a/pkgs/by-name/va/vaultwarden/webvault.nix
+++ b/pkgs/by-name/va/vaultwarden/webvault.nix
@@ -2,43 +2,23 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  git,
   nixosTests,
   python3,
   vaultwarden,
 }:
 
-let
-  version = "2025.1.1";
-
-  suffix = lib.head (lib.match "[0-9.]*([a-z]*)" version);
-
-  bw_web_builds = fetchFromGitHub {
-    owner = "dani-garcia";
-    repo = "bw_web_builds";
-    rev = "v${version}";
-    hash = "sha256-wQGpl7N0D83FrrV4T+LFe9h3n5Q/MqLbGGO2F5R9k2g=";
-  };
-
-in
 buildNpmPackage rec {
   pname = "vaultwarden-webvault";
-  inherit version;
+  version = "2025.5.0.0";
 
   src = fetchFromGitHub {
-    owner = "bitwarden";
-    repo = "clients";
-    rev = "web-v${lib.removeSuffix suffix version}";
-    hash = "sha256-Bq133V8CsDMnLeaKrW5JmLTGRaZVLRbp+tTgG725tqE=";
+    owner = "vaultwarden";
+    repo = "vw_web_builds";
+    tag = "v${version}";
+    hash = "sha256-Z3QPKeo7+QV3XnECvLXz2Upv41h579WoVH0Vev0fixk=";
   };
 
-  npmDepsHash = "sha256-bWcp3VJI2bObLH/XBx3cdxXQY9Cw+IFpeNA2TXVTtFg=";
-
-  postPatch = ''
-    ln -s ${bw_web_builds}/{patches,resources} ..
-    PATH="${git}/bin:$PATH" VAULT_VERSION="${lib.removePrefix "web-" src.rev}" \
-      bash ${bw_web_builds}/scripts/apply_patches.sh
-  '';
+  npmDepsHash = "sha256-FC3x7H0MQDVGajtaMA2PUK5+soG6kD9AaDbq/s1pOnY=";
 
   nativeBuildInputs = [
     python3
@@ -73,7 +53,6 @@ buildNpmPackage rec {
   '';
 
   passthru = {
-    inherit bw_web_builds;
     tests = nixosTests.vaultwarden;
   };
 

--- a/pkgs/by-name/va/vaultwarden/webvault.nix
+++ b/pkgs/by-name/va/vaultwarden/webvault.nix
@@ -9,16 +9,16 @@
 
 buildNpmPackage rec {
   pname = "vaultwarden-webvault";
-  version = "2025.5.0.0";
+  version = "2025.7.0.0";
 
   src = fetchFromGitHub {
     owner = "vaultwarden";
     repo = "vw_web_builds";
     tag = "v${version}";
-    hash = "sha256-Z3QPKeo7+QV3XnECvLXz2Upv41h579WoVH0Vev0fixk=";
+    hash = "sha256-CnVOi4xE0+VFTm0yI4++MBv8w0vgtsRE5E2RwsLojMI=";
   };
 
-  npmDepsHash = "sha256-FC3x7H0MQDVGajtaMA2PUK5+soG6kD9AaDbq/s1pOnY=";
+  npmDepsHash = "sha256-QoZtiZpS8jVIaGKHcfKbtBrrn+RcMRvm1/oF23nPPQw=";
 
   nativeBuildInputs = [
     python3
@@ -56,12 +56,12 @@ buildNpmPackage rec {
     tests = nixosTests.vaultwarden;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Integrates the web vault into vaultwarden";
     homepage = "https://github.com/dani-garcia/bw_web_builds";
-    changelog = "https://github.com/dani-garcia/bw_web_builds/releases/tag/v${version}";
-    platforms = platforms.all;
-    license = licenses.gpl3Plus;
+    changelog = "https://github.com/dani-garcia/bw_web_builds/releases/tag/v${lib.concatStringsSep "." (lib.take 3 (lib.versions.splitVersion version))}";
+    platforms = lib.platforms.all;
+    license = lib.licenses.gpl3Plus;
     inherit (vaultwarden.meta) maintainers;
   };
 }


### PR DESCRIPTION
Closes #451030

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
