### PR TITLE
tqftpserv: init at 1.1-unstable-2025-08-01

### DIFF
--- a/pkgs/by-name/tq/tqftpserv/package.nix
+++ b/pkgs/by-name/tq/tqftpserv/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  meson,
+  ninja,
+  pkg-config,
+  qrtr,
+  systemd,
+  zstd,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tqftpserv";
+  # Use unstable for fixed systemd service
+  # with removed qrtr-ns dependency.
+  version = "1.1-unstable-2025-08-01";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "tqftpserv";
+    rev = "408ca1ed5e4e0a9ac3650b13d3f3c60079b3e2a3";
+    hash = "sha256-IlM/HVdo/7cA9NnJrCW/B0yKks5jWYqxRyy3ay4wDr8=";
+  };
+
+  nativeBuildInputs = [ meson ];
+
+  buildInputs = [
+    qrtr
+    ninja
+    pkg-config
+    systemd
+    zstd
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Trivial File Transfer Protocol server over AF_QIPCRTR";
+    homepage = "https://github.com/linux-msm/tqftpserv";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "tqftpserv";
+  };
+})


### PR DESCRIPTION
Add tqftpserv, a TFTP implementation over AF_QIPCRTR.

This is required to get modem & Wi-Fi working on Qualcomm devices.

Depends on https://github.com/NixOS/nixpkgs/pull/457178

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
