### PR TITLE
models-dev: 0-unstable-2025-10-28 -> 0-unstable-2025-10-30

### DIFF
--- a/pkgs/by-name/mo/models-dev/package.nix
+++ b/pkgs/by-name/mo/models-dev/package.nix
@@ -8,12 +8,12 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "models-dev";
-  version = "0-unstable-2025-10-28";
+  version = "0-unstable-2025-10-30";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "models.dev";
-    rev = "86138343a8c048caa813c17ac56fda39e92458bf";
-    hash = "sha256-VYR9Sp7AKQ6abJg1Dyhr/GyYwGgE9XcuKHLW3an5/wY=";
+    rev = "b97ee9233088cb71668ee91a679d41b36ffae312";
+    hash = "sha256-uN9hCqzELCpOLRtNqp5M/80pHqo2zmdXXfnqVqdIAjY=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {


### PR DESCRIPTION
Automatic update generated by [nixpkgs-update-gha](https://github.com/delafthi/nixpkgs-update-gha). This update was made based on information from `passthru.updateScript`.

meta.description for models-dev is: Comprehensive open-source database of AI model specifications, pricing, and capabilities

meta.homepage for models-dev is: https://github.com/sst/models-dev

meta.changelog for models-dev is: 

###### Updates performed

- Ran `passthru.updateScript`

###### To inspect upstream changes

https://github.com/sst/models-dev

###### Impact

<b>Checks done</b>

---

- built on NixOS
- found 0-unstable-2025-10-30 in filename of file in /nix/store/9phdbdmwpx07bczikkcby1m1skks56ps-models-dev-0-unstable-2025-10-30
- nixpkgs-review-gha triggered for multi-platform testing ([view workflow runs](https://github.com/delafthi/nixpkgs-review-gha/actions))

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
Build logs: https://github.com/delafthi/nixpkgs-update-gha/actions/runs/18961649088
```

</details>

### Pre-merge build results

We have automatically built all packages that will get rebuilt due to
this change.

This gives evidence on whether the upgrade will break dependent packages.
Note sometimes packages show up as _failed to build_ independent of the
change, simply because they are already broken on the target branch.

## `nixpkgs-review` result

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>models-dev</li>
    <li>opencode</li>
  </ul>
</details>

###### Maintainer pings

cc @delafthi for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.com/blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
