### PR TITLE
imapgoose: init at 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3667,6 +3667,12 @@
     githubId = 10221570;
     name = "Bo Bakker";
   };
+  bobberb = {
+    email = "bobberb@half-done.org";
+    github = "bobberb";
+    githubId = 1891836;
+    name = "bobberb";
+  };
   bobby285271 = {
     name = "Bobby Rong";
     email = "rjl931189261@126.com";

--- a/pkgs/by-name/im/imapgoose/package.nix
+++ b/pkgs/by-name/im/imapgoose/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromSourcehut,
+  installShellFiles,
+}:
+buildGoModule rec {
+  pname = "imapgoose";
+  version = "0.4.2";
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = "ImapGoose";
+    tag = "v${version}";
+    hash = "sha256-Zu2cHCTl6RyZzndFrLM7xTeD/T3isVerIB8D6vD3jIU=";
+  };
+
+  vendorHash = "sha256-6mh6KsJlijXn+bLzmtJSC4lcYFChQdyBKEjFzbQMIM0=";
+
+  subPackages = [
+    "cmd/imapgoose"
+    "cmd/capcheck"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage imapgoose.1
+    installManPage imapgoose.conf.5
+  '';
+
+  meta = {
+    description = "IMAP to Maildir synchronization tool";
+    longDescription = ''
+      ImapGoose is a daemon that continuously keeps local mailboxes in sync
+      with an IMAP server. It monitors both the IMAP server and local
+      filesystem, immediately synchronizing changes within seconds. Unlike
+      traditional sync tools, ImapGoose is highly optimized to reduce network
+      traffic by leveraging modern IMAP extensions (CONDSTORE, QRESYNC, and
+      NOTIFY) to perform efficient incremental syncs. It can monitor multiple
+      mailboxes per connection and automatically reconnects with exponential
+      back-off when network issues occur.
+    '';
+    homepage = "https://git.sr.ht/~whynothugo/ImapGoose";
+    changelog = "https://git.sr.ht/~whynothugo/ImapGoose/refs/v${version}";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.linux;
+    mainProgram = "imapgoose";
+    maintainers = with lib.maintainers; [
+      bobberb
+    ];
+  };
+}


### PR DESCRIPTION
Adds the imapgoose package.

https://git.sr.ht/~whynothugo/ImapGoose

An modern imap <-> maildir syncing program written in Go.

Also provides the "capcheck" binary to test if one's IMAP server has the required extensions. 

I plan to follow this up with a NixOS module.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
