### PR TITLE
rust: 1.90.0 -> 1.91.0

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -774,6 +774,7 @@ rec {
           # On Darwin, the debug symbols are in a separate directory.
           "./bin/test_binary1.dSYM/Contents/Info.plist"
           "./bin/test_binary1.dSYM/Contents/Resources/DWARF/test_binary1"
+          "./bin/test_binary1.dSYM/Contents/Resources/Relocations/${stdenv.hostPlatform.rust.platform.arch}/test_binary1.yml"
         ];
       };
 

--- a/pkgs/development/compilers/rust/1_91.nix
+++ b/pkgs/development/compilers/rust/1_91.nix
@@ -44,8 +44,8 @@ let
 in
 import ./default.nix
   {
-    rustcVersion = "1.90.0";
-    rustcSha256 = "sha256-eZqfnLpO1TUeBxBIvPa1VgdV2QCWSN7zOkB91JYfm34=";
+    rustcVersion = "1.91.0";
+    rustcSha256 = "sha256-Mn9SgVF1MBPworLH9IlVoDPXGPJppLxYYxTWddDUPoo=";
 
     llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
@@ -59,30 +59,30 @@ import ./default.nix
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
     # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
-    bootstrapVersion = "1.90.0";
+    bootstrapVersion = "1.91.0";
 
     # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
     bootstrapHashes = {
-      i686-unknown-linux-gnu = "8f389b9eb1513785f5589816b60b5a7ca3b24c29bedce7ec0d1c2f8c3ccfb0cc";
-      x86_64-unknown-linux-gnu = "e453bae1c68d02fe2eae065c5452d5731308164cd154154c6ee442d2fa590685";
-      x86_64-unknown-linux-musl = "251c9fe4e3374f2f9f629a7a83238c618e016b1bda1b9de5e8385cb3a6f057fa";
-      arm-unknown-linux-gnueabihf = "61f3987f61bf73562f04dcacfee1a2bad8d16d41f7a3f81ad82dd9b9cbc559ce";
-      armv7-unknown-linux-gnueabihf = "06cfb7f1bd3ce50480eed73ad9ae4f8f665d154fa4c713bc08541197eecd4ae0";
-      aarch64-unknown-linux-gnu = "293f412e3412c3aa3398c78ebbdf898fa08eacad80c85a7332ce1a455504c5fc";
-      aarch64-unknown-linux-musl = "b3ac31ca2e1a720709bf4fb678b2a2f98464c55662c516dfffcbdadd95a420c9";
-      x86_64-apple-darwin = "3d1d24e1d4bedb421ca1a16060c21f4d803eaefba585c0b5b5d0b1e56692ef4b";
-      aarch64-apple-darwin = "a11b52e34f5e80cb25d49f7943ae60e0b069b431727a4c09b2c890ceebee3687";
-      powerpc64-unknown-linux-gnu = "39720c905b8a730cfa725b7e201cd238d15c33112bd4c31b168ca6d1cb898cac";
-      powerpc64le-unknown-linux-gnu = "4061405099dc0aba379fe7b7a616d320272ef9325114dfa8f106c303f9b5695c";
-      powerpc64le-unknown-linux-musl = "0d97ef122126a0de87a8581f48ef85ff0887b733b429ffcec4651699b5444511";
-      riscv64gc-unknown-linux-gnu = "42cc3b3bb008e24a39bd98887c43ef32c2d997f801c86ca47f2119e5e3589fcb";
-      s390x-unknown-linux-gnu = "345c9b902ebee656533d2cfba39c1a020e6a41a4a9609f87430ff8a5d680d649";
-      loongarch64-unknown-linux-gnu = "1c116041a2bc7ab2697218f99ad8cccbe3d6b63fcbf516cb9d985cb00efcdb09";
-      loongarch64-unknown-linux-musl = "0ae18468c7cd3872d1b685cf960426aeb7467629f69eabb497bee6f0fff9cb04";
-      x86_64-unknown-freebsd = "6c7ebf6acbe00873680a190152d47aeebe76e237195b974c593a67227123b2ef";
+      i686-unknown-linux-gnu = "7f455c2b498a6197db7f00d636899ed0fb20ce152f1b1573a3ee524ee98b1b80";
+      x86_64-unknown-linux-gnu = "bad9a353330d9f409fe9db790da5701074112f804073506bb2808dd97b940b3c";
+      x86_64-unknown-linux-musl = "ac925e53b6cef81445f73e6d45213ab56d11585ac525a3ac21fc09ef4ca664ab";
+      arm-unknown-linux-gnueabihf = "4cba316544d91b240529a5e835a42526eaeba85d3574f72b24e7ef73a7bb9132";
+      armv7-unknown-linux-gnueabihf = "d86de4cd9e8264ff8dff1b2ec52b8fd2dbb9a01acb6c23ad73e38695d2de98e6";
+      aarch64-unknown-linux-gnu = "29c5a608861cc9c06d3f86852a7d7b1a868de2d7ab90d4ff625aeebfb9383390";
+      aarch64-unknown-linux-musl = "e97e8821ca7e3aa9986a776cd145ee1b01b8984d31912d345c6059b9535cb72e";
+      x86_64-apple-darwin = "b329b458c8074023e5f6934bcd6c0bbef5075ac0090548c3d45a7de82e0c5b0c";
+      aarch64-apple-darwin = "ec42d93940933340ee55e67003699ebe264aa82d7cf0d5ae08100c06b1bfacfa";
+      powerpc64-unknown-linux-gnu = "9c325b63643bbc4ca98aec820c056f6fb4e82ddc6cc14b1e1382db1f10855ff3";
+      powerpc64le-unknown-linux-gnu = "1a357b1e44f7ec7c2da62461a4180d8d8b599dd06045e7e2b83cd7f93972d6d7";
+      powerpc64le-unknown-linux-musl = "584b4e37b7c06f850f167b2f8e5095a7a1ca961d8e66c8aae0f4a5ccfba4736e";
+      riscv64gc-unknown-linux-gnu = "216a1c6d178e0494ac488f3310e600ef17c62ce38d43e9b14557d1f16f3637f7";
+      s390x-unknown-linux-gnu = "e2cda4e86f68e3d4ca9df4f9d80d53fc34a555a96012fceefa4190a388e987d4";
+      loongarch64-unknown-linux-gnu = "8121c8d7d9152a835c84bf6b586c107ae582ed051780d37cb1e6f4f9bdad23aa";
+      loongarch64-unknown-linux-musl = "58344f7047aceefa44e9aef552b9b84ae3d16fded31a5c6ba9b63abc2c269f43";
+      x86_64-unknown-freebsd = "b996571bffafb11951b1a29526bb79518c9f5d74618cf414989b297375c7264f";
     };
 
-    selectRustPackage = pkgs: pkgs.rust_1_90;
+    selectRustPackage = pkgs: pkgs.rust_1_91;
   }
 
   (

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -62,12 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     passthru.isReleaseTarball = true;
   };
 
