### PR TITLE
qrtr: init at 1.1

### DIFF
--- a/pkgs/by-name/qr/qrtr/package.nix
+++ b/pkgs/by-name/qr/qrtr/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  meson,
+  ninja,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qrtr";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "qrtr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cPd7bd+S2uVILrFF797FwumPWBOJFDI4NvtoZ9HiWKM=";
+  };
+
+  nativeBuildInputs = [ meson ];
+
+  buildInputs = [
+    ninja
+    pkg-config
+  ];
+
+  mesonFlags = [
+    # The user space QRTR nameservice is not required because
+    # there is a kernel space driver since Linux v5.7-rc1.
+    (lib.mesonEnable "qrtr-ns" false)
+    (lib.mesonEnable "systemd-service" false)
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Userspace reference for net/qrtr in the Linux kernel";
+    homepage = "https://github.com/linux-msm/qrtr";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "qrtr-cfg";
+  };
+})


### PR DESCRIPTION
Add qrtr, a userspace reference for net/qrtr in the Linux kernel

Required for:
 - https://github.com/NixOS/nixpkgs/pull/457181
 - https://github.com/NixOS/nixpkgs/pull/457180
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
