### PR TITLE
python3Packages.aioautomower: 2.3.1 -> 2.7.0

### DIFF
--- a/pkgs/development/python-modules/aioautomower/default.nix
+++ b/pkgs/development/python-modules/aioautomower/default.nix
@@ -7,6 +7,7 @@
   freezegun,
   ical,
   mashumaro,
+  orjson,
   poetry-core,
   poetry-dynamic-versioning,
   pyjwt,
@@ -22,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "aioautomower";
-  version = "2.3.1";
+  version = "2.7.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -31,7 +32,7 @@ buildPythonPackage rec {
     owner = "Thomas55555";
     repo = "aioautomower";
     tag = "v${version}";
-    hash = "sha256-M0BAErX5S3BjP+YSv+j2m453T4+U4uHV6N0kWmc42ls=";
+    hash = "sha256-qhjfnneLJjdDDP4XrecSI/psqEqKGP5ziaPd/iRiZfM=";
   };
 
   postPatch = ''
@@ -49,6 +50,7 @@ buildPythonPackage rec {
     aiohttp
     ical
     mashumaro
+    orjson
     pyjwt
     python-dateutil
     tzlocal
@@ -67,23 +69,17 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "aioautomower" ];
 
   disabledTests = [
-    # File is missing
-    "test_standard_mower"
-    # Call no found
-    "test_post_commands"
     # Timezone mismatches
-    "test_full_planner_event"
-    "test_sinlge_planner_event"
     "test_set_datetime"
     "test_message_event"
     "test_async_get_messages"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Module to communicate with the Automower Connect API";
     homepage = "https://github.com/Thomas55555/aioautomower";
     changelog = "https://github.com/Thomas55555/aioautomower/releases/tag/${src.tag}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/Thomas55555/aioautomower/compare/v2.3.1...v2.7.0

Changelog: https://github.com/Thomas55555/aioautomower/releases/tag/v2.7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
