### PR TITLE
nixos/syncthing-discovery: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12280,6 +12280,13 @@
     githubId = 8900;
     name = "Johan Magnus Jonsson";
   };
+  jmsuen = {
+   name = "Jenmin Suen";
+   email = "jenmin.suen@outlook.com";
+   github = "jmsuen";
+   githubId = 85784679;
+   keys = [{ fingerprint = "557A E33E 80F7 697F 68E0  0C18 A15D 9620 FC95 0747"; }];
+  };
   JManch = {
     email = "jmanch@protonmail.com";
     github = "JManch";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1372,6 +1372,7 @@
   ./services/networking/supybot.nix
   ./services/networking/suricata/default.nix
   ./services/networking/syncplay.nix
+  ./services/networking/syncthing-discovery.nix
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncthing.nix
   ./services/networking/tailscale-auth.nix

--- a/nixos/modules/services/networking/syncthing-discovery.nix
+++ b/nixos/modules/services/networking/syncthing-discovery.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.syncthing.discovery;
+
+  dataDirectory = "/var/lib/syncthing-discovery";
+
+  discoveryOptions = [
+    "--db-dir=${dataDirectory}"
+    "--listen=${cfg.listenAddress}:${toString cfg.port}"
+  ]
+  ++ optional (cfg.http) "--http"
+  ++ optional (cfg.cert != null) "--cert=${dataDirectory}/${cfg.cert}"
+  ++ optional (cfg.key != null) "--key=${dataDirectory}/${cfg.key}"
+  ++ cfg.extraOptions;
+in
+{
+  ###### interface
+
+  options.services.syncthing.discovery = {
+    enable = mkEnableOption "Syncthing discovery service";
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "";
+      example = "1.2.3.4";
+      description = ''
+        Address to listen on for discovery server.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8443;
+      description = ''
+        Port to listen on for discovery server.
+      '';
+    };
+
+    http = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to listen on HTTP (behind an HTTPS proxy).
+      '';
+    };
+
+    cert = mkOption {
+      type = types.nullOr types.str;
+      default = "cert.pem";
+      description = ''
+        Path to the `cert.pem` file.
+      '';
+    };
+
+    key = mkOption {
+      type = types.nullOr types.str;
+      default = "key.pem";
+      description = ''
+        Path to the `key.pem` file.
+      '';
+    };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Extra command line arguments to pass to stdiscosrv.
+      '';
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    systemd.services.syncthing-discovery = {
+      description = "Syncthing discovery service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = baseNameOf dataDirectory;
+
+        Restart = "on-failure";
+        ExecStart = "${pkgs.syncthing-discovery}/bin/stdiscosrv ${concatStringsSep " " discoveryOptions}";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds a new NixOS module for the [Syncthing discovery server](https://docs.syncthing.net/users/stdiscosrv.html).  [Syncthing](https://syncthing.net/) users can use this to build their own discovery servers and find peers on the network.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