-  hardeningDisable = optionals stdenv.cc.isClang [
-    # remove once https://github.com/NixOS/nixpkgs/issues/318674 is
-    # addressed properly
-    "zerocallusedregs"
-  ];
-
   __darwinAllowLocalNetworking = true;
 
   # rustc complains about modified source files otherwise
@@ -238,6 +232,11 @@ stdenv.mkDerivation (finalAttrs: {
       # doesn't work) to build a linker.
       "--disable-llvm-bitcode-linker"
     ]
+    ++ optionals (!fastCross && stdenv.targetPlatform.config != "wasm32-unknown-none") [
+      # See https://github.com/rust-lang/rust/issues/132802
+      "--set=target.wasm32-unknown-unknown.optimized-compiler-builtins=false"
+      "--set=target.wasm32v1-none.optimized-compiler-builtins=false"
+    ]
     ++ optionals (stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.useLLVM or false)) [
       "--enable-profiler" # build libprofiler_builtins
     ]
@@ -281,12 +280,13 @@ stdenv.mkDerivation (finalAttrs: {
       ''
         runHook preBuild
 
-        mkdir -p build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-{std,rustc}/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/
+        mkdir -p build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage{0,1}-{std,rustc}/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/
         ln -s ${rustc.unwrapped}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/libstd-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/libstd.so
         ln -s ${rustc.unwrapped}/lib/rustlib/${stdenv.hostPlatform.rust.rustcTargetSpec}/librustc_driver-*.so build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/librustc.so
         ln -s ${rustc.unwrapped}/bin/rustc build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/rustc-main
+        ln -s ${rustc.unwrapped}/bin/rustc build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage1-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/rustc-main
         touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-std/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.libstd-stamp
-        touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage0-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.librustc-stamp
+        touch build/${stdenv.hostPlatform.rust.rustcTargetSpec}/stage{0,1}-rustc/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/.librustc-stamp
         python ./x.py --keep-stage=0 --stage=1 build library
 
         runHook postBuild

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5290,15 +5290,15 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... }@args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_90 = callPackage ../development/compilers/rust/1_90.nix { };
-  rust = rust_1_90;
+  rust_1_91 = callPackage ../development/compilers/rust/1_91.nix { };
+  rust = rust_1_91;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
-  rustPackages_1_90 = rust_1_90.packages.stable;
-  rustPackages = rustPackages_1_90;
+  rustPackages_1_91 = rust_1_91.packages.stable;
+  rustPackages = rustPackages_1_91;
 
   inherit (rustPackages)
     cargo


### PR DESCRIPTION
https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/

build on x86_64-linux:
- [x] fd
- [x] firefox

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
