### PR TITLE
tyrolienne: init at 1.1.0

### DIFF
--- a/pkgs/by-name/ty/tyrolienne/package.nix
+++ b/pkgs/by-name/ty/tyrolienne/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  rustPlatform,
+  copyDesktopItems,
+  fetchFromGitea,
+  ffmpeg,
+  imagemagick,
+  libadwaita,
+  makeDesktopItem,
+  nix-update-script,
+  pkg-config,
+  wrapGAppsHook4,
+  zenity,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tyrolienne";
+  version = "1.1.0";
+
+  src = fetchFromGitea {
+    domain = "git.uku3lig.net";
+    owner = "uku";
+    repo = "tyrolienne";
+    tag = finalAttrs.version;
+    hash = "sha256-LJZxQLATVGEhb0HK8PO3Fe+N+GjJdwX1Z7mOCIwQkqo=";
+  };
+
+  cargoHash = "sha256-ax8Akv26XFFxKVstUIAHUDKypzkJOS8mpBDIT3NfBbE=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [ libadwaita ];
+
+  # Tests are disabled because there are none, avoids having to recompile everything twice
+  doCheck = false;
+
+  postInstall = ''
+    for size in 16 32 48 128 256; do
+      dir="$out/share/icons/hicolor/''${size}x''${size}/apps"
+      mkdir -p "$dir"
+      magick data/icons/tyrolienne.png -resize ''${size}x "$dir/net.uku3lig.tyrolienne.png"
+    done
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ffmpeg
+          zenity
+        ]
+      }
+    )
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "net.uku3lig.tyrolienne";
+      desktopName = "Tyrolienne";
+      type = "Application";
+      comment = "Compresses and uploads videos to Zipline";
+      exec = "tyrolienne";
+      icon = "net.uku3lig.tyrolienne";
+      terminal = false;
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple tool to convert, upload, and embed videos to Zipline";
+    homepage = "https://git.uku3lig.net/uku/tyrolienne";
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ uku3lig ];
+    mainProgram = "tyrolienne";
+  };
+})


### PR DESCRIPTION
Tyrolienne is a small libadwaita app I wrote to compress and upload videos to a zipline server.

Homepage/source: https://git.uku3lig.net/uku/tyrolienne

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
