### PR TITLE
rmtfs: init at 1.1.1

### DIFF
--- a/pkgs/by-name/rm/rmtfs/package.nix
+++ b/pkgs/by-name/rm/rmtfs/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  qrtr,
+  udev,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rmtfs";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "linux-msm";
+    repo = "rmtfs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ehd8SbKNOpyVoF9oc7e5uYmJOHI+Q6woLyvwO8hhKEc=";
+  };
+
+  buildInputs = [
+    qrtr
+    udev
+  ];
+
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Qualcomm Remote Filesystem Service Implementation";
+    homepage = "https://github.com/linux-msm/rmtfs";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "rmtfs";
+  };
+})


### PR DESCRIPTION
Add rmtfs, a Qualcomm remote filesystem service implementation.

This is required to get the remote processors working on Qualcomm SoCs.

Depends on https://github.com/NixOS/nixpkgs/pull/457178

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. --> addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
