### PR TITLE
python313Packages.pydicom: add missing pydicom[pixeldata] optdepends

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -10,7 +10,9 @@
   # optional/test dependencies
   gdcm,
   pillow,
+  pydicom,
   pyjpegls,
+  pylibjpeg,
   pylibjpeg-libjpeg,
   writableTmpDirAsHomeHook,
 }:
@@ -46,11 +48,12 @@ buildPythonPackage rec {
     pixeldata = [
       pillow
       pyjpegls
-      #pylibjpeg.optional-dependencies.openjpeg # infinite recursion
-      #pylibjpeg.optional-dependencies.rle # infinite recursion
+      pylibjpeg
       pylibjpeg-libjpeg
       gdcm
-    ];
+    ]
+    ++ pylibjpeg.optional-dependencies.openjpeg
+    ++ pylibjpeg.optional-dependencies.rle;
   };
 
   nativeCheckInputs = [
@@ -60,6 +63,12 @@ buildPythonPackage rec {
   ++ optional-dependencies.pixeldata;
 
   passthru.pydicom-data = test_data;
+
+  doCheck = false; # circular dependency
+
+  passthru.tests.pytest = pydicom.overridePythonAttrs {
+    doCheck = true;
+  };
 
   # Setting $HOME to prevent pytest to try to create a folder inside
   # /homeless-shelter which is read-only.


### PR DESCRIPTION
Also moved tests to passthru to break dependency cycle

Now runs 3631 tests instead of 3337 as previously.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
