### PR TITLE
nixpkgs: pass `lib` to config function

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -9,6 +9,32 @@
 - Node.js default version has been updated from 22 LTS to 24 LTS.
   This introduces some breaking changes; Refer to the [upstream migration article](https://nodejs.org/en/blog/migrations/v22-to-v24) for details.
 
+- Nixpkgs configuration, specified for NixOS using `nixpkgs.config`, or using the `config` argument when importing nixpkgs, has learned to accept a `lib` argument as well as `pkgs`, which allows the configuration to be computed without depending on the `pkgs` fixed point.  If you are referencing licenses in `lib.licenses` by having this configuration be a function taking a `pkgs` arg, you may wish to change to using `lib` for faster computation and to avoid infinite recursion errors if pkgs depends on parts of the computed configuration in future.
+
+    For example, if you currently have configuration that looks like this:
+
+        { pkgs, ... }:
+        {
+          allowlistedLicenses = [ pkgs.lib.licenses.nasa13 ];
+          blocklistedLicenses = with pkgs.lib.licenses; [ gpl3Only gpl3Plus ];
+        }
+
+    You may wish to update it to something like this:
+
+        { lib, ... }:
+        {
+          allowlistedLicenses = [ lib.licenses.nasa13 ];
+          blocklistedLicenses = with lib.licenses; [ gpl3Only gpl3Plus ];
+        }
+
+    Or, if you need configuration that works with both 26.05 and 25.11:
+
+        { pkgs, lib ? pkgs.lib, ... }:
+        {
+          allowlistedLicenses = [ lib.licenses.nasa13 ];
+          blocklistedLicenses = with lib.licenses; [ gpl3Only gpl3Plus ];
+        }
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -16,8 +16,8 @@ let
   mergeConfig =
     lhs_: rhs_:
     let
-      lhs = optCall lhs_ { inherit pkgs; };
-      rhs = optCall rhs_ { inherit pkgs; };
+      lhs = optCall lhs_ { inherit lib pkgs; };
+      rhs = optCall rhs_ { inherit lib pkgs; };
     in
     lib.recursiveUpdate lhs rhs
     // lib.optionalAttrs (lhs ? packageOverrides) {

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -109,7 +109,7 @@ let
   # Allow both:
   # { /* the config */ } and
   # { pkgs, ... } : { /* the config */ }
-  config1 = if lib.isFunction config0 then config0 { inherit pkgs; } else config0;
+  config1 = if lib.isFunction config0 then config0 { inherit lib pkgs; } else config0;
 
   configEval = lib.evalModules {
     modules = [


### PR DESCRIPTION
Nixpkgs config, for defining things like which licenses are permitted, can either be an attrset or a function that is passed a `pkgs` argument.  Evaluating that `pkgs` argument requires computing the Nixpkgs fixpoint, which requires checking whether the derivations used in the Nixpkgs bootstrap have valid licenses.  This works provided nothing tries to use Nixpkgs functions to validate or merge anything included in the configuration.

f5deefd4631e (config: add and document {allow,block}listedLicenses, 2025-08-31), in #437723, added type checking and merging to the lists of permitted/forbidden licenses.  That resulted in a recursion loop if a list of licenses included, say, `pkgs.lib.licenses.bsd0`.

To allow licenses to be specified from Nixpkgs' library, pass `lib` as well as `pkgs` to any config function.  Computing `lib` doesn't require working out the full Nixpkgs fixpoint.  The change in #437723 will still break things for some people, but it at least provides a sensible route to getting the config working again.

Fixes #456994.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
