### PR TITLE
yaziPlugins: update on 2025-10-30

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/dupes/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/dupes/default.nix
@@ -7,13 +7,13 @@
 }:
 mkYaziPlugin {
   pname = "dupes.yazi";
-  version = "0-unstable-2025-10-16";
+  version = "0-unstable-2025-10-23";
 
   src = fetchFromGitHub {
     owner = "mshnwq";
     repo = "dupes.yazi";
-    rev = "012a21e1864296503f7bb1e7297b71fe57af8994";
-    hash = "sha256-VUF7vmtnXuEsbyS0/pPTgwrDDrnMqt77eIkeQZFxoZk=";
+    rev = "18a9395d38f42e406805b92834154fc7ad15a7b8";
+    hash = "sha256-hBpUoMKGZgKrgxAOYZQ9CU4BKPSiYpYVWyuHYXHZ/Pc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "recycle-bin.yazi";
-  version = "0-unstable-2025-09-16";
+  version = "0-unstable-2025-10-25";
 
   src = fetchFromGitHub {
     owner = "uhs-robert";
     repo = "recycle-bin.yazi";
-    rev = "03f6c4a3085c218a0909671dcc2014558fff18a7";
-    hash = "sha256-M33RjtFQhnh9pIFKQKrsvZuWZNbe0lfepDKFsAuaYC4=";
+    rev = "8bb62865fdef06ea27c10367595017c118ef2831";
+    hash = "sha256-p7UBJCWvyOHpt2EbjDNJJ0wuPxK425vyy+9lf9al9F0=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "rich-preview.yazi";
-  version = "0-unstable-2025-05-31";
+  version = "0-unstable-2025-10-22";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "rich-preview.yazi";
-    rev = "843c3faf0a99f5ce31d02372c868d8dae92ca29d";
-    hash = "sha256-celObHo9Y3pFCd1mTx1Lz77Tc22SJTleRblAkbH/RqY=";
+    rev = "831234e828d292913f4b174a1ca2be2fb1080f22";
+    hash = "sha256-CK3ynjs53I1tRqARoOYMgBczBrcle+pwpUhHt3VpSXs=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
@@ -5,12 +5,12 @@
 }:
 mkYaziPlugin {
   pname = "rsync.yazi";
-  version = "0-unstable-2025-09-20";
+  version = "0-unstable-2025-10-23";
   src = fetchFromGitHub {
     owner = "GianniBYoung";
     repo = "rsync.yazi";
-    rev = "824d8a35bf1f13742d19ecd93521bedc547fa809";
-    hash = "sha256-GqrwhJ4Fyxk4vzOSkFPoxvq5EV50YejaB84m2K006Bc=";
+    rev = "14d28283f49b39593a2763d7457e0dacb78f7597";
+    hash = "sha256-LT+4NKiCkiF72RG9g/tOjS6F+Wc4tY3vtnHNHPxbn1w=";
   };
 
   meta = {


### PR DESCRIPTION
- dupes: 0-unstable-2025-10-16 → 0-unstable-2025-10-23
- recycle-bin: 0-unstable-2025-09-16 → 0-unstable-2025-10-25
- rich-preview: 0-unstable-2025-05-31 → 0-unstable-2025-10-22
- rsync: 0-unstable-2025-09-20 → 0-unstable-2025-10-23


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
