### PR TITLE
magic-wormhole: 0.21.0 -> 0.21.1

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -42,14 +42,14 @@
 
 buildPythonPackage rec {
   pname = "magic-wormhole";
-  version = "0.21.0";
+  version = "0.21.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "magic-wormhole";
     repo = "magic-wormhole";
     tag = version;
-    hash = "sha256-gsNdV6JvxsdlyPOSn07nTrvU4ju+3si3SQhyN8ZX/ac=";
+    hash = "sha256-HZ6ZS2dkJoW+yL6F3U9WguUHicfG2KWnk4/YuNPwpUc=";
   };
 
   postPatch =


### PR DESCRIPTION
https://github.com/magic-wormhole/magic-wormhole/blob/refs/tags/0.21.1/NEWS.md
https://github.com/magic-wormhole/magic-wormhole/compare/refs/tags/0.21.0...refs/tags/0.21.1

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `a798bc8225340574da7434947c410fd942c81fe3`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 9 packages built:</summary>
  <ul>
    <li>magic-wormhole (python313Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python313Packages.magic-wormhole.dist)</li>
    <li>python312Packages.magic-wormhole</li>
    <li>python312Packages.magic-wormhole.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
    <li>tahoe-lafs.man</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc