### PR TITLE
bella: init at 0.1.3

### DIFF
--- a/pkgs/by-name/be/bella/package.nix
+++ b/pkgs/by-name/be/bella/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  desktop-file-utils,
+  appstream-glib,
+  gjs,
+  glib,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  libportal,
+  meson,
+  ninja,
+  wrapGAppsHook4,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bella";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "josephmawa";
+    repo = "Bella";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JSzgh56Ph8LjVY2uPfu1tacdr7BBbBzRfdWtcTRga7I=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    desktop-file-utils # `desktop-file-validate`, `update-desktop-database`
+    appstream-glib # `appstream-util`
+    gjs
+    glib # `glib-compile-schemas`
+    gobject-introspection
+    gtk4 # `gtk4-update-icon-cache`
+    meson
+    ninja
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    libportal
+  ];
+
+  # GJS uses argv[0] to find gresource files, and wrappers will cause that mechanism to fail.
+  # Manually overriding the entrypoint name should do the job.
+  #
+  # - https://gitlab.gnome.org/GNOME/gjs/-/blob/6aca7b50785fa1638f144b17060870d721e3f65a/modules/script/package.js#L159
+  # - https://gitlab.gnome.org/GNOME/gjs/-/blob/6aca7b50785fa1638f144b17060870d721e3f65a/modules/script/package.js#L37
+  preFixup = ''
+    sed -i "1 a imports.package._findEffectiveEntryPointName = () => 'io.github.josephmawa.Bella';" $out/bin/io.github.josephmawa.Bella
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple eye dropper and color picker";
+    homepage = "https://github.com/josephmawa/Bella";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pluiedev ];
+    mainProgram = "io.github.josephmawa.Bella";
+    platforms = lib.lists.intersectLists lib.platforms.linux gjs.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
