### PR TITLE
fakesip: init at 0.9.1

### DIFF
--- a/pkgs/by-name/fa/fakesip/package.nix
+++ b/pkgs/by-name/fa/fakesip/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libnetfilter_queue,
+  libnfnetlink,
+  libmnl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fakesip";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "MikeWang000000";
+    repo = "FakeSIP";
+    tag = finalAttrs.version;
+    hash = "sha256-iY9EAvy4E6aM59B1sn9d0xoUMdOsX75LslVzB/Cf5XM=";
+  };
+
+  buildInputs = [
+    libnetfilter_queue
+    libnfnetlink
+    libmnl
+  ];
+
+  makeFlags = [
+    "CROSS_PREFIX=${stdenv.cc.targetPrefix}"
+    "VERSION=${finalAttrs.version}"
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Disguise your UDP traffic as SIP protocol to evade DPI detection";
+    homepage = "https://github.com/MikeWang000000/FakeSIP";
+    changelog = "https://github.com/MikeWang000000/FakeSIP/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "fakesip";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Also tested cross builds, both .#pkgsCross.riscv64.fakesip and .#pkgsCross.loongarch64-linux.fakesip built successfully.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
